### PR TITLE
CI: give credential for remote PR to publish storybook

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Cache node modules
         uses: actions/cache@v1


### PR DESCRIPTION
When working on a Pull Request from a remote branch, where the user has no push right on the upstream repository, the publication of story book fails.

```
Deploying to directory: facet-keywords
remote: Permission to geonetwork/geonetwork-ui.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/geonetwork/geonetwork-ui.git/': The requested URL returned error: 403
```

I presume that it uses the credentials of the user who has done the PR...