### PR TITLE
Fixes for the Card and List components

### DIFF
--- a/libs/ui/src/lib/record-preview-card/record-preview-card.component.html
+++ b/libs/ui/src/lib/record-preview-card/record-preview-card.component.html
@@ -1,21 +1,44 @@
 <!-- <div class="h-64"> -->
 <div
-  class="h-full border-2 bg-white border-gray-200 rounded-md overflow-hidden"
+  class="h-full border-2 bg-white border-gray-100 rounded-md overflow-hidden"
 >
-  <img
-    class="lg:h-48 md:h-36 w-full object-cover object-center"
-    [src]="record.thumbnailUrl"
-    alt="thumbnail"
-  />
-  <div class="p-6">
-    <h1 class="title-font text-lg font-medium text-gray-900 mb-3">
-      {{ record.title }}
-    </h1>
-    <p class="leading-relaxed md:h-20 mb-3 clamp-3">{{ record.abstract }}</p>
+  <div class="flex flex-col min-h-full">
+    <div class="lg:h-48 md:h-36 border-b border-blue-200 bg-blue-100">
+      <img
+        *ngIf="record.thumbnailUrl"
+        class="lg:h-48 md:h-36 w-full object-cover object-center"
+        [src]="record.thumbnailUrl"
+        alt="thumbnail"
+      />
+      <div
+        *ngIf="!record.thumbnailUrl"
+        class="flex justify-center md:mt-16 lg:mt-16 text-blue-300"
+      >
+        <svg
+          class="h-12 w-12"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+          />
+        </svg>
+      </div>
+    </div>
 
-    <div
-      class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between mt-4"
-    >
+    <div class="flex-grow p-4">
+      <h1 class="title-font text-lg font-medium text-gray-900 mb-3">
+        {{ record.title }}
+      </h1>
+      <p class="leading-relaxed md:h-20 clamp-3">{{ record.abstract }}</p>
+    </div>
+
+    <div class="flex justify-end sm:items-center sm:justify-between p-4">
       <a
         class="inline-flex items-center md:mb-2 lg:mb-0 hover:underline"
         [href]="record.url"

--- a/libs/ui/src/lib/record-preview-list/record-preview-list.component.html
+++ b/libs/ui/src/lib/record-preview-list/record-preview-list.component.html
@@ -2,11 +2,33 @@
   <div
     class="h-full flex sm:flex-row flex-col items-center sm:justify-start justify-center text-center sm:text-left bg-white border-gray-200 border-2 rounded-md"
   >
-    <img
-      class="flex-shrink-0 w-48 h-48 object-cover object-center sm:mb-0 mb-4"
-      [src]="record.thumbnailUrl"
-      alt="thumbnail"
-    />
+    <div class="w-48 h-48 border-r border-blue-200 bg-blue-100">
+      <img
+        *ngIf="record.thumbnailUrl"
+        class="flex-shrink-0 w-48 h-48 object-cover object-center sm:mb-0 mb-4"
+        [src]="record.thumbnailUrl"
+        alt="thumbnail"
+      />
+      <div
+        *ngIf="!record.thumbnailUrl"
+        class="flex justify-center md:mt-16 lg:mt-16 text-blue-300"
+      >
+        <svg
+          class="h-12 w-12"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+          />
+        </svg>
+      </div>
+    </div>
     <div class="flex-grow sm:pl-8 sm:pr-8">
       <h1 class="title-font text-lg font-medium text-gray-900 mb-3">
         {{ record.title }}


### PR DESCRIPTION
This PR fixes height issues in the **Card** component: the links are aligned to the bottom of the Card. 

Is also fixes the missing thumbnail image, a fallback is shown for the **Card** and **List** component.

![gn-card-fix](https://user-images.githubusercontent.com/19608667/96150363-93482300-0f0a-11eb-904d-965aee3a24a8.png)

Changes:
- the links on the Card are aligned to the bottom
- a fallback image is added when there is no thumbnail