### PR TITLE
Fix for the height of the search result list items

### DIFF
--- a/libs/ui/src/lib/record-preview-text/record-preview-text.component.html
+++ b/libs/ui/src/lib/record-preview-text/record-preview-text.component.html
@@ -7,7 +7,9 @@
       <h1 class="title-font text-lg font-medium text-gray-900 mb-3">
         {{ record.title }}
       </h1>
-      <p class="leading-relaxed mb-3 text-gray-700 text-sm whitespace-pre-line clamp-3">
+      <p
+        class="leading-relaxed mb-3 text-gray-700 text-sm whitespace-pre-line clamp-3"
+      >
         {{ record.abstract }}
       </p>
 

--- a/libs/ui/src/lib/record-preview-text/record-preview-text.component.html
+++ b/libs/ui/src/lib/record-preview-text/record-preview-text.component.html
@@ -1,13 +1,13 @@
 <!-- Record list item: List Small -->
 <div class="mb-4">
   <div
-    class="h-full flex sm:flex-row flex-col p-5 items-center sm:justify-start justify-center text-center sm:text-left bg-white hover:bg-gray-100 border-gray-200 border rounded-sm transition duration-200"
+    class="flex sm:flex-row flex-col p-5 items-center sm:justify-start justify-center text-center sm:text-left bg-white hover:bg-gray-100 border-gray-200 border rounded-sm transition duration-200"
   >
     <div class="flex-grow">
       <h1 class="title-font text-lg font-medium text-gray-900 mb-3">
         {{ record.title }}
       </h1>
-      <p class="leading-relaxed mb-3 text-gray-700 text-sm whitespace-pre-line">
+      <p class="leading-relaxed mb-3 text-gray-700 text-sm whitespace-pre-line clamp-3">
         {{ record.abstract }}
       </p>
 


### PR DESCRIPTION
This PR has a small fix for the height of the items, it now hasn't a full height anymore, but still no fixed height. It now depends on title, 3 lines of abstract and the link. So if the font-size is increased, the height of the list item 'grows' with it

Small fixes for the height of the search result list item:
- removed the class `h-full`, gave the item the full height
- added `clamp-3` to display only the first 3 lines and end with `...`