### PR TITLE
Search / Records metric / Add aggregation config object.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ Run `ng test` to execute the unit tests via Jest.
 You can test a specific lib or app with
 ```shell script
 ng test (lib_name) (--prod)
+eg. 
+ng test lib-search --testNamePattern=RecordsMetric*
 ```
 
 To run the tests in Intellij, install the Jest plugin and run the test as usual.

--- a/apps/search/src/app/app.component.html
+++ b/apps/search/src/app/app.component.html
@@ -1,6 +1,8 @@
 <div>
   <catalog-site-title></catalog-site-title>
-  <search-records-metrics field="tag" count="20"></search-records-metrics>
+  <search-records-metrics
+    config='{"terms":{"field":"codelist_hierarchyLevel_text","size":20}}'
+  ></search-records-metrics>
   <div class="mb-3 mx-4 p-5 bg-gray-500 rounded flex flex-row">
     <div class="w-4/5 mr-3">
       <search-fuzzy-search></search-fuzzy-search>

--- a/libs/gn-api/src/lib/fixtures/search-responses.ts
+++ b/libs/gn-api/src/lib/fixtures/search-responses.ts
@@ -4,7 +4,7 @@ export const aggsOnly = {
   _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
   hits: { total: { value: 6073, relation: 'eq' }, max_score: null, hits: [] },
   aggregations: {
-    results: {
+    metric: {
       doc_count_error_upper_bound: 0,
       sum_other_doc_count: 910,
       buckets: [

--- a/libs/search/src/lib/records-metrics/records-metrics.component.spec.ts
+++ b/libs/search/src/lib/records-metrics/records-metrics.component.spec.ts
@@ -86,8 +86,7 @@ describe('RecordsMetricsComponent', () => {
     })
 
     it('report warning in console in case of invalid config.', () => {
-      component.config =
-        '{"terms":{"field":"tag","size":2'
+      component.config = '{"terms":{"field":"tag","size":2'
       fixture.detectChanges()
       // TODO: How to check config error is reported?
     })

--- a/libs/search/src/lib/records-metrics/records-metrics.component.ts
+++ b/libs/search/src/lib/records-metrics/records-metrics.component.ts
@@ -13,6 +13,7 @@ import { SearchResponse } from 'elasticsearch'
 export class RecordsMetricsComponent implements OnInit {
   @Input() field: string
   @Input() count = 10
+  @Input() config: any
   @Input() queryString = '+isTemplate:n'
   @Output() metricSelect = new EventEmitter<RecordMetric>()
   results$: Observable<RecordMetric[]>
@@ -20,28 +21,49 @@ export class RecordsMetricsComponent implements OnInit {
   constructor(private searchService: SearchApiService) {}
 
   ngOnInit(): void {
+    if (!!this.field === false && !!this.config === false) {
+      console.warn('A field name (eg. tag) '
+        + 'or a JSON aggregation config (eg. {"terms":{"field":"tag","size":2}}) MUST be defined.')
+      return
+    }
+
+    if (this.config) {
+      try {
+        this.config = JSON.parse(this.config)
+      } catch (parseException) {
+        console.warn(`JSON config ${this.config} is invalid.`, parseException)
+        return
+      }
+    }
+
+    const agg = this.config || {
+        terms: {
+          field: this.field,
+          size: this.count,
+        },
+      }
+    const search = {
+      size: 0,
+      track_total_hits: true,
+      query: {
+        bool: {
+          filter: { query: { query_string: { query: this.queryString } } },
+        },
+      },
+      aggs: {
+        metric: agg
+      },
+    }
     this.results$ = this.searchService
       .call(
         '_search',
         'bucket',
-        JSON.stringify({
-          size: 0,
-          track_total_hits: true,
-          query: { query_string: { query: this.queryString } },
-          aggs: {
-            results: {
-              terms: {
-                field: this.field,
-                size: this.count,
-              },
-            },
-          },
-        })
+        JSON.stringify(search)
       )
       .pipe(
         map<any, RecordMetric[]>(
           (response: SearchResponse<any>) =>
-            response.aggregations.results.buckets.map((category) => ({
+            response.aggregations.metric.buckets.map((category) => ({
               value: category.key,
               recordCount: category.doc_count,
             })) as RecordMetric[]

--- a/libs/search/src/lib/records-metrics/records-metrics.component.ts
+++ b/libs/search/src/lib/records-metrics/records-metrics.component.ts
@@ -22,8 +22,10 @@ export class RecordsMetricsComponent implements OnInit {
 
   ngOnInit(): void {
     if (!!this.field === false && !!this.config === false) {
-      console.warn('A field name (eg. tag) '
-        + 'or a JSON aggregation config (eg. {"terms":{"field":"tag","size":2}}) MUST be defined.')
+      console.warn(
+        'A field name (eg. tag) ' +
+          'or a JSON aggregation config (eg. {"terms":{"field":"tag","size":2}}) MUST be defined.'
+      )
       return
     }
 
@@ -37,11 +39,11 @@ export class RecordsMetricsComponent implements OnInit {
     }
 
     const agg = this.config || {
-        terms: {
-          field: this.field,
-          size: this.count,
-        },
-      }
+      terms: {
+        field: this.field,
+        size: this.count,
+      },
+    }
     const search = {
       size: 0,
       track_total_hits: true,
@@ -51,15 +53,11 @@ export class RecordsMetricsComponent implements OnInit {
         },
       },
       aggs: {
-        metric: agg
+        metric: agg,
       },
     }
     this.results$ = this.searchService
-      .call(
-        '_search',
-        'bucket',
-        JSON.stringify(search)
-      )
+      .call('_search', 'bucket', JSON.stringify(search))
       .pipe(
         map<any, RecordMetric[]>(
           (response: SearchResponse<any>) =>


### PR DESCRIPTION
To take advantage of the variety of bucket aggregation in Elasticsearch
(see
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket.html)
add support for a config object.

Move the query filter to a filter section of the query (which will
benefit of Elasticsearch cache for filter).

Add some input checks to explain what may be wrong with the component
config. Maybe there is a better approach ?


```html
  <search-records-metrics
    config='{"terms":{"field":"tag","size":20, "include": "IDP_DPSIR.*"}}'
  ></search-records-metrics>
```

![image](https://user-images.githubusercontent.com/1701393/97023144-5fe24580-1555-11eb-8056-20e05a20f4bb.png)

