### PR TITLE
Allow multiple searches in the state

### DIFF
--- a/apps/search/src/app/app.component.html
+++ b/apps/search/src/app/app.component.html
@@ -1,24 +1,8 @@
-<div>
-  <div class="p-4">
-    <catalog-site-title></catalog-site-title>
-  </div>
-  <search-records-metrics field="tag" count="20"></search-records-metrics>
-  <div class="mb-3 mx-4 rounded flex flex-row">
-    <div class="w-2/4 mr-3">
-      <search-fuzzy-search></search-fuzzy-search>
-    </div>
-    <div class="w-1/4 mr-3">
-      <search-sort-by></search-sort-by>
-    </div>
-    <div class="flex-grow">
-      <search-results-layout></search-results-layout>
-    </div>
-  </div>
-  <div class="flex flex-row">
-    <search-facets-container class="w-1/4"></search-facets-container>
-    <div class="w-3/4">
-      <search-results-hits></search-results-hits>
-      <search-results-list-container></search-results-list-container>
-    </div>
-  </div>
+<div class="p-4">
+  <catalog-site-title></catalog-site-title>
+</div>
+<search-records-metrics field="tag" count="20"></search-records-metrics>
+
+<div searchSearchStateContainer="mainSearch">
+  <app-main-search></app-main-search>
 </div>

--- a/apps/search/src/app/app.component.spec.ts
+++ b/apps/search/src/app/app.component.spec.ts
@@ -1,29 +1,9 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { async, TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
-import { BootstrapService } from '@lib/common'
-import { SearchFacade } from '@lib/search'
 import { EffectsModule } from '@ngrx/effects'
 import { StoreModule } from '@ngrx/store'
-import { of } from 'rxjs'
 import { AppComponent } from './app.component'
-
-const configFacetMock = {
-  mods: {
-    search: {
-      facetConfig: {
-        tag: {},
-      },
-    },
-  },
-}
-const boostrapServiceMock = {
-  uiConfReady: jest.fn(() => of(configFacetMock)),
-}
-const searchFacadeMock = {
-  setConfigAggregations: jest.fn(),
-  requestMoreResults: jest.fn(),
-}
 
 describe('AppComponent', () => {
   beforeEach(async(() => {
@@ -35,16 +15,6 @@ describe('AppComponent', () => {
       ],
       declarations: [AppComponent],
       schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        {
-          provide: BootstrapService,
-          useValue: boostrapServiceMock,
-        },
-        {
-          provide: SearchFacade,
-          useValue: searchFacadeMock,
-        },
-      ],
     }).compileComponents()
   }))
 

--- a/apps/search/src/app/app.component.ts
+++ b/apps/search/src/app/app.component.ts
@@ -1,7 +1,5 @@
 import { Component, OnInit } from '@angular/core'
-import { BootstrapService, ColorService } from '@lib/common'
-import { SearchFacade } from '@lib/search'
-import { map, pluck, take, tap } from 'rxjs/operators'
+import { ColorService } from '@lib/common'
 
 @Component({
   selector: 'app-root',
@@ -11,24 +9,9 @@ import { map, pluck, take, tap } from 'rxjs/operators'
 export class AppComponent implements OnInit {
   title = 'search'
 
-  constructor(
-    private bootstrap: BootstrapService,
-    private searchFacade: SearchFacade
-  ) {
+  constructor() {
     ColorService.applyCssVariables('#e73f51', '#c2e9dc', '#212029', '#fdfbff')
   }
 
-  ngOnInit(): void {
-    this.bootstrap
-      .uiConfReady('srv')
-      .pipe(
-        take(1),
-        map((config) => config.mods.search.facetConfig),
-        tap((aggregationsConfig) => {
-          this.searchFacade.setConfigAggregations(aggregationsConfig)
-          this.searchFacade.requestMoreResults()
-        })
-      )
-      .subscribe()
-  }
+  ngOnInit(): void {}
 }

--- a/apps/search/src/app/app.module.ts
+++ b/apps/search/src/app/app.module.ts
@@ -13,13 +13,14 @@ import { storeFreeze } from 'ngrx-store-freeze'
 import { environment } from '../environments/environment'
 import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
+import { MainSearchComponent } from './main-search/main-search.component'
 
 export const metaReducers: MetaReducer<any>[] = !environment.production
   ? [storeFreeze]
   : []
 
 @NgModule({
-  declarations: [AppComponent],
+  declarations: [AppComponent, MainSearchComponent],
   imports: [
     BrowserModule,
     AppRoutingModule,

--- a/apps/search/src/app/main-search/main-search.component.html
+++ b/apps/search/src/app/main-search/main-search.component.html
@@ -1,0 +1,18 @@
+<div class="mb-3 mx-4 rounded flex flex-row">
+  <div class="w-2/4 mr-3">
+    <search-fuzzy-search></search-fuzzy-search>
+  </div>
+  <div class="w-1/4 mr-3">
+    <search-sort-by></search-sort-by>
+  </div>
+  <div class="flex-grow">
+    <search-results-layout></search-results-layout>
+  </div>
+</div>
+<div class="flex flex-row">
+  <search-facets-container class="w-1/4"></search-facets-container>
+  <div class="w-3/4">
+    <search-results-hits></search-results-hits>
+    <search-results-list-container></search-results-list-container>
+  </div>
+</div>

--- a/apps/search/src/app/main-search/main-search.component.spec.ts
+++ b/apps/search/src/app/main-search/main-search.component.spec.ts
@@ -1,0 +1,58 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core'
+import { async, ComponentFixture, TestBed } from '@angular/core/testing'
+import { RouterTestingModule } from '@angular/router/testing'
+import { BootstrapService } from '@lib/common'
+import { SearchFacade } from '@lib/search'
+import { EffectsModule } from '@ngrx/effects'
+import { StoreModule } from '@ngrx/store'
+import { of } from 'rxjs'
+import { AppComponent } from '../app.component'
+
+import { MainSearchComponent } from './main-search.component'
+
+const configFacetMock = {
+  mods: {
+    search: {
+      facetConfig: {
+        tag: {},
+      },
+    },
+  },
+}
+const boostrapServiceMock = {
+  uiConfReady: jest.fn(() => of(configFacetMock)),
+}
+const searchFacadeMock = {
+  setConfigAggregations: jest.fn(),
+  requestMoreResults: jest.fn(),
+}
+
+describe('MainSearchComponent', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        RouterTestingModule,
+        EffectsModule.forRoot(),
+        StoreModule.forRoot({}),
+      ],
+      declarations: [AppComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        {
+          provide: BootstrapService,
+          useValue: boostrapServiceMock,
+        },
+        {
+          provide: SearchFacade,
+          useValue: searchFacadeMock,
+        },
+      ],
+    }).compileComponents()
+  }))
+
+  it('should create the app', () => {
+    const fixture = TestBed.createComponent(AppComponent)
+    const app = fixture.componentInstance
+    expect(app).toBeTruthy()
+  })
+})

--- a/apps/search/src/app/main-search/main-search.component.ts
+++ b/apps/search/src/app/main-search/main-search.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core'
+import { BootstrapService } from '@lib/common'
+import { SearchFacade } from '@lib/search'
+import { map, take, tap } from 'rxjs/operators'
+
+@Component({
+  selector: 'app-main-search',
+  templateUrl: './main-search.component.html',
+  styleUrls: ['./main-search.component.scss'],
+})
+export class MainSearchComponent implements OnInit {
+  constructor(
+    private bootstrap: BootstrapService,
+    private searchFacade: SearchFacade
+  ) {}
+
+  ngOnInit(): void {
+    this.bootstrap
+      .uiConfReady('srv')
+      .pipe(
+        take(1),
+        map((config) => config.mods.search.facetConfig),
+        tap((aggregationsConfig) => {
+          this.searchFacade.setConfigAggregations(aggregationsConfig)
+          this.searchFacade.requestMoreResults()
+        })
+      )
+      .subscribe()
+  }
+}

