### PR TITLE
Migrate ol 6.6

### DIFF
--- a/apps/datafeeder/jest.config.js
+++ b/apps/datafeeder/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   displayName: 'datafeeder',
   preset: '../../jest.preset.js',
-  transformIgnorePatterns: ['node_modules/(?!(ol))'],
   transform: { '\\.ts$': ['ts-jest'] },
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {

--- a/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.ts
+++ b/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.ts
@@ -14,11 +14,12 @@ import { Feature } from 'geojson'
 import { asArray, asString } from 'ol/color'
 import { isEmpty } from 'ol/extent'
 import GeoJSON from 'ol/format/GeoJSON'
+import { Geometry } from 'ol/geom'
 import { Tile as TileLayer, Vector as VectorLayer } from 'ol/layer'
 import Map from 'ol/Map'
-import { transform } from 'ol/proj'
 import { OSM, Vector as VectorSource } from 'ol/source'
-import { Fill, Stroke, Style, RegularShape } from 'ol/style'
+import { Fill, RegularShape, Stroke, Style } from 'ol/style'
+import { StyleLike } from 'ol/style/Style'
 import View from 'ol/View'
 
 const DEFAULT_PRIMARY_COLOR = '#9a9a9a'
@@ -46,8 +47,8 @@ export class DataImportValidationMapPanelComponent
   selectedValue: any
 
   private map: Map
-  private source: VectorSource
-  private vectorLayer: VectorLayer
+  private source: VectorSource<Geometry>
+  private vectorLayer: VectorLayer<VectorSource<Geometry>>
   private format: any = new GeoJSON({})
 
   ngOnInit(): void {
@@ -110,7 +111,6 @@ export class DataImportValidationMapPanelComponent
     this.map.getView().fit(this.source.getExtent(), {
       padding:
         this.padding.length === 0 ? Array(4).fill(PADDING) : this.padding,
-      constrainResolution: false,
       maxZoom: 18,
     })
   }
@@ -132,7 +132,7 @@ export class DataImportValidationMapPanelComponent
     this.propertyChange.emit(event)
   }
 
