### PR TITLE
Optimize search API calls on page loading

### DIFF
--- a/apps/search/src/app/app.component.spec.ts
+++ b/apps/search/src/app/app.component.spec.ts
@@ -1,14 +1,40 @@
-import { TestBed, async } from '@angular/core/testing'
-import { RouterTestingModule } from '@angular/router/testing'
-import { AppComponent } from './app.component'
 import { NO_ERRORS_SCHEMA } from '@angular/core'
+import { async, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { BootstrapService } from '@lib/common'
+import { EffectsModule } from '@ngrx/effects'
+import { StoreModule } from '@ngrx/store'
+import { of } from 'rxjs'
+import { AppComponent } from './app.component'
 
+const configFacetMock = {
+  mods: {
+    search: {
+      facetConfig: {
+        tag: {},
+      },
+    },
+  },
+}
+const boostrapServiceMock = {
+  uiConfReady: jest.fn(() => of(configFacetMock)),
+}
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [
+        RouterTestingModule,
+        EffectsModule.forRoot(),
+        StoreModule.forRoot({}),
+      ],
       declarations: [AppComponent],
       schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        {
+          provide: BootstrapService,
+          useValue: boostrapServiceMock,
+        },
+      ],
     }).compileComponents()
   }))
 
@@ -16,11 +42,5 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent)
     const app = fixture.componentInstance
     expect(app).toBeTruthy()
-  })
-
-  it(`should have as title 'search'`, () => {
-    const fixture = TestBed.createComponent(AppComponent)
-    const app = fixture.componentInstance
-    expect(app.title).toEqual('search')
   })
 })

--- a/apps/search/src/app/app.component.ts
+++ b/apps/search/src/app/app.component.ts
@@ -1,15 +1,41 @@
-import { Component } from '@angular/core'
-import { ColorService } from '@lib/common'
+import { Component, OnInit } from '@angular/core'
+import { BootstrapService, ColorService } from '@lib/common'
+import {
+  RequestMoreResults,
+  SearchState,
+  SetConfigAggregations,
+} from '@lib/search'
+import { Store } from '@ngrx/store'
+import { map, pluck, take, tap } from 'rxjs/operators'
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'search'
 
-  constructor() {
+  constructor(
+    private bootstrap: BootstrapService,
+    private store: Store<SearchState>
+  ) {
     ColorService.applyCssVariables('#e73f51', '#c2e9dc', '#212029', '#fdfbff')
+  }
+
+  ngOnInit(): void {
+    this.bootstrap
+      .uiConfReady('srv')
+      .pipe(
+        take(1),
+        map((config) => config.mods.search.facetConfig),
+        // TODO: make the config work not just for tag
+        pluck('tag'),
+        tap((tagConfig) => {
+          this.store.dispatch(new SetConfigAggregations({ tag: tagConfig }))
+          this.store.dispatch(new RequestMoreResults())
+        })
+      )
+      .subscribe()
   }
 }

--- a/libs/auth/src/lib/auth.service.ts
+++ b/libs/auth/src/lib/auth.service.ts
@@ -1,17 +1,22 @@
 import { Injectable } from '@angular/core'
-import { MeApiService } from '@lib/gn-api'
+import { MeApiService, MeResponseApiModel } from '@lib/gn-api'
+import { Observable } from 'rxjs'
 import { map, shareReplay } from 'rxjs/operators'
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
+  authReady$: Observable<MeResponseApiModel>
+
   constructor(private meApi: MeApiService) {}
 
   authReady() {
-    return this.meApi.getMe().pipe(
-      map(() => {}),
-      shareReplay()
-    )
+    if (!this.authReady$) {
+      this.authReady$ = this.meApi
+        .getMe()
+        .pipe(shareReplay({ bufferSize: 1, refCount: true }))
+    }
+    return this.authReady$
   }
 }

--- a/libs/search/src/lib/results-list/results-list.container.component.ts
+++ b/libs/search/src/lib/results-list/results-list.container.component.ts
@@ -1,19 +1,13 @@
 import { Component, Input, OnInit } from '@angular/core'
 import { BootstrapService, ResultsListLayout } from '@lib/common'
 import { select, Store } from '@ngrx/store'
+import { SetResultsLayout } from '../state/actions'
 import { SearchState } from '../state/reducer'
 import {
   getSearchResults,
   getSearchResultsLayout,
   getSearchResultsLoading,
 } from '../state/selectors'
-import {
-  RequestMoreResults,
-  SetConfigAggregations,
-  SetResultsLayout,
-  UpdateFilters,
-} from '../state/actions'
-import { map, pluck, take, tap } from 'rxjs/operators'
 
 @Component({
   selector: 'search-results-list-container',
@@ -27,26 +21,9 @@ export class ResultsListContainerComponent implements OnInit {
   layout$ = this.store.pipe(select(getSearchResultsLayout))
   isLoading$ = this.store.pipe(select(getSearchResultsLoading))
 
-  constructor(
-    private bootstrap: BootstrapService,
-    private store: Store<SearchState>
-  ) {}
+  constructor(private store: Store<SearchState>) {}
 
   ngOnInit(): void {
-    // initial load when showing the component
-    this.bootstrap
-      .uiConfReady('srv')
-      .pipe(
-        take(1),
-        map((config) => config.mods.search.facetConfig),
-        // TODO: make the config work not just for tag
-        pluck('tag'),
-        tap((tagConfig) => {
-          this.store.dispatch(new SetResultsLayout(this.layout))
-          this.store.dispatch(new SetConfigAggregations({ tag: tagConfig }))
-          this.store.dispatch(new RequestMoreResults())
-        })
-      )
-      .subscribe()
+    this.store.dispatch(new SetResultsLayout(this.layout))
   }
 }


### PR DESCRIPTION
Slight improvments and refactoring to avoid parasite search api calls:

- fix of `shareReplay` usage for `/me` api calls, that were called once per search request
- move `RequestMore` action dispatch out of `results-list-container` component. It is not the responsability of the component to perform a search request, it should be done at a higher level like during the application init. This was causing parasite search api calls while the initial state was not ready yet.

gn-results-list web component now just perform 2 request on load as expected
- `me`
- `_search`