### PR TITLE
suggestion for a mapping file from core strings

### DIFF
--- a/apps/search/src/assets/i18n/translations.map
+++ b/apps/search/src/assets/i18n/translations.map
@@ -1,0 +1,21 @@
+/*
+This file proposes a mapping of keys, between the new gn-ui and core application
+For each key, a mapped value of {filename}:{key} is suggested (empty if none)
+So we can define a script to import existing keys from transifex
+*/
+
+{
+	"Find your metadata": "core:anyPlaceHolder",
+	"Sort by": "core:ui-sortBy",
+	"records": "core:records",
+	"recordViewable": "search:mdActions-view",
+	"recordDownloadable": "search:mdActions-download",
+	"readMore": "search:viewMore",
+	"search.loading": "",
+	"last changed": "search:changeDate",
+	"popularity": "core:popularity",
+	"dropFile": "admin:chooseOrDropResource",
+	"Back": "",
+    "facets.block.title.tag": "core:Keywords",
+    "results.layout.selectOne": ""
+}


### PR DESCRIPTION
in order to persist as many of current translations, i suggest to set up a mapping from core-app to ui-app, so we can develop a script to import existing translations into transifex. We can use this pr to discuss the approach, and if positive also draft a script to facilitate the actual import