### PR TITLE
[datafeeder] - fix validation when CRS unknown

### DIFF
--- a/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.ts
+++ b/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.ts
@@ -53,11 +53,9 @@ export class DataImportValidationMapPanelComponent
   ngOnInit(): void {
     this.selectedValue = this.footerValue || ''
     this.vectorLayer = this.buildVectorLayer()
-
-    if (!this.geoJson) {
-      return
+    if (this.geoJson) {
+      this.addFeature()
     }
-    this.addFeature()
   }
 
   addFeature() {
@@ -88,7 +86,6 @@ export class DataImportValidationMapPanelComponent
         new TileLayer({
           source: new OSM(),
         }),
-        this.vectorLayer,
       ],
       controls: [],
       interactions: [],
@@ -98,6 +95,9 @@ export class DataImportValidationMapPanelComponent
         constrainResolution: true,
       }),
     })
+    if (this.vectorLayer) {
+      this.map.addLayer(this.vectorLayer)
+    }
 
     this.fit()
   }
@@ -155,11 +155,14 @@ export class DataImportValidationMapPanelComponent
   }
 
   private buildVectorLayer(): VectorLayer {
-    this.source = new VectorSource({
-      features: this.format.readFeatures(this.geoJson, {
-        featureProjection: 'EPSG:3857',
-      }),
-    })
+    this.source = new VectorSource({})
+    if (this.geoJson) {
+      this.source.addFeatures(
+        this.format.readFeatures(this.geoJson, {
+          featureProjection: 'EPSG:3857',
+        })
+      )
+    }
     return new VectorLayer({
       source: this.source,
       style: this.getDefaultStyle(),

--- a/apps/datafeeder/src/app/presentation/pages/dataset-validation-page/dataset-validation-page.html
+++ b/apps/datafeeder/src/app/presentation/pages/dataset-validation-page/dataset-validation-page.html
@@ -40,7 +40,6 @@
           [geoJson]="geoJSONBBox"
           [showProperties]="false"
           (propertyChange)="handleCrsChange($event)"
-          *ngIf="geoJSONBBox"
         ></gn-ui-data-import-validation-map-panel>
       </div>
     </div>

--- a/apps/datafeeder/src/app/presentation/pages/dataset-validation-page/dataset-validation-page.ts
+++ b/apps/datafeeder/src/app/presentation/pages/dataset-validation-page/dataset-validation-page.ts
@@ -111,13 +111,18 @@ export class DatasetValidationPageComponent implements OnInit, OnDestroy {
   loadBounds() {
     this.fileUploadApiService
       .getBounds(this.rootId.toString(), this.dataset.name, viewSrs, this.crs)
-      .subscribe((bbox: BoundingBoxApiModel) => {
-        const { minx, miny, maxx, maxy } = bbox
-        this.geoJSONBBox = this.format.writeFeatureObject(
-          new Feature({ geometry: fromExtent([minx, miny, maxx, maxy]) }),
-          { featureProjection: viewSrs }
-        )
-      })
+      .subscribe(
+        (bbox: BoundingBoxApiModel) => {
+          const { minx, miny, maxx, maxy } = bbox
+          this.geoJSONBBox = this.format.writeFeatureObject(
+            new Feature({ geometry: fromExtent([minx, miny, maxx, maxy]) }),
+            { featureProjection: viewSrs }
+          )
+        },
+        (error) => {
+          this.geoJSONBBox = null
+        }
+      )
   }
 
   handleEncodingChange(encoding) {

--- a/libs/ui/inputs/src/lib/chips-input/chips-input.component.html
+++ b/libs/ui/inputs/src/lib/chips-input/chips-input.component.html
@@ -4,6 +4,7 @@
   onlyFromAutocomplete="true"
   [placeholder]="placeholder"
   [secondaryPlaceholder]="placeholder"
+  [ripple]="false"
   [animationDuration]="{ enter: '0ms', leave: '0ms' }"
   onTextChangeDebounce="100"
   class="border-2 border-primary h-full rounded-lg p-2 bg-white text-sm focus:border-primary"
@@ -12,6 +13,7 @@
   <tag-input-dropdown
     [autocompleteObservable]="requestAutocompleteItems"
     [minimumTextLength]="0"
+    [keepOpen]="false"
     [showDropdownIfEmpty]="true"
   >
     <ng-template let-item="item" let-index="index">


### PR DESCRIPTION
If the data has no CRS, we let the user be able to manually pick one CRS and check if the result is ok on the map. 