### PR TITLE
Add filter and size parameter to results list

### DIFF
--- a/libs/common/src/lib/i18n/i18n.module.ts
+++ b/libs/common/src/lib/i18n/i18n.module.ts
@@ -11,6 +11,31 @@ export function HttpLoaderFactory(http: HttpClient) {
   return new TranslateHttpLoader(http)
 }
 
+export const LANG_3_TO_2_MAPPER = {
+  eng: 'en',
+  dut: 'nl',
+  fre: 'fr',
+  ger: 'de',
+  kor: 'ko',
+  spa: 'es',
+  cze: 'cs',
+  cat: 'ca',
+  fin: 'fi',
+  ice: 'is',
+  ita: 'it',
+  por: 'pt',
+  rus: 'ru',
+  chi: 'zh',
+  slo: 'sk',
+}
+
+export const LANG_2_TO_3_MAPPER = Object.entries(LANG_3_TO_2_MAPPER).reduce(
+  (mapperObject, langEntry) => {
+    return { ...mapperObject, [langEntry[1]]: langEntry[0] }
+  },
+  {}
+)
+
 @NgModule({
   declarations: [],
   imports: [

--- a/libs/common/src/lib/services/index.ts
+++ b/libs/common/src/lib/services/index.ts
@@ -1,3 +1,4 @@
 export * from './bootstrap.service'
 export * from './color.service'
 export * from './log.service'
+export * from './metadata-url.service'

--- a/libs/common/src/lib/services/metadata-url.service.spec.ts
+++ b/libs/common/src/lib/services/metadata-url.service.spec.ts
@@ -1,0 +1,52 @@
+import { TestBed } from '@angular/core/testing'
+import { LogService } from '@lib/common'
+import { SiteApiService, UiApiService } from '@lib/gn-api'
+import { TranslateService } from '@ngx-translate/core'
+
+import { MetadataUrlService } from './metadata-url.service'
+
+const translateServiceMock = {
+  currentLang: 'en',
+}
+describe('MetadataUrlService', () => {
+  let service: MetadataUrlService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: TranslateService,
+          useValue: translateServiceMock,
+        },
+      ],
+    })
+    service = TestBed.inject(MetadataUrlService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+  describe('#getUrl', () => {
+    const uuid = `500b154c-f99b-4235-97c5-7ef48dfc67d5`
+    let apiPath
+    describe('when remote api path', () => {
+      beforeEach(() => {
+        apiPath = 'https://apps.titellus.net/geonetwork/srv/api'
+      })
+      it('link to external gn metadata ui', () => {
+        const url = service.getUrl(uuid, apiPath)
+        expect(url).toBe(
+          'https://apps.titellus.net/geonetwork/srv/api/../eng/catalog.search#/metadata/500b154c-f99b-4235-97c5-7ef48dfc67d5'
+        )
+      })
+    })
+    describe('when no api path', () => {
+      it('link to /geonetwork metadata ui', () => {
+        const url = service.getUrl(uuid)
+        expect(url).toBe(
+          '/geonetwork/srv/api/../eng/catalog.search#/metadata/500b154c-f99b-4235-97c5-7ef48dfc67d5'
+        )
+      })
+    })
+  })
+})

--- a/libs/common/src/lib/services/metadata-url.service.ts
+++ b/libs/common/src/lib/services/metadata-url.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core'
+import { LANG_2_TO_3_MAPPER } from '@lib/common'
+import { TranslateService } from '@ngx-translate/core'
+
+const DEFAULT_API_PATH = '/geonetwork/srv/api'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MetadataUrlService {
+  constructor(private translate: TranslateService) {}
+
+  getUrl(uuid: string, apiPath: string = DEFAULT_API_PATH) {
+    const prefix = `${apiPath}/../`
+    return `${prefix}${
+      LANG_2_TO_3_MAPPER[this.translate.currentLang]
+    }/catalog.search#/metadata/${uuid}`
+  }
+}

--- a/libs/search/src/lib/elasticsearch/elasticsearch.mapper.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.mapper.ts
@@ -1,21 +1,24 @@
-import { RecordBrief, RecordSummary } from '@lib/common'
+import { Injectable } from '@angular/core'
+import { MetadataUrlService, RecordSummary } from '@lib/common'
 import { SearchResponse } from 'elasticsearch'
 