-  private getDefaultStyle(): Style {
+  private getDefaultStyle(): StyleLike {
     const stroke = new Stroke({
       color: this.getSecondaryColor(1),
       width: 3,
@@ -155,7 +155,7 @@ export class DataImportValidationMapPanelComponent
     ]
   }
 
-  private buildVectorLayer(): VectorLayer {
+  private buildVectorLayer(): VectorLayer<VectorSource<Geometry>> {
     this.source = new VectorSource({})
     if (this.geoJson) {
       this.source.addFeatures(

--- a/apps/datafeeder/src/app/presentation/pages/dataset-validation-page/dataset-validation-page.ts
+++ b/apps/datafeeder/src/app/presentation/pages/dataset-validation-page/dataset-validation-page.ts
@@ -9,8 +9,9 @@ import {
   UploadJobStatusApiModel,
 } from '@geonetwork-ui/data-access/datafeeder'
 import { WizardService } from '@geonetwork-ui/feature/editor'
-import Feature from 'ol/Feature'
+import { Feature } from 'geojson'
 import GeoJSON from 'ol/format/GeoJSON'
+import OlFeature from 'ol/Feature'
 import { fromExtent } from 'ol/geom/Polygon'
 import { Subscription } from 'rxjs'
 import { take } from 'rxjs/operators'
@@ -38,8 +39,8 @@ export class DatasetValidationPageComponent implements OnInit, OnDestroy {
   encodingList = SETTINGS.encodings
   refSystem = [{ label: unknownLabel, value: '' }, ...SETTINGS.projections]
 
-  geoJSONData: Record<string, unknown>
-  geoJSONBBox: Record<string, unknown>
+  geoJSONData: Feature
+  geoJSONBBox: Feature
 
   dataset: DatasetUploadStatusApiModel
 
@@ -105,9 +106,7 @@ export class DatasetValidationPageComponent implements OnInit, OnDestroy {
         viewSrs,
         this.crs
       )
-      .subscribe(
-        (feature) => (this.geoJSONData = feature as Record<string, any>)
-      )
+      .subscribe((feature: Feature) => (this.geoJSONData = feature))
   }
 
   loadBounds() {
@@ -117,7 +116,7 @@ export class DatasetValidationPageComponent implements OnInit, OnDestroy {
         (bbox: BoundingBoxApiModel) => {
           const { minx, miny, maxx, maxy } = bbox
           this.geoJSONBBox = this.format.writeFeatureObject(
-            new Feature({ geometry: fromExtent([minx, miny, maxx, maxy]) }),
+            new OlFeature({ geometry: fromExtent([minx, miny, maxx, maxy]) }),
             { featureProjection: viewSrs }
           )
         },

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,3 +1,7 @@
 const nxPreset = require('@nrwl/jest/preset')
 
-module.exports = { ...nxPreset, setupFiles: ['jest-canvas-mock'] }
+module.exports = {
+  ...nxPreset,
+  setupFiles: ['jest-canvas-mock'],
+  transformIgnorePatterns: ['node_modules/(?!(ol|@mapbox))'],
+}

--- a/libs/ui/map/jest.config.js
+++ b/libs/ui/map/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   displayName: 'ui-map',
   preset: '../../../jest.preset.js',
-  transformIgnorePatterns: ['node_modules/(?!(ol))'],
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {

--- a/libs/ui/map/src/lib/components/map-context/map-context.component.ts
+++ b/libs/ui/map/src/lib/components/map-context/map-context.component.ts
@@ -6,8 +6,9 @@ import {
   OnInit,
   Output,
 } from '@angular/core'
-
 import Feature from 'ol/Feature'
+import { Geometry } from 'ol/geom'
+
 import Map from 'ol/Map'
 import { forkJoin, Observable, of } from 'rxjs'
 import { MapContextModel } from '../../models/map-context.model'
@@ -22,7 +23,7 @@ import { MapUtilsService } from '../../services/map-utils.service'
 })
 export class MapContextComponent implements OnInit {
   @Input() context: MapContextModel
-  @Output() featureClicked = new EventEmitter<Feature[]>()
+  @Output() featureClicked = new EventEmitter<Feature<Geometry>[]>()
 
   map: Map
 
@@ -46,7 +47,7 @@ export class MapContextComponent implements OnInit {
         this.mapUtils.getVectorFeaturesFromClick(this.map, event)
       )
 
-      const featuresObservablesArray: Observable<Feature[]>[] = [
+      const featuresObservablesArray: Observable<Feature<Geometry>[]>[] = [
         ...gfiFeaturesObservables,
         vectorFeatures$,
       ]

--- a/libs/ui/map/src/lib/components/map/map.component.spec.ts
+++ b/libs/ui/map/src/lib/components/map/map.component.spec.ts
@@ -15,7 +15,7 @@ describe('MapComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MapComponent)
     component = fixture.componentInstance
-    component.map = new Map()
+    component.map = new Map({})
     fixture.detectChanges()
   })
 

--- a/libs/ui/map/src/lib/services/map-utils.service.spec.ts
+++ b/libs/ui/map/src/lib/services/map-utils.service.spec.ts
@@ -1,15 +1,16 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { TestBed } from '@angular/core/testing'
+import Feature from 'ol/Feature'
+import { Polygon } from 'ol/geom'
 import ImageLayer from 'ol/layer/Image'
-import ImageWMS from 'ol/source/ImageWMS'
 import TileLayer from 'ol/layer/Tile'
+import ImageWMS from 'ol/source/ImageWMS'
 import TileWMS from 'ol/source/TileWMS'
 import XYZ from 'ol/source/XYZ'
 
 import { FEATURE_COLLECTION_POLYGON_FIXTURE_4326 } from '../fixtures/geojson.fixtures'
 
 import { MapUtilsService } from './map-utils.service'
-import Feature from 'ol/Feature'
 
 const wmsTileLayer = new TileLayer({
   source: new TileWMS({
@@ -46,7 +47,7 @@ describe('MapUtilsService', () => {
 
   describe('#readFeatureCollection', () => {
     const collection = FEATURE_COLLECTION_POLYGON_FIXTURE_4326
-    let olFeatures, featureSample: Feature
+    let olFeatures, featureSample: Feature<Polygon>
     describe('when no option', () => {
       beforeEach(() => {
         olFeatures = service.readFeatureCollection(collection)

--- a/libs/ui/map/src/lib/services/map-utils.service.ts
+++ b/libs/ui/map/src/lib/services/map-utils.service.ts
@@ -1,12 +1,13 @@
 import { HttpClient } from '@angular/common/http'
 import { Injectable } from '@angular/core'
 import { FeatureCollection } from 'geojson'
-import Feature from 'ol/Feature'
 import OlFeature from 'ol/Feature'
 import GeoJSON from 'ol/format/GeoJSON'
+import { Geometry } from 'ol/geom'
+import { Source } from 'ol/source'
 import ImageWMS from 'ol/source/ImageWMS'
 import TileWMS from 'ol/source/TileWMS'
-import Layer from 'ol/layer/Base'
+import Layer from 'ol/layer/Layer'
 import VectorSource from 'ol/source/Vector'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
@@ -24,7 +25,7 @@ export class MapUtilsService {
     featureCollection: FeatureCollection,
     featureProjection = FEATURE_PROJECTION,
     dataProjection = DATA_PROJECTION
-  ): OlFeature[] => {
+  ): OlFeature<Geometry>[] => {
     const olFeatures = new GeoJSON().readFeatures(featureCollection, {
       featureProjection,
       dataProjection,
@@ -32,7 +33,7 @@ export class MapUtilsService {
     return olFeatures
   }
 
-  isWMSLayer(layer: Layer): boolean {
+  isWMSLayer(layer: Layer<Source>): boolean {
     return (
       layer.getSource() instanceof TileWMS ||
       layer.getSource() instanceof ImageWMS
@@ -57,11 +58,11 @@ export class MapUtilsService {
     return url
   }
 
-  getVectorFeaturesFromClick(olMap, event): Feature[] {
+  getVectorFeaturesFromClick(olMap, event): OlFeature<Geometry>[] {
     const features = []
     const hit = olMap.forEachFeatureAtPixel(
       event.pixel,
-      (feature: Feature) => {
+      (feature: OlFeature<Geometry>) => {
         return feature
       },
       { layerFilter: (layer) => layer.getSource() instanceof VectorSource }
@@ -72,7 +73,10 @@ export class MapUtilsService {
     return features
   }
 
-  getGFIFeaturesObservablesFromClick(olMap, event): Observable<Feature[]>[] {
+  getGFIFeaturesObservablesFromClick(
+    olMap,
+    event
+  ): Observable<OlFeature<Geometry>[]>[] {
     const wmsLayers = olMap.getLayers().getArray().filter(this.isWMSLayer)
 
     if (wmsLayers.length > 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "ngx-dropzone": "^3.0.0",
         "ngx-infinite-scroll": "^10.0.1",
         "ngx-translate-messageformat-compiler": "^4.10.0",
-        "ol": "^6.5.0",
+        "ol": "^6.6.1",
         "rxjs": "~6.6.0",
         "tslib": "^2.0.0",
         "whatwg-fetch": "^3.6.2",
@@ -3338,9 +3338,9 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-style-spec": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.20.0.tgz",
-      "integrity": "sha512-66d9vIPuKDI5IKq/l6s+oTD2DIufo+ONyQ9TZ5muGPJ/scO7ZJ+aWOLUjV1RUsgRqgJCq3a4Ba8Z0fDOWRcxKQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
+      "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -16131,11 +16131,11 @@
       "dev": true
     },
     "node_modules/ol": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.5.0.tgz",
-      "integrity": "sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.6.1.tgz",
+      "integrity": "sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==",
       "dependencies": {
-        "ol-mapbox-style": "^6.1.1",
+        "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -16145,16 +16145,16 @@
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.3.2.tgz",
-      "integrity": "sha512-itWZuwZHilztRM9983WmJ+ounaXIS0PdXF8h5xJd7cJhSv02M27w4RQkhiUw35/VLlUdTT/ei3KYi0w2TGDw2A==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.4.1.tgz",
+      "integrity": "sha512-qeHgB5lEaCjvpaR6oK8bPWqPTUAYzM2CTSfYJzujIU3egYLPCvJfVagIfTEMRDUG3CXTtIYHOI2Pg58ihhWJYA==",
       "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.14.0",
+        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.0",
         "webfont-matcher": "^1.1.0"
       },
       "peerDependencies": {
-        "ol": "^6.1.0"
+        "ol": ">= 6.1.0 < 7"
       }
     },
     "node_modules/on-finished": {
@@ -28331,9 +28331,9 @@
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-style-spec": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.20.0.tgz",
-      "integrity": "sha512-66d9vIPuKDI5IKq/l6s+oTD2DIufo+ONyQ9TZ5muGPJ/scO7ZJ+aWOLUjV1RUsgRqgJCq3a4Ba8Z0fDOWRcxKQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.21.0.tgz",
+      "integrity": "sha512-qGRAZEHQfhjknjd9eCsNmKclXG5zK62DRdbgUiqAnrdkjjXrFNbs0KFaeyY8RzbdXzKRkwge6nqeKJfjYoD3vw==",
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -38219,21 +38219,21 @@
       "dev": true
     },
     "ol": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.5.0.tgz",
-      "integrity": "sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-6.6.1.tgz",
+      "integrity": "sha512-QHNth7ty7UAPi5oEL5N5rJB/cgdFGAAzigYEM8LTUKCq/StTOTWDf2fFrom3wQVmsr1etf6i6hTBowtY/LiGgg==",
       "requires": {
-        "ol-mapbox-style": "^6.1.1",
+        "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       }
     },
     "ol-mapbox-style": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.3.2.tgz",
-      "integrity": "sha512-itWZuwZHilztRM9983WmJ+ounaXIS0PdXF8h5xJd7cJhSv02M27w4RQkhiUw35/VLlUdTT/ei3KYi0w2TGDw2A==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.4.1.tgz",
+      "integrity": "sha512-qeHgB5lEaCjvpaR6oK8bPWqPTUAYzM2CTSfYJzujIU3egYLPCvJfVagIfTEMRDUG3CXTtIYHOI2Pg58ihhWJYA==",
       "requires": {
-        "@mapbox/mapbox-gl-style-spec": "^13.14.0",
+        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.0",
         "webfont-matcher": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ngx-dropzone": "^3.0.0",
     "ngx-infinite-scroll": "^10.0.1",
     "ngx-translate-messageformat-compiler": "^4.10.0",
-    "ol": "^6.5.0",
+    "ol": "^6.6.1",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "whatwg-fetch": "^3.6.2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,8 +20,6 @@
     "noImplicitAny": false,
     "esModuleInterop": true,
     "paths": {
-      "ol": ["node_modules/ol/src"],
-      "ol/*": ["node_modules/ol/src/*"],
       "@geonetwork-ui/feature/search": ["libs/feature/search/src/index.ts"],
       "@geonetwork-ui/feature/auth": ["libs/feature/auth/src/index.ts"],
       "@geonetwork-ui/ui/search": ["libs/ui/search/src/index.ts"],


### PR DESCRIPTION
Mostly to have a better typescript support.

`definitlytyped` are now offically exported in the package what eases the development under IDE such as IntelliJ
- auto import
- completion
- types


This needed some fixes in the actual type definition of GN code related to openlayers.