### PR TITLE
web component: watch input changes

### DIFF
--- a/apps/search/src/app/app.component.spec.ts
+++ b/apps/search/src/app/app.component.spec.ts
@@ -1,14 +1,40 @@
-import { TestBed, async } from '@angular/core/testing'
-import { RouterTestingModule } from '@angular/router/testing'
-import { AppComponent } from './app.component'
 import { NO_ERRORS_SCHEMA } from '@angular/core'
+import { async, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { BootstrapService } from '@lib/common'
+import { EffectsModule } from '@ngrx/effects'
+import { StoreModule } from '@ngrx/store'
+import { of } from 'rxjs'
+import { AppComponent } from './app.component'
 
+const configFacetMock = {
+  mods: {
+    search: {
+      facetConfig: {
+        tag: {},
+      },
+    },
+  },
+}
+const boostrapServiceMock = {
+  uiConfReady: jest.fn(() => of(configFacetMock)),
+}
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      imports: [
+        RouterTestingModule,
+        EffectsModule.forRoot(),
+        StoreModule.forRoot({}),
+      ],
       declarations: [AppComponent],
       schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        {
+          provide: BootstrapService,
+          useValue: boostrapServiceMock,
+        },
+      ],
     }).compileComponents()
   }))
 
@@ -16,11 +42,5 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent)
     const app = fixture.componentInstance
     expect(app).toBeTruthy()
-  })
-
-  it(`should have as title 'search'`, () => {
-    const fixture = TestBed.createComponent(AppComponent)
-    const app = fixture.componentInstance
-    expect(app.title).toEqual('search')
   })
 })

--- a/apps/search/src/app/app.component.ts
+++ b/apps/search/src/app/app.component.ts
@@ -1,15 +1,41 @@
-import { Component } from '@angular/core'
-import { ColorService } from '@lib/common'
+import { Component, OnInit } from '@angular/core'
+import { BootstrapService, ColorService } from '@lib/common'
+import {
+  RequestMoreResults,
+  SearchState,
+  SetConfigAggregations,
+} from '@lib/search'
+import { Store } from '@ngrx/store'
+import { map, pluck, take, tap } from 'rxjs/operators'
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'search'
 
-  constructor() {
+  constructor(
+    private bootstrap: BootstrapService,
+    private store: Store<SearchState>
+  ) {
     ColorService.applyCssVariables('#e73f51', '#c2e9dc', '#212029', '#fdfbff')
+  }
+
+  ngOnInit(): void {
+    this.bootstrap
+      .uiConfReady('srv')
+      .pipe(
+        take(1),
+        map((config) => config.mods.search.facetConfig),
+        // TODO: make the config work not just for tag
+        pluck('tag'),
+        tap((tagConfig) => {
+          this.store.dispatch(new SetConfigAggregations({ tag: tagConfig }))
+          this.store.dispatch(new RequestMoreResults())
+        })
+      )
+      .subscribe()
   }
 }

--- a/libs/auth/src/lib/auth.service.ts
+++ b/libs/auth/src/lib/auth.service.ts
@@ -1,17 +1,22 @@
 import { Injectable } from '@angular/core'
-import { MeApiService } from '@lib/gn-api'
+import { MeApiService, MeResponseApiModel } from '@lib/gn-api'
+import { Observable } from 'rxjs'
 import { map, shareReplay } from 'rxjs/operators'
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
+  authReady$: Observable<MeResponseApiModel>
+
   constructor(private meApi: MeApiService) {}
 
   authReady() {
-    return this.meApi.getMe().pipe(
-      map(() => {}),
-      shareReplay()
-    )
+    if (!this.authReady$) {
+      this.authReady$ = this.meApi
+        .getMe()
+        .pipe(shareReplay({ bufferSize: 1, refCount: true }))
+    }
+    return this.authReady$
   }
 }

--- a/libs/search/src/lib/results-list/results-list.container.component.ts
+++ b/libs/search/src/lib/results-list/results-list.container.component.ts
@@ -1,19 +1,13 @@
 import { Component, Input, OnInit } from '@angular/core'
 import { BootstrapService, ResultsListLayout } from '@lib/common'
 import { select, Store } from '@ngrx/store'
+import { SetResultsLayout } from '../state/actions'
 import { SearchState } from '../state/reducer'
 import {
   getSearchResults,
   getSearchResultsLayout,
   getSearchResultsLoading,
 } from '../state/selectors'
