### PR TITLE
fix: make translation module work in apps, wc and storybook

### DIFF
--- a/apps/datafeeder/src/app/app.module.ts
+++ b/apps/datafeeder/src/app/app.module.ts
@@ -4,7 +4,11 @@ import { NgModule } from '@angular/core'
 import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
 import { UploadDataComponent } from './presentation/components/upload-data/upload-data.component'
-import { HttpLoaderFactory, I18nModule } from '@lib/common'
+import {
+  HttpLoaderFactory,
+  I18nModule,
+  TRANSLATE_DEFAULT_CONFIG,
+} from '@lib/common'
 import { UiModule } from '@lib/ui'
 import { UploadDataPageComponent } from './presentation/pages/upload-data-page/upload-data.page'
 import { UploadDataRulesComponent } from './presentation/components/upload-data-rules/upload-data-rules.component'
@@ -35,16 +39,10 @@ import { AnalysisProgressIllustrationsComponent } from './presentation/component
   imports: [
     BrowserModule,
     AppRoutingModule,
-    I18nModule,
     UiModule,
     HttpClientModule,
-    TranslateModule.forRoot({
-      loader: {
-        provide: TranslateLoader,
-        useFactory: HttpLoaderFactory,
-        deps: [HttpClient],
-      },
-    }),
+    I18nModule,
+    TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.spec.ts
+++ b/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.spec.ts
@@ -2,12 +2,13 @@ if (typeof global.URL.createObjectURL !== 'function') {
   global.URL.createObjectURL = jest.fn()
 }
 
+import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { By } from '@angular/platform-browser'
 import { I18nModule } from '@lib/common'
+import { TranslateModule } from '@ngx-translate/core'
 
 import { DataImportValidationMapPanelComponent } from './data-import-validation-map-panel.component'
-import { NO_ERRORS_SCHEMA } from '@angular/core'
-import { By } from '@angular/platform-browser'
 
 describe('MapViewComponent', () => {
   let component: DataImportValidationMapPanelComponent
@@ -15,7 +16,7 @@ describe('MapViewComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [I18nModule],
+      imports: [I18nModule, TranslateModule.forRoot()],
       declarations: [DataImportValidationMapPanelComponent],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents()

--- a/apps/search/src/app/app.module.ts
+++ b/apps/search/src/app/app.module.ts
@@ -1,13 +1,14 @@
 import { HttpClientModule } from '@angular/common/http'
 import { NgModule } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
-import { I18nModule } from '@lib/common'
+import { LibCatalogModule } from '@lib/catalog'
+import { I18nModule, TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
 import { BASE_PATH } from '@lib/gn-api'
 import { LibSearchModule } from '@lib/search'
-import { LibCatalogModule } from '@lib/catalog'
 import { EffectsModule } from '@ngrx/effects'
 import { MetaReducer, StoreModule } from '@ngrx/store'
 import { StoreDevtoolsModule } from '@ngrx/store-devtools'
+import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { storeFreeze } from 'ngrx-store-freeze'
 import { environment } from '../environments/environment'
 import { AppRoutingModule } from './app-routing.module'
@@ -24,6 +25,7 @@ export const metaReducers: MetaReducer<any>[] = !environment.production
     AppRoutingModule,
     HttpClientModule,
     I18nModule,
+    TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
     LibSearchModule,
     LibCatalogModule,
     StoreModule.forRoot({}, { metaReducers }),
@@ -38,4 +40,9 @@ export const metaReducers: MetaReducer<any>[] = !environment.production
   ],
   bootstrap: [AppComponent],
 })
-export class AppModule {}
+export class AppModule {
+  constructor(translate: TranslateService) {
+    translate.setDefaultLang('en')
+    translate.use('en')
+  }
+}

--- a/libs/common/src/lib/i18n/i18n.module.ts
+++ b/libs/common/src/lib/i18n/i18n.module.ts
@@ -36,18 +36,17 @@ export const LANG_2_TO_3_MAPPER = Object.entries(LANG_3_TO_2_MAPPER).reduce(
   {}
 )
 
+export const TRANSLATE_DEFAULT_CONFIG = {
+  loader: {
+    provide: TranslateLoader,
+    useFactory: HttpLoaderFactory,
+    defaultLanguage: 'en',
+    deps: [HttpClient],
+  },
+}
+
 @NgModule({
-  declarations: [],
-  imports: [
-    HttpClientModule,
-    TranslateModule.forRoot({
-      loader: {
-        provide: TranslateLoader,
-        useFactory: HttpLoaderFactory,
-        deps: [HttpClient],
-      },
-    }),
-  ],
+  imports: [HttpClientModule],
   exports: [TranslateModule],
 })
 export class I18nModule {

--- a/libs/common/src/lib/services/metadata-url.service.spec.ts
+++ b/libs/common/src/lib/services/metadata-url.service.spec.ts
@@ -1,6 +1,4 @@
 import { TestBed } from '@angular/core/testing'
-import { LogService } from '@lib/common'
-import { SiteApiService, UiApiService } from '@lib/gn-api'
 import { TranslateService } from '@ngx-translate/core'
 
 import { MetadataUrlService } from './metadata-url.service'

--- a/libs/search/src/lib/results-list/results-list.container.component.spec.ts
+++ b/libs/search/src/lib/results-list/results-list.container.component.spec.ts
@@ -4,6 +4,7 @@ import { UiModule } from '@lib/ui'
 
 import { EffectsModule } from '@ngrx/effects'
 import { StoreModule } from '@ngrx/store'
+import { TranslateModule } from '@ngx-translate/core'
 import { initialState, reducer, SEARCH_FEATURE_KEY } from '../state/reducer'
 import { ResultsListContainerComponent } from './results-list.container.component'
 
@@ -16,6 +17,7 @@ describe('ResultsListContainerComponent', () => {
       declarations: [ResultsListContainerComponent],
       imports: [
         I18nModule,
+        TranslateModule.forRoot(),
         UiModule,
         EffectsModule.forRoot(),
         StoreModule.forRoot({}),

--- a/libs/ui/src/lib/button/button.stories.ts
+++ b/libs/ui/src/lib/button/button.stories.ts
@@ -1,4 +1,5 @@
-import { I18nModule } from '@lib/common'
+import { TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
+import { TranslateModule } from '@ngx-translate/core'
 import { withA11y } from '@storybook/addon-a11y'
 import { select, text, withKnobs } from '@storybook/addon-knobs'
 import { Meta, moduleMetadata, Story } from '@storybook/angular'
@@ -6,7 +7,7 @@ import { UiModule } from '../ui.module'
 import { ButtonComponent } from './button.component'
 
 const moduleMetadatas = {
-  imports: [I18nModule, UiModule],
+  imports: [TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG), UiModule],
 }
 
 export default {

--- a/libs/ui/src/lib/drag-and-drop-file-input/drag-and-drop-file-input.stories.ts
+++ b/libs/ui/src/lib/drag-and-drop-file-input/drag-and-drop-file-input.stories.ts
@@ -1,13 +1,17 @@
-import { I18nModule } from '@lib/common'
+import { TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
+import { TranslateModule } from '@ngx-translate/core'
 import { withA11y } from '@storybook/addon-a11y'
 import { action } from '@storybook/addon-actions'
 import { text, withKnobs } from '@storybook/addon-knobs'
 import { Meta, moduleMetadata } from '@storybook/angular'
-import { DragAndDropFileInputComponent } from './drag-and-drop-file-input.component'
 import { NgxDropzoneModule } from 'ngx-dropzone'
+import { DragAndDropFileInputComponent } from './drag-and-drop-file-input.component'
 
 const moduleMetadatas = {
-  imports: [I18nModule, NgxDropzoneModule],
+  imports: [
+    TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
+    NgxDropzoneModule,
+  ],
 }
 
 export default {

--- a/libs/ui/src/lib/dropdown-selector/dropdown-selector.stories.ts
+++ b/libs/ui/src/lib/dropdown-selector/dropdown-selector.stories.ts
@@ -1,12 +1,13 @@
-import { I18nModule } from '@lib/common'
+import { TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
+import { TranslateModule } from '@ngx-translate/core'
 import { withA11y } from '@storybook/addon-a11y'
 import { action } from '@storybook/addon-actions'
 import { object, text, withKnobs } from '@storybook/addon-knobs'
-import { Meta, moduleMetadata, Story } from '@storybook/angular'
+import { Meta, moduleMetadata } from '@storybook/angular'
 import { DropdownSelectorComponent } from './dropdown-selector.component'
 
 const moduleMetadatas = {
-  imports: [I18nModule],
+  imports: [TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG)],
 }
 
 export default {

--- a/libs/ui/src/lib/facets/facet-block/facet-block.stories.ts
+++ b/libs/ui/src/lib/facets/facet-block/facet-block.stories.ts
@@ -1,4 +1,5 @@
-import { I18nModule } from '@lib/common'
+import { TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
+import { TranslateModule } from '@ngx-translate/core'
 import { withA11y } from '@storybook/addon-a11y'
 import { action } from '@storybook/addon-actions'
 import { boolean, object, text, withKnobs } from '@storybook/addon-knobs'
@@ -9,7 +10,7 @@ import { FacetBlockComponent } from './facet-block.component'
 
 const moduleMetadatas = {
   declarations: [FacetItemComponent],
-  imports: [I18nModule],
+  imports: [TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG)],
 }
 
 export default {

--- a/libs/ui/src/lib/facets/facet-item/facet-item.stories.ts
+++ b/libs/ui/src/lib/facets/facet-item/facet-item.stories.ts
@@ -1,4 +1,5 @@
-import { I18nModule } from '@lib/common'
+import { TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
+import { TranslateModule } from '@ngx-translate/core'
 import { withA11y } from '@storybook/addon-a11y'
 import { action } from '@storybook/addon-actions'
 import { boolean, number, text, withKnobs } from '@storybook/addon-knobs'
@@ -6,7 +7,7 @@ import { Meta, moduleMetadata } from '@storybook/angular'
 import { FacetItemComponent } from './facet-item.component'
 
 const moduleMetadatas = {
-  imports: [I18nModule],
+  imports: [TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG)],
 }
 
 export default {

--- a/libs/ui/src/lib/record-metric/record-metric.stories.ts
+++ b/libs/ui/src/lib/record-metric/record-metric.stories.ts
@@ -1,11 +1,12 @@
-import { I18nModule } from '@lib/common'
+import { TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
+import { TranslateModule } from '@ngx-translate/core'
 import { withA11y } from '@storybook/addon-a11y'
 import { number, text, withKnobs } from '@storybook/addon-knobs'
 import { Meta, moduleMetadata } from '@storybook/angular'
 import { RecordMetricComponent } from './record-metric.component'
 
 const moduleMetadatas = {
-  imports: [I18nModule],
+  imports: [TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG)],
 }
 
 export default {

--- a/libs/ui/src/lib/results-list/results-list.stories.ts
+++ b/libs/ui/src/lib/results-list/results-list.stories.ts
@@ -1,13 +1,18 @@
+import {
+  RecordSummary,
+  ResultsListLayout,
+  TRANSLATE_DEFAULT_CONFIG,
+} from '@lib/common'
+import { TranslateModule } from '@ngx-translate/core'
 import { withA11y } from '@storybook/addon-a11y'
 import { object, select, withKnobs } from '@storybook/addon-knobs'
 import { moduleMetadata } from '@storybook/angular'
-import { I18nModule, RecordSummary, ResultsListLayout } from '@lib/common'
 import { UiModule } from '../ui.module'
 import { ResultsListComponent } from './results-list.component'
 
 const moduleMetadatas = {
   declaration: [],
-  imports: [I18nModule, UiModule],
+  imports: [TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG), UiModule],
 }
 
 export default {

--- a/webcomponents/gn-aggregated-records/stories/angular.stories.ts
+++ b/webcomponents/gn-aggregated-records/stories/angular.stories.ts
@@ -1,12 +1,16 @@
+import { TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
+import { TranslateModule } from '@ngx-translate/core'
 import { withA11y } from '@storybook/addon-a11y'
-import { Meta, moduleMetadata } from '@storybook/angular'
 import { color, number, text, withKnobs } from '@storybook/addon-knobs'
-import { I18nModule } from '@lib/common'
+import { Meta, moduleMetadata } from '@storybook/angular'
 import { GnAggregatedRecordsComponent } from '../src/app/gn-aggregated-records.component'
 import { GnAggregatedRecordsModule } from '../src/app/gn-aggregated-records.module'
 
 const moduleMetadatas = {
-  imports: [I18nModule, GnAggregatedRecordsModule],
+  imports: [
+    TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
+    GnAggregatedRecordsModule,
+  ],
 }
 
 export default {

--- a/webcomponents/gn-results-list/src/app/gn-results-list.module.ts
+++ b/webcomponents/gn-results-list/src/app/gn-results-list.module.ts
@@ -1,8 +1,10 @@
 import { Injector, NgModule } from '@angular/core'
 import { createCustomElement } from '@angular/elements'
+import { I18nModule, TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
 import { LibSearchModule } from '@lib/search'
 import { StoreModule } from '@ngrx/store'
 import { EffectsModule } from '@ngrx/effects'
+import { TranslateModule } from '@ngx-translate/core'
 import { WcCommonModule } from '../../../wc-common.module'
 import { GnResultsListComponent } from './gn-results-list.component'
 
@@ -15,6 +17,8 @@ const WC_TAG_NAME = 'gn-results-list'
     LibSearchModule,
     StoreModule.forRoot({}),
     EffectsModule.forRoot(),
+    I18nModule,
+    TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
   ],
 })
 export class GnResultsListModule {

--- a/webcomponents/gn-results-list/stories/angular.stories.ts
+++ b/webcomponents/gn-results-list/stories/angular.stories.ts
@@ -1,12 +1,17 @@
+import { TranslateModule } from '@ngx-translate/core'
 import { withA11y } from '@storybook/addon-a11y'
 import { color, text, withKnobs } from '@storybook/addon-knobs'
 import { moduleMetadata } from '@storybook/angular'
-import { I18nModule } from '../../../libs/common/src'
+import { I18nModule, TRANSLATE_DEFAULT_CONFIG } from '../../../libs/common/src'
 import { GnResultsListComponent } from '../src/app/gn-results-list.component'
 import { GnResultsListModule } from '../src/app/gn-results-list.module'
 
 const moduleMetadatas = {
-  imports: [I18nModule, GnResultsListModule],
+  imports: [
+    I18nModule,
+    TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
+    GnResultsListModule,
+  ],
 }
 
 export default {

--- a/webcomponents/gn-search-input/src/app/gn-search-input.module.ts
+++ b/webcomponents/gn-search-input/src/app/gn-search-input.module.ts
@@ -1,8 +1,10 @@
 import { Injector, NgModule } from '@angular/core'
 import { createCustomElement } from '@angular/elements'
+import { I18nModule, TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
 import { LibSearchModule } from '@lib/search'
 import { StoreModule } from '@ngrx/store'
 import { EffectsModule } from '@ngrx/effects'
+import { TranslateModule } from '@ngx-translate/core'
 import { GnSearchInputComponent } from './gn-search-input.component'
 import { WcCommonModule } from '../../../wc-common.module'
 
@@ -15,6 +17,8 @@ const WC_TAG_NAME = 'gn-search-input'
     LibSearchModule,
     StoreModule.forRoot({}),
     EffectsModule.forRoot(),
+    I18nModule,
+    TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
   ],
 })
 export class GnSearchInputModule {

--- a/webcomponents/gn-search-input/stories/angular.stories.ts
+++ b/webcomponents/gn-search-input/stories/angular.stories.ts
@@ -1,12 +1,17 @@
+import { TranslateModule } from '@ngx-translate/core'
 import { withA11y } from '@storybook/addon-a11y'
 import { color, text, withKnobs } from '@storybook/addon-knobs'
 import { moduleMetadata, storiesOf } from '@storybook/angular'
-import { I18nModule } from '../../../libs/common/src'
+import { I18nModule, TRANSLATE_DEFAULT_CONFIG } from '../../../libs/common/src'
 import { GnSearchInputComponent } from '../src/app/gn-search-input.component'
 import { GnSearchInputModule } from '../src/app/gn-search-input.module'
 
 const moduleMetadatas = {
-  imports: [I18nModule, GnSearchInputModule],
+  imports: [
+    I18nModule,
+    TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
+    GnSearchInputModule,
+  ],
 }
 
 storiesOf('_Web Component', module)

--- a/webcomponents/wc-common.module.ts
+++ b/webcomponents/wc-common.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core'
-import { I18nModule } from '@lib/common'
+import { TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
 import { Configuration } from '@lib/gn-api'
+import { TranslateModule } from '@ngx-translate/core'
 import { apiConfiguration, BaseComponent } from './base.component'
 
 /**
@@ -8,7 +9,7 @@ import { apiConfiguration, BaseComponent } from './base.component'
  */
 @NgModule({
   declarations: [BaseComponent],
-  imports: [I18nModule],
+  imports: [TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG)],
   providers: [
     {
       provide: Configuration,


### PR DESCRIPTION
Fix translation module initialisation.
You must bootstrap `TranslateModule` in root module of your application:
```js
    I18nModule,
    TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
```
Importing `I18nModule` ensure to set up the default and current language (otherwise it does not work).

Do that in application root module, stories and webcomponent root module to see it work everywhere.