### PR TITLE
Infinite scroll on search results

### DIFF
--- a/libs/common/src/lib/models/index.ts
+++ b/libs/common/src/lib/models/index.ts
@@ -1,3 +1,4 @@
 export * from './facets.model'
 export * from './search.model'
 export * from './elasticsearch.model'
+export * from './infinite-scroll.model'

--- a/libs/common/src/lib/models/infinite-scroll.model.ts
+++ b/libs/common/src/lib/models/infinite-scroll.model.ts
@@ -1,0 +1,13 @@
+export interface InfiniteScrollModel {
+  distance?: number
+  upDistance?: number
+  throttle?: number
+  disabled?: boolean
+}
+
+export const InfiniteScrollOptionsDefault = {
+  distance: 1,
+  upDistance: 2,
+  throttle: 300,
+  disabled: false,
+}

--- a/libs/search/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.service.ts
@@ -17,7 +17,7 @@ export class ElasticsearchService {
   }
 
   buildPayload(state: SearchState): SearchParams {
-    const { size, sortBy } = state.params
+    const { size, sortBy, from } = state.params
     const sort: SortParams = sortBy
       ? sortBy.split(',').map((s) => {
           if (s.startsWith('-')) {
@@ -30,7 +30,7 @@ export class ElasticsearchService {
 
     const payload = {
       aggs: state.config.aggregations,
-      from: 0,
+      from,
       size,
       sort: sort as NameList,
       query: this.partialBuildQuery(state),

--- a/libs/search/src/lib/results-list/results-list.container.component.html
+++ b/libs/search/src/lib/results-list/results-list.container.component.html
@@ -1,5 +1,15 @@
-<ui-results-list
-  [loading]="isLoading$ | async"
-  [records]="results$ | async"
-  [layout]="layout$ | async"
-></ui-results-list>
+<div
+  class="search-results"
+  infinite-scroll
+  [infiniteScrollDistance]="scrollableConfig.distance"
+  [infiniteScrollUpDistance]="scrollableConfig.upDistance"
+  [infiniteScrollThrottle]="scrollableConfig.throttle"
+  [infiniteScrollDisabled]="scrollableConfig.disabled"
+  (scrolled)="onScrollDown()"
+>
+  <ui-results-list
+    [loading]="facade.isLoading$ | async"
+    [records]="facade.results$ | async"
+    [layout]="facade.layout$ | async"
+  ></ui-results-list>
+</div>

--- a/libs/search/src/lib/results-list/results-list.container.component.spec.ts
+++ b/libs/search/src/lib/results-list/results-list.container.component.spec.ts
@@ -1,3 +1,4 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 import { I18nModule } from '@lib/common'
 import { UiModule } from '@lib/ui'
@@ -15,6 +16,7 @@ describe('ResultsListContainerComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ResultsListContainerComponent],
+      schemas: [NO_ERRORS_SCHEMA],
       imports: [
         I18nModule,
         TranslateModule.forRoot(),

--- a/libs/search/src/lib/results-list/results-list.container.component.ts
+++ b/libs/search/src/lib/results-list/results-list.container.component.ts
@@ -13,7 +13,9 @@ import { SearchFacade } from '../state/search.facade'
 })
 export class ResultsListContainerComponent implements OnInit {
   @Input() layout: ResultsListLayout = ResultsListLayout.CARD
+  @Input() scrollableOptions: InfiniteScrollModel = {}
 
+  scrollableConfig: InfiniteScrollModel
 
   constructor(public facade: SearchFacade) {}
 

--- a/libs/search/src/lib/results-list/results-list.container.component.ts
+++ b/libs/search/src/lib/results-list/results-list.container.component.ts
@@ -1,13 +1,10 @@
 import { Component, Input, OnInit } from '@angular/core'
-import { ResultsListLayout } from '@lib/common'
-import { select, Store } from '@ngrx/store'
-import { SetResultsLayout } from '../state/actions'
-import { SearchState } from '../state/reducer'
 import {
-  getSearchResults,
-  getSearchResultsLayout,
-  getSearchResultsLoading,
-} from '../state/selectors'
+  InfiniteScrollModel,
+  InfiniteScrollOptionsDefault,
+  ResultsListLayout,
+} from '@lib/common'
+import { SearchFacade } from '../state/search.facade'
 
 @Component({
   selector: 'search-results-list-container',
@@ -17,13 +14,18 @@ import {
 export class ResultsListContainerComponent implements OnInit {
   @Input() layout: ResultsListLayout = ResultsListLayout.CARD
 
-  results$ = this.store.pipe(select(getSearchResults))
-  layout$ = this.store.pipe(select(getSearchResultsLayout))
-  isLoading$ = this.store.pipe(select(getSearchResultsLoading))
 
-  constructor(private store: Store<SearchState>) {}
+  constructor(public facade: SearchFacade) {}
 
   ngOnInit(): void {
-    this.store.dispatch(new SetResultsLayout(this.layout))
+    this.scrollableConfig = {
+      ...InfiniteScrollOptionsDefault,
+      ...this.scrollableOptions,
+    }
+    this.facade.setResultsLayout(this.layout)
+  }
+
+  onScrollDown() {
+    this.facade.scroll()
   }
 }

--- a/libs/search/src/lib/search.module.ts
+++ b/libs/search/src/lib/search.module.ts
@@ -6,6 +6,7 @@ import { UiModule } from '@lib/ui'
 import { EffectsModule } from '@ngrx/effects'
 import { StoreModule } from '@ngrx/store'
 import { TranslateModule } from '@ngx-translate/core'
+import { InfiniteScrollModule } from 'ngx-infinite-scroll'
 import { FacetsModule } from './facets/facets.module'
 import { FuzzySearchComponent } from './fuzzy-search/fuzzy-search.component'
 import { RecordsMetricsComponent } from './records-metrics/records-metrics.component'
@@ -37,6 +38,7 @@ import { ResultsHitsContainerComponent } from './results-hits-number/results-hit
     UiModule,
     GnApiModule,
     FacetsModule,
+    InfiniteScrollModule,
   ],
   exports: [
     SortByComponent,

--- a/libs/search/src/lib/state/actions.ts
+++ b/libs/search/src/lib/state/actions.ts
@@ -10,6 +10,9 @@ export const SET_FILTERS = '[Search] Set Filters'
 export const UPDATE_FILTERS = '[Search] Update Filters'
 export const SET_SEARCH = '[Search] Set overall search configuration'
 export const SET_SORT_BY = '[Search] Sort By'
+export const SET_PAGINATION = '[Search] Set pagination'
+export const PAGINATE = '[Search] Paginate'
+export const SCROLL = '[Search] Scroll'
 export const SET_RESULTS_LAYOUT = '[Search] Set results layout'
 export const ADD_RESULTS = '[Search] Add Results'
 export const CLEAR_RESULTS = '[Search] Clear Results'
@@ -44,8 +47,22 @@ export class SetSearch implements Action {
 
 export class SetSortBy implements Action {
   readonly type = SET_SORT_BY
-
   constructor(public sortBy: string) {}
+}
+
+export class SetPagination implements Action {
+  readonly type = SET_PAGINATION
+  constructor(public from: number, public size: number) {}
+}
+
+export class Paginate implements Action {
+  readonly type = PAGINATE
+  constructor(public delta: number) {}
+}
+
+export class Scroll implements Action {
+  readonly type = SCROLL
+  constructor() {}
 }
 
 export class SetResultsLayout implements Action {
@@ -114,6 +131,9 @@ export type SearchActions =
   | UpdateFilters
   | SetSearch
   | SetSortBy
+  | SetPagination
+  | Paginate
+  | Scroll
   | SetResultsLayout
   | AddResults
   | ClearResults

--- a/libs/search/src/lib/state/effects.spec.ts
+++ b/libs/search/src/lib/state/effects.spec.ts
@@ -3,6 +3,7 @@ import { AuthService } from '@lib/auth'
 import { SearchApiService } from '@lib/gn-api'
 import {
   ElasticsearchMapper,
+  Scroll,
   SetIncludeOnAggregation,
   UpdateRequestAggregationTerm,
 } from '@lib/search'
@@ -125,6 +126,16 @@ describe('Effects', () => {
       })
 
       expect(effects.clearResults$).toBeObservable(expected)
+    })
+  })
+
+  describe('scroll$', () => {
+    it('clear results list on sortBy action', () => {
+      actions$ = hot('-a---', { a: new Scroll() })
+      const expected = hot('-(b)', {
+        b: new RequestMoreResults(),
+      })
+      expect(effects.scroll$).toBeObservable(expected)
     })
   })
 

--- a/libs/search/src/lib/state/effects.ts
+++ b/libs/search/src/lib/state/effects.ts
@@ -27,6 +27,9 @@ import {
   UpdateRequestAggregationTerm,
   SET_INCLUDE_ON_AGGREGATION,
   SetIncludeOnAggregation,
+  PAGINATE,
+  SCROLL,
+  SET_PAGINATION,
 } from './actions'
 import { SearchState } from './reducer'
 import { getSearchState } from './selectors'
@@ -44,8 +47,22 @@ export class SearchEffects {
 
   clearResults$ = createEffect(() =>
     this.actions$.pipe(
-      ofType(SET_SORT_BY, SET_FILTERS, UPDATE_FILTERS, SET_SEARCH),
+      ofType(
+        SET_SORT_BY,
+        SET_FILTERS,
+        UPDATE_FILTERS,
+        SET_SEARCH,
+        SET_PAGINATION,
+        PAGINATE
+      ),
       switchMap(() => of(new ClearResults(), new RequestMoreResults()))
+    )
+  )
+
+  scroll$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(SCROLL),
+      map(() => new RequestMoreResults())
     )
   )
 

--- a/libs/search/src/lib/state/reducer.spec.ts
+++ b/libs/search/src/lib/state/reducer.spec.ts
@@ -92,11 +92,37 @@ describe('Search Reducer', () => {
     })
   })
 
-  describe('SortBy action', () => {
+  describe('SetSortBy action', () => {
     it('should set sort by params', () => {
       const action = new fromActions.SetSortBy('fieldA')
       const state = reducer(initialState, action)
       expect(state.params.sortBy).toEqual('fieldA')
+    })
+  })
+
+  describe('SetPagination action', () => {
+    it('should set from and size', () => {
+      const action = new fromActions.SetPagination(12, 15)
+      const state = reducer(initialState, action)
+      expect(state.params.from).toEqual(12)
+      expect(state.params.size).toEqual(15)
+    })
+  })
+
+  describe('Paginate action', () => {
+    it('should set from property and keep size', () => {
+      const action = new fromActions.Paginate(30)
+      const state = reducer(initialState, action)
+      expect(state.params.from).toEqual(30)
+      expect(state.params.size).toEqual(10)
+    })
+  })
+  describe('Scroll action', () => {
+    it('increment `from` property with `size` value', () => {
+      const action = new fromActions.Scroll()
+      const state = reducer(initialState, action)
+      expect(state.params.from).toEqual(10)
+      expect(state.params.size).toEqual(10)
     })
   })
 

--- a/libs/search/src/lib/state/reducer.ts
+++ b/libs/search/src/lib/state/reducer.ts
@@ -1,5 +1,4 @@
 import { RecordSummary, SearchFilters } from '@lib/common'
-import { UPDATE_REQUEST_AGGREGATION_TERM } from './actions'
 import * as fromActions from './actions'
 
 export const SEARCH_FEATURE_KEY = 'searchState'
@@ -81,6 +80,29 @@ export function reducer(
         params: {
           ...state.params,
           sortBy: action.sortBy,
+        },
+      }
+    }
+    case fromActions.SET_PAGINATION: {
+      const { from, size } = action
+      return {
+        ...state,
+        params: {
+          ...state.params,
+          from,
+          size,
+        },
+      }
+    }
+    case fromActions.SCROLL:
+    case fromActions.PAGINATE: {
+      const delta = (action as Paginate).delta || state.params.size
+      const from = Math.max(0, state.params.from + delta)
+      return {
+        ...state,
+        params: {
+          ...state.params,
+          from,
         },
       }
     }

--- a/libs/search/src/lib/state/reducer.ts
+++ b/libs/search/src/lib/state/reducer.ts
@@ -7,6 +7,7 @@ export interface SearchStateParams {
   filters?: SearchFilters
   sortBy?: string
   size?: number
+  from?: number
 }
 
 export interface SearchState {
@@ -31,6 +32,7 @@ export const initialState: SearchState = {
   params: {
     filters: {},
     size: 10,
+    from: 0,
   },
   results: {
     hits: null,

--- a/libs/search/src/lib/state/reducer.ts
+++ b/libs/search/src/lib/state/reducer.ts
@@ -1,4 +1,5 @@
 import { RecordSummary, SearchFilters } from '@lib/common'
+import { Paginate } from './actions'
 import * as fromActions from './actions'
 
 export const SEARCH_FEATURE_KEY = 'searchState'

--- a/libs/search/src/lib/state/search.facade.ts
+++ b/libs/search/src/lib/state/search.facade.ts
@@ -1,18 +1,33 @@
 import { Injectable } from '@angular/core'
-import { Store } from '@ngrx/store'
+import { ResultsListLayout } from '@lib/common'
+import { select, Store } from '@ngrx/store'
 import {
+  Paginate,
   RequestMoreOnAggregation,
   RequestMoreResults,
+  Scroll,
   SetConfigAggregations,
   SetIncludeOnAggregation,
+  SetPagination,
+  SetResultsLayout,
 } from './actions'
 import { SearchState } from './reducer'
+import {
+  getSearchResults,
+  getSearchResultsLayout,
+  getSearchResultsLoading,
+} from './selectors'
 
 @Injectable({
   providedIn: 'root',
 })
 export class SearchFacade {
+  results$ = this.store.pipe(select(getSearchResults))
+  layout$ = this.store.pipe(select(getSearchResultsLayout))
+  isLoading$ = this.store.pipe(select(getSearchResultsLoading))
+
   constructor(private store: Store<SearchState>) {}
+
   setConfigAggregations(config: any): void {
     this.store.dispatch(new SetConfigAggregations(config))
   }
@@ -23,6 +38,10 @@ export class SearchFacade {
 
   requestMoreOnAggregation(key: string, increment: number): void {
     this.store.dispatch(new RequestMoreOnAggregation(key, increment))
+  }
+
+  setResultsLayout(layout: ResultsListLayout): void {
+    this.store.dispatch(new SetResultsLayout(layout))
   }
 
   setIncludeOnAggregation(key: string, include: string): void {

--- a/libs/search/src/lib/state/search.facade.ts
+++ b/libs/search/src/lib/state/search.facade.ts
@@ -28,4 +28,16 @@ export class SearchFacade {
   setIncludeOnAggregation(key: string, include: string): void {
     this.store.dispatch(new SetIncludeOnAggregation(key, include))
   }
+
+  setPagination(from: number, size: number): void {
+    this.store.dispatch(new SetPagination(from, size))
+  }
+
+  paginate(delta: number): void {
+    this.store.dispatch(new Paginate(delta))
+  }
+
+  scroll(): void {
+    this.store.dispatch(new Scroll())
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4005,6 +4005,11 @@
         }
       }
     },
+    "@scarf/scarf": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.1.0.tgz",
+      "integrity": "sha512-b2iE8kjjzzUo2WZ0xuE2N77kfnTds7ClrDxcz3Atz7h2XrNVoAPUoT75i7CY0st5x++70V91Y+c6RpBX9MX7Jg=="
+    },
     "@schematics/angular": {
       "version": "10.0.8",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-10.0.8.tgz",
@@ -16869,6 +16874,15 @@
         }
       }
     },
+    "ngx-infinite-scroll": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-infinite-scroll/-/ngx-infinite-scroll-10.0.1.tgz",
+      "integrity": "sha512-7is0eJZ9kJPsaHohRmMhJ/QFHAW9jp9twO5HcHRvFM/Yl/R8QCiokgjwmH0/CR3MuxUanxfHZMfO3PbYTwlBEg==",
+      "requires": {
+        "@scarf/scarf": "^1.1.0",
+        "opencollective-postinstall": "^2.0.2"
+      }
+    },
     "ngx-translate-messageformat-compiler": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/ngx-translate-messageformat-compiler/-/ngx-translate-messageformat-compiler-4.8.0.tgz",
@@ -17573,6 +17587,11 @@
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
       }
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
     },
     "opener": {
       "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "mydatepicker": "^9.0.2",
     "ngx-chips": "^2.2.2",
     "ngx-dropzone": "^2.2.2",
+    "ngx-infinite-scroll": "^10.0.1",
     "ngx-translate-messageformat-compiler": "^4.8.0",
     "ol": "^5.3.3",
     "parse5": "^6.0.0",

--- a/webcomponents/src/app/components/gn-results-list/gn-results-list.component.ts
+++ b/webcomponents/src/app/components/gn-results-list/gn-results-list.component.ts
@@ -42,7 +42,7 @@ export class GnResultsListComponent extends BaseComponent {
 
   private setSearch_() {
     this.store.dispatch(
-      new SetSearch({ filters: { any: this.filter }, size: this.size })
+      new SetSearch({ filters: { any: this.filter }, size: this.size, from: 0 })
     )
   }
 


### PR DESCRIPTION
Add infinite scrolling in search application.
It is based on the third party library https://github.com/orizens/ngx-infinite-scroll

The `results-list-container` take a `scrollable-options` attribute to configure the scrolling behavior.
Passing `{ disabled: true }` will disable the scrolling.
It is now the default behavior in search application and gn-results-list web component.

Demo: https://geonetwork.github.io/geonetwork-ui/infinite-scroll/demo/webcomponents/gn-facets.sample.html