-import {
-  RequestMoreResults,
-  SetConfigAggregations,
-  SetResultsLayout,
-  UpdateFilters,
-} from '../state/actions'
-import { map, pluck, take, tap } from 'rxjs/operators'
 
 @Component({
   selector: 'search-results-list-container',
@@ -27,26 +21,9 @@ export class ResultsListContainerComponent implements OnInit {
   layout$ = this.store.pipe(select(getSearchResultsLayout))
   isLoading$ = this.store.pipe(select(getSearchResultsLoading))
 
-  constructor(
-    private bootstrap: BootstrapService,
-    private store: Store<SearchState>
-  ) {}
+  constructor(private store: Store<SearchState>) {}
 
   ngOnInit(): void {
-    // initial load when showing the component
-    this.bootstrap
-      .uiConfReady('srv')
-      .pipe(
-        take(1),
-        map((config) => config.mods.search.facetConfig),
-        // TODO: make the config work not just for tag
-        pluck('tag'),
-        tap((tagConfig) => {
-          this.store.dispatch(new SetResultsLayout(this.layout))
-          this.store.dispatch(new SetConfigAggregations({ tag: tagConfig }))
-          this.store.dispatch(new RequestMoreResults())
-        })
-      )
-      .subscribe()
+    this.store.dispatch(new SetResultsLayout(this.layout))
   }
 }

--- a/webcomponents/base.component.ts
+++ b/webcomponents/base.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input, OnInit } from '@angular/core'
+import {
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+} from '@angular/core'
 import { ColorService } from '@lib/common'
 import { Configuration } from '@lib/gn-api'
 
@@ -8,22 +14,28 @@ export const apiConfiguration = new Configuration()
   selector: 'wc-base',
   template: `<div></div>`,
 })
-export class BaseComponent implements OnInit {
+export class BaseComponent implements OnInit, OnChanges {
   @Input() apiUrl = '/'
   @Input() primaryColor = '#9a9a9a'
   @Input() secondaryColor = '#767676'
   @Input() mainColor = '#1a1a1a'
   @Input() backgroundColor = '#cecece'
 
+  isInitialized = false
+
   constructor() {}
 
-  ngOnInit(): void {
-    apiConfiguration.basePath = this.apiUrl
-    ColorService.applyCssVariables(
-      this.primaryColor,
-      this.secondaryColor,
-      this.mainColor,
-      this.backgroundColor
-    )
+  ngOnInit(): void {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!this.isInitialized) {
+      apiConfiguration.basePath = this.apiUrl
+      ColorService.applyCssVariables(
+        this.primaryColor,
+        this.secondaryColor,
+        this.mainColor,
+        this.backgroundColor
+      )
+    }
   }
 }

--- a/webcomponents/gn-results-list/src/app/gn-results-list.component.ts
+++ b/webcomponents/gn-results-list/src/app/gn-results-list.component.ts
@@ -1,12 +1,14 @@
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   Input,
+  SimpleChanges,
   ViewEncapsulation,
 } from '@angular/core'
 import { ResultsListLayout } from '@lib/common'
-import { SearchState, SetSearch } from '@lib/search'
-import { Store } from '@ngrx/store'
+import { getSearchResultsLoading, SearchState, SetSearch } from '@lib/search'
+import { select, Store } from '@ngrx/store'
 import { BaseComponent } from '../../../base.component'
 
 @Component({
@@ -21,14 +23,31 @@ export class GnResultsListComponent extends BaseComponent {
   @Input() size = 10
   @Input() filter = ''
 
-  constructor(private store: Store<SearchState>) {
+  constructor(
+    private store: Store<SearchState>,
+    private changeDetector: ChangeDetectorRef
+  ) {
     super()
   }
 
   ngOnInit(): void {
     super.ngOnInit()
+    setTimeout(() => {
+      // Be sure to update the source page when the state is updated
+      this.store.pipe(select(getSearchResultsLoading)).subscribe((v) => {
+        this.changeDetector.detectChanges()
+      })
+    })
+  }
+
+  private setSearch_() {
     this.store.dispatch(
       new SetSearch({ filters: { any: this.filter }, size: this.size })
     )
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    super.ngOnChanges(changes)
+    this.setSearch_()
   }
 }


### PR DESCRIPTION
Show how to update the behavior of the web component from the source page, by changing wc inputs values.
Angular component should handle input changes within `onChanges` implementation. 

The PR implements the `onChanges` method in `gn-results-list component`, it must follow some rules
- don't call api request before the web component has initiliazed `API_BASE_PATH`
- be sure to trigger the change detection when it is expected, because the web component execution (even though it's in an angular custom element) is outside of an Angular zone, meaning the change detection is not triggered.

In my case, I had to watch for the `loading` property of the search state, informing me that the search is done. When it's done, I trigger the change detection otherwise the results are not shown.
I added a setTimeout to subscribe to loading selector after all other subscription to the same observable to be sure all angular components has been updated from loading observable before I run the change detection.

This is a bit complex overall, but no choices.

Here an exemple on how to update the input from source page:

```html
 <div>
    <button id="changeSizeBtn">Change size</button>
 </div>
 <gn-results-list api-url="https://apps.titellus.net/geonetwork/srv/api"></gn-results-list>

 <script>
    const wc = document.getElementsByTagName('gn-results-list')[0]
    const btn = document.getElementById('changeSizeBtn')
    btn.addEventListener('click', () => wc.size = 3)
 </script>
```