### PR TITLE
Results preview improvements & consistency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ To run the lint step, use `npm run lint`.
 To check whether your code is formatted properly, use `npm run format:check`.
 
 If you want Prettier to run on all the code and make sure everything is formatted, run `npm run format:fix`.
-**This should be done before committint.**
+**This should be done before committing.**
 
 ### Angular CLI
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,26 @@
 
 # GeoNetwork UI
 
-GeoNetwork UI is a client application to browse your GeoNetwork catalogue.
+GeoNetwork UI is a library of UI and Web Components to embed your catalogue in third party website or to build custom application on top of it. It relies on the GeoNetwork 4 OpenAPI.
+
+The target audience is: 
+* GeoNetwork developers
+* Developers of SDI, portals 
+* Website and CMS maintainers
+
 
 ## Getting started
 
-Install first GeoNetwork 4 [from source](https://geonetwork-opensource.org/manuals/trunk/en/maintainer-guide/installing/installing-from-source-code.html#the-quick-way) 
-or using [docker](https://github.com/geonetwork/docker-geonetwork/tree/master/4.0.0-alpha.1).
+Install first GeoNetwork 4 [from source](https://geonetwork-opensource.org/manuals/4.0.x/eng/users/install-guide/installing-from-source-code.html#building-running) 
+or using [docker](https://github.com/geonetwork/docker-geonetwork/tree/master/4.0.1).
 
 Run `npm install` to fetch all dependencies of the project.
 
-Run `npm run start` to start the full search app in a dev server, available at `http://localhost:4200/`. 
+Run `npm run start` to start the default app.
+
+Run `ng serve app-search` to start the search app in a dev server.
+
+Once started the application is available at `http://localhost:4200/`. 
 
 [The contributing guide](CONTRIBUTING.md) explains the structure of the project and how to work with it.
 

--- a/apps/search/src/assets/i18n/en.json
+++ b/apps/search/src/assets/i18n/en.json
@@ -6,7 +6,7 @@
 	"openRecord": "Open record",
 	"recordViewable": "viewable",
 	"recordDownloadable": "downloadable",
-	"loadResults": "Load results",
+	"search.loading": "Loading ...",
 	"last changed": "last changed",
 	"popularity": "popularity",
 	"dropFile": "drop file",

--- a/libs/common/src/lib/model.ts
+++ b/libs/common/src/lib/model.ts
@@ -7,7 +7,7 @@ export interface RecordSummary {
   uuid: string
   title: string
   abstract: string
-  url: string
+  metadataUrl: string
   thumbnailUrl: string
   logoUrl?: string
   downloadable?: boolean
@@ -26,9 +26,9 @@ export interface RecordMetric {
 }
 
 export enum ResultsListLayout {
-  'BLOCK' = 'BLOCK',
-  'LIST' = 'LIST',
-  'TEXT' = 'TEXT',
+  CARD = 'CARD',
+  LIST = 'LIST',
+  TEXT = 'TEXT',
 }
 
 export const RESULTS_PAGE_SIZE = 10

--- a/libs/common/src/lib/model.ts
+++ b/libs/common/src/lib/model.ts
@@ -29,6 +29,7 @@ export enum ResultsListLayout {
   CARD = 'CARD',
   LIST = 'LIST',
   TEXT = 'TEXT',
+  TITLE = 'TITLE',
 }
 
 export const RESULTS_PAGE_SIZE = 10

--- a/libs/search/src/lib/elasticsearch/elasticsearch.mapper.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.mapper.ts
@@ -15,7 +15,7 @@ export class ElasticsearchMapper {
       title: hit._source.resourceTitleObject?.default || 'no title',
       abstract: hit._source.resourceAbstractObject?.default || 'no abstract',
       thumbnailUrl: this.getFirstValue(hit._source.overview)?.url || '',
-      url: `/geonetwork/srv/eng/catalog.search#/metadata/${hit._source.uuid}`,
+      metadataUrl: `/geonetwork/srv/eng/catalog.search#/metadata/${hit._source.uuid}`,
       downloadable: (hit as any).download,
       viewable: (hit as any).view,
       logoUrl: `/geonetwork${hit._source.logo}`,

--- a/libs/search/src/lib/results-list/results-list.container.component.ts
+++ b/libs/search/src/lib/results-list/results-list.container.component.ts
@@ -2,10 +2,7 @@ import { Component, Input, OnInit } from '@angular/core'
 import { ResultsListLayout } from '@lib/common'
 import { select, Store } from '@ngrx/store'
 import { SearchState } from '../state/reducer'
-import {
-  getSearchResults,
-  getSearchResultsLoading,
-} from '../state/selectors'
+import { getSearchResults, getSearchResultsLoading } from '../state/selectors'
 import { RequestMoreResults } from '../state/actions'
 
 @Component({

--- a/libs/search/src/lib/results-list/results-list.container.component.ts
+++ b/libs/search/src/lib/results-list/results-list.container.component.ts
@@ -2,7 +2,10 @@ import { Component, Input, OnInit } from '@angular/core'
 import { ResultsListLayout } from '@lib/common'
 import { select, Store } from '@ngrx/store'
 import { SearchState } from '../state/reducer'
-import { getSearchResults, getSearchResultsLoading } from '../state/selectors'
+import {
+  getSearchResults,
+  getSearchResultsLoading,
+} from '../state/selectors'
 import { RequestMoreResults } from '../state/actions'
 
 @Component({
@@ -11,7 +14,7 @@ import { RequestMoreResults } from '../state/actions'
   styleUrls: ['./results-list.container.component.css'],
 })
 export class ResultsListContainerComponent implements OnInit {
-  @Input() layout: ResultsListLayout = ResultsListLayout.BLOCK
+  @Input() layout: ResultsListLayout = ResultsListLayout.CARD
 
   results$ = this.store.pipe(select(getSearchResults))
   isLoading$ = this.store.pipe(select(getSearchResultsLoading))

--- a/libs/ui/README.md
+++ b/libs/ui/README.md
@@ -4,9 +4,9 @@ This library was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Code scaffolding
 
-Run `ng generate component component-name --project ui` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project ui`.
+From the root folder, run `ng generate component component-name --project lib-ui` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module --project lib-ui`.
 
-> Note: Don't forget to add `--project ui` or else it will be added to the default project in your `angular.json` file.
+> Note: Don't forget to add `--project lib-ui` or else it will be added to the default project in your `angular.json` file.
 
 ## Build
 

--- a/libs/ui/src/lib/record-preview-card/record-preview-card.component.html
+++ b/libs/ui/src/lib/record-preview-card/record-preview-card.component.html
@@ -1,85 +1,25 @@
-<!-- <div class="h-64"> -->
 <div
-  class="h-full border-2 bg-white border-gray-100 rounded-md overflow-hidden"
+  class="h-full border-2 bg-white border-gray-100 rounded-md overflow-hidden transition duration-200 hover:bg-gray-100 border-gray-300"
 >
-  <div class="flex flex-col min-h-full">
-    <div class="lg:h-48 md:h-36 border-b border-blue-200 bg-blue-100">
-      <img
-        *ngIf="record.thumbnailUrl"
-        class="lg:h-48 md:h-36 w-full object-cover object-center"
-        [src]="record.thumbnailUrl"
-        alt="thumbnail"
-      />
-      <div
-        *ngIf="!record.thumbnailUrl"
-        class="flex justify-center md:mt-16 lg:mt-16 text-blue-300"
-      >
-        <svg
-          class="h-12 w-12"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-          />
-        </svg>
+  <a
+    [href]="record.metadataUrl"
+    [title]="record.abstract"
+    [target]="linkTarget"
+  >
+    <div class="flex flex-col min-h-full">
+      <ui-record-thumbnail
+        class="lg:h-48 md:h-36 border-b border-gray-200 bg-gray-100"
+        [thumbnailUrl]="record.thumbnailUrl"
+      ></ui-record-thumbnail>
+
+      <div class="flex-grow p-4">
+        <h1 class="title-font text-lg font-medium text-gray-900 mb-3">
+          {{ record.title }}
+        </h1>
+        <p class="leading-relaxed md:h-20 text-gray-700 clamp-3">
+          {{ record.abstract }}
+        </p>
       </div>
     </div>
-
-    <div class="flex-grow p-4">
-      <h1 class="title-font text-lg font-medium text-gray-900 mb-3">
-        {{ record.title }}
-      </h1>
-      <p class="leading-relaxed md:h-20 clamp-3">{{ record.abstract }}</p>
-    </div>
-
-    <div class="flex justify-end sm:items-center sm:justify-between p-4">
-      <a
-        class="inline-flex items-center md:mb-2 lg:mb-0 hover:underline"
-        [href]="record.url"
-      >
-        <span translate>readMore</span>
-        <svg
-          class="h-5 w-5"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M9 5l7 7-7 7"
-          />
-        </svg>
-      </a>
-      <a
-        class="inline-flex items-center md:mb-2 lg:mb-0 hover:underline"
-        [href]="record.url"
-      >
-        <span translate>openRecord</span>
-        <svg
-          class="h-5 w-6"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-          />
-        </svg>
-      </a>
-    </div>
-  </div>
+  </a>
 </div>
-<!-- </div> -->

--- a/libs/ui/src/lib/record-preview-card/record-preview-card.component.html
+++ b/libs/ui/src/lib/record-preview-card/record-preview-card.component.html
@@ -13,7 +13,7 @@
       ></ui-record-thumbnail>
 
       <div class="flex-grow p-4">
-        <h1 class="title-font text-lg font-medium text-gray-900 mb-3">
+        <h1 class="title-font text-lg font-medium text-gray-900 mb-3 clamp-2">
           {{ record.title }}
         </h1>
         <p class="leading-relaxed md:h-20 text-gray-700 clamp-3">

--- a/libs/ui/src/lib/record-preview-card/record-preview-card.component.spec.ts
+++ b/libs/ui/src/lib/record-preview-card/record-preview-card.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { NO_ERRORS_SCHEMA } from '@angular/core'
 
 import { RecordPreviewCardComponent } from './record-preview-card.component'
 
@@ -9,6 +10,7 @@ describe('RecordPreviewCardComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [RecordPreviewCardComponent],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents()
   }))
 
@@ -20,7 +22,7 @@ describe('RecordPreviewCardComponent', () => {
       uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
       title: 'abcd',
       abstract: 'Abcd',
-      url: '/abcd.html',
+      metadataUrl: '/abcd.html',
       thumbnailUrl: '/abcd.jpg',
     }
     fixture.detectChanges()

--- a/libs/ui/src/lib/record-preview-card/record-preview-card.component.ts
+++ b/libs/ui/src/lib/record-preview-card/record-preview-card.component.ts
@@ -1,10 +1,5 @@
-import {
-  Component,
-  OnInit,
-  ChangeDetectionStrategy,
-  Input,
-} from '@angular/core'
-import type { RecordSummary } from '@lib/common'
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { RecordPreviewComponent } from '../record-preview/record-preview.component'
 
 @Component({
   selector: 'ui-record-preview-card',
@@ -12,9 +7,4 @@ import type { RecordSummary } from '@lib/common'
   styleUrls: ['./record-preview-card.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RecordPreviewCardComponent implements OnInit {
-  @Input() record: RecordSummary
-  constructor() {}
-
-  ngOnInit(): void {}
-}
+export class RecordPreviewCardComponent extends RecordPreviewComponent {}

--- a/libs/ui/src/lib/record-preview-card/record-preview-card.stories.ts
+++ b/libs/ui/src/lib/record-preview-card/record-preview-card.stories.ts
@@ -24,7 +24,8 @@ RecordPreviewCardComponentStory.args = {
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     abstract:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas dapibus euismod libero, eu ullamcorper nisl placerat sit amet. Nulla vel sapien odio. Integer convallis scelerisque lorem, eget ultricies elit ultrices sit amet. Mauris nunc felis, vulputate laoreet lacinia et, volutpat et ligula. Sed a magna et augue convallis pretium. Fusce euismod dui in sapien tincidunt aliquet. Curabitur porttitor mauris a bibendum eleifend.',
-    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
+    metadataUrl:
+      'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
   },
 }
 

--- a/libs/ui/src/lib/record-preview-card/record-preview-card.stories.ts
+++ b/libs/ui/src/lib/record-preview-card/record-preview-card.stories.ts
@@ -24,7 +24,7 @@ RecordPreviewCardComponentStory.args = {
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     abstract:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas dapibus euismod libero, eu ullamcorper nisl placerat sit amet. Nulla vel sapien odio. Integer convallis scelerisque lorem, eget ultricies elit ultrices sit amet. Mauris nunc felis, vulputate laoreet lacinia et, volutpat et ligula. Sed a magna et augue convallis pretium. Fusce euismod dui in sapien tincidunt aliquet. Curabitur porttitor mauris a bibendum eleifend.',
-    url: 'www.goto.com',
+    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
   },
 }
 

--- a/libs/ui/src/lib/record-preview-card/record-preview-card.stories.ts
+++ b/libs/ui/src/lib/record-preview-card/record-preview-card.stories.ts
@@ -1,32 +1,31 @@
 import { withA11y } from '@storybook/addon-a11y'
 import { withKnobs } from '@storybook/addon-knobs'
-import { Meta, Story } from '@storybook/angular'
+import { moduleMetadata } from '@storybook/angular'
+import { RecordThumbnailComponent } from '../record-thumbnail/record-thumbnail.component'
 import { RecordPreviewCardComponent } from './record-preview-card.component'
+
+const moduleMetadatas = {
+  declarations: [RecordThumbnailComponent],
+}
 
 export default {
   title: 'UI/Record preview',
-  component: RecordPreviewCardComponent,
-  decorators: [withKnobs, withA11y],
-} as Meta
-
-const Template: Story<RecordPreviewCardComponent> = (args) => ({
-  component: RecordPreviewCardComponent,
-  props: args,
-})
-
-export const RecordPreviewCardComponentStory = Template.bind({})
-
-RecordPreviewCardComponentStory.args = {
-  record: {
-    uuid: 'uiiudiiddeaafdjsqmlkfdq',
-    title: 'A very nice record',
-    thumbnailUrl:
-      'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
-    abstract:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas dapibus euismod libero, eu ullamcorper nisl placerat sit amet. Nulla vel sapien odio. Integer convallis scelerisque lorem, eget ultricies elit ultrices sit amet. Mauris nunc felis, vulputate laoreet lacinia et, volutpat et ligula. Sed a magna et augue convallis pretium. Fusce euismod dui in sapien tincidunt aliquet. Curabitur porttitor mauris a bibendum eleifend.',
-    metadataUrl:
-      'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
-  },
+  decorators: [moduleMetadata(moduleMetadatas), withKnobs, withA11y],
 }
 
+export const RecordPreviewCardComponentStory = () => ({
+  component: RecordPreviewCardComponent,
+  props: {
+    record: {
+      uuid: 'uiiudiiddeaafdjsqmlkfdq',
+      title: 'A very nice record',
+      thumbnailUrl:
+        'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
+      abstract:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas dapibus euismod libero, eu ullamcorper nisl placerat sit amet. Nulla vel sapien odio. Integer convallis scelerisque lorem, eget ultricies elit ultrices sit amet. Mauris nunc felis, vulputate laoreet lacinia et, volutpat et ligula. Sed a magna et augue convallis pretium. Fusce euismod dui in sapien tincidunt aliquet. Curabitur porttitor mauris a bibendum eleifend.',
+      metadataUrl:
+        'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
+    },
+  },
+})
 RecordPreviewCardComponentStory.storyName = 'Card record'

--- a/libs/ui/src/lib/record-preview-list/record-preview-list.component.html
+++ b/libs/ui/src/lib/record-preview-list/record-preview-list.component.html
@@ -1,81 +1,43 @@
-<div class="h-40">
-  <div
-    class="h-full flex flex-row items-center bg-white border border-gray-200 p-1 rounded-md shadow-sm"
+<div
+  class="h-40 bg-white transition duration-200 hover:bg-gray-100 border-gray-300"
+>
+  <a
+    [href]="record.metadataUrl"
+    [target]="linkTarget"
+    [title]="record.abstract"
   >
     <div
-      class="w-40 h-full relative flex-shrink-0 bg-gray-100 rounded overflow-hidden"
+      class="h-full flex flex-row items-center border border-gray-200 rounded-md shadow-sm"
     >
-      <svg
-        class="text-gray-200 absolute h-12 w-12 transform -translate-x-1/2 -translate-y-1/2"
-        style="top: 50%; left: 50%;"
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-        />
-      </svg>
-      <img
-        *ngIf="record.thumbnailUrl"
-        class="relative h-full w-full object-cover object-left-top"
-        [src]="record.thumbnailUrl"
-        alt="thumbnail"
-      />
-    </div>
-    <div class="flex-grow h-full px-6 py-4 flex flex-col overflow-hidden">
-      <div class="mb-3 flex flex-row items-center">
-        <a
-          class="title-font text-primary hover:underline font-bold text-gray-900 truncate mr-6 flex flex-row items-center"
-          [href]="record.url"
-        >
-          <span class="truncate">{{ record.title }}</span>
-          <svg
-            class="h-5 w-5 flex-shrink-0"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
+      <ui-record-thumbnail
+        class="w-40 h-full flex-shrink-0 border-r border-gray-200 bg-gray-100"
+        [thumbnailUrl]="record.thumbnailUrl"
+      ></ui-record-thumbnail>
+
+      <div class="flex-grow h-full px-6 py-4 flex flex-col overflow-hidden">
+        <div class="title-font text-lg font-medium text-gray-900">
+          <h1 class="truncate">{{ record.title }}</h1>
+        </div>
+        <p class="leading-relaxed flex-grow clamp-3 text-sm text-gray-700">
+          {{ record.abstract }}
+        </p>
+        <div class="flex flex-row items-center">
+          <div
+            class="text-gray-500 text-xs truncate capitalize border-r mr-4 pr-4"
+            *ngIf="record.updateFrequency"
           >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M9 5l7 7-7 7"
-            />
-          </svg>
-        </a>
-        <div class="flex-grow"></div>
-        <img
-          *ngIf="record.logoUrl"
-          class="relative h-6 object-contain"
-          [src]="record.logoUrl"
-          alt="logo"
-        />
-      </div>
-      <p class="leading-relaxed flex-grow mb-4 clamp-2 text-sm">
-        {{ record.abstract }}
-      </p>
-      <div class="flex flex-row items-center">
-        <div
-          class="text-gray-500 text-sm truncate capitalize border-r mr-4 pr-4"
-          *ngIf="record.updateFrequency"
-        >
-          <span translate>{{ record.updateFrequency }}</span>
-        </div>
-        <div
-          class="text-gray-500 text-sm border-gray-300 truncate viewable-downloadable"
-          *ngIf="isViewable || isDownloadable"
-        >
-          <span *ngIf="isViewable" translate>recordViewable</span>
-          <span *ngIf="isViewable && isDownloadable">,&nbsp;</span>
-          <span *ngIf="isDownloadable" translate>recordDownloadable</span>
+            <span translate>{{ record.updateFrequency }}</span>
+          </div>
+          <div
+            class="text-gray-500 text-xs border-gray-300 truncate viewable-downloadable"
+            *ngIf="isViewable || isDownloadable"
+          >
+            <span *ngIf="isViewable" translate>recordViewable</span>
+            <span *ngIf="isViewable && isDownloadable">,&nbsp;</span>
+            <span *ngIf="isDownloadable" translate>recordDownloadable</span>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </a>
 </div>

--- a/libs/ui/src/lib/record-preview-list/record-preview-list.component.html
+++ b/libs/ui/src/lib/record-preview-list/record-preview-list.component.html
@@ -18,9 +18,10 @@
         <div class="title-font text-lg font-medium text-gray-900">
           <h1 class="truncate">{{ record.title }}</h1>
         </div>
-        <p class="leading-relaxed flex-grow clamp-3 text-sm text-gray-700">
+        <p class="leading-relaxed clamp-3 text-sm text-gray-700">
           {{ record.abstract }}
         </p>
+        <div class="flex-grow"></div>
         <div class="flex flex-row items-center">
           <div
             class="text-gray-500 text-xs truncate capitalize border-r mr-4 pr-4"

--- a/libs/ui/src/lib/record-preview-list/record-preview-list.component.spec.ts
+++ b/libs/ui/src/lib/record-preview-list/record-preview-list.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { RecordPreviewListComponent } from './record-preview-list.component'
-import {NO_ERRORS_SCHEMA} from '@angular/core'
+import { NO_ERRORS_SCHEMA } from '@angular/core'
 
 describe('RecordPreviewListComponent', () => {
   let component: RecordPreviewListComponent

--- a/libs/ui/src/lib/record-preview-list/record-preview-list.component.spec.ts
+++ b/libs/ui/src/lib/record-preview-list/record-preview-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { RecordPreviewListComponent } from './record-preview-list.component'
+import {NO_ERRORS_SCHEMA} from '@angular/core'
 
 describe('RecordPreviewListComponent', () => {
   let component: RecordPreviewListComponent
@@ -9,6 +10,7 @@ describe('RecordPreviewListComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [RecordPreviewListComponent],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents()
   }))
 
@@ -20,7 +22,7 @@ describe('RecordPreviewListComponent', () => {
       uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
       title: 'abcd',
       abstract: 'Abcd',
-      url: '/abcd.html',
+      metadataUrl: '/abcd.html',
       thumbnailUrl: '/abcd.jpg',
     }
     fixture.detectChanges()

--- a/libs/ui/src/lib/record-preview-list/record-preview-list.component.ts
+++ b/libs/ui/src/lib/record-preview-list/record-preview-list.component.ts
@@ -1,10 +1,5 @@
-import {
-  Component,
-  OnInit,
-  ChangeDetectionStrategy,
-  Input,
-} from '@angular/core'
-import { RecordSummary } from '@lib/common'
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { RecordPreviewComponent } from '../record-preview/record-preview.component'
 
 @Component({
   selector: 'ui-record-preview-list',
@@ -12,16 +7,4 @@ import { RecordSummary } from '@lib/common'
   styleUrls: ['./record-preview-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RecordPreviewListComponent implements OnInit {
-  @Input() record: RecordSummary
-  constructor() {}
-
-  get isViewable() {
-    return this.record.viewable
-  }
-  get isDownloadable() {
-    return this.record.downloadable
-  }
-
-  ngOnInit(): void {}
-}
+export class RecordPreviewListComponent extends RecordPreviewComponent {}

--- a/libs/ui/src/lib/record-preview-list/record-preview-list.stories.ts
+++ b/libs/ui/src/lib/record-preview-list/record-preview-list.stories.ts
@@ -1,18 +1,17 @@
 import { withA11y } from '@storybook/addon-a11y'
 import { boolean, date, text, withKnobs } from '@storybook/addon-knobs'
-import { Meta, Story } from '@storybook/angular'
+import { Meta, moduleMetadata, Story } from '@storybook/angular'
+import { RecordThumbnailComponent } from '../record-thumbnail/record-thumbnail.component'
 import { RecordPreviewListComponent } from './record-preview-list.component'
-import { NO_ERRORS_SCHEMA } from '@angular/core'
+
+const moduleMetadatas = {
+  declarations: [RecordThumbnailComponent],
+}
 
 export default {
   title: 'UI/Record preview',
-  decorators: [withKnobs, withA11y],
+  decorators: [moduleMetadata(moduleMetadatas), withKnobs, withA11y],
 } as Meta
-
-function dateObj(name, defaultValue) {
-  const stringTimestamp = date(name, defaultValue)
-  return new Date(stringTimestamp)
-}
 
 export const RecordPreviewListComponentStory: Story<RecordPreviewListComponent> = () => ({
   component: RecordPreviewListComponent,

--- a/libs/ui/src/lib/record-preview-list/record-preview-list.stories.ts
+++ b/libs/ui/src/lib/record-preview-list/record-preview-list.stories.ts
@@ -28,7 +28,10 @@ export const RecordPreviewListComponentStory: Story<RecordPreviewListComponent> 
         'Abstract',
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas dapibus euismod libero, eu ullamcorper nisl placerat sit amet. Nulla vel sapien odio. Integer convallis scelerisque lorem, eget ultricies elit ultrices sit amet. Mauris nunc felis, vulputate laoreet lacinia et, volutpat et ligula. Sed a magna et augue convallis pretium. Fusce euismod dui in sapien tincidunt aliquet. Curabitur porttitor mauris a bibendum eleifend.'
       ),
-      metadataUrl: text('Record URL', 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8'),
+      metadataUrl: text(
+        'Record URL',
+        'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8'
+      ),
       updateFrequency: text('Update frequency', 'Updated every month'),
       logoUrl: text(
         'Logo URL',

--- a/libs/ui/src/lib/record-preview-list/record-preview-list.stories.ts
+++ b/libs/ui/src/lib/record-preview-list/record-preview-list.stories.ts
@@ -28,7 +28,7 @@ export const RecordPreviewListComponentStory: Story<RecordPreviewListComponent> 
         'Abstract',
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas dapibus euismod libero, eu ullamcorper nisl placerat sit amet. Nulla vel sapien odio. Integer convallis scelerisque lorem, eget ultricies elit ultrices sit amet. Mauris nunc felis, vulputate laoreet lacinia et, volutpat et ligula. Sed a magna et augue convallis pretium. Fusce euismod dui in sapien tincidunt aliquet. Curabitur porttitor mauris a bibendum eleifend.'
       ),
-      url: text('Record URL', 'www.goto.com'),
+      metadataUrl: text('Record URL', 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8'),
       updateFrequency: text('Update frequency', 'Updated every month'),
       logoUrl: text(
         'Logo URL',

--- a/libs/ui/src/lib/record-preview-list/record-preview-list.stories.ts
+++ b/libs/ui/src/lib/record-preview-list/record-preview-list.stories.ts
@@ -2,6 +2,7 @@ import { withA11y } from '@storybook/addon-a11y'
 import { boolean, date, text, withKnobs } from '@storybook/addon-knobs'
 import { Meta, Story } from '@storybook/angular'
 import { RecordPreviewListComponent } from './record-preview-list.component'
+import { NO_ERRORS_SCHEMA } from '@angular/core'
 
 export default {
   title: 'UI/Record preview',

--- a/libs/ui/src/lib/record-preview-text/record-preview-text.component.html
+++ b/libs/ui/src/lib/record-preview-text/record-preview-text.component.html
@@ -1,25 +1,36 @@
 <!-- Record list item: List Small -->
-<div
-  class="h-10 border-b border-gray-200 transition duration-200 hover:bg-gray-100 border-gray-300"
->
-  <a
-    [href]="record.metadataUrl"
-    [target]="linkTarget"
-    [title]="record.abstract"
+<div class="mb-4">
+  <div
+    class="h-full flex sm:flex-row flex-col p-5 items-center sm:justify-start justify-center text-center sm:text-left bg-white border-gray-200 border-2 rounded-md"
   >
-    <div class="h-full flex flex-row items-center">
-      <ui-record-thumbnail
-        class="w-10 h-full flex-shrink-0 border-r border-gray-200 bg-gray-100"
-        [thumbnailUrl]="record.thumbnailUrl"
-      ></ui-record-thumbnail>
+    <div class="flex-grow">
+      <h1 class="title-font text-lg font-medium text-gray-900 mb-3">
+        {{ record.title }}
+      </h1>
+      <p class="leading-relaxed mb-3">{{ record.abstract }}</p>
 
-      <div class="flex-grow h-full px-1 py-1 flex flex-col overflow-hidden">
-        <h1
-          class="title-font text-sm font-bold text-gray-900 truncate md:overflow-clip"
+      <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+        <a
+          class="inline-flex items-center md:mb-2 lg:mb-0 hover:underline"
+          [href]="record.metadataUrl"
         >
-          {{ record.title }}
-        </h1>
+          <span translate>readMore</span>
+          <svg
+            class="h-5 w-5"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        </a>
       </div>
     </div>
-  </a>
+  </div>
 </div>

--- a/libs/ui/src/lib/record-preview-text/record-preview-text.component.html
+++ b/libs/ui/src/lib/record-preview-text/record-preview-text.component.html
@@ -1,36 +1,25 @@
 <!-- Record list item: List Small -->
-<div class="mb-4">
-  <div
-    class="h-full flex sm:flex-row flex-col p-5 items-center sm:justify-start justify-center text-center sm:text-left bg-white border-gray-200 border-2 rounded-md"
+<div
+  class="h-10 border-b border-gray-200 transition duration-200 hover:bg-gray-100 border-gray-300"
+>
+  <a
+    [href]="record.metadataUrl"
+    [target]="linkTarget"
+    [title]="record.abstract"
   >
-    <div class="flex-grow">
-      <h1 class="title-font text-lg font-medium text-gray-900 mb-3">
-        {{ record.title }}
-      </h1>
-      <p class="leading-relaxed mb-3">{{ record.abstract }}</p>
+    <div class="h-full flex flex-row items-center">
+      <ui-record-thumbnail
+        class="w-10 h-full flex-shrink-0 border-r border-gray-200 bg-gray-100"
+        [thumbnailUrl]="record.thumbnailUrl"
+      ></ui-record-thumbnail>
 
-      <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
-        <a
-          class="inline-flex items-center md:mb-2 lg:mb-0 hover:underline"
-          [href]="record.url"
+      <div class="flex-grow h-full px-1 py-1 flex flex-col overflow-hidden">
+        <h1
+          class="title-font text-sm font-bold text-gray-900 truncate md:overflow-clip"
         >
-          <span translate>readMore</span>
-          <svg
-            class="h-5 w-5"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M9 5l7 7-7 7"
-            />
-          </svg>
-        </a>
+          {{ record.title }}
+        </h1>
       </div>
     </div>
-  </div>
+  </a>
 </div>

--- a/libs/ui/src/lib/record-preview-text/record-preview-text.component.spec.ts
+++ b/libs/ui/src/lib/record-preview-text/record-preview-text.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { RecordPreviewTextComponent } from './record-preview-text.component'
+import { NO_ERRORS_SCHEMA } from '@angular/core'
 
 describe('RecordPreviewTextComponent', () => {
   let component: RecordPreviewTextComponent
@@ -9,6 +10,7 @@ describe('RecordPreviewTextComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [RecordPreviewTextComponent],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents()
   }))
 
@@ -20,7 +22,7 @@ describe('RecordPreviewTextComponent', () => {
       uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
       title: 'abcd',
       abstract: 'Abcd',
-      url: '/abcd.html',
+      metadataUrl: '/abcd.html',
       thumbnailUrl: '/abcd.jpg',
     }
     fixture.detectChanges()

--- a/libs/ui/src/lib/record-preview-text/record-preview-text.component.ts
+++ b/libs/ui/src/lib/record-preview-text/record-preview-text.component.ts
@@ -1,10 +1,5 @@
-import {
-  Component,
-  OnInit,
-  ChangeDetectionStrategy,
-  Input,
-} from '@angular/core'
-import type { RecordSummary } from '@lib/common'
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { RecordPreviewComponent } from '../record-preview/record-preview.component'
 
 @Component({
   selector: 'ui-record-preview-text',
@@ -12,9 +7,4 @@ import type { RecordSummary } from '@lib/common'
   styleUrls: ['./record-preview-text.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RecordPreviewTextComponent implements OnInit {
-  @Input() record: RecordSummary
-  constructor() {}
-
-  ngOnInit(): void {}
-}
+export class RecordPreviewTextComponent extends RecordPreviewComponent {}

--- a/libs/ui/src/lib/record-preview-text/record-preview-text.stories.ts
+++ b/libs/ui/src/lib/record-preview-text/record-preview-text.stories.ts
@@ -24,7 +24,7 @@ RecordPreviewTextComponentStory.args = {
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     abstract:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas dapibus euismod libero, eu ullamcorper nisl placerat sit amet. Nulla vel sapien odio. Integer convallis scelerisque lorem, eget ultricies elit ultrices sit amet. Mauris nunc felis, vulputate laoreet lacinia et, volutpat et ligula. Sed a magna et augue convallis pretium. Fusce euismod dui in sapien tincidunt aliquet. Curabitur porttitor mauris a bibendum eleifend.',
-    url: 'www.goto.com',
+    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
   },
 }
 

--- a/libs/ui/src/lib/record-preview-text/record-preview-text.stories.ts
+++ b/libs/ui/src/lib/record-preview-text/record-preview-text.stories.ts
@@ -24,7 +24,8 @@ RecordPreviewTextComponentStory.args = {
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     abstract:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas dapibus euismod libero, eu ullamcorper nisl placerat sit amet. Nulla vel sapien odio. Integer convallis scelerisque lorem, eget ultricies elit ultrices sit amet. Mauris nunc felis, vulputate laoreet lacinia et, volutpat et ligula. Sed a magna et augue convallis pretium. Fusce euismod dui in sapien tincidunt aliquet. Curabitur porttitor mauris a bibendum eleifend.',
-    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
+    metadataUrl:
+      'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
   },
 }
 

--- a/libs/ui/src/lib/record-preview-title/record-preview-title.component.html
+++ b/libs/ui/src/lib/record-preview-title/record-preview-title.component.html
@@ -1,0 +1,25 @@
+<!-- Record list item: List Small -->
+<div
+  class="h-10 border-b border-gray-200 transition duration-200 hover:bg-gray-100 border-gray-300"
+>
+  <a
+    [href]="record.metadataUrl"
+    [target]="linkTarget"
+    [title]="record.abstract"
+  >
+    <div class="h-full flex flex-row items-center">
+      <ui-record-thumbnail
+        class="w-10 h-full flex-shrink-0 border-r border-gray-200 bg-gray-100"
+        [thumbnailUrl]="record.thumbnailUrl"
+      ></ui-record-thumbnail>
+
+      <div class="flex-grow h-full px-1 py-1 flex flex-col overflow-hidden">
+        <h1
+          class="title-font text-sm font-bold text-gray-900 truncate md:overflow-clip"
+        >
+          {{ record.title }}
+        </h1>
+      </div>
+    </div>
+  </a>
+</div>

--- a/libs/ui/src/lib/record-preview-title/record-preview-title.component.spec.ts
+++ b/libs/ui/src/lib/record-preview-title/record-preview-title.component.spec.ts
@@ -1,0 +1,34 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { NO_ERRORS_SCHEMA } from '@angular/core'
+import { RecordPreviewTitleComponent } from './record-preview-title.component'
+
+describe('RecordPreviewTextComponent', () => {
+  let component: RecordPreviewTitleComponent
+  let fixture: ComponentFixture<RecordPreviewTitleComponent>
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [RecordPreviewTitleComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents()
+  }))
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecordPreviewTitleComponent)
+    component = fixture.componentInstance
+    component.record = {
+      id: '139',
+      uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
+      title: 'abcd',
+      abstract: 'Abcd',
+      metadataUrl: '/abcd.html',
+      thumbnailUrl: '/abcd.jpg',
+    }
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/ui/src/lib/record-preview-title/record-preview-title.component.ts
+++ b/libs/ui/src/lib/record-preview-title/record-preview-title.component.ts
@@ -1,0 +1,10 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { RecordPreviewComponent } from '../record-preview/record-preview.component'
+
+@Component({
+  selector: 'ui-record-preview-title',
+  templateUrl: './record-preview-title.component.html',
+  styleUrls: ['./record-preview-title.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RecordPreviewTitleComponent extends RecordPreviewComponent {}

--- a/libs/ui/src/lib/record-preview-title/record-preview-title.stories.ts
+++ b/libs/ui/src/lib/record-preview-title/record-preview-title.stories.ts
@@ -1,15 +1,16 @@
 import { withA11y } from '@storybook/addon-a11y'
 import { withKnobs } from '@storybook/addon-knobs'
 import { Meta, Story } from '@storybook/angular'
-import { RecordPreviewTextComponent } from './record-preview-text.component'
+import { RecordPreviewTitleComponent } from './record-preview-title.component'
 
 export default {
   title: 'UI/Record preview',
+  component: RecordPreviewTitleComponent,
   decorators: [withKnobs, withA11y],
 } as Meta
 
-const Template: Story<RecordPreviewTextComponent> = (args) => ({
-  component: RecordPreviewTextComponent,
+const Template: Story<RecordPreviewTitleComponent> = (args) => ({
+  component: RecordPreviewTitleComponent,
   props: args,
 })
 
@@ -28,4 +29,4 @@ RecordPreviewTextComponentStory.args = {
   },
 }
 
-RecordPreviewTextComponentStory.storyName = 'Title record'
+RecordPreviewTextComponentStory.storyName = 'Text record'

--- a/libs/ui/src/lib/record-preview/record-preview.component.spec.ts
+++ b/libs/ui/src/lib/record-preview/record-preview.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { RecordPreviewComponent } from './record-preview.component'
+
+describe('RecordResultsComponent', () => {
+  let component: RecordPreviewComponent
+  let fixture: ComponentFixture<RecordPreviewComponent>
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [RecordPreviewComponent],
+    }).compileComponents()
+  }))
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecordPreviewComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/ui/src/lib/record-preview/record-preview.component.ts
+++ b/libs/ui/src/lib/record-preview/record-preview.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input, OnInit } from '@angular/core'
+import { RecordSummary } from '@lib/common'
+
+@Component({
+  selector: 'ui-record-preview',
+  template: '',
+})
+export class RecordPreviewComponent implements OnInit {
+  @Input() record: RecordSummary
+  @Input() linkTarget = '_blank'
+
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  get isViewable() {
+    return this.record.viewable
+  }
+  get isDownloadable() {
+    return this.record.downloadable
+  }
+}

--- a/libs/ui/src/lib/record-thumbnail/record-thumbnail.component.html
+++ b/libs/ui/src/lib/record-thumbnail/record-thumbnail.component.html
@@ -1,0 +1,23 @@
+<div class="h-full h-full relative flex-shrink-0 overflow-hidden">
+  <svg
+    class="text-gray-200 absolute h-12 w-12 transform -translate-x-1/2 -translate-y-1/2"
+    style="top: 50%; left: 50%;"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+    />
+  </svg>
+  <img
+    *ngIf="thumbnailUrl"
+    class="relative h-full w-full object-cover object-left-top"
+    [src]="thumbnailUrl"
+    alt="thumbnail"
+  />
+</div>

--- a/libs/ui/src/lib/record-thumbnail/record-thumbnail.component.spec.ts
+++ b/libs/ui/src/lib/record-thumbnail/record-thumbnail.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { RecordThumbnailComponent } from './record-thumbnail.component'
+
+describe('RecordThumbnailComponent', () => {
+  let component: RecordThumbnailComponent
+  let fixture: ComponentFixture<RecordThumbnailComponent>
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [RecordThumbnailComponent],
+    }).compileComponents()
+  }))
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RecordThumbnailComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/ui/src/lib/record-thumbnail/record-thumbnail.component.spec.ts
+++ b/libs/ui/src/lib/record-thumbnail/record-thumbnail.component.spec.ts
@@ -1,10 +1,13 @@
+import { DebugElement } from '@angular/core'
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { By } from '@angular/platform-browser'
 
 import { RecordThumbnailComponent } from './record-thumbnail.component'
 
 describe('RecordThumbnailComponent', () => {
   let component: RecordThumbnailComponent
   let fixture: ComponentFixture<RecordThumbnailComponent>
+  let de: DebugElement
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -15,10 +18,35 @@ describe('RecordThumbnailComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(RecordThumbnailComponent)
     component = fixture.componentInstance
+    de = fixture.debugElement
     fixture.detectChanges()
   })
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  describe('<img> element', () => {
+    describe('When no url is given', () => {
+      it('is not diplayed', () => {
+        const img = de.query(By.css('img'))
+        expect(img).toBeFalsy()
+      })
+    })
+    describe('When an url is given', () => {
+      const url = 'http://test.com/img.png'
+      let img
+      beforeEach(() => {
+        component.thumbnailUrl = url
+        fixture.detectChanges()
+        img = de.query(By.css('img'))
+      })
+      it('is displayed', () => {
+        expect(img).toBeTruthy()
+      })
+      it('url attribute as url @Input', () => {
+        expect(img.properties.src).toEqual(url)
+      })
+    })
   })
 })

--- a/libs/ui/src/lib/record-thumbnail/record-thumbnail.component.ts
+++ b/libs/ui/src/lib/record-thumbnail/record-thumbnail.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, OnInit } from '@angular/core'
-import { RecordSummary } from '@lib/common'
 
 @Component({
   selector: 'ui-record-thumbnail',

--- a/libs/ui/src/lib/record-thumbnail/record-thumbnail.component.ts
+++ b/libs/ui/src/lib/record-thumbnail/record-thumbnail.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input, OnInit } from '@angular/core'
+import { RecordSummary } from '@lib/common'
+
+@Component({
+  selector: 'ui-record-thumbnail',
+  templateUrl: './record-thumbnail.component.html',
+})
+export class RecordThumbnailComponent implements OnInit {
+  @Input() thumbnailUrl: string
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/libs/ui/src/lib/record-thumbnail/record-thumbnail.stories.ts
+++ b/libs/ui/src/lib/record-thumbnail/record-thumbnail.stories.ts
@@ -1,24 +1,19 @@
 import { withA11y } from '@storybook/addon-a11y'
-import { withKnobs } from '@storybook/addon-knobs'
-import { Meta, Story } from '@storybook/angular'
+import { text, withKnobs } from '@storybook/addon-knobs'
 import { RecordThumbnailComponent } from './record-thumbnail.component'
 
 export default {
   title: 'UI/Record preview',
-  component: RecordThumbnailComponent,
   decorators: [withKnobs, withA11y],
-} as Meta
-
-const Template: Story<RecordThumbnailComponent> = (args) => ({
-  component: RecordThumbnailComponent,
-  props: args,
-})
-
-export const RecordThumbnailComponentStory = Template.bind({})
-
-RecordThumbnailComponentStory.args = {
-  thumbnailUrl:
-    'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
 }
 
+export const RecordThumbnailComponentStory = () => ({
+  component: RecordThumbnailComponent,
+  props: {
+    thumbnailUrl: text(
+      'url',
+      'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png'
+    ),
+  },
+})
 RecordThumbnailComponentStory.storyName = 'Record thumbnail'

--- a/libs/ui/src/lib/record-thumbnail/record-thumbnail.stories.ts
+++ b/libs/ui/src/lib/record-thumbnail/record-thumbnail.stories.ts
@@ -17,8 +17,8 @@ const Template: Story<RecordThumbnailComponent> = (args) => ({
 export const RecordThumbnailComponentStory = Template.bind({})
 
 RecordThumbnailComponentStory.args = {
-    thumbnailUrl:
-      'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
+  thumbnailUrl:
+    'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
 }
 
 RecordThumbnailComponentStory.storyName = 'Record thumbnail'

--- a/libs/ui/src/lib/record-thumbnail/record-thumbnail.stories.ts
+++ b/libs/ui/src/lib/record-thumbnail/record-thumbnail.stories.ts
@@ -1,0 +1,24 @@
+import { withA11y } from '@storybook/addon-a11y'
+import { withKnobs } from '@storybook/addon-knobs'
+import { Meta, Story } from '@storybook/angular'
+import { RecordThumbnailComponent } from './record-thumbnail.component'
+
+export default {
+  title: 'UI/Record preview',
+  component: RecordThumbnailComponent,
+  decorators: [withKnobs, withA11y],
+} as Meta
+
+const Template: Story<RecordThumbnailComponent> = (args) => ({
+  component: RecordThumbnailComponent,
+  props: args,
+})
+
+export const RecordThumbnailComponentStory = Template.bind({})
+
+RecordThumbnailComponentStory.args = {
+    thumbnailUrl:
+      'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
+}
+
+RecordThumbnailComponentStory.storyName = 'Record thumbnail'

--- a/libs/ui/src/lib/results-list/results-list.component.html
+++ b/libs/ui/src/lib/results-list/results-list.component.html
@@ -1,6 +1,6 @@
 <ng-container [ngSwitch]="layout">
   <ng-container
-    *ngSwitchCase="layoutEnum.BLOCK"
+    *ngSwitchCase="layoutEnum.CARD"
     [ngTemplateOutlet]="block"
   ></ng-container>
   <div *ngSwitchCase="layoutEnum.LIST" class="gap-4 p-4">
@@ -23,8 +23,9 @@
     <ui-record-preview-card
       *ngFor="let record of records"
       [record]="record"
+      linkTarget="_blank"
     ></ui-record-preview-card>
   </div>
 </ng-template>
 
-<div *ngIf="loading" class="p-4"><span translate>loadResults</span>...</div>
+<div *ngIf="loading" class="p-4"><span translate>search.loading</span>...</div>

--- a/libs/ui/src/lib/results-list/results-list.component.html
+++ b/libs/ui/src/lib/results-list/results-list.component.html
@@ -8,6 +8,11 @@
       <ui-record-preview-list [record]="record"></ui-record-preview-list>
     </div>
   </div>
+  <div *ngSwitchCase="layoutEnum.TITLE" class="gap-4 p-4">
+    <div class="pb-4" *ngFor="let record of records">
+      <ui-record-preview-title [record]="record"></ui-record-preview-title>
+    </div>
+  </div>
   <div *ngSwitchCase="layoutEnum.TEXT" class="gap-4 p-4">
     <ui-record-preview-text
       style="height: 24rem;"

--- a/libs/ui/src/lib/results-list/results-list.component.spec.ts
+++ b/libs/ui/src/lib/results-list/results-list.component.spec.ts
@@ -4,6 +4,7 @@ import { RecordPreviewCardComponent } from '../record-preview-card/record-previe
 import { RecordPreviewTextComponent } from '../record-preview-text/record-preview-text.component'
 
 import { ResultsListComponent } from './results-list.component'
+import {NO_ERRORS_SCHEMA} from '@angular/core'
 
 describe('ResultsListComponent', () => {
   let component: ResultsListComponent
@@ -17,6 +18,7 @@ describe('ResultsListComponent', () => {
         RecordPreviewCardComponent,
         RecordPreviewTextComponent,
       ],
+      schemas: [NO_ERRORS_SCHEMA],
       imports: [],
     }).compileComponents()
   }))

--- a/libs/ui/src/lib/results-list/results-list.component.spec.ts
+++ b/libs/ui/src/lib/results-list/results-list.component.spec.ts
@@ -4,7 +4,7 @@ import { RecordPreviewCardComponent } from '../record-preview-card/record-previe
 import { RecordPreviewTextComponent } from '../record-preview-text/record-preview-text.component'
 
 import { ResultsListComponent } from './results-list.component'
-import {NO_ERRORS_SCHEMA} from '@angular/core'
+import { NO_ERRORS_SCHEMA } from '@angular/core'
 
 describe('ResultsListComponent', () => {
   let component: ResultsListComponent

--- a/libs/ui/src/lib/results-list/results-list.component.ts
+++ b/libs/ui/src/lib/results-list/results-list.component.ts
@@ -15,7 +15,7 @@ import { RecordSummary, ResultsListLayout } from '@lib/common'
 export class ResultsListComponent implements OnInit {
   @Input() records: RecordSummary[]
   @Input() loading: boolean
-  @Input() layout: ResultsListLayout = ResultsListLayout.BLOCK
+  @Input() layout: ResultsListLayout = ResultsListLayout.CARD
   layoutEnum = ResultsListLayout
 
   constructor() {}

--- a/libs/ui/src/lib/results-list/results-list.stories.ts
+++ b/libs/ui/src/lib/results-list/results-list.stories.ts
@@ -21,7 +21,7 @@ const records: RecordSummary[] = [
     uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
     title: 'metadata 1',
     abstract: 'this is the abstract of metadata 1',
-    url: '',
+    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',
@@ -36,7 +36,7 @@ const records: RecordSummary[] = [
     title: 'metadata 2',
     abstract:
       'this is the abstract of metadata 2. This abstract will contain some extra dummy text just to see how it displays on more than one line',
-    url: '',
+    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',
@@ -50,7 +50,7 @@ const records: RecordSummary[] = [
     uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
     title: 'metadata 3',
     abstract: 'this is the abstract of metadata 3',
-    url: '',
+    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',
@@ -64,7 +64,7 @@ const records: RecordSummary[] = [
     uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
     title: 'metadata 4',
     abstract: 'this is the abstract of metadata 4',
-    url: '',
+    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',

--- a/libs/ui/src/lib/results-list/results-list.stories.ts
+++ b/libs/ui/src/lib/results-list/results-list.stories.ts
@@ -21,7 +21,8 @@ const records: RecordSummary[] = [
     uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
     title: 'metadata 1',
     abstract: 'this is the abstract of metadata 1',
-    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
+    metadataUrl:
+      'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',
@@ -36,7 +37,8 @@ const records: RecordSummary[] = [
     title: 'metadata 2',
     abstract:
       'this is the abstract of metadata 2. This abstract will contain some extra dummy text just to see how it displays on more than one line',
-    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
+    metadataUrl:
+      'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',
@@ -50,7 +52,8 @@ const records: RecordSummary[] = [
     uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
     title: 'metadata 3',
     abstract: 'this is the abstract of metadata 3',
-    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
+    metadataUrl:
+      'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',
@@ -64,7 +67,8 @@ const records: RecordSummary[] = [
     uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
     title: 'metadata 4',
     abstract: 'this is the abstract of metadata 4',
-    metadataUrl: 'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
+    metadataUrl:
+      'https://sdi.eea.europa.eu/catalogue/srv/api/records/c88e743d-e838-49e1-8c80-54f26bcf4ab8',
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',

--- a/libs/ui/src/lib/ui.module.ts
+++ b/libs/ui/src/lib/ui.module.ts
@@ -14,6 +14,7 @@ import { RecordMetricComponent } from './record-metric/record-metric.component'
 import { RecordPreviewCardComponent } from './record-preview-card/record-preview-card.component'
 import { RecordPreviewListComponent } from './record-preview-list/record-preview-list.component'
 import { RecordPreviewTextComponent } from './record-preview-text/record-preview-text.component'
+import { RecordPreviewTitleComponent } from './record-preview-title/record-preview-title.component'
 import { ResultsListComponent } from './results-list/results-list.component'
 import { TextInputComponent } from './text-input/text-input.component'
 import { RecordPreviewComponent } from './record-preview/record-preview.component'
@@ -26,16 +27,17 @@ import { RecordThumbnailComponent } from './record-thumbnail/record-thumbnail.co
     ButtonComponent,
     TextInputComponent,
     ColorScaleComponent,
+    RecordPreviewComponent,
     RecordPreviewListComponent,
     RecordPreviewCardComponent,
     RecordPreviewTextComponent,
+    RecordPreviewTitleComponent,
     RecordMetricComponent,
     RecordThumbnailComponent,
     ResultsListComponent,
     CatalogTitleComponent,
     DragAndDropFileInputComponent,
     ProgressBarComponent,
-    RecordPreviewComponent,
   ],
   imports: [
     BrowserModule,
@@ -51,6 +53,7 @@ import { RecordThumbnailComponent } from './record-thumbnail/record-thumbnail.co
     RecordPreviewListComponent,
     RecordPreviewCardComponent,
     RecordPreviewTextComponent,
+    RecordPreviewTitleComponent,
     RecordMetricComponent,
     RecordThumbnailComponent,
     ResultsListComponent,

--- a/libs/ui/src/lib/ui.module.ts
+++ b/libs/ui/src/lib/ui.module.ts
@@ -16,6 +16,8 @@ import { RecordPreviewListComponent } from './record-preview-list/record-preview
 import { RecordPreviewTextComponent } from './record-preview-text/record-preview-text.component'
 import { ResultsListComponent } from './results-list/results-list.component'
 import { TextInputComponent } from './text-input/text-input.component'
+import { RecordPreviewComponent } from './record-preview/record-preview.component'
+import { RecordThumbnailComponent } from './record-thumbnail/record-thumbnail.component'
 
 @NgModule({
   declarations: [
@@ -28,10 +30,12 @@ import { TextInputComponent } from './text-input/text-input.component'
     RecordPreviewCardComponent,
     RecordPreviewTextComponent,
     RecordMetricComponent,
+    RecordThumbnailComponent,
     ResultsListComponent,
     CatalogTitleComponent,
     DragAndDropFileInputComponent,
     ProgressBarComponent,
+    RecordPreviewComponent,
   ],
   imports: [
     BrowserModule,
@@ -48,11 +52,13 @@ import { TextInputComponent } from './text-input/text-input.component'
     RecordPreviewCardComponent,
     RecordPreviewTextComponent,
     RecordMetricComponent,
+    RecordThumbnailComponent,
     ResultsListComponent,
     CatalogTitleComponent,
     DragAndDropFileInputComponent,
     ProgressBarComponent,
     FacetsModule,
+    RecordPreviewComponent,
   ],
 })
 export class UiModule {}

--- a/webcomponents/gn-results-list/src/app/gn-results-list.component.ts
+++ b/webcomponents/gn-results-list/src/app/gn-results-list.component.ts
@@ -15,7 +15,7 @@ import { BaseComponent } from '../../../base.component'
   encapsulation: ViewEncapsulation.ShadowDom,
 })
 export class GnResultsListComponent extends BaseComponent {
-  @Input() layout: ResultsListLayout = ResultsListLayout.BLOCK
+  @Input() layout: ResultsListLayout = ResultsListLayout.CARD
   @Input() lines = 10
   @Input() filter
 

--- a/webcomponents/gn-results-list/stories/angular.stories.ts
+++ b/webcomponents/gn-results-list/stories/angular.stories.ts
@@ -46,3 +46,14 @@ export const AngularGnResultsListTextStory = () => ({
   },
 })
 AngularGnResultsListTextStory.storyName = 'Text'
+
+export const AngularGnResultsListTitleStory = () => ({
+  component: GnResultsListComponent,
+  props: {
+    apiUrl: text('api url', 'https://apps.titellus.net/geonetwork/srv/api'),
+    layout: 'TITLE',
+    primaryColor: color('Primary Color', 'blue'),
+    secondaryColor: color('Secondary Color', 'grey'),
+  },
+})
+AngularGnResultsListTitleStory.storyName = 'Title'

--- a/webcomponents/gn-results-list/stories/elements.stories.ts
+++ b/webcomponents/gn-results-list/stories/elements.stories.ts
@@ -63,3 +63,18 @@ export const GnResultsListTextStory = () => ({
   },
 })
 GnResultsListTextStory.storyName = 'Text'
+
+export const GnResultsListTitleStory = () => ({
+  template: `
+<gn-results-list
+  api-url="https://apps.titellus.net/geonetwork/srv/api"
+  primary-color="{{primaryColor}}"
+  layout="TITLE"
+  secondary-color="{{secondaryColor}}">
+</gn-results-list>`,
+  props: {
+    primaryColor: color('Primary Color', 'blue'),
+    secondaryColor: color('Secondary Color', 'grey'),
+  },
+})
+GnResultsListTitleStory.storyName = 'Title'

--- a/webcomponents/gn-results-list/stories/elements.stories.ts
+++ b/webcomponents/gn-results-list/stories/elements.stories.ts
@@ -34,12 +34,12 @@ export const GnResultsListListStory = () => ({
 })
 GnResultsListListStory.storyName = 'List'
 
-export const GnResultsListBlockStory = () => ({
+export const GnResultsListCardStory = () => ({
   template: `
 <gn-results-list
   api-url="https://apps.titellus.net/geonetwork/srv/api"
   primary-color="{{primaryColor}}"
-  layout="BLOCKED"
+  layout="CARD"
   secondary-color="{{secondaryColor}}">
 </gn-results-list>`,
   props: {
@@ -47,7 +47,7 @@ export const GnResultsListBlockStory = () => ({
     secondaryColor: color('Secondary Color', 'grey'),
   },
 })
-GnResultsListBlockStory.storyName = 'Block'
+GnResultsListCardStory.storyName = 'Card'
 
 export const GnResultsListTextStory = () => ({
   template: `


### PR DESCRIPTION

* Add a base record preview component 
* Extend base preview component for card/list/text
* Enum / ResultListLayout / Rename BLOCK > CARD to be consistent with component name
* Add a component for the thumbnail
* Consistent styling in each modes
* Add a target attribute to open a record in another browser tab or specific iframe with a name
