### PR TITLE
datafeeder: support ENV for settings

### DIFF
--- a/apps/datafeeder/README.md
+++ b/apps/datafeeder/README.md
@@ -30,4 +30,4 @@ envsubst < assets/env.template.js > assets/env.js
 ```
 
 ### Other settings
-Other settings are fetched as a second step from the API `/datafeeder/config/setting`
+Other settings are fetched as a second step from the API `/datafeeder/config/frontend`

--- a/apps/datafeeder/README.md
+++ b/apps/datafeeder/README.md
@@ -1,0 +1,33 @@
+# Datafeeder
+UI of the web application `datafeeder`.
+
+`datafeeder` is for now a georchestra web application. Its purpose is to ease data and metadata publication.
+
+Basically, it invites the user to upload a SHP file and ask few questions about the data. 
+
+At the end, the data is published in GeoServer, and an INSPIRE compliant metadata is published in GeoNetwork.
+
+## Dev
+```
+npm start datafeeder
+```
+will run `datafeeder` as an Angular application available on localhost:4200.
+
+## Configuration
+### API url
+By default the api url is `/datafeeder`.
+
+A proxy configuration in dev mode redirects to `localhost:8080/import`
+
+You can override this URL with an ENV variable `${DATAFEEDER_API_URL}`.
+You can override this ENV from your docker entrypoint using the `assets/env.template.js`
+```
+# Set environment variable
+export DATAFEEDER_API_URL="/my-datafeeder";
+
+# Replace variables in env.js
+envsubst < assets/env.template.js > assets/env.js
+```
+
+### Other settings
+Other settings are fetched as a second step from the API `/datafeeder/config/setting`

--- a/apps/datafeeder/src/app/app.module.ts
+++ b/apps/datafeeder/src/app/app.module.ts
@@ -1,10 +1,9 @@
 import { BrowserModule } from '@angular/platform-browser'
 import { NgModule } from '@angular/core'
-import { BASE_PATH, Configuration } from '@lib/datafeeder-api'
+import { ApiModule, BASE_PATH, Configuration } from '@lib/datafeeder-api'
 import { StoreModule } from '@ngrx/store'
 import { StoreDevtoolsModule } from '@ngrx/store-devtools'
-import { environment } from '../../../search/src/environments/environment'
-import SETTINGS from '../settings'
+import { environment } from '../environments/environment'
 
 import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
@@ -68,6 +67,7 @@ export function apiConfigurationFactory() {
     HttpClientModule,
     I18nModule,
     EditorModule,
+    ApiModule.forRoot(apiConfigurationFactory),
     TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
     StoreModule.forRoot({
       [DATAFEEDER_STATE_KEY]: reducer,
@@ -77,7 +77,7 @@ export function apiConfigurationFactory() {
   providers: [
     {
       provide: BASE_PATH,
-      useFactory: () => SETTINGS.apiUrl,
+      useFactory: () => environment.apiUrl,
     },
   ],
   bootstrap: [AppComponent],

--- a/apps/datafeeder/src/app/presentation/pages/analysis-progress-page/analysis-progress.page.ts
+++ b/apps/datafeeder/src/app/presentation/pages/analysis-progress-page/analysis-progress.page.ts
@@ -7,7 +7,7 @@ import {
   UploadJobStatusApiModel,
 } from '@lib/datafeeder-api'
 import { interval, Observable, Subscription } from 'rxjs'
-import { filter, switchMap, take, tap } from 'rxjs/operators'
+import { filter, mergeMap, switchMap, take, tap } from 'rxjs/operators'
 import { DatafeederFacade } from '../../../store/datafeeder.facade'
 
 const { PENDING, ANALYZING, DONE } = AnalysisStatusEnumApiModel
@@ -33,7 +33,7 @@ export class AnalysisProgressPageComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.subscription = new Subscription()
     this.statusFetch$ = this.activatedRoute.params.pipe(
-      switchMap(({ id }) =>
+      mergeMap(({ id }) =>
         interval(500).pipe(
           switchMap(() => this.fileUploadApiService.findUploadJob(id)),
           tap((job: UploadJobStatusApiModel) => this.facade.setUpload(job)),

--- a/apps/datafeeder/src/app/presentation/pages/publish-page/publish-page.component.ts
+++ b/apps/datafeeder/src/app/presentation/pages/publish-page/publish-page.component.ts
@@ -7,7 +7,7 @@ import {
   UploadJobStatusApiModel,
 } from '@lib/datafeeder-api'
 import { interval, Observable, Subscription } from 'rxjs'
-import { filter, switchMap, take, tap } from 'rxjs/operators'
+import { filter, mergeMap, switchMap, take, tap } from 'rxjs/operators'
 import { DatafeederFacade } from '../../../store/datafeeder.facade'
 
 const { PENDING, RUNNING, DONE } = PublishStatusEnumApiModel
@@ -34,7 +34,7 @@ export class PublishPageComponent implements OnInit, OnDestroy {
     this.subscription = new Subscription()
 
     this.statusFetch$ = this.activatedRoute.params.pipe(
-      switchMap(({ id }) => {
+      mergeMap(({ id }) => {
         this.rootId = id
         return interval(500).pipe(
           switchMap(() => this.publishService.getPublishingStatus(id)),

--- a/apps/datafeeder/src/assets/env.js
+++ b/apps/datafeeder/src/assets/env.js
@@ -1,0 +1,4 @@
+((window) => {
+  window['env'] = window['env'] || {}
+  window['env']['apiUrl'] = '/datafeeder'
+})(this)

--- a/apps/datafeeder/src/assets/env.js
+++ b/apps/datafeeder/src/assets/env.js
@@ -1,4 +1,4 @@
-((window) => {
+;((window) => {
   window['env'] = window['env'] || {}
   window['env']['apiUrl'] = '/datafeeder'
 })(this)

--- a/apps/datafeeder/src/assets/env.template.js
+++ b/apps/datafeeder/src/assets/env.template.js
@@ -1,0 +1,4 @@
+;((window) => {
+  window['env'] = window['env'] || {}
+  window['env']['apiUrl'] = '${DATAFEEDER_API_URL}'
+})(this)

--- a/apps/datafeeder/src/assets/settings.json
+++ b/apps/datafeeder/src/assets/settings.json
@@ -1,3 +1,0 @@
-{
-  "apiUrl": "/datafeeder"
-}

--- a/apps/datafeeder/src/environments/environment.prod.ts
+++ b/apps/datafeeder/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
   production: true,
+  apiUrl: window['env']['apiUrl'],
 }

--- a/apps/datafeeder/src/environments/environment.ts
+++ b/apps/datafeeder/src/environments/environment.ts
@@ -4,6 +4,7 @@
 
 export const environment = {
   production: false,
+  apiUrl: window['env']['apiUrl'],
 }
 
 /*

--- a/apps/datafeeder/src/index.html
+++ b/apps/datafeeder/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Datafeeder</title>
-    <base href="/" />
+    <base href="./" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <script src="assets/env.js"></script>

--- a/apps/datafeeder/src/index.html
+++ b/apps/datafeeder/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Datafeeder</title>
-    <base href="./" />
+    <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <script src="assets/env.js"></script>

--- a/apps/datafeeder/src/index.html
+++ b/apps/datafeeder/src/index.html
@@ -6,6 +6,7 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <script src="assets/env.js"></script>
   </head>
   <body class="m-0 h-full flex flex-col">
     <div class="flex justify-center h-32 items-center">HEADER</div>

--- a/apps/datafeeder/src/settings.ts
+++ b/apps/datafeeder/src/settings.ts
@@ -1,7 +1,9 @@
 import 'whatwg-fetch'
+import { environment } from './environments/environment'
+
+const SETTING_API = `${environment.apiUrl}/config/frontend`
 
 class Settings {
-  apiUrl = ''
   encodings = [
     {
       label: 'UTF-8',
@@ -28,7 +30,7 @@ class Settings {
   ]
 
   init() {
-    return fetch('assets/settings.json')
+    return fetch(SETTING_API)
       .then((response) => response.json())
       .then((json) => {
         Object.assign(this, json)

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,4 +11,9 @@ module.exports = {
     '@lib/common': '<rootDir>libs/common/src/index.ts',
     '@lib/auth': '<rootDir>libs/auth/src/index.ts',
   },
+  globals: {
+    env: {
+      apiUrl: '/datafeeder',
+    },
+  },
 }


### PR DESCRIPTION
Update the settings mecanism to use angular `environnement` object instead of a custom Class `SETTINGS` for specific ENV settings.
It also avoids an asynchronous load to the `settings.json` file as it's now done through a javascript file, imported directly in the index.html file.

The UI has been tested alone, the backend was not working, so not sure about the `config/frontend` stuff, that's why I put it in draft while I have not tested the backend.