--- a/libs/search/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -1,4 +1,10 @@
-import { ElasticsearchService, initialState } from '@lib/search'
+import {
+  DEFAULT_SEARCH_KEY,
+  ElasticsearchService,
+  initialState,
+} from '@lib/search'
+
+const initialStateSearch = initialState[DEFAULT_SEARCH_KEY]
 
 describe('ElasticsearchService', () => {
   let service: ElasticsearchService
@@ -15,7 +21,7 @@ describe('ElasticsearchService', () => {
   describe('#Sort', () => {
     it('One sort and default direction', () => {
       const body = service.buildPayload({
-        ...initialState,
+        ...initialStateSearch,
         params: {
           filters: {
             any: '',
@@ -28,7 +34,7 @@ describe('ElasticsearchService', () => {
 
     it('One sort and DESC direction', () => {
       const body = service.buildPayload({
-        ...initialState,
+        ...initialStateSearch,
         params: {
           filters: {
             any: '',
@@ -41,7 +47,7 @@ describe('ElasticsearchService', () => {
 
     it('Multiple sorts', () => {
       const body = service.buildPayload({
-        ...initialState,
+        ...initialStateSearch,
         params: {
           filters: {
             any: '',

--- a/libs/search/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core'
 import { SortParams } from '@lib/common'
 import { NameList, SearchParams } from 'elasticsearch'
-import { SearchState } from '../state/reducer'
+import { SearchState, SearchStateSearch } from '../state/reducer'
 import { ElasticsearchMetadataModels, ElasticSearchSources } from './constant'
 
 @Injectable({
@@ -10,13 +10,16 @@ import { ElasticsearchMetadataModels, ElasticSearchSources } from './constant'
 export class ElasticsearchService {
   constructor() {}
 
-  search(state: SearchState, model: ElasticsearchMetadataModels): SearchParams {
+  search(
+    state: SearchStateSearch,
+    model: ElasticsearchMetadataModels
+  ): SearchParams {
     const payload = this.buildPayload(state)
     payload._source = ElasticSearchSources[model]
     return payload
   }
 
-  buildPayload(state: SearchState): SearchParams {
+  buildPayload(state: SearchStateSearch): SearchParams {
     const { size, sortBy, from } = state.params
     const sort: SortParams = sortBy
       ? sortBy.split(',').map((s) => {
@@ -38,7 +41,10 @@ export class ElasticsearchService {
     return payload
   }
 
-  buildMoreOnAggregationPayload(state: SearchState, key: string): SearchParams {
+  buildMoreOnAggregationPayload(
+    state: SearchStateSearch,
+    key: string
+  ): SearchParams {
     const payload = {
       aggregations: { [key]: state.config.aggregations[key] },
       size: 0,
@@ -47,7 +53,7 @@ export class ElasticsearchService {
     return payload
   }
 
-  partialBuildQuery(state: SearchState) {
+  partialBuildQuery(state: SearchStateSearch) {
     const filters = state.params.filters
     const { any, ...searchFilters } = filters
     const queryFilters = this.facetsToLuceneQuery(searchFilters)

--- a/libs/search/src/lib/facets/facets-container/facets-container.component.spec.ts
+++ b/libs/search/src/lib/facets/facets-container/facets-container.component.spec.ts
@@ -2,10 +2,8 @@ import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 import { SearchFilters } from '@lib/common'
 import { SearchFacade } from '@lib/search'
-import { EffectsModule } from '@ngrx/effects'
-import { StoreModule } from '@ngrx/store'
+import { of } from 'rxjs'
 import { SEARCH_STATE_FILTERS_FIXTURE } from '../../state/fixtures/search-state.fixtures'
-import { initialState, reducer, SEARCH_FEATURE_KEY } from '../../state/reducer'
 
 import { FacetsContainerComponent } from './facets-container.component'
 
@@ -14,6 +12,9 @@ const searchFacadeMock = {
   requestMoreResults: jest.fn(),
   setIncludeOnAggregation: jest.fn(),
   requestMoreOnAggregation: jest.fn(),
+  searchFilters$: of({}),
+  configAggregations$: of({}),
+  resultsAggregations$: of({}),
 }
 
 describe('FacetsContainerComponent', () => {
@@ -24,13 +25,7 @@ describe('FacetsContainerComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [FacetsContainerComponent],
-      imports: [
-        EffectsModule.forRoot(),
-        StoreModule.forRoot({}),
-        StoreModule.forFeature(SEARCH_FEATURE_KEY, reducer, {
-          initialState,
-        }),
-      ],
+      imports: [],
       providers: [
         {
           provide: SearchFacade,

--- a/libs/search/src/lib/results-hits-number/results-hits.container.component.html
+++ b/libs/search/src/lib/results-hits-number/results-hits.container.component.html
@@ -1,4 +1,4 @@
 <ui-results-hits-number
-  [loading]="loading$ | async"
-  [hits]="hits$ | async"
+  [loading]="facade.isLoading$ | async"
+  [hits]="facade.resultsHits$ | async"
 ></ui-results-hits-number>

--- a/libs/search/src/lib/results-hits-number/results-hits.container.component.spec.ts
+++ b/libs/search/src/lib/results-hits-number/results-hits.container.component.spec.ts
@@ -1,11 +1,11 @@
+import { Component, DebugElement, Input, NO_ERRORS_SCHEMA } from '@angular/core'
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
+import { SearchFacade } from '@lib/search'
+import { TranslateModule } from '@ngx-translate/core'
+import { of } from 'rxjs'
 
 import { ResultsHitsContainerComponent } from './results-hits.container.component'
-import { Component, DebugElement, Input, NO_ERRORS_SCHEMA } from '@angular/core'
-import { TranslateModule } from '@ngx-translate/core'
-import { StoreModule } from '@ngrx/store'
-import { initialState, reducer, SEARCH_FEATURE_KEY } from '@lib/search'
 
 @Component({
   selector: 'ui-results-hits-number',
@@ -14,6 +14,11 @@ import { initialState, reducer, SEARCH_FEATURE_KEY } from '@lib/search'
 class ResultsHitsNumberComponentMock {
   @Input() hits
   @Input() loading: boolean
+}
+
+const searchFacadeMock = {
+  isLoading$: of(false),
+  resultsHits$: of(null),
 }
 
 describe('ResultsHitsContainerComponent', () => {
@@ -28,12 +33,12 @@ describe('ResultsHitsContainerComponent', () => {
         ResultsHitsContainerComponent,
         ResultsHitsNumberComponentMock,
       ],
-      imports: [
-        StoreModule.forRoot({}),
-        StoreModule.forFeature(SEARCH_FEATURE_KEY, reducer, {
-          initialState,
-        }),
-        TranslateModule.forRoot(),
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        {
+          provide: SearchFacade,
+          useValue: searchFacadeMock,
+        },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents()

--- a/libs/search/src/lib/results-hits-number/results-hits.container.component.ts
+++ b/libs/search/src/lib/results-hits-number/results-hits.container.component.ts
@@ -1,20 +1,11 @@
 import { Component, OnInit } from '@angular/core'
-import { select, Store } from '@ngrx/store'
-import {
-  getSearchResultsHits,
-  getSearchResultsLoading,
-} from '../state/selectors'
-import { SearchState } from '../state/reducer'
+import { SearchFacade } from '../state/search.facade'
 
 @Component({
   selector: 'search-results-hits',
   templateUrl: './results-hits.container.component.html',
 })
 export class ResultsHitsContainerComponent implements OnInit {
-  hits$ = this.store.pipe(select(getSearchResultsHits))
-  loading$ = this.store.pipe(select(getSearchResultsLoading))
-
-  constructor(private store: Store<SearchState>) {}
-
+  constructor(public facade: SearchFacade) {}
   ngOnInit(): void {}
 }

--- a/libs/search/src/lib/results-layout/results-layout.component.html
+++ b/libs/search/src/lib/results-layout/results-layout.component.html
@@ -3,5 +3,5 @@
   [ariaName]="'results.layout.selectOne' | translate"
   [choices]="choices"
   (selectValue)="change($event)"
-  [selected]="currentLayout$ | async"
+  [selected]="searchFacade.layout$ | async"
 ></ui-dropdown-selector>

--- a/libs/search/src/lib/results-layout/results-layout.component.spec.ts
+++ b/libs/search/src/lib/results-layout/results-layout.component.spec.ts
@@ -1,26 +1,55 @@
+import {
+  Component,
+  DebugElement,
+  EventEmitter,
+  Input,
+  NO_ERRORS_SCHEMA,
+  Output,
+} from '@angular/core'
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
-import { UiModule } from '@lib/ui'
+import { By } from '@angular/platform-browser'
+import { SearchFacade } from '@lib/search'
 import { TranslateModule } from '@ngx-translate/core'
-import { initialState, reducer, SEARCH_FEATURE_KEY } from '../state/reducer'
+import { of } from 'rxjs'
 import { ResultsLayoutComponent } from './results-layout.component'
-import { EffectsModule } from '@ngrx/effects'
-import { StoreModule } from '@ngrx/store'
+
+@Component({
+  selector: 'ui-dropdown-selector',
+  template: '',
+})
+class DropdownSelectorMockComponent {
+  @Input() title: string
+  @Input() showTitle = true
+  @Input() ariaName: string
+  @Input() choices: {
+    value: any
+    label: string
+  }[]
+  @Input() selected: any
+  @Output() selectValue = new EventEmitter<any>()
+}
+
+const searchFacadeMock = {
+  layout$: of('CARD'),
+  setResultsLayout: jest.fn(),
+}
 
 describe('ResultsLayoutComponent', () => {
   let component: ResultsLayoutComponent
   let fixture: ComponentFixture<ResultsLayoutComponent>
+  let de: DebugElement
+  let items: DebugElement[]
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ResultsLayoutComponent],
-      imports: [
-        UiModule,
-        EffectsModule.forRoot(),
-        TranslateModule.forRoot(),
-        StoreModule.forRoot({}),
-        StoreModule.forFeature(SEARCH_FEATURE_KEY, reducer, {
-          initialState,
-        }),
+      declarations: [ResultsLayoutComponent, DropdownSelectorMockComponent],
+      imports: [TranslateModule.forRoot()],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        {
+          provide: SearchFacade,
+          useValue: searchFacadeMock,
+        },
       ],
     }).compileComponents()
   }))
@@ -28,10 +57,36 @@ describe('ResultsLayoutComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ResultsLayoutComponent)
     component = fixture.componentInstance
+    de = fixture.debugElement
+    items = de.queryAll(By.directive(DropdownSelectorMockComponent))
     fixture.detectChanges()
   })
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  it('init list from state', () => {
+    const uiComponent = items[0]
+    expect(uiComponent).toBeTruthy()
+    expect(uiComponent.componentInstance.selected).toBe('CARD')
+    expect(uiComponent.componentInstance.choices).toEqual([
+      {
+        label: 'CARD',
+        value: 'CARD',
+      },
+      { label: 'LIST', value: 'LIST' },
+      {
+        label: 'TEXT',
+        value: 'TEXT',
+      },
+      { label: 'TITLE', value: 'TITLE' },
+    ])
+  })
+
+  it('dispatch action on change', () => {
+    const uiComponent = items[0]
+    uiComponent.componentInstance.selectValue.emit('TITLE')
+    expect(searchFacadeMock.setResultsLayout).toHaveBeenCalledWith('TITLE')
   })
 })

--- a/libs/search/src/lib/results-layout/results-layout.component.ts
+++ b/libs/search/src/lib/results-layout/results-layout.component.ts
@@ -14,13 +14,10 @@ export class ResultsLayoutComponent implements OnInit {
       value: v,
     }
   })
-  currentLayout$: Observable<string>
 
-  constructor(private searchFacade: SearchFacade) {}
+  constructor(public searchFacade: SearchFacade) {}
 
-  ngOnInit(): void {
-    this.currentLayout$ = this.searchFacade.layout$
-  }
+  ngOnInit(): void {}
 
   change(layout: any) {
     this.searchFacade.setResultsLayout(layout)

--- a/libs/search/src/lib/results-layout/results-layout.component.ts
+++ b/libs/search/src/lib/results-layout/results-layout.component.ts
@@ -1,9 +1,7 @@
 import { Component, OnInit } from '@angular/core'
-import { select, Store } from '@ngrx/store'
-import { SetResultsLayout } from '../state/actions'
-import { SearchState } from '../state/reducer'
-import { getSearchResultsLayout } from '../state/selectors'
 import { ResultsListLayout } from '@lib/common'
+import { Observable } from 'rxjs'
+import { SearchFacade } from '../state/search.facade'
 
 @Component({
   selector: 'search-results-layout',
@@ -16,13 +14,15 @@ export class ResultsLayoutComponent implements OnInit {
       value: v,
     }
   })
-  currentLayout$ = this.store.pipe(select(getSearchResultsLayout))
+  currentLayout$: Observable<string>
 
-  constructor(private store: Store<SearchState>) {}
+  constructor(private searchFacade: SearchFacade) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.currentLayout$ = this.searchFacade.layout$
+  }
 
   change(layout: any) {
-    this.store.dispatch(new SetResultsLayout(layout))
+    this.searchFacade.setResultsLayout(layout)
   }
 }

--- a/libs/search/src/lib/results-list/results-list.container.component.spec.ts
+++ b/libs/search/src/lib/results-list/results-list.container.component.spec.ts
@@ -1,31 +1,51 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core'
+import {
+  Component,
+  DebugElement,
+  EventEmitter,
+  Input,
+  NO_ERRORS_SCHEMA,
+  Output,
+} from '@angular/core'
 import { async, ComponentFixture, TestBed } from '@angular/core/testing'
-import { I18nModule } from '@lib/common'
-import { UiModule } from '@lib/ui'
-
-import { EffectsModule } from '@ngrx/effects'
-import { StoreModule } from '@ngrx/store'
-import { TranslateModule } from '@ngx-translate/core'
-import { initialState, reducer, SEARCH_FEATURE_KEY } from '../state/reducer'
+import { By } from '@angular/platform-browser'
+import { RecordSummary, ResultsListLayout } from '@lib/common'
+import { SearchFacade } from '@lib/search'
+import { of } from 'rxjs'
 import { ResultsListContainerComponent } from './results-list.container.component'
+
+@Component({
+  selector: 'ui-results-list',
+  template: '',
+})
+class ResultsListMockComponent {
+  @Input() records: RecordSummary[]
+  @Input() loading: boolean
+  @Input() layout: ResultsListLayout = ResultsListLayout.CARD
+}
+
+const searchFacadeMock = {
+  isLoading$: of(true),
+  results$: of(['one']),
+  layout$: of('CARD'),
+  setResultsLayout: jest.fn(),
+  scroll: jest.fn(),
+}
 
 describe('ResultsListContainerComponent', () => {
   let component: ResultsListContainerComponent
   let fixture: ComponentFixture<ResultsListContainerComponent>
+  let de: DebugElement
+  let items: DebugElement[]
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ResultsListContainerComponent],
+      declarations: [ResultsListContainerComponent, ResultsListMockComponent],
       schemas: [NO_ERRORS_SCHEMA],
-      imports: [
-        I18nModule,
-        TranslateModule.forRoot(),
-        UiModule,
-        EffectsModule.forRoot(),
-        StoreModule.forRoot({}),
-        StoreModule.forFeature(SEARCH_FEATURE_KEY, reducer, {
-          initialState,
-        }),
+      providers: [
+        {
+          provide: SearchFacade,
+          useValue: searchFacadeMock,
+        },
       ],
     }).compileComponents()
   }))
@@ -33,10 +53,27 @@ describe('ResultsListContainerComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ResultsListContainerComponent)
     component = fixture.componentInstance
+    de = fixture.debugElement
+    items = de.queryAll(By.directive(ResultsListMockComponent))
     fixture.detectChanges()
   })
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  it('init list from state', () => {
+    const uiComponent = items[0]
+    expect(uiComponent).toBeTruthy()
+    expect(searchFacadeMock.setResultsLayout).toHaveBeenCalledWith('CARD')
+
+    expect(uiComponent.componentInstance.loading).toBe(true)
+    expect(uiComponent.componentInstance.layout).toBe('CARD')
+    expect(uiComponent.componentInstance.records).toEqual(['one'])
+  })
+
+  it('scroll call facade', () => {
+    component.onScrollDown()
+    expect(searchFacadeMock.scroll).toHaveBeenCalled()
   })
 })

--- a/libs/search/src/lib/search.module.ts
+++ b/libs/search/src/lib/search.module.ts
@@ -16,6 +16,7 @@ import { SortByComponent } from './sort-by/sort-by.component'
 import { SearchEffects } from './state/effects'
 import { initialState, reducer, SEARCH_FEATURE_KEY } from './state/reducer'
 import { ResultsHitsContainerComponent } from './results-hits-number/results-hits.container.component'
+import { SearchStateContainerDirective } from './state/container/search-state.container.directive'
 
 @NgModule({
   declarations: [
@@ -25,6 +26,7 @@ import { ResultsHitsContainerComponent } from './results-hits-number/results-hit
     RecordsMetricsComponent,
     ResultsListContainerComponent,
     ResultsHitsContainerComponent,
+    SearchStateContainerDirective,
   ],
   imports: [
     CommonModule,
@@ -48,6 +50,7 @@ import { ResultsHitsContainerComponent } from './results-hits-number/results-hit
     ResultsListContainerComponent,
     ResultsHitsContainerComponent,
     FacetsModule,
+    SearchStateContainerDirective,
   ],
 })
 export class LibSearchModule {}

--- a/libs/search/src/lib/state/actions.ts
+++ b/libs/search/src/lib/state/actions.ts
@@ -6,6 +6,8 @@ import {
 import { Action } from '@ngrx/store'
 import { SearchStateParams } from './reducer'
 
+export const ADD_SEARCH = '[Search] Add search instance'
+
 export const SET_FILTERS = '[Search] Set Filters'
 export const UPDATE_FILTERS = '[Search] Update Filters'
 export const SET_SEARCH = '[Search] Set overall search configuration'
@@ -34,6 +36,11 @@ abstract class AbstractAction {
   protected constructor(id?: string) {
     this.id = id || DEFAULT_SEARCH_KEY
   }
+}
+
+export class AddSearch implements Action {
+  readonly type = ADD_SEARCH
+  constructor(public id: string) {}
 }
 
 export class SetFilters extends AbstractAction implements Action {
@@ -178,6 +185,7 @@ export class PatchResultsAggregations extends AbstractAction implements Action {
 }
 
 export type SearchActions =
+  | AddSearch
   | SetFilters
   | UpdateFilters
   | SetSearch

--- a/libs/search/src/lib/state/actions.ts
+++ b/libs/search/src/lib/state/actions.ts
@@ -27,103 +27,154 @@ export const UPDATE_REQUEST_AGGREGATION_TERM =
   '[Search] Update request aggregation term'
 export const PATCH_RESULTS_AGGREGATIONS = '[Search] Patch Results Aggregations'
 
-export class SetFilters implements Action {
+export const DEFAULT_SEARCH_KEY = 'default'
+
+abstract class AbstractAction {
+  id?: string
+  protected constructor(id?: string) {
+    this.id = id || DEFAULT_SEARCH_KEY
+  }
+}
+
+export class SetFilters extends AbstractAction implements Action {
   readonly type = SET_FILTERS
 
-  constructor(public payload: SearchFilters) {}
+  constructor(public payload: SearchFilters, id?: string) {
+    super(id)
+  }
 }
 
-export class UpdateFilters implements Action {
+export class UpdateFilters extends AbstractAction implements Action {
   readonly type = UPDATE_FILTERS
 
-  constructor(public payload: SearchFilters) {}
+  constructor(public payload: SearchFilters, id?: string) {
+    super(id)
+  }
 }
 
-export class SetSearch implements Action {
+export class SetSearch extends AbstractAction implements Action {
   readonly type = SET_SEARCH
 
-  constructor(public payload: SearchStateParams) {}
+  constructor(public payload: SearchStateParams, id?: string) {
+    super(id)
+  }
 }
 
-export class SetSortBy implements Action {
+export class SetSortBy extends AbstractAction implements Action {
   readonly type = SET_SORT_BY
-  constructor(public sortBy: string) {}
+  constructor(public sortBy: string, id?: string) {
+    super(id)
+  }
 }
 
-export class SetPagination implements Action {
+export class SetPagination extends AbstractAction implements Action {
   readonly type = SET_PAGINATION
-  constructor(public from: number, public size: number) {}
+  constructor(public from: number, public size: number, id?: string) {
+    super(id)
+  }
 }
 
-export class Paginate implements Action {
+export class Paginate extends AbstractAction implements Action {
   readonly type = PAGINATE
-  constructor(public delta: number) {}
+  constructor(public delta: number, id?: string) {
+    super(id)
+  }
 }
 
-export class Scroll implements Action {
+export class Scroll extends AbstractAction implements Action {
   readonly type = SCROLL
-  constructor() {}
+  constructor(id?: string) {
+    super(id)
+  }
 }
 
-export class SetResultsLayout implements Action {
+export class SetResultsLayout extends AbstractAction implements Action {
   readonly type = SET_RESULTS_LAYOUT
 
-  constructor(public resultsLayout: string) {}
+  constructor(public resultsLayout: string, id?: string) {
+    super(id)
+  }
 }
 
-export class AddResults implements Action {
+export class AddResults extends AbstractAction implements Action {
   readonly type = ADD_RESULTS
 
-  constructor(public payload: RecordSummary[]) {}
+  constructor(public payload: RecordSummary[], id?: string) {
+    super(id)
+  }
 }
 
-export class ClearResults implements Action {
+export class ClearResults extends AbstractAction implements Action {
   readonly type = CLEAR_RESULTS
 
-  constructor() {}
+  constructor(id?: string) {
+    super(id)
+  }
 }
 
-export class RequestMoreResults implements Action {
+export class RequestMoreResults extends AbstractAction implements Action {
   readonly type = REQUEST_MORE_RESULTS
 
-  constructor() {}
+  constructor(id?: string) {
+    super(id)
+  }
 }
 
-export class SetResultsAggregations implements Action {
+export class SetResultsAggregations extends AbstractAction implements Action {
   readonly type = SET_RESULTS_AGGREGATIONS
 
-  constructor(public payload: any) {}
+  constructor(public payload: any, id?: string) {
+    super(id)
+  }
 }
 
-export class SetResultsHits implements Action {
+export class SetResultsHits extends AbstractAction implements Action {
   readonly type = SET_RESULTS_HITS
-  constructor(public payload: any) {}
+  constructor(public payload: any, id?: string) {
+    super(id)
+  }
 }
 
-export class SetConfigAggregations implements Action {
+export class SetConfigAggregations extends AbstractAction implements Action {
   readonly type = SET_CONFIG_AGGREGATIONS
-  constructor(public payload: any) {}
+  constructor(public payload: any, id?: string) {
+    super(id)
+  }
 }
 
-export class RequestMoreOnAggregation implements Action {
+export class RequestMoreOnAggregation extends AbstractAction implements Action {
   readonly type = REQUEST_MORE_ON_AGGREGATION
-  constructor(public key: string, public increment: number) {}
+  constructor(public key: string, public increment: number, id?: string) {
+    super(id)
+  }
 }
 
-export class SetIncludeOnAggregation implements Action {
+export class SetIncludeOnAggregation extends AbstractAction implements Action {
   readonly type = SET_INCLUDE_ON_AGGREGATION
-  constructor(public key: string, public include: string) {}
+  constructor(public key: string, public include: string, id?: string) {
+    super(id)
+  }
 }
 
-export class UpdateRequestAggregationTerm implements Action {
+export class UpdateRequestAggregationTerm
+  extends AbstractAction
+  implements Action {
   readonly type = UPDATE_REQUEST_AGGREGATION_TERM
-  constructor(public key: string, public patch: EsRequestAggTermPatch) {}
+  constructor(
+    public key: string,
+    public patch: EsRequestAggTermPatch,
+    id?: string
+  ) {
+    super(id)
+  }
 }
 
-export class PatchResultsAggregations implements Action {
+export class PatchResultsAggregations extends AbstractAction implements Action {
   readonly type = PATCH_RESULTS_AGGREGATIONS
 
-  constructor(public key: string, public payload: any) {}
+  constructor(public key: string, public payload: any, id?: string) {
+    super(id)
+  }
 }
 
 export type SearchActions =

--- a/libs/search/src/lib/state/container/search-state.container.directive.spec.ts
+++ b/libs/search/src/lib/state/container/search-state.container.directive.spec.ts
@@ -1,0 +1,21 @@
+import { SearchStateContainerDirective } from './search-state.container.directive'
+
+const searchFacadeMock: any = {
+  init: jest.fn(),
+}
+
+describe('SearchStateContainerDirective', () => {
+  let directive: SearchStateContainerDirective
+  beforeEach(() => {
+    directive = new SearchStateContainerDirective(searchFacadeMock)
+    directive.searchId = 'main'
+  })
+  it('should create an instance', () => {
+    expect(directive).toBeTruthy()
+  })
+
+  it('should create an instance', () => {
+    directive.ngOnInit()
+    expect(searchFacadeMock.init).toHaveBeenCalledWith('main')
+  })
+})

--- a/libs/search/src/lib/state/container/search-state.container.directive.ts
+++ b/libs/search/src/lib/state/container/search-state.container.directive.ts
@@ -1,0 +1,16 @@
+import { Directive, Host, Input, OnInit } from '@angular/core'
+import { SearchFacade } from '../search.facade'
+
+@Directive({
+  selector: '[searchSearchStateContainer]',
+  providers: [SearchFacade],
+})
+export class SearchStateContainerDirective implements OnInit {
+  @Input('searchSearchStateContainer') searchId: string
+
+  constructor(@Host() private facade: SearchFacade) {}
+
+  ngOnInit(): void {
+    this.facade.init(this.searchId)
+  }
+}

--- a/libs/search/src/lib/state/effects.spec.ts
+++ b/libs/search/src/lib/state/effects.spec.ts
@@ -1,12 +1,13 @@
 import { TestBed } from '@angular/core/testing'
 import { AuthService } from '@lib/auth'
 import { SearchApiService } from '@lib/gn-api'
+import { ElasticsearchMapper } from '../elasticsearch/elasticsearch.mapper'
 import {
-  ElasticsearchMapper,
+  DEFAULT_SEARCH_KEY,
   Scroll,
   SetIncludeOnAggregation,
   UpdateRequestAggregationTerm,
-} from '@lib/search'
+} from './actions'
 import { EffectsModule } from '@ngrx/effects'
 import { provideMockActions } from '@ngrx/effects/testing'
 import { StoreModule } from '@ngrx/store'
@@ -29,10 +30,14 @@ import { SearchEffects } from './effects'
 import { ES_FIXTURE_AGGS_REQUEST } from '../elasticsearch/fixtures/aggregations-request'
 import { initialState, reducer, SEARCH_FEATURE_KEY } from './reducer'
 
+const initialStateSearchMock = initialState[DEFAULT_SEARCH_KEY]
 const initialStateMock = {
   ...initialState,
-  config: {
-    aggregations: ES_FIXTURE_AGGS_REQUEST,
+  [DEFAULT_SEARCH_KEY]: {
+    ...initialStateSearchMock,
+    config: {
+      aggregations: ES_FIXTURE_AGGS_REQUEST,
+    },
   },
 }
 

--- a/libs/search/src/lib/state/effects.spec.ts
+++ b/libs/search/src/lib/state/effects.spec.ts
@@ -39,6 +39,9 @@ const initialStateMock = {
       aggregations: ES_FIXTURE_AGGS_REQUEST,
     },
   },
+  main: {
+    ...initialStateSearchMock,
+  },
 }
 
 const searchServiceMock = {
@@ -123,11 +126,11 @@ describe('Effects', () => {
     })
     it('clear results list on setSearch action', () => {
       actions$ = hot('-a---', {
-        a: new SetSearch({ filters: { any: 'abcd' } }),
+        a: new SetSearch({ filters: { any: 'abcd' } }, 'main'),
       })
       const expected = hot('-(bc)', {
-        b: new ClearResults(),
-        c: new RequestMoreResults(),
+        b: new ClearResults('main'),
+        c: new RequestMoreResults('main'),
       })
 
       expect(effects.clearResults$).toBeObservable(expected)
@@ -136,9 +139,9 @@ describe('Effects', () => {
 
   describe('scroll$', () => {
     it('clear results list on sortBy action', () => {
-      actions$ = hot('-a---', { a: new Scroll() })
+      actions$ = hot('-a---', { a: new Scroll('main') })
       const expected = hot('-(b)', {
-        b: new RequestMoreResults(),
+        b: new RequestMoreResults('main'),
       })
       expect(effects.scroll$).toBeObservable(expected)
     })
@@ -151,6 +154,17 @@ describe('Effects', () => {
         b: new AddResults([]),
         c: new SetResultsAggregations({ abc: {} }),
         d: new SetResultsHits(undefined),
+      })
+
+      expect(effects.loadResults$).toBeObservable(expected)
+    })
+
+    it('propagate action search id', () => {
+      actions$ = hot('-a-', { a: new RequestMoreResults('main') })
+      const expected = hot('-(bcd)-', {
+        b: new AddResults([], 'main'),
+        c: new SetResultsAggregations({ abc: {} }, 'main'),
+        d: new SetResultsHits(undefined, 'main'),
       })
 
       expect(effects.loadResults$).toBeObservable(expected)

--- a/libs/search/src/lib/state/effects.ts
+++ b/libs/search/src/lib/state/effects.ts
@@ -32,7 +32,7 @@ import {
   SET_PAGINATION,
 } from './actions'
 import { SearchState } from './reducer'
-import { getSearchState } from './selectors'
+import { getSearchState, getSearchStateSearch } from './selectors'
 
 @Injectable()
 export class SearchEffects {
@@ -70,7 +70,7 @@ export class SearchEffects {
     this.actions$.pipe(
       ofType(REQUEST_MORE_RESULTS),
       switchMap(() => this.authService.authReady()), // wait for auth to be known
-      withLatestFrom(this.store$.pipe(select(getSearchState))),
+      withLatestFrom(this.store$.pipe(select(getSearchStateSearch))),
       switchMap(([_, state]) =>
         this.searchService.search(
           'bucket',
@@ -129,7 +129,7 @@ export class SearchEffects {
     return updateTermAction$.pipe(
       tap((action) => (aggregationKey = action.key)),
       switchMap(() => this.authService.authReady()), // wait for auth to be known
-      withLatestFrom(this.store$.pipe(select(getSearchState))),
+      withLatestFrom(this.store$.pipe(select(getSearchStateSearch))),
       switchMap(([_, state]) =>
         this.searchService.search(
           'bucket',

--- a/libs/search/src/lib/state/effects.ts
+++ b/libs/search/src/lib/state/effects.ts
@@ -5,7 +5,7 @@ import { Actions, createEffect, ofType } from '@ngrx/effects'
 import { select, Store } from '@ngrx/store'
 import { SearchResponse } from 'elasticsearch'
 import { of } from 'rxjs'
-import { map, switchMap, withLatestFrom } from 'rxjs/operators'
+import { flatMap, map, switchMap, withLatestFrom } from 'rxjs/operators'
 import { ElasticsearchMetadataModels } from '../elasticsearch/constant'
 import { ElasticsearchMapper } from '../elasticsearch/elasticsearch.mapper'
 import { ElasticsearchService } from '../elasticsearch/elasticsearch.service'
@@ -72,7 +72,9 @@ export class SearchEffects {
   loadResults$ = createEffect(() =>
     this.actions$.pipe(
       ofType(REQUEST_MORE_RESULTS),
-      switchMap((action: SearchActions) =>
+      // flatMap is used because of multiple search concerns
+      // TODO: should implement our own switchMap to filter by searchId
+      flatMap((action: SearchActions) =>
         this.authService.authReady().pipe(
           withLatestFrom(
             this.store$.pipe(select(getSearchStateSearch, action.id))

--- a/libs/search/src/lib/state/reducer.spec.ts
+++ b/libs/search/src/lib/state/reducer.spec.ts
@@ -4,8 +4,16 @@ import {
   ES_FIXTURE_AGGS_RESPONSE,
   ES_FIXTURE_AGGS_RESPONSE_MORE,
 } from '../elasticsearch/fixtures/aggregations-response'
+import { DEFAULT_SEARCH_KEY } from './actions'
 import * as fromActions from './actions'
-import { initialState, reducer, SearchStateParams } from './reducer'
+import {
+  initialState,
+  reducer,
+  reducerSearch,
+  SearchStateParams,
+} from './reducer'
+
+const initialStateSearch = initialState[DEFAULT_SEARCH_KEY]
 
 describe('Search Reducer', () => {
   describe('undefined action', () => {
@@ -23,18 +31,18 @@ describe('Search Reducer', () => {
         any: 'blah',
         other: 'Some value',
       })
-      const state = reducer(initialState, action)
+      const state = reducerSearch(initialStateSearch, action)
       expect(state.params.filters).toEqual({ any: 'blah', other: 'Some value' })
     })
     it('should update defined filters and remove undefined filters', () => {
       const action = new fromActions.SetFilters({
         any: 'abc',
       })
-      const state = reducer(
+      const state = reducerSearch(
         {
-          ...initialState,
+          ...initialStateSearch,
           params: {
-            ...initialState.params,
+            ...initialStateSearch.params,
             filters: {
               any: 'def',
               other: 'Some value',
@@ -53,18 +61,18 @@ describe('Search Reducer', () => {
         any: 'blah',
         other: 'Some value',
       })
-      const state = reducer(initialState, action)
+      const state = reducerSearch(initialStateSearch, action)
       expect(state.params.filters).toEqual({ any: 'blah', other: 'Some value' })
     })
     it('should update defined filters and keep undefined filters', () => {
       const action = new fromActions.UpdateFilters({
         any: 'abc',
       })
-      const state = reducer(
+      const state = reducerSearch(
         {
-          ...initialState,
+          ...initialStateSearch,
           params: {
-            ...initialState.params,
+            ...initialStateSearch.params,
             filters: {
               any: 'def',
               other: 'Some value',
@@ -87,7 +95,7 @@ describe('Search Reducer', () => {
         },
       }
       const action = new fromActions.SetSearch(searchParams)
-      const state = reducer(initialState, action)
+      const state = reducerSearch(initialStateSearch, action)
       expect(state.params).toEqual(searchParams)
     })
   })
@@ -95,7 +103,7 @@ describe('Search Reducer', () => {
   describe('SetSortBy action', () => {
     it('should set sort by params', () => {
       const action = new fromActions.SetSortBy('fieldA')
-      const state = reducer(initialState, action)
+      const state = reducerSearch(initialStateSearch, action)
       expect(state.params.sortBy).toEqual('fieldA')
     })
   })
@@ -103,7 +111,7 @@ describe('Search Reducer', () => {
   describe('SetPagination action', () => {
     it('should set from and size', () => {
       const action = new fromActions.SetPagination(12, 15)
-      const state = reducer(initialState, action)
+      const state = reducerSearch(initialStateSearch, action)
       expect(state.params.from).toEqual(12)
       expect(state.params.size).toEqual(15)
     })
@@ -112,7 +120,7 @@ describe('Search Reducer', () => {
   describe('Paginate action', () => {
     it('should set from property and keep size', () => {
       const action = new fromActions.Paginate(30)
-      const state = reducer(initialState, action)
+      const state = reducerSearch(initialStateSearch, action)
       expect(state.params.from).toEqual(30)
       expect(state.params.size).toEqual(10)
     })
@@ -120,7 +128,7 @@ describe('Search Reducer', () => {
   describe('Scroll action', () => {
     it('increment `from` property with `size` value', () => {
       const action = new fromActions.Scroll()
-      const state = reducer(initialState, action)
+      const state = reducerSearch(initialStateSearch, action)
       expect(state.params.from).toEqual(10)
       expect(state.params.size).toEqual(10)
     })
@@ -129,7 +137,7 @@ describe('Search Reducer', () => {
   describe('Set result layout action', () => {
     it('should set result layout', () => {
       const action = new fromActions.SetResultsLayout(ResultsListLayout.CARD)
-      const state = reducer(initialState, action)
+      const state = reducerSearch(initialStateSearch, action)
       expect(state.resultsLayout).toEqual(ResultsListLayout.CARD)
     })
   })
@@ -138,11 +146,11 @@ describe('Search Reducer', () => {
     it('should add results to the list', () => {
       const payload = [{ title: 'record1' } as any, { title: 'record2' } as any]
       const action = new fromActions.AddResults(payload)
-      const state = reducer(
+      const state = reducerSearch(
         {
-          ...initialState,
+          ...initialStateSearch,
           results: {
-            ...initialState.results,
+            ...initialStateSearch.results,
             records: [{ title: 'abcd' } as any],
           },
         },
@@ -156,9 +164,9 @@ describe('Search Reducer', () => {
     it('should remove the loadingMore flag', () => {
       const payload = [{ title: 'record1' } as any]
       const action = new fromActions.AddResults(payload)
-      const state = reducer(
+      const state = reducerSearch(
         {
-          ...initialState,
+          ...initialStateSearch,
           loadingMore: true,
         },
         action
@@ -170,11 +178,11 @@ describe('Search Reducer', () => {
   describe('ClearResults action', () => {
     it('should clear the results list', () => {
       const action = new fromActions.ClearResults()
-      const state = reducer(
+      const state = reducerSearch(
         {
-          ...initialState,
+          ...initialStateSearch,
           results: {
-            ...initialState.results,
+            ...initialStateSearch.results,
             records: [{ title: 'abcd' } as any],
           },
         },
@@ -187,7 +195,7 @@ describe('Search Reducer', () => {
   describe('RequestMoreResults action', () => {
     it('should set the loadingMore flag', () => {
       const action = new fromActions.RequestMoreResults()
-      const state = reducer(initialState, action)
+      const state = reducerSearch(initialStateSearch, action)
       expect(state.loadingMore).toEqual(true)
     })
   })
@@ -196,11 +204,11 @@ describe('Search Reducer', () => {
     it('should replace the aggregations in the result', () => {
       const payload = ES_FIXTURE_AGGS_RESPONSE
       const action = new fromActions.SetResultsAggregations(payload)
-      const state = reducer(
+      const state = reducerSearch(
         {
-          ...initialState,
+          ...initialStateSearch,
           results: {
-            ...initialState.results,
+            ...initialStateSearch.results,
             aggregations: { someKey: 'someValue' },
           },
         },
@@ -214,11 +222,11 @@ describe('Search Reducer', () => {
     it('should replace the aggregations in the config', () => {
       const payload = ES_FIXTURE_AGGS_REQUEST
       const action = new fromActions.SetConfigAggregations(payload)
-      const state = reducer(
+      const state = reducerSearch(
         {
-          ...initialState,
+          ...initialStateSearch,
           config: {
-            ...initialState.config,
+            ...initialStateSearch.config,
             aggregations: { someKey: 'someValue' },
           },
         },
@@ -235,11 +243,11 @@ describe('Search Reducer', () => {
           'tag.default',
           { increment: 20 }
         )
-        const state = reducer(
+        const state = reducerSearch(
           {
-            ...initialState,
+            ...initialStateSearch,
             config: {
-              ...initialState.config,
+              ...initialStateSearch.config,
               aggregations: ES_FIXTURE_AGGS_REQUEST,
             },
           },
@@ -257,11 +265,11 @@ describe('Search Reducer', () => {
           'tag.default',
           { include: '.*Land.*' }
         )
-        const state = reducer(
+        const state = reducerSearch(
           {
-            ...initialState,
+            ...initialStateSearch,
             config: {
-              ...initialState.config,
+              ...initialStateSearch.config,
               aggregations: ES_FIXTURE_AGGS_REQUEST,
             },
           },
@@ -281,11 +289,11 @@ describe('Search Reducer', () => {
         'tag.default',
         payload
       )
-      const state = reducer(
+      const state = reducerSearch(
         {
-          ...initialState,
+          ...initialStateSearch,
           results: {
-            ...initialState.results,
+            ...initialStateSearch.results,
             aggregations: ES_FIXTURE_AGGS_RESPONSE,
           },
         },

--- a/libs/search/src/lib/state/reducer.spec.ts
+++ b/libs/search/src/lib/state/reducer.spec.ts
@@ -25,6 +25,28 @@ describe('Search Reducer', () => {
     })
   })
 
+  describe('ADD_SEARCH', () => {
+    let action
+    describe('when search already in the state', () => {
+      beforeEach(() => {
+        action = new fromActions.AddSearch('default')
+      })
+      it('does nothing', () => {
+        const state = reducer(initialState, action)
+        expect(state).toEqual(initialState)
+      })
+    })
+    describe('when search is not in the state', () => {
+      beforeEach(() => {
+        action = new fromActions.AddSearch('main')
+      })
+      it('create the search in the state for the given id', () => {
+        const state = reducer(initialState, action)
+        expect(state).toEqual({ ...initialState, main: initialState.default })
+      })
+    })
+  })
+
   describe('SetFilters action', () => {
     it('should add new filters', () => {
       const action = new fromActions.SetFilters({

--- a/libs/search/src/lib/state/reducer.ts
+++ b/libs/search/src/lib/state/reducer.ts
@@ -57,12 +57,14 @@ export function reducer(
 ): SearchState {
   const { id } = action
   if (id) {
-    const stateSearch = state[id] || initSearch()
-    const reducedStateSearch = reducerSearch(stateSearch, action)
-    if (reducedStateSearch) {
+    let stateSearch = state[id] || initSearch()
+    if (action.type !== fromActions.ADD_SEARCH) {
+      stateSearch = reducerSearch(stateSearch, action)
+    }
+    if (stateSearch) {
       return {
         ...state,
-        [id]: reducedStateSearch,
+        [id]: stateSearch,
       }
     }
   }

--- a/libs/search/src/lib/state/search.facade.ts
+++ b/libs/search/src/lib/state/search.facade.ts
@@ -1,62 +1,111 @@
 import { Injectable } from '@angular/core'
-import { ResultsListLayout } from '@lib/common'
+import { ResultsListLayout, SearchFilters } from '@lib/common'
 import { select, Store } from '@ngrx/store'
+import { Observable } from 'rxjs'
 import {
+  AddSearch,
+  DEFAULT_SEARCH_KEY,
   Paginate,
   RequestMoreOnAggregation,
   RequestMoreResults,
   Scroll,
   SetConfigAggregations,
+  SetFilters,
   SetIncludeOnAggregation,
   SetPagination,
   SetResultsLayout,
+  SetSearch,
+  UpdateFilters,
 } from './actions'
-import { SearchState } from './reducer'
+import { SearchState, SearchStateParams } from './reducer'
 import {
+  getSearchConfigAggregations,
+  getSearchFilters,
   getSearchResults,
+  getSearchResultsAggregations,
+  getSearchResultsHits,
   getSearchResultsLayout,
   getSearchResultsLoading,
 } from './selectors'
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class SearchFacade {
-  results$ = this.store.pipe(select(getSearchResults))
-  layout$ = this.store.pipe(select(getSearchResultsLayout))
-  isLoading$ = this.store.pipe(select(getSearchResultsLoading))
+  results$: Observable<any>
+  layout$: Observable<string>
+  isLoading$: Observable<boolean>
+  searchFilters$: Observable<SearchFilters>
+  configAggregations$: Observable<any>
+  resultsAggregations$: Observable<any>
+  resultsHits$: Observable<any>
+
+  searchId: string
 
   constructor(private store: Store<SearchState>) {}
 
+  init(searchId: string = DEFAULT_SEARCH_KEY): void {
+    console.log('init facade', searchId)
+    this.searchId = searchId
+    this.store.dispatch(new AddSearch(searchId))
+
+    this.results$ = this.store.pipe(select(getSearchResults, searchId))
+    this.layout$ = this.store.pipe(select(getSearchResultsLayout, searchId))
+    this.isLoading$ = this.store.pipe(select(getSearchResultsLoading, searchId))
+    this.searchFilters$ = this.store.pipe(select(getSearchFilters, searchId))
+    this.resultsHits$ = this.store.pipe(select(getSearchResultsHits, searchId))
+    this.configAggregations$ = this.store.pipe(
+      select(getSearchConfigAggregations, searchId)
+    )
+    this.resultsAggregations$ = this.store.pipe(
+      select(getSearchResultsAggregations, searchId)
+    )
+  }
+
   setConfigAggregations(config: any): void {
-    this.store.dispatch(new SetConfigAggregations(config))
+    this.store.dispatch(new SetConfigAggregations(config, this.searchId))
   }
 
   requestMoreResults(): void {
-    this.store.dispatch(new RequestMoreResults())
+    this.store.dispatch(new RequestMoreResults(this.searchId))
   }
 
   requestMoreOnAggregation(key: string, increment: number): void {
-    this.store.dispatch(new RequestMoreOnAggregation(key, increment))
+    this.store.dispatch(
+      new RequestMoreOnAggregation(key, increment, this.searchId)
+    )
   }
 
   setResultsLayout(layout: ResultsListLayout): void {
-    this.store.dispatch(new SetResultsLayout(layout))
+    this.store.dispatch(new SetResultsLayout(layout, this.searchId))
+  }
+
+  setFilters(filters: SearchFilters): void {
+    this.store.dispatch(new SetFilters(filters, this.searchId))
+  }
+
+  updateFilters(filters: SearchFilters): void {
+    this.store.dispatch(new UpdateFilters(filters, this.searchId))
+  }
+
+  setSearch(params: SearchStateParams): void {
+    console.log('setSerach', this.searchId)
+    this.store.dispatch(new SetSearch(params, this.searchId))
   }
 
   setIncludeOnAggregation(key: string, include: string): void {
-    this.store.dispatch(new SetIncludeOnAggregation(key, include))
+    this.store.dispatch(
+      new SetIncludeOnAggregation(key, include, this.searchId)
+    )
   }
 
   setPagination(from: number, size: number): void {
-    this.store.dispatch(new SetPagination(from, size))
+    this.store.dispatch(new SetPagination(from, size, this.searchId))
   }
 
   paginate(delta: number): void {
-    this.store.dispatch(new Paginate(delta))
+    this.store.dispatch(new Paginate(delta, this.searchId))
   }
 
   scroll(): void {
-    this.store.dispatch(new Scroll())
+    this.store.dispatch(new Scroll(this.searchId))
   }
 }

--- a/libs/search/src/lib/state/selectors.spec.ts
+++ b/libs/search/src/lib/state/selectors.spec.ts
@@ -1,15 +1,18 @@
 import { ES_FIXTURE_AGGS_REQUEST } from '../elasticsearch/fixtures/aggregations-request'
 import { ES_FIXTURE_AGGS_RESPONSE } from '../elasticsearch/fixtures/aggregations-response'
+import { DEFAULT_SEARCH_KEY } from './actions'
 import { initialState } from './reducer'
 import * as fromSelectors from './selectors'
+
+const initialStateSearch = initialState[DEFAULT_SEARCH_KEY]
 
 describe('Search Selectors', () => {
   describe('getSearchFilters', () => {
     it('should return search filters', () => {
       const result = fromSelectors.getSearchFilters.projector({
-        ...initialState,
+        ...initialStateSearch,
         params: {
-          ...initialState.params,
+          ...initialStateSearch.params,
           filters: {
             any: 'abcd',
           },
@@ -24,9 +27,9 @@ describe('Search Selectors', () => {
   describe('getSearchSortBy', () => {
     it('should return sort by criteria', () => {
       const result = fromSelectors.getSearchSortBy.projector({
-        ...initialState,
+        ...initialStateSearch,
         params: {
-          ...initialState.params,
+          ...initialStateSearch.params,
           sortBy: 'title',
         },
       })
@@ -37,9 +40,9 @@ describe('Search Selectors', () => {
   describe('getSearchConfigAggregations', () => {
     it('should return aggregations configuration', () => {
       const result = fromSelectors.getSearchConfigAggregations.projector({
-        ...initialState,
+        ...initialStateSearch,
         config: {
-          ...initialState.config,
+          ...initialStateSearch.config,
           aggregations: ES_FIXTURE_AGGS_REQUEST,
         },
       })
@@ -51,10 +54,10 @@ describe('Search Selectors', () => {
     it('should return search results', () => {
       const records = [{ title: 'record1' } as any]
       const result = fromSelectors.getSearchResults.projector({
-        ...initialState,
+        ...initialStateSearch,
         results: {
-          ...initialState.results,
-          records: records,
+          ...initialStateSearch.results,
+          records,
         },
       })
       expect(result).toEqual(records)
@@ -64,7 +67,7 @@ describe('Search Selectors', () => {
   describe('getSearchResultsLoading', () => {
     it('should return whether more results are loading', () => {
       const result = fromSelectors.getSearchResultsLoading.projector({
-        ...initialState,
+        ...initialStateSearch,
         loadingMore: true,
       })
       expect(result).toEqual(true)
@@ -75,10 +78,10 @@ describe('Search Selectors', () => {
     it('should return search aggregations results', () => {
       const aggregations = ES_FIXTURE_AGGS_RESPONSE
       const result = fromSelectors.getSearchResultsAggregations.projector({
-        ...initialState,
+        ...initialStateSearch,
         results: {
-          ...initialState.results,
-          aggregations: aggregations,
+          ...initialStateSearch.results,
+          aggregations,
         },
       })
       expect(result).toEqual(aggregations)

--- a/libs/search/src/lib/state/selectors.ts
+++ b/libs/search/src/lib/state/selectors.ts
@@ -1,46 +1,52 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store'
-import { SEARCH_FEATURE_KEY, SearchState } from './reducer'
+import { DEFAULT_SEARCH_KEY } from './actions'
+import { SEARCH_FEATURE_KEY, SearchState, SearchStateSearch } from './reducer'
 
 export const getSearchState = createFeatureSelector<SearchState>(
   SEARCH_FEATURE_KEY
 )
 
-export const getSearchFilters = createSelector(
+export const getSearchStateSearch = createSelector(
   getSearchState,
-  (state: SearchState) => state.params.filters
+  (state: SearchState, id: string = DEFAULT_SEARCH_KEY) => state[id]
+)
+
+export const getSearchFilters = createSelector(
+  getSearchStateSearch,
+  (state: SearchStateSearch) => state.params.filters
 )
 
 export const getSearchSortBy = createSelector(
-  getSearchState,
-  (state: SearchState) => state.params.sortBy
+  getSearchStateSearch,
+  (state: SearchStateSearch) => state.params.sortBy
 )
 
 export const getSearchResultsLayout = createSelector(
-  getSearchState,
-  (state: SearchState) => state.resultsLayout
+  getSearchStateSearch,
+  (state: SearchStateSearch) => state.resultsLayout
 )
 
 export const getSearchConfigAggregations = createSelector(
-  getSearchState,
-  (state: SearchState) => state.config.aggregations
+  getSearchStateSearch,
+  (state: SearchStateSearch) => state.config.aggregations
 )
 
 export const getSearchResults = createSelector(
-  getSearchState,
-  (state: SearchState) => state.results.records
+  getSearchStateSearch,
+  (state: SearchStateSearch) => state.results.records
 )
 
 export const getSearchResultsLoading = createSelector(
-  getSearchState,
-  (state: SearchState) => state.loadingMore
+  getSearchStateSearch,
+  (state: SearchStateSearch) => state.loadingMore
 )
 
 export const getSearchResultsAggregations = createSelector(
-  getSearchState,
-  (state: SearchState) => state.results.aggregations
+  getSearchStateSearch,
+  (state: SearchStateSearch) => state.results.aggregations
 )
 
 export const getSearchResultsHits = createSelector(
-  getSearchState,
-  (state: SearchState) => state.results.hits
+  getSearchStateSearch,
+  (state: SearchStateSearch) => state.results.hits
 )

--- a/tools/build/webcomponent/prepare-wc-pages.sh
+++ b/tools/build/webcomponent/prepare-wc-pages.sh
@@ -15,12 +15,9 @@ rm -f ${DIST_WC_PATH}polyfills.js
 rm -f ${DIST_WC_PATH}runtime.js
 rm -f ${DIST_WC_PATH}styles.css
 
-sampleLinks=""
 for c in webcomponents/src/app/components/gn-* ; do
   echo "-- Copy HTML sample for:" `basename $c`
-  fileName=`basename $c`".sample.html"
-  cp $c/$fileName $DIST_WC_PATH
-  sampleLinks+="<a href='"$fileName"'>"`basename $c`"</a>"
+  cp $c/*".sample.html" $DIST_WC_PATH
 done
 
 echo "-- Copy demo pages"

--- a/webcomponents/src/app/components/base.component.ts
+++ b/webcomponents/src/app/components/base.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@angular/core'
 import { ColorService } from '@lib/common'
 import { Configuration } from '@lib/gn-api'
+import { SearchFacade } from '@lib/search'
 
 export const apiConfiguration = new Configuration()
 
@@ -16,6 +17,7 @@ export const apiConfiguration = new Configuration()
 })
 export class BaseComponent implements OnInit, OnChanges {
   @Input() apiUrl = '/'
+  @Input() searchId: string
   @Input() primaryColor = '#9a9a9a'
   @Input() secondaryColor = '#767676'
   @Input() mainColor = '#1a1a1a'
@@ -23,7 +25,7 @@ export class BaseComponent implements OnInit, OnChanges {
 
   isInitialized = false
 
-  constructor() {}
+  constructor(protected facade: SearchFacade) {}
 
   ngOnInit(): void {}
 
@@ -36,6 +38,8 @@ export class BaseComponent implements OnInit, OnChanges {
         this.mainColor,
         this.backgroundColor
       )
+      this.isInitialized = true
+      this.facade.init(this.searchId)
     }
   }
 }

--- a/webcomponents/src/app/components/gn-aggregated-records/gn-aggregated-records.component.ts
+++ b/webcomponents/src/app/components/gn-aggregated-records/gn-aggregated-records.component.ts
@@ -4,9 +4,8 @@ import {
   Input,
   ViewEncapsulation,
 } from '@angular/core'
+import { SearchFacade } from '@lib/search'
 import { BaseComponent } from '../base.component'
-import { Store } from '@ngrx/store'
-import { SearchState, UpdateFilters } from '@lib/search'
 
 @Component({
   selector: 'wc-gn-aggregated-records',
@@ -22,8 +21,8 @@ export class GnAggregatedRecordsComponent extends BaseComponent {
 
   activeFilter = null
 
-  constructor(private store: Store<SearchState>) {
-    super()
+  constructor(facade: SearchFacade) {
+    super(facade)
   }
 
   ngOnInit(): void {
@@ -32,7 +31,7 @@ export class GnAggregatedRecordsComponent extends BaseComponent {
 
   setFilter(value: string) {
     this.activeFilter = `+${this.aggregationField}:"${value}"`
-    this.store.dispatch(new UpdateFilters({ any: this.activeFilter }))
+    this.facade.updateFilters({ any: this.activeFilter })
   }
 
   clearFilter() {

--- a/webcomponents/src/app/components/gn-facets/gn-facets.component.ts
+++ b/webcomponents/src/app/components/gn-facets/gn-facets.component.ts
@@ -17,13 +17,13 @@ import { BaseComponent } from '../base.component'
 export class GnFacetsComponent extends BaseComponent {
   @Input() facetConfig: string = '{}'
 
-  constructor(private searchFacade: SearchFacade) {
-    super()
+  constructor(facade: SearchFacade) {
+    super(facade)
   }
 
   ngOnInit(): void {
     super.ngOnInit()
-    this.searchFacade.setConfigAggregations(JSON.parse(this.facetConfig))
-    this.searchFacade.requestMoreResults()
+    this.facade.setConfigAggregations(JSON.parse(this.facetConfig))
+    this.facade.requestMoreResults()
   }
 }

--- a/webcomponents/src/app/components/gn-results-list/gn-results-list-multiple.sample.html
+++ b/webcomponents/src/app/components/gn-results-list/gn-results-list-multiple.sample.html
@@ -15,11 +15,17 @@
       layout="TITLE"
       filter="+tag.default:forest"
     ></gn-results-list>
+    <gn-facets
+      api-url="https://apps.titellus.net/geonetwork/srv/api"
+      facet-config='{"tag.default":{"terms":{"field":"tag.default","include":".*","size": 10}}}'
+    ></gn-facets>
 
     <h2>Marine</h2>
     <gn-results-list
       api-url="https://apps.titellus.net/geonetwork/srv/api"
       size="5"
+      primary-color="#343e9c"
+      search-id="marine"
       filter="+tag.default:marine"
       layout="TITLE"
     ></gn-results-list>

--- a/webcomponents/src/app/components/gn-results-list/gn-results-list-multiple.sample.html
+++ b/webcomponents/src/app/components/gn-results-list/gn-results-list-multiple.sample.html
@@ -8,10 +8,19 @@
   </head>
   <body>
     <script src="gn-wc.js"></script>
+    <h2>Forest</h2>
     <gn-results-list
       api-url="https://apps.titellus.net/geonetwork/srv/api"
       size="5"
-      primary-color="#343e9c"
+      layout="TITLE"
+      filter="+tag.default:forest"
+    ></gn-results-list>
+
+    <h2>Marine</h2>
+    <gn-results-list
+      api-url="https://apps.titellus.net/geonetwork/srv/api"
+      size="5"
+      filter="+tag.default:marine"
       layout="TITLE"
     ></gn-results-list>
   </body>

--- a/webcomponents/src/app/components/gn-results-list/gn-results-list-multiple.sample.html
+++ b/webcomponents/src/app/components/gn-results-list/gn-results-list-multiple.sample.html
@@ -15,10 +15,6 @@
       layout="TITLE"
       filter="+tag.default:forest"
     ></gn-results-list>
-    <gn-facets
-      api-url="https://apps.titellus.net/geonetwork/srv/api"
-      facet-config='{"tag.default":{"terms":{"field":"tag.default","include":".*","size": 10}}}'
-    ></gn-facets>
 
     <h2>Marine</h2>
     <gn-results-list

--- a/webcomponents/src/app/components/gn-results-list/gn-results-list-watch.sample.html
+++ b/webcomponents/src/app/components/gn-results-list/gn-results-list-watch.sample.html
@@ -10,9 +10,19 @@
     <script src="gn-wc.js"></script>
     <gn-results-list
       api-url="https://apps.titellus.net/geonetwork/srv/api"
-      size="5"
+      size="10"
       primary-color="#343e9c"
       layout="TITLE"
+      filter="GRID"
     ></gn-results-list>
+    <div>
+      <button id="changeSizeBtn" onclick="moreRecords()">Load more ...</button>
+    </div>
   </body>
+  <script>
+    function moreRecords() {
+      const wc = document.getElementsByTagName('gn-results-list')[0]
+      wc.size = parseInt(wc.size) + 10
+    }
+  </script>
 </html>

--- a/webcomponents/src/app/components/gn-results-list/gn-results-list.component.ts
+++ b/webcomponents/src/app/components/gn-results-list/gn-results-list.component.ts
@@ -7,8 +7,7 @@ import {
   ViewEncapsulation,
 } from '@angular/core'
 import { ResultsListLayout } from '@lib/common'
-import { getSearchResultsLoading, SearchState, SetSearch } from '@lib/search'
-import { select, Store } from '@ngrx/store'
+import { SearchFacade } from '@lib/search'
 import { BaseComponent } from '../base.component'
 
 @Component({
@@ -17,33 +16,34 @@ import { BaseComponent } from '../base.component'
   styleUrls: ['./gn-results-list.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.ShadowDom,
+  providers: [SearchFacade],
 })
 export class GnResultsListComponent extends BaseComponent {
   @Input() layout: ResultsListLayout = ResultsListLayout.CARD
   @Input() size = 10
   @Input() filter = ''
 
-  constructor(
-    private store: Store<SearchState>,
-    private changeDetector: ChangeDetectorRef
-  ) {
-    super()
+  constructor(facade: SearchFacade, private changeDetector: ChangeDetectorRef) {
+    super(facade)
   }
 
   ngOnInit(): void {
     super.ngOnInit()
     setTimeout(() => {
       // Be sure to update the source page when the state is updated
-      this.store.pipe(select(getSearchResultsLoading)).subscribe((v) => {
+      // timeout cause must be the last subscriber to the change
+      this.facade.isLoading$.subscribe((v) => {
         this.changeDetector.detectChanges()
       })
     })
   }
 
   private setSearch_() {
-    this.store.dispatch(
-      new SetSearch({ filters: { any: this.filter }, size: this.size, from: 0 })
-    )
+    this.facade.setSearch({
+      filters: { any: this.filter },
+      size: this.size,
+      from: 0,
+    })
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/webcomponents/src/app/gn-wc.module.ts
+++ b/webcomponents/src/app/gn-wc.module.ts
@@ -3,10 +3,11 @@ import { Injector, NgModule } from '@angular/core'
 import { createCustomElement } from '@angular/elements'
 import { I18nModule, TRANSLATE_DEFAULT_CONFIG } from '@lib/common'
 import { Configuration } from '@lib/gn-api'
-import { LibSearchModule } from '@lib/search'
+import { LibSearchModule, SearchFacade } from '@lib/search'
 import { UiModule } from '@lib/ui'
 import { StoreModule } from '@ngrx/store'
 import { EffectsModule } from '@ngrx/effects'
+import { StoreDevtoolsModule } from '@ngrx/store-devtools'
 import { TranslateModule } from '@ngx-translate/core'
 import { apiConfiguration, BaseComponent } from './components/base.component'
 import { GnAggregatedRecordsComponent } from './components/gn-aggregated-records/gn-aggregated-records.component'
@@ -34,12 +35,14 @@ const CUSTOM_ELEMENTS: any[] = [
     EffectsModule.forRoot(),
     I18nModule,
     TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
+    StoreDevtoolsModule.instrument(),
   ],
   providers: [
     {
       provide: Configuration,
       useValue: apiConfiguration,
     },
+    SearchFacade,
   ],
 })
 export class GnWcModule {

--- a/webcomponents/src/index.html
+++ b/webcomponents/src/index.html
@@ -14,6 +14,16 @@
         <a href="gn-results-list.sample.html">Simple list of results</a>
       </li>
       <li>
+        <a href="gn-results-list-watch.sample.html"
+          >List of result with input watchers
+        </a>
+      </li>
+      <li>
+        <a href="gn-results-list-multiple.sample.html"
+          >Multiple searches in same page</a
+        >
+      </li>
+      <li>
         <a href="gn-facets.sample.html">Aggregations and results</a>
       </li>
     </ul>


### PR DESCRIPTION
This PR aims to change the search state structure to handle multiple searches in the same page.
Before, the state structure allowed to store a unique search, matching the `SearchSate` interface. This structure has been enhanced so the state stores a dictionnary of searches, the `SearchSate` has become a dictionnary of `SearchSateSearch`.
The dictionnary key is the search id, used to bind any component and action to a specific search, the default key is `default`.

I tried to keep the code simple so the change is quite transparent:
- I kept the original reducer that is now called to reduce one element of the state pool
- If the state pool does not contain the search id provided by the action, it initiates a new search structure for this new id
- If an action does not provide any id, then it passes the `default` value
- All effects propagate the search id along the actions flow

By default, the `initialState` contains a search state for the `default` id, and all actions work on this id in a transparent way.
At the moment, the application looks to run exactly the same.

- [x] Refactor the search state
- [x] Add 2 searches in the same page
- [x] Update the effects and the facade to dispatch the correct search id
- [x] Demonstrate the work in a web component

**State Facade**

- The facade has been reworked so it is transparent for any component to be binded with the correct search.
- Facade is no more a singleton, there should be one facade per search
- Facade is not injected at root level
- Facade is instanciated when you declare the `searchSearchStateContainer="mainSearch"` directive
- If you don't provide the directive (I made it almost mandatory to force the developper to know what is is doing), you are responsible to inject and initiate the Facade service (as done in the web component)
- Any component that is below the directive in the DOM, and that inject the facade, will retrieve the directive instance of the facade, binded to a specific `searchId`
- When you don't provide a `searchId`, the default value is `default`.

I had to refactor many components and tests that were using the store directly.

I don't guarantee everything is working perfectly but it looks ok with the tests I've made.
Demo: https://geonetwork.github.io/geonetwork-ui/multiple_search/demo/webcomponents/gn-results-list-multiple.sample.html

The commit https://github.com/geonetwork/geonetwork-ui/pull/93/commits/1057df235ddaf2c56030977700b95ba4aa02529e should be adressed (usage of `flatMap` operator).