### PR TITLE
Split storybook applications

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,14 +79,14 @@ jobs:
           echo "Deploying to directory: ${{env.BRANCH_NAME}}"
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          npx gh-pages --dist dist/ -- src storybook/**/* --dest ${{env.BRANCH_NAME}} --remove "${{env.BRANCH_NAME}}/**" --add --repo "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
+          npx gh-pages --dist dist/ --src storybook*/**/* --dest ${{env.BRANCH_NAME}} --remove "${{env.BRANCH_NAME}}/**" --add --repo "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: add PR comment
         uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: 'Link to the Storybook:
-                  - angular components: https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}/storybook
-                  - webcomponents: https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}/storybook-wc'
+          msg: 'Link to the Storybook
+                  https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}/storybook/
+                  https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}/storybook-wc/'
           check_for_duplicate_msg: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,12 +79,14 @@ jobs:
           echo "Deploying to directory: ${{env.BRANCH_NAME}}"
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          npx gh-pages --dist dist/storybook --dest ${{env.BRANCH_NAME}} --remove "${{env.BRANCH_NAME}}/**" --add --repo "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
+          npx gh-pages --dist dist/ -- src storybook/**/* --dest ${{env.BRANCH_NAME}} --remove "${{env.BRANCH_NAME}}/**" --add --repo "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: add PR comment
         uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: 'Link to the Storybook: https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}'
+          msg: 'Link to the Storybook:
+                  - angular components: https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}/storybook
+                  - webcomponents: https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}/storybook-wc'
           check_for_duplicate_msg: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         run: npm run build -- --project=search-wc
 
       - name: Build storybook
-        run: npx build-storybook -o .out --quiet
+        run: npm run build:storybook
 
       - run: echo "::set-env name=BRANCH_NAME::${GITHUB_HEAD_REF#refs/heads/}"
 
@@ -79,7 +79,7 @@ jobs:
           echo "Deploying to directory: ${{env.BRANCH_NAME}}"
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          npx gh-pages --dist .out --dest ${{env.BRANCH_NAME}} --remove "${{env.BRANCH_NAME}}/**" --add --repo "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
+          npx gh-pages --dist dist/storybook --dest ${{env.BRANCH_NAME}} --remove "${{env.BRANCH_NAME}}/**" --add --repo "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: add PR comment
         uses: unsplash/comment-on-pr@master

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,6 @@
 module.exports = {
   stories: [
     '../libs/ui/**/*.stories.[tj]s',
-    '../webcomponents/**/*.stories.[tj]s',
+    '../webcomponents/**/angular.stories.[tj]s',
   ],
 }

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -2,11 +2,14 @@
   "extends": "../tsconfig.base.json",
   "exclude": [
     "../apps/**/*.spec.ts",
-    "../libs/**/*.spec.ts"
+    "../libs/**/*.spec.ts",
+    "../webcomponents/**/*.spec.ts",
+    "../ssr/**/*.ts"
   ],
   "include": [
     "../src/**/*",
     "../apps/**/*",
+    "../webcomponents/**/*",
     "../libs/**/*"
   ]
 }

--- a/angular.json
+++ b/angular.json
@@ -196,8 +196,7 @@
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
             "tsConfig": [
-              "webcomponents/search-wc/tsconfig.app.json",
-              "webcomponents/search-wc/tsconfig.spec.json"
+              "webcomponents/search-wc/tsconfig.app.json"
             ],
             "exclude": [
               "**/node_modules/**",

--- a/libs/ui/src/lib/record-summary/record-summary.component.ts
+++ b/libs/ui/src/lib/record-summary/record-summary.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core'
-import { RecordSimple } from '@lib/search'
+import type { RecordSimple } from '@lib/search'
 
 @Component({
   selector: 'ui-record-summary',

--- a/package-lock.json
+++ b/package-lock.json
@@ -597,6 +597,12 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
+        "parse5": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+          "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+          "dev": true
+        },
         "pnp-webpack-plugin": {
           "version": "1.6.4",
           "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
@@ -21806,10 +21812,9 @@
       }
     },
     "parse5": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
-      "dev": true
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.0.tgz",
+      "integrity": "sha512-lC0A+4DefTdRr+DLQlEwwZqndL9VzEjiuegI5bj3hp4bnzzwQldSqCpHv7+msRpSOHGJyJvkcCa4q15LMUJ8rg=="
     },
     "parseqs": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "ng build",
     "test": "ng test",
     "storybook": "npm run generate-css & start-storybook -p 4201",