+@Injectable({
+  providedIn: 'root',
+})
 export class ElasticsearchMapper {
-  response: SearchResponse<any>
+  constructor(private metadataUrlService: MetadataUrlService) {}
 
-  constructor(response: SearchResponse<any>) {
-    this.response = response
-  }
-
-  toRecordSummary(): RecordSummary[] {
-    return this.response.hits.hits.map((hit) => ({
+  toRecordSummary(
+    response: SearchResponse<any>,
+    apiPath?: string
+  ): RecordSummary[] {
+    return response.hits.hits.map((hit) => ({
       uuid: hit._id,
       id: hit._source.id,
       title: hit._source.resourceTitleObject?.default || 'no title',
       abstract: hit._source.resourceAbstractObject?.default || 'no abstract',
       thumbnailUrl: this.getFirstValue(hit._source.overview)?.url || '',
-      metadataUrl: `/geonetwork/srv/eng/catalog.search#/metadata/${hit._source.uuid}`,
+      metadataUrl: this.metadataUrlService.getUrl(hit._source.uuid, apiPath),
       downloadable: (hit as any).download,
       viewable: (hit as any).view,
       logoUrl: `/geonetwork${hit._source.logo}`,

--- a/libs/search/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.service.ts
@@ -17,14 +17,15 @@ export class ElasticsearchService {
   }
 
   buildPayload(state: SearchState): SearchParams {
+    const { size, sortBy, filters } = state.params
     const payload = {
       aggregations: state.config.aggregations,
       from: 0,
-      size: RESULTS_PAGE_SIZE,
-      sort: state.params.sortBy ? [state.params.sortBy] : undefined,
+      size,
+      sort: sortBy ? [sortBy] : undefined,
       query: {
         bool: {
-          must: [{ query_string: { query: state.params.filters.any || '*' } }],
+          must: [{ query_string: { query: filters.any || '*' } }],
         },
       },
     }

--- a/libs/search/src/lib/state/actions.ts
+++ b/libs/search/src/lib/state/actions.ts
@@ -1,7 +1,9 @@
 import { RecordSummary, SearchFilters } from '@lib/common'
 import { Action } from '@ngrx/store'
+import { SearchStateParams } from './reducer'
 
 export const UPDATE_FILTERS = '[Search] Update Filters'
+export const SET_SEARCH = '[Search] Set overall search configuration'
 export const SORT_BY = '[Search] Sort By'
 export const ADD_RESULTS = '[Search] Add Results'
 export const CLEAR_RESULTS = '[Search] Clear Results'
@@ -13,6 +15,12 @@ export class UpdateFilters implements Action {
   readonly type = UPDATE_FILTERS
 
   constructor(public payload: SearchFilters) {}
+}
+
+export class SetSearch implements Action {
+  readonly type = SET_SEARCH
+
+  constructor(public payload: SearchStateParams) {}
 }
 
 export class SortBy implements Action {
@@ -53,6 +61,7 @@ export class SetConfigAggregations implements Action {
 
 export type SearchActions =
   | UpdateFilters
+  | SetSearch
   | SortBy
   | AddResults
   | ClearResults

--- a/libs/search/src/lib/state/effects.spec.ts
+++ b/libs/search/src/lib/state/effects.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing'
 import { AuthService } from '@lib/auth'
 import { SearchApiService } from '@lib/gn-api'
+import { ElasticsearchMapper } from '@lib/search'
 import { EffectsModule } from '@ngrx/effects'
 import { provideMockActions } from '@ngrx/effects/testing'
 import { StoreModule } from '@ngrx/store'
@@ -20,9 +21,15 @@ import { initialState, reducer, SEARCH_FEATURE_KEY } from './reducer'
 
 const searchServiceMock = {
   search: () => of({ hits: { hits: [] }, aggregations: {} }), // TODO: use a fixture here
+  configuration: {
+    basePath: 'http://geonetwork/srv/api',
+  },
 }
 const authServiceMock = {
   authReady: () => of(true),
+}
+const esMapperMock = {
+  toRecordSummary: () => [],
 }
 
 describe('Effects', () => {
@@ -48,6 +55,10 @@ describe('Effects', () => {
         {
           provide: AuthService,
           useValue: authServiceMock,
+        },
+        {
+          provide: ElasticsearchMapper,
+          useValue: esMapperMock,
         },
       ],
     })

--- a/libs/search/src/lib/state/effects.spec.ts
+++ b/libs/search/src/lib/state/effects.spec.ts
@@ -11,6 +11,7 @@ import {
   ClearResults,
   RequestMoreResults,
   SetResultsAggregations,
+  SetSearch,
   SortBy,
   UpdateFilters,
 } from './actions'
@@ -69,6 +70,17 @@ describe('Effects', () => {
     })
     it('clear results list on updateParams action', () => {
       actions$ = hot('-a---', { a: new UpdateFilters({ any: 'abcd' }) })
+      const expected = hot('-(bc)', {
+        b: new ClearResults(),
+        c: new RequestMoreResults(),
+      })
+
+      expect(effects.clearResults$).toBeObservable(expected)
+    })
+    it('clear results list on SetSearch action', () => {
+      actions$ = hot('-a---', {
+        a: new SetSearch({ filters: { any: 'abcd' } }),
+      })
       const expected = hot('-(bc)', {
         b: new ClearResults(),
         c: new RequestMoreResults(),

--- a/libs/search/src/lib/state/effects.ts
+++ b/libs/search/src/lib/state/effects.ts
@@ -17,6 +17,7 @@ import {
   SetResultsAggregations,
   SORT_BY,
   UPDATE_FILTERS,
+  SET_SEARCH,
 } from './actions'
 import { SearchState } from './reducer'
 import { getSearchState } from './selectors'
@@ -33,7 +34,7 @@ export class SearchEffects {
 
   clearResults$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(SORT_BY, UPDATE_FILTERS),
+      ofType(SORT_BY, UPDATE_FILTERS, SET_SEARCH),
       switchMap(() => of(new ClearResults(), new RequestMoreResults()))
     )
   )

--- a/libs/search/src/lib/state/effects.ts
+++ b/libs/search/src/lib/state/effects.ts
@@ -29,7 +29,8 @@ export class SearchEffects {
     private searchService: SearchApiService,
     private store$: Store<SearchState>,
     private authService: AuthService,
-    private esService: ElasticsearchService
+    private esService: ElasticsearchService,
+    private esMapper: ElasticsearchMapper
   ) {}
 
   clearResults$ = createEffect(() =>
@@ -53,8 +54,10 @@ export class SearchEffects {
         )
       ),
       switchMap((response: SearchResponse<any>) => {
-        const mapper = new ElasticsearchMapper(response)
-        const records = mapper.toRecordSummary()
+        const records = this.esMapper.toRecordSummary(
+          response,
+          this.searchService.configuration.basePath
+        )
         const aggregations = response.aggregations
         return [
           new AddResults(records),

--- a/libs/search/src/lib/state/reducer.spec.ts
+++ b/libs/search/src/lib/state/reducer.spec.ts
@@ -1,4 +1,4 @@
-import { initialState, reducer } from './reducer'
+import { initialState, reducer, SearchStateParams } from './reducer'
 import * as fromActions from './actions'
 
 describe('Search Reducer', () => {
@@ -36,6 +36,21 @@ describe('Search Reducer', () => {
         action
       )
       expect(state.params.filters).toEqual({})
+    })
+  })
+
+  describe('SET_SEARCH action', () => {
+    it('should set serach params', () => {
+      const searchParams: SearchStateParams = {
+        size: 12,
+        sortBy: 'asc',
+        filters: {
+          any: 'tag:river',
+        },
+      }
+      const action = new fromActions.SetSearch(searchParams)
+      const state = reducer(initialState, action)
+      expect(state.params).toEqual(searchParams)
     })
   })
 

--- a/libs/search/src/lib/state/reducer.ts
+++ b/libs/search/src/lib/state/reducer.ts
@@ -1,17 +1,20 @@
 import { RecordSummary, SearchFilters } from '@lib/common'
+import { SET_SEARCH } from './actions'
 import * as fromActions from './actions'
 
 export const SEARCH_FEATURE_KEY = 'searchState'
+
+export interface SearchStateParams {
+  filters?: SearchFilters
+  sortBy?: string
+  size?: number
+}
 
 export interface SearchState {
   config: {
     aggregations?: any
   }
-  params: {
-    filters: SearchFilters
-    sortBy?: string
-    size?: number
-  }
+  params: SearchStateParams
   results: {
     records: RecordSummary[]
     aggregations: any
@@ -23,6 +26,7 @@ export const initialState: SearchState = {
   config: {},
   params: {
     filters: {},
+    size: 10,
   },
   results: {
     records: [],
@@ -42,6 +46,14 @@ export function reducer(
         params: {
           ...state.params,
           filters: { ...action.payload },
+        },
+      }
+    }
+    case fromActions.SET_SEARCH: {
+      return {
+        ...state,
+        params: {
+          ...action.payload,
         },
       }
     }

--- a/webcomponents/gn-results-list/src/app/gn-results-list.component.ts
+++ b/webcomponents/gn-results-list/src/app/gn-results-list.component.ts
@@ -5,6 +5,8 @@ import {
   ViewEncapsulation,
 } from '@angular/core'
 import { ResultsListLayout } from '@lib/common'
+import { SearchState, SetSearch } from '@lib/search'
+import { Store } from '@ngrx/store'
 import { BaseComponent } from '../../../base.component'
 
 @Component({
@@ -16,14 +18,17 @@ import { BaseComponent } from '../../../base.component'
 })
 export class GnResultsListComponent extends BaseComponent {
   @Input() layout: ResultsListLayout = ResultsListLayout.CARD
-  @Input() lines = 10
-  @Input() filter
+  @Input() size = 10
+  @Input() filter = ''
 
-  constructor() {
+  constructor(private store: Store<SearchState>) {
     super()
   }
 
   ngOnInit(): void {
     super.ngOnInit()
+    this.store.dispatch(
+      new SetSearch({ filters: { any: this.filter }, size: this.size })
+    )
   }
 }


### PR DESCRIPTION
For now tentative. Filter is working in "normal" mode but not in webcomponent mode.

In normal mode:
```
      <search-results-list-container
        size="3"
        filter="GRID"
      ></search-results-list-container>
```

In webcomponent mode

```
 npm run serve:wc -- gn-results-list
```
the file built looks to be empty.
![image](https://user-images.githubusercontent.com/1701393/101386687-d052e500-38bd-11eb-8cd5-91acf253fa8b.png)


When building web component only colors stuffs are added and can't figure out how to add the useful properties. Story book starts locally but display grey pages only, with color knobs only.

Not sure to understand the difference between angular.stories.ts and elements.stories.ts