### PR TITLE
Add filter params in ES query

### DIFF
--- a/demo/eea/results-list.html
+++ b/demo/eea/results-list.html
@@ -842,7 +842,7 @@
                       api-url="https://apps.titellus.net/geonetwork/srv/api"
                       layout="TITLE"
                       size="4"
-                      filter="forest"
+                      query="forest"
                       primary-color="#251"
                       secondary-color="#c2e9dc"
                       main-color="#212029"

--- a/libs/common/src/lib/i18n/gn4.translate.loader.spec.ts
+++ b/libs/common/src/lib/i18n/gn4.translate.loader.spec.ts
@@ -5,7 +5,7 @@ import { Gn4TranslateLoader } from './gn4.translate.loader'
 
 const toolsApiServiceMock = {
   getTranslationsPackage1: jest.fn(() =>
-    of({ farming: 'Farming', legacy: '{{ id }} id' })
+    of({ farming: 'Farming', legacy: ' {{ id }} id' })
   ),
 }
 

--- a/libs/common/src/lib/i18n/gn4.translate.loader.ts
+++ b/libs/common/src/lib/i18n/gn4.translate.loader.ts
@@ -17,7 +17,7 @@ export class Gn4TranslateLoader implements TranslateLoader {
       map((json) =>
         Object.keys(json).reduce((translations, key) => {
           const value = json[key]
-          if (!value.includes('{{')) {
+          if (!value.includes(' {{')) {
             translations[key] = value
           }
           return translations

--- a/libs/common/src/lib/models/search.model.ts
+++ b/libs/common/src/lib/models/search.model.ts
@@ -3,6 +3,11 @@ export interface SearchFilters {
   [x: string]: any
 }
 
+export interface StateConfigFilters {
+  custom?: SearchFilters
+  elastic?: any
+}
+
 export interface RecordSummary {
   id: string
   uuid: string

--- a/libs/search/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -113,6 +113,7 @@ describe('ElasticsearchService', () => {
       })
       expect(sort).toEqual({
         bool: {
+          filter: [],
           must: [
             {
               query_string: {

--- a/libs/search/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -58,7 +58,7 @@ describe('ElasticsearchService', () => {
       expect(body.sort).toEqual(['_score', { changeDate: 'desc' }])
     })
   })
-  describe('#facetsToLuceneQuery', () => {
+  describe('#stateFiltersToQueryString', () => {
     describe('when simple terms', () => {
       beforeEach(() => {
         searchFilters = {
@@ -69,7 +69,7 @@ describe('ElasticsearchService', () => {
         }
       })
       it('return OR separated query', () => {
-        const query = service.facetsToLuceneQuery(searchFilters)
+        const query = service.stateFiltersToQueryString(searchFilters)
         expect(query).toBe('(tag.default:"world" tag.default:"vector")')
       })
     })
@@ -88,7 +88,7 @@ describe('ElasticsearchService', () => {
         }
       })
       it('nest sub key with AND operator', () => {
-        const query = service.facetsToLuceneQuery(searchFilters)
+        const query = service.stateFiltersToQueryString(searchFilters)
         expect(query).toBe(
           '((resourceType:"service" AND (serviceType:"OGC:WMS")) resourceType:"dataset")'
         )

--- a/libs/search/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -9,6 +9,7 @@ const initialStateSearch = initialState[DEFAULT_SEARCH_KEY]
 describe('ElasticsearchService', () => {
   let service: ElasticsearchService
   let searchFilters
+  let state
 
   beforeEach(() => {
     service = new ElasticsearchService()
@@ -120,6 +121,90 @@ describe('ElasticsearchService', () => {
             },
           ],
         },
+      })
+    })
+  })
+
+  describe('#buildPayloadFilter', () => {
+    describe('when elastic object config', () => {
+      beforeEach(() => {
+        state = {
+          ...initialStateSearch,
+          config: {
+            filters: {
+              elastic: { term: { 'cl_hierarchyLevel.key': 'service' } },
+            },
+          },
+        }
+      })
+      it('returns the input config', () => {
+        const filter = service['buildPayloadFilter'](state)
+        expect(filter).toEqual([
+          { term: { 'cl_hierarchyLevel.key': 'service' } },
+        ])
+      })
+    })
+    describe('when elastic array config', () => {
+      beforeEach(() => {
+        state = {
+          ...initialStateSearch,
+          config: {
+            filters: {
+              elastic: [{ term: { 'cl_hierarchyLevel.key': 'service' } }],
+            },
+          },
+        }
+      })
+      it('returns the input config', () => {
+        const filter = service['buildPayloadFilter'](state)
+        expect(filter).toEqual([
+          { term: { 'cl_hierarchyLevel.key': 'service' } },
+        ])
+      })
+    })
+    describe('when custom config', () => {
+      beforeEach(() => {
+        state = {
+          ...initialStateSearch,
+          config: {
+            filters: {
+              custom: {
+                'cl_hierarchyLevel.key': {
+                  service: true,
+                },
+              },
+            },
+          },
+        }
+      })
+      it('returns the corresponding query_string', () => {
+        const filter = service['buildPayloadFilter'](state)
+        expect(filter).toEqual([
+          { query_string: { query: '(cl_hierarchyLevel.key:"service")' } },
+        ])
+      })
+    })
+    describe('when having both config', () => {
+      beforeEach(() => {
+        state = {
+          ...initialStateSearch,
+          config: {
+            filters: {
+              elastic: [{ term: { 'cl_hierarchyLevel.key': 'service' } }],
+              custom: {
+                'cl_hierarchyLevel.key': {
+                  service: true,
+                },
+              },
+            },
+          },
+        }
+      })
+      it('elastic config priors', () => {
+        const filter = service['buildPayloadFilter'](state)
+        expect(filter).toEqual([
+          { term: { 'cl_hierarchyLevel.key': 'service' } },
+        ])
       })
     })
   })

--- a/libs/search/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -20,7 +20,7 @@ describe('ElasticsearchService', () => {
 
   describe('#Sort', () => {
     it('One sort and default direction', () => {
-      const body = service.buildPayload({
+      const sort = service['buildPayloadSort']({
         ...initialStateSearch,
         params: {
           filters: {
@@ -29,11 +29,11 @@ describe('ElasticsearchService', () => {
           sortBy: '_score',
         },
       })
-      expect(body.sort).toEqual(['_score'])
+      expect(sort).toEqual(['_score'])
     })
 
     it('One sort and DESC direction', () => {
-      const body = service.buildPayload({
+      const sort = service['buildPayloadSort']({
         ...initialStateSearch,
         params: {
           filters: {
@@ -42,11 +42,11 @@ describe('ElasticsearchService', () => {
           sortBy: '-changeDate',
         },
       })
-      expect(body.sort).toEqual([{ changeDate: 'desc' }])
+      expect(sort).toEqual([{ changeDate: 'desc' }])
     })
 
     it('Multiple sorts', () => {
-      const body = service.buildPayload({
+      const sort = service['buildPayloadSort']({
         ...initialStateSearch,
         params: {
           filters: {
@@ -55,7 +55,7 @@ describe('ElasticsearchService', () => {
           sortBy: '_score,-changeDate',
         },
       })
-      expect(body.sort).toEqual(['_score', { changeDate: 'desc' }])
+      expect(sort).toEqual(['_score', { changeDate: 'desc' }])
     })
   })
   describe('#stateFiltersToQueryString', () => {
@@ -92,6 +92,34 @@ describe('ElasticsearchService', () => {
         expect(query).toBe(
           '((resourceType:"service" AND (serviceType:"OGC:WMS")) resourceType:"dataset")'
         )
+      })
+    })
+  })
+
+  describe('#buildPayloadQuery', () => {
+    it('return OR separated query', () => {
+      const sort = service['buildPayloadQuery']({
+        ...initialStateSearch,
+        params: {
+          filters: {
+            'tag.default': {
+              world: true,
+              vector: true,
+            },
+            any: '',
+          },
+        },
+      })
+      expect(sort).toEqual({
+        bool: {
+          must: [
+            {
+              query_string: {
+                query: '(*) AND (tag.default:"world" tag.default:"vector")',
+              },
+            },
+          ],
+        },
       })
     })
   })

--- a/libs/search/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.service.ts
@@ -56,7 +56,7 @@ export class ElasticsearchService {
   partialBuildQuery(state: SearchStateSearch) {
     const filters = state.params.filters
     const { any, ...searchFilters } = filters
-    const queryFilters = this.facetsToLuceneQuery(searchFilters)
+    const queryFilters = this.stateFiltersToQueryString(searchFilters)
     const queryAny = `(${filters.any || '*'})`
     const query =
       queryAny + (queryFilters.length > 0 ? ` AND ${queryFilters}` : '')
@@ -99,7 +99,7 @@ export class ElasticsearchService {
    *   }
    * }
    */
-  facetsToLuceneQuery(facetsState) {
+  stateFiltersToQueryString(facetsState) {
     const query = []
     for (const indexKey in facetsState) {
       if (facetsState.hasOwnProperty(indexKey)) {

--- a/libs/search/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/search/src/lib/elasticsearch/elasticsearch.service.ts
@@ -50,9 +50,31 @@ export class ElasticsearchService {
     const partialQuery = {
       bool: {
         must: [{ query_string: { query } }],
+        filter: this.buildPayloadFilter(state),
       },
     }
     return partialQuery
+  }
+
+  private buildPayloadFilter(state: SearchStateSearch) {
+    const { filters } = state.config
+    const { custom, elastic } = filters
+    const queryString = this.stateFiltersToQueryString(custom)
+    const query = []
+    if (elastic) {
+      if (!Array.isArray(elastic)) {
+        query.push(elastic)
+      } else {
+        query.push(...elastic)
+      }
+    } else if (custom) {
+      query.push({
+        query_string: {
+          query: queryString,
+        },
+      })
+    }
+    return query
   }
 
   buildMoreOnAggregationPayload(

--- a/libs/search/src/lib/state/actions.ts
+++ b/libs/search/src/lib/state/actions.ts
@@ -2,6 +2,7 @@ import {
   EsRequestAggTermPatch,
   RecordSummary,
   SearchFilters,
+  StateConfigFilters,
 } from '@lib/common'
 import { Action } from '@ngrx/store'
 import { SearchStateParams } from './reducer'
@@ -9,6 +10,7 @@ import { SearchStateParams } from './reducer'
 export const ADD_SEARCH = '[Search] Add search instance'
 
 export const SET_FILTERS = '[Search] Set Filters'
+export const SET_CONFIG_FILTERS = '[Search] Set config filters'
 export const UPDATE_FILTERS = '[Search] Update Filters'
 export const SET_SEARCH = '[Search] Set overall search configuration'
 export const SET_SORT_BY = '[Search] Sort By'
@@ -42,6 +44,14 @@ abstract class AbstractAction {
 export class AddSearch implements Action {
   readonly type = ADD_SEARCH
   constructor(public id: string) {}
+}
+
+export class SetConfigFilters extends AbstractAction implements Action {
+  readonly type = SET_CONFIG_FILTERS
+
+  constructor(public payload: StateConfigFilters, id?: string) {
+    super(id)
+  }
 }
 
 export class SetFilters extends AbstractAction implements Action {
@@ -195,6 +205,7 @@ export class PatchResultsAggregations extends AbstractAction implements Action {
 
 export type SearchActions =
   | AddSearch
+  | SetConfigFilters
   | SetFilters
   | UpdateFilters
   | SetSearch

--- a/libs/search/src/lib/state/effects.spec.ts
+++ b/libs/search/src/lib/state/effects.spec.ts
@@ -37,6 +37,7 @@ const initialStateMock = {
   [DEFAULT_SEARCH_KEY]: {
     ...initialStateSearchMock,
     config: {
+      ...initialStateSearchMock.config,
       aggregations: ES_FIXTURE_AGGS_REQUEST,
     },
   },

--- a/libs/search/src/lib/state/effects.ts
+++ b/libs/search/src/lib/state/effects.ts
@@ -89,7 +89,7 @@ export class SearchEffects {
             this.searchService.search(
               'bucket',
               JSON.stringify(
-                this.esService.search(
+                this.esService.getSearchRequestBody(
                   state,
                   ElasticsearchMetadataModels.SUMMARY
                 )

--- a/libs/search/src/lib/state/reducer.spec.ts
+++ b/libs/search/src/lib/state/reducer.spec.ts
@@ -47,6 +47,20 @@ describe('Search Reducer', () => {
     })
   })
 
+  describe('SetConfigFilters action', () => {
+    it('set config filters', () => {
+      const action = new fromActions.SetConfigFilters({
+        custom: { any: 'blah', other: 'Some value' },
+        elastic: {},
+      })
+      const state = reducerSearch(initialStateSearch, action)
+      expect(state.config.filters).toEqual({
+        custom: { any: 'blah', other: 'Some value' },
+        elastic: {},
+      })
+    })
+  })
+
   describe('SetFilters action', () => {
     it('should add new filters', () => {
       const action = new fromActions.SetFilters({

--- a/libs/search/src/lib/state/reducer.ts
+++ b/libs/search/src/lib/state/reducer.ts
@@ -1,4 +1,9 @@
-import { RecordSummary, RESULTS_PAGE_SIZE, SearchFilters } from '@lib/common'
+import {
+  RecordSummary,
+  RESULTS_PAGE_SIZE,
+  SearchFilters,
+  StateConfigFilters,
+} from '@lib/common'
 import * as fromActions from './actions'
 import { DEFAULT_SEARCH_KEY } from './actions'
 
@@ -14,6 +19,7 @@ export interface SearchStateParams {
 export interface SearchStateSearch {
   config: {
     aggregations?: any
+    filters?: StateConfigFilters
   }
   params: SearchStateParams
   results: {
@@ -32,7 +38,9 @@ export type SearchState = { [key: string]: SearchStateSearch }
 
 export const initSearch = (): SearchStateSearch => {
   return {
-    config: {},
+    config: {
+      filters: {},
+    },
     params: {
       filters: {},
       size: RESULTS_PAGE_SIZE,
@@ -76,6 +84,15 @@ export function reducerSearch(
   action: fromActions.SearchActions
 ): SearchStateSearch {
   switch (action.type) {
+    case fromActions.SET_CONFIG_FILTERS: {
+      return {
+        ...state,
+        config: {
+          ...state.config,
+          filters: { ...action.payload },
+        },
+      }
+    }
     case fromActions.SET_FILTERS: {
       return {
         ...state,

--- a/libs/search/src/lib/state/search.facade.ts
+++ b/libs/search/src/lib/state/search.facade.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@angular/core'
-import { ResultsListLayout, SearchFilters } from '@lib/common'
+import {
+  ResultsListLayout,
+  SearchFilters,
+  StateConfigFilters,
+} from '@lib/common'
 import { select, Store } from '@ngrx/store'
 import { Observable } from 'rxjs'
 import {
@@ -10,6 +14,7 @@ import {
   RequestMoreResults,
   Scroll,
   SetConfigAggregations,
+  SetConfigFilters,
   SetFilters,
   SetIncludeOnAggregation,
   SetPagination,
@@ -64,6 +69,10 @@ export class SearchFacade {
 
   setConfigAggregations(config: any): void {
     this.store.dispatch(new SetConfigAggregations(config, this.searchId))
+  }
+
+  setConfigFilters(filters: StateConfigFilters): void {
+    this.store.dispatch(new SetConfigFilters(filters, this.searchId))
   }
 
   requestMoreResults(): void {

--- a/tslint.json
+++ b/tslint.json
@@ -70,6 +70,7 @@
     ],
     "no-non-null-assertion": true,
     "no-redundant-jsdoc": true,
+    "no-string-literal": false,
     "no-switch-case-fall-through": true,
     "no-var-requires": false,
     "object-literal-key-quotes": [

--- a/webcomponents/src/app/components/gn-facets/gn-facets.component.ts
+++ b/webcomponents/src/app/components/gn-facets/gn-facets.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   Input,
+  OnInit,
   ViewEncapsulation,
 } from '@angular/core'
 import { SearchFacade } from '@lib/search'
@@ -14,8 +15,8 @@ import { BaseComponent } from '../base.component'
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.ShadowDom,
 })
-export class GnFacetsComponent extends BaseComponent {
-  @Input() facetConfig: string = '{}'
+export class GnFacetsComponent extends BaseComponent implements OnInit {
+  @Input() facetConfig = '{}'
 
   constructor(facade: SearchFacade) {
     super(facade)

--- a/webcomponents/src/app/components/gn-facets/gn-facets.sample.html
+++ b/webcomponents/src/app/components/gn-facets/gn-facets.sample.html
@@ -14,6 +14,7 @@
     ></gn-facets>
     <gn-results-list
       api-url="https://apps.titellus.net/geonetwork/srv/api"
+      query='{"tag.default": { "land use": true }}'
     ></gn-results-list>
   </body>
 </html>

--- a/webcomponents/src/app/components/gn-results-list/gn-results-list-filter.sample.html
+++ b/webcomponents/src/app/components/gn-results-list/gn-results-list-filter.sample.html
@@ -8,24 +8,24 @@
   </head>
   <body>
     <script src="gn-wc.js"></script>
-    <h2>Forest</h2>
+    <h1>Filter on services</h1>
+    <h2>elasticsearch object</h2>
     <gn-results-list
       api-url="https://apps.titellus.net/geonetwork/srv/api"
       size="5"
       layout="TITLE"
+      search-id="elastic"
       fixed="true"
-      query="+tag.default:forest"
+      filter='{"elastic": [{ "term": { "cl_hierarchyLevel.key": "service" } }]}'
     ></gn-results-list>
-
-    <h2>Marine</h2>
+    <h2>custom object</h2>
     <gn-results-list
       api-url="https://apps.titellus.net/geonetwork/srv/api"
       size="5"
-      primary-color="#343e9c"
-      search-id="marine"
-      fixed="true"
-      query="+tag.default:marine"
       layout="TITLE"
+      search-id="custom"
+      fixed="true"
+      filter='{"custom": { "cl_hierarchyLevel.key": { "service": true } }}'
     ></gn-results-list>
   </body>
 </html>

--- a/webcomponents/src/app/components/gn-results-list/gn-results-list-watch.sample.html
+++ b/webcomponents/src/app/components/gn-results-list/gn-results-list-watch.sample.html
@@ -13,7 +13,7 @@
       size="10"
       primary-color="#343e9c"
       layout="TITLE"
-      filter="GRID"
+      fixed="true"
     ></gn-results-list>
     <div>
       <button id="changeSizeBtn" onclick="moreRecords()">Load more ...</button>

--- a/webcomponents/src/app/components/gn-results-list/gn-results-list.component.ts
+++ b/webcomponents/src/app/components/gn-results-list/gn-results-list.component.ts
@@ -3,11 +3,17 @@ import {
   ChangeDetectorRef,
   Component,
   Input,
+  OnChanges,
+  OnInit,
   SimpleChanges,
   ViewEncapsulation,
 } from '@angular/core'
-import { ResultsListLayout } from '@lib/common'
-import { SearchFacade } from '@lib/search'
+import {
+  ResultsListLayout,
+  SearchFilters,
+  StateConfigFilters,
+} from '@lib/common'
+import { SearchFacade, SearchStateParams } from '@lib/search'
 import { BaseComponent } from '../base.component'
 
 @Component({
@@ -18,13 +24,16 @@ import { BaseComponent } from '../base.component'
   encapsulation: ViewEncapsulation.ShadowDom,
   providers: [SearchFacade],
 })
-export class GnResultsListComponent extends BaseComponent {
+export class GnResultsListComponent
+  extends BaseComponent
+  implements OnInit, OnChanges {
   @Input() layout: ResultsListLayout = ResultsListLayout.CARD
   @Input() size = 10
-  @Input() filter = ''
-  _fixed: boolean
+  @Input() query: string
+  @Input() filter: string
+  scrollDisabled: boolean
   @Input() set fixed(value: string) {
-    this._fixed = value === 'true'
+    this.scrollDisabled = value === 'true'
   }
 
   constructor(facade: SearchFacade, private changeDetector: ChangeDetectorRef) {
@@ -43,11 +52,30 @@ export class GnResultsListComponent extends BaseComponent {
   }
 
   private setSearch_() {
-    this.facade.setSearch({
-      filters: { any: this.filter },
+    const filter = this.filter
+    const query = this.query
+    const searchActionPayload: SearchStateParams = {
       size: this.size,
       from: 0,
-    })
+      filters: {},
+    }
+    if (query) {
+      try {
+        // we assume it's an object
+        const queryFilters: SearchFilters = JSON.parse(query)
+        searchActionPayload.filters = queryFilters
+      } catch (e) {
+        // we assume it's a string
+        searchActionPayload.filters = {
+          any: query,
+        }
+      }
+    }
+    if (filter) {
+      const configFilters: StateConfigFilters = JSON.parse(filter)
+      this.facade.setConfigFilters(configFilters)
+    }
+    this.facade.setSearch(searchActionPayload)
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/webcomponents/src/app/components/gn-results-list/gn-results-list.html
+++ b/webcomponents/src/app/components/gn-results-list/gn-results-list.html
@@ -1,4 +1,4 @@
 <search-results-list-container
   [layout]="layout"
-  [scrollableOptions]="{disabled: _fixed}"
+  [scrollableOptions]="{disabled: scrollDisabled}"
 ></search-results-list-container>

--- a/webcomponents/src/index.html
+++ b/webcomponents/src/index.html
@@ -24,6 +24,11 @@
         >
       </li>
       <li>
+        <a href="gn-results-list-filter.sample.html"
+          >Search using filter config</a
+        >
+      </li>
+      <li>
         <a href="gn-facets.sample.html">Aggregations and results</a>
       </li>
     </ul>

--- a/webcomponents/tslint.json
+++ b/webcomponents/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tslint.json",
+  "extends": "../tslint.json",
   "rules": {
     "directive-selector": [
       true,


### PR DESCRIPTION
Allows to set permanent filters to all elasticsearch search requests.
These filters are stored in the `filter` property of es request body (in `query.bool` path).
```
request
  - query
    - bool
      - must (user filters)
      - filter (permanent filters)
```
**State**
The permanent filters can be configured 2 ways:

- custom way: a friendly user format (based on internal state filters structure)
- elastic: a pure filter object passed as it is

Example:
```js
this.searchFacade.setConfigFilters({
  custom: {
    'cl_hierarchyLevel.key': {
      service: true,
    },
  },
  elastic: [
     { term: { 'cl_hierarchyLevel.key': 'service' } },
     { query_string: { "query": "-resourceType:service" }
  ],
})
```

custom config will generate:
```js
{ query_string: { query: '(cl_hierarchyLevel.key:"service")' } }
```

elastic config will generate:
```js
[
   { term: { 'cl_hierarchyLevel.key': 'service' } },
   { query_string: { "query": "-resourceType:service" }
]
```

Both configurations can't coexist, the elastic one has the priority

**Web components**
`gn-result-list` can now take 2 inputs to define the search state: `filter` and `query`

Example

```html
<gn-results-list
      query="+tag.default:forest"
      query='{"tag.default": { "land use": true }}'
      filter='{"custom": { "cl_hierarchyLevel.key": { "service": true } }}'
      filter='{"elastic": [{ "term": { "cl_hierarchyLevel.key": "service" } }]}'
></gn-results-list>

```
