### PR TITLE
Aggregation minor improvements

### DIFF
--- a/demo/eea/datacatalogue.html
+++ b/demo/eea/datacatalogue.html
@@ -611,7 +611,24 @@
                     >
                       <gn-facets
                         api-url="https://apps.titellus.net/geonetwork/srv/api"
-                        facet-config='{"tag.default":{"terms":{"field":"tag.default","include":".*","size": 10}}}'
+                        facet-config='{
+                          "th_gemet.default":{"terms":{
+                            "field":"th_gemet.default",
+                            "include":".*",
+                            "size": 10}},
+                          "Countries":{"terms":{
+                            "field":"keywordType-place.default",
+                            "include": "Austria|Belgium|Bulgaria|Croatia|Cyprus|Czech Republic|Denmark|Estonia|Finland|France|Germany|Greece|Hungary|Ireland|Italy|Kosovo|Latvia|Lithuania|Luxembourg|Malta|Montenegro|Netherlands|North Macedonia|Norway|Poland|Portugal|Romania|Serbia|Slovakia|Slovenia|Spain|Sweden",
+                            "size": 30}, "meta": {"field": "keywordType-place.default"}},
+                              "creationYearForResource": {
+                          "histogram": {
+                            "field": "creationYearForResource",
+                            "interval": 5,
+                            "keyed" : true,
+                            "min_doc_count": 1}},
+                          "resourceType":{"terms":{
+                            "field":"resourceType",
+                            "size": 10}}}'
                       ></gn-facets>
                     </div>
                     <div class="facets_footer_slot"></div>

--- a/libs/search/src/lib/facets/facets.service.ts
+++ b/libs/search/src/lib/facets/facets.service.ts
@@ -31,7 +31,7 @@ export class FacetsService {
       doc_count: number
     }
 
-    for (const key in responseAggregations) {
+    for (const key in requestAggregations) {
       if (responseAggregations.hasOwnProperty(key)) {
         const requestAgg = requestAggregations[key]
         const responseAgg = responseAggregations[key]

--- a/libs/search/src/lib/facets/facets.service.ts
+++ b/libs/search/src/lib/facets/facets.service.ts
@@ -39,7 +39,8 @@ export class FacetsService {
         let blockModel: any = {
           key,
           items: [],
-          path: [...path, key],
+          path: [...path, responseAgg.meta?.field || key],
+          meta: responseAgg.meta,
         }
         if (requestAgg.hasOwnProperty(AggregationsTypesEnum.TERMS)) {
           blockModel = {


### PR DESCRIPTION
Restore some GN4 logic.

* fix(aggs): Preserve aggregation order as defined in the configuration. See https://github.com/geonetwork/core-geonetwork/blob/4.0.x/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js#L287.
* fix(aggs): Aggregation search field is not always the key.
    
User may need to label differently an aggregation. The label is based on the key. The search field can then be different. Same as in GN4.
    
Example of configuration of a more restricted facet on resourceType labeled differently:
    
    ```json
    facetConfig: {
            DataServiceOrMap: {
              terms: {
                field: 'cl_hierarchyLevel.key',
                include: 'dataset|service|map'
              },
              meta: {
                field: 'cl_hierarchyLevel.key'
              }
            },
    ```