+    "storybook-wc": "npm run generate-css & start-storybook -p 4202  --config-dir webcomponents/.storybook",
+    "build:storybook": "build-storybook -o dist/storybook && build-storybook -c webcomponents/.storybook -o dist/storybook-wc",
     "package": "cat dist/search-wc/{runtime-es2015,polyfills-es2015,main-es2015}.js | gzip > elements.js.gz",
     "serve-wc": "http-server --gzip",
     "lint": "ng lint",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nguniversal/express-engine": "^10.0.0",
     "document-register-element": "^1.7.2",
     "express": "^4.15.2",
+    "parse5": "^6.0.0",
     "prettier": "^2.0.5",
     "rxjs": "~6.5.4",
     "tslib": "^2.0.0",

--- a/webcomponents/.storybook/addons.js
+++ b/webcomponents/.storybook/addons.js
@@ -1,0 +1,4 @@
+import '@storybook/addon-knobs/register'
+import '@storybook/addon-actions/register'
+import '@storybook/addon-notes/register'
+import '@storybook/addon-a11y/register'

--- a/webcomponents/.storybook/main.js
+++ b/webcomponents/.storybook/main.js
@@ -1,0 +1,5 @@
+module.exports = {
+  stories: [
+    '../**/elements.stories.[tj]s',
+  ],
+}

--- a/webcomponents/.storybook/main.js
+++ b/webcomponents/.storybook/main.js
@@ -1,5 +1,3 @@
 module.exports = {
-  stories: [
-    '../**/elements.stories.[tj]s',
-  ],
+  stories: ['../**/elements.stories.[tj]s'],
 }

--- a/webcomponents/.storybook/preview-head.html
+++ b/webcomponents/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<style type="text/css">
+  body {
+    margin: 3em;
+    padding: 3em;
+  }
+</style>

--- a/webcomponents/.storybook/tsconfig.json
+++ b/webcomponents/.storybook/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../.storybook/tsconfig.json",
+  "include": [
+    "../**/*"
+  ]
+}

--- a/webcomponents/search-wc/stories/angular.stories.ts
+++ b/webcomponents/search-wc/stories/angular.stories.ts
@@ -1,0 +1,21 @@
+import { moduleMetadata, storiesOf } from '@storybook/angular'
+import { color, withKnobs } from '@storybook/addon-knobs'
+import { withA11y } from '@storybook/addon-a11y'
+import { AppModule } from '../src/app/app.module'
+import { SearchSnapshotWcComponent } from '../src/app/search-snapshot-wc/search-snapshot-wc.component'
+
+const moduleMetadatas = {
+  imports: [AppModule],
+}
+
+storiesOf('Angular components', module)
+  .addDecorator(moduleMetadata(moduleMetadatas))
+  .addDecorator(withKnobs)
+  .addDecorator(withA11y)
+  .add('Search Snapshot', () => ({
+    component: SearchSnapshotWcComponent,
+    props: {
+      primaryColor: color('Primary Color', 'blue'),
+      secondaryColor: color('Secondary Color', 'grey'),
+    },
+  }))

--- a/webcomponents/search-wc/stories/elements.stories.ts
+++ b/webcomponents/search-wc/stories/elements.stories.ts
@@ -5,11 +5,11 @@ import { NO_ERRORS_SCHEMA } from '@angular/core'
 
 // import compiled webcomponents here
 // TODO: write a script to concatenate all these
-import '../search-wc/dist/runtime-es2015'
-import '../search-wc/dist/main-es2015'
-import '../search-wc/dist/polyfills-es2015'
-import '../search-wc/dist/vendor-es2015'
-import '../search-wc/dist/styles-es2015'
+import '../dist/runtime-es2015'
+import '../dist/main-es2015'
+import '../dist/polyfills-es2015'
+import '../dist/vendor-es2015'
+import '../dist/styles-es2015'
 
 const moduleMetadatas = {
   schemas: [NO_ERRORS_SCHEMA],


### PR DESCRIPTION
Angular components and Webcomponents cannot live in the same application because angular is registering twice the same tag id.

The Pr resolves that in spliting stories in 2 disctinct applications.

.`/storybook` defines the project storybook configuration, excluding compiled webcomponents. It loads all angular elements from libraries and webcomponents applications.

`./webcomponents/.storybook` defines the configuration for compiled webcomponents.

You can run both storybooks with
- `npm run storybook`
- `npm run storybook-wc`

To build both applications in /dist, use
npm run build:storybook`
