### PR TITLE
Dataviz - Figure component

### DIFF
--- a/apps/demo/.storybook/preview-head.html
+++ b/apps/demo/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<link
+  href="https://fonts.googleapis.com/icon?family=Material+Icons"
+  rel="stylesheet"
+/>

--- a/libs/feature/dataviz/src/lib/feature-dataviz.module.ts
+++ b/libs/feature/dataviz/src/lib/feature-dataviz.module.ts
@@ -4,10 +4,11 @@ import { FeatureMapModule } from '@geonetwork-ui/feature/map'
 import { UiMapModule } from '@geonetwork-ui/ui/map'
 import { GeoTableViewComponent } from './geo-table-view/geo-table-view.component'
 import { UiLayoutModule } from '@geonetwork-ui/ui/layout'
+import { FigureContainerComponent } from './figure/figure-container/figure-container.component'
 
 @NgModule({
   imports: [CommonModule, UiLayoutModule, FeatureMapModule, UiMapModule],
-  declarations: [GeoTableViewComponent],
-  exports: [GeoTableViewComponent],
+  declarations: [GeoTableViewComponent, FigureContainerComponent],
+  exports: [GeoTableViewComponent, FigureContainerComponent],
 })
 export class FeatureDatavizModule {}

--- a/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.html
+++ b/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.html
@@ -1,0 +1,6 @@
+<gn-ui-figure
+  [figure]="figure"
+  [icon]="icon"
+  [title]="title"
+  [unit]="unit"
+></gn-ui-figure>

--- a/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.spec.ts
+++ b/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.spec.ts
@@ -1,0 +1,68 @@
+import { ChangeDetectionStrategy, NO_ERRORS_SCHEMA } from '@angular/core'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import {
+  TABLE_ITEM_FIXTURE,
+  TABLE_ITEM_FIXTURE_HAB,
+} from '@geonetwork-ui/ui/layout'
+import { FigureContainerComponent } from './figure-container.component'
+
+describe('FigureContainerComponent', () => {
+  let component: FigureContainerComponent
+  let fixture: ComponentFixture<FigureContainerComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FigureContainerComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    })
+      .overrideComponent(FigureContainerComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents()
+  })
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FigureContainerComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+  describe('when average', () => {
+    beforeEach(() => {
+      component.dataset = TABLE_ITEM_FIXTURE
+      component.expression = 'average|age'
+      component.ngOnChanges(null)
+    })
+    it('computes the average', () => {
+      expect(component.figure).toEqual('26.67')
+    })
+    it('with correct digits', () => {
+      component.digits = 3
+      component.ngOnChanges(null)
+      expect(component.figure).toEqual('26.667')
+    })
+  })
+  describe('when sum', () => {
+    beforeEach(() => {
+      component.dataset = TABLE_ITEM_FIXTURE_HAB
+      component.expression = 'sum|pop'
+      component.ngOnChanges(null)
+    })
+    it('computes the sum', () => {
+      expect(component.figure).toEqual('159176260999')
+    })
+  })
+  describe('when bad expression', () => {
+    beforeEach(() => {
+      component.dataset = TABLE_ITEM_FIXTURE_HAB
+      component.expression = 'sumfds--fdfdspop'
+      component.ngOnChanges(null)
+    })
+    it('returns Nan', () => {
+      expect(component.figure).toEqual('NaN')
+    })
+  })
+})

--- a/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.stories.ts
+++ b/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.stories.ts
@@ -1,0 +1,52 @@
+import {
+  TABLE_ITEM_FIXTURE,
+  TABLE_ITEM_FIXTURE_HAB,
+  UiLayoutModule,
+} from '@geonetwork-ui/ui/layout'
+import {
+  moduleMetadata,
+  Story,
+  Meta,
+  componentWrapperDecorator,
+} from '@storybook/angular'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+import { FigureContainerComponent } from './figure-container.component'
+
+export default {
+  title: 'Dataviz/FigureContainerComponent',
+  component: FigureContainerComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [UiLayoutModule, BrowserAnimationsModule],
+    }),
+    componentWrapperDecorator(
+      (story) => `<div style="max-width: 700px">${story}</div>`
+    ),
+  ],
+} as Meta<FigureContainerComponent>
+
+const Template: Story<FigureContainerComponent> = (
+  args: FigureContainerComponent
+) => ({
+  component: FigureContainerComponent,
+  props: args,
+})
+
+export const Sum = Template.bind({})
+Sum.args = {
+  title: 'Sum of inhabitants',
+  icon: 'maps_home_work',
+  unit: 'hab.',
+  expression: 'sum|pop',
+  dataset: TABLE_ITEM_FIXTURE_HAB,
+}
+
+export const Average = Template.bind({})
+Average.args = {
+  title: 'Average age of the population',
+  icon: 'group',
+  unit: 'years old',
+  expression: 'average|age',
+  digits: 3,
+  dataset: TABLE_ITEM_FIXTURE,
+}

--- a/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.stories.ts
+++ b/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.stories.ts
@@ -20,7 +20,10 @@ export default {
       imports: [UiLayoutModule, BrowserAnimationsModule],
     }),
     componentWrapperDecorator(
-      (story) => `<div style="max-width: 700px">${story}</div>`
+      (story) => `
+<div class="border border-gray-300 p-2" style="width: 300px; resize: both; overflow: auto">
+  ${story}
+</div>`
     ),
   ],
 } as Meta<FigureContainerComponent>

--- a/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.ts
+++ b/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.ts
@@ -7,7 +7,7 @@ import {
   SimpleChanges,
 } from '@angular/core'
 import { TableItemModel } from '@geonetwork-ui/ui/layout'
-import { FigureService } from '../figure-service.service'
+import { FigureService } from '../figure.service'
 
 @Component({
   selector: 'gn-ui-figure-container',

--- a/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.ts
+++ b/libs/feature/dataviz/src/lib/figure/figure-container/figure-container.component.ts
@@ -1,0 +1,35 @@
+import {
+  Component,
+  OnInit,
+  ChangeDetectionStrategy,
+  Input,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core'
+import { TableItemModel } from '@geonetwork-ui/ui/layout'
+import { FigureService } from '../figure-service.service'
+
+@Component({
+  selector: 'gn-ui-figure-container',
+  templateUrl: './figure-container.component.html',
+  styleUrls: ['./figure-container.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FigureContainerComponent implements OnChanges {
+  @Input() dataset: TableItemModel[]
+  @Input() expression: string
+  @Input() icon: string
+  @Input() title: string
+  @Input() unit: string
+  @Input() digits?: number = 2
+  figure: string
+
+  constructor(private service: FigureService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    const figure = this.service
+      .compute(this.expression, this.dataset)
+      .toFixed(this.digits)
+    this.figure = parseFloat(figure).toString()
+  }
+}

--- a/libs/feature/dataviz/src/lib/figure/figure.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/figure/figure.service.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing'
+import {
+  TABLE_ITEM_FIXTURE,
+  TABLE_ITEM_FIXTURE_HAB,
+} from '@geonetwork-ui/ui/layout'
+
+import { FigureService } from './figure.service'
+
+describe('FigureServiceService', () => {
+  let service: FigureService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+    service = TestBed.inject(FigureService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+  describe('#operations', () => {
+    const data = [10, 50, 100, 0]
+
+    it('sum', () => {
+      expect(service['operations']['sum'](data)).toBe(160)
+    })
+    it('average', () => {
+      expect(service['operations']['average'](data)).toBe(40)
+    })
+  })
+
+  describe('#compute', () => {
+    let expression
+    let dataset
+    let figure
+
+    describe('average', () => {
+      beforeEach(() => {
+        dataset = TABLE_ITEM_FIXTURE
+        expression = 'average|age'
+        figure = service.compute(expression, dataset)
+      })
+
+      it('returns the correct average', () => {
+        expect(figure).toEqual(26.666666666666668)
+      })
+    })
+    describe('sum', () => {
+      beforeEach(() => {
+        dataset = TABLE_ITEM_FIXTURE_HAB
+        expression = 'sum|pop'
+        figure = service.compute(expression, dataset)
+      })
+
+      it('returns the correct sum', () => {
+        expect(figure).toEqual(159176260999)
+      })
+    })
+    describe('error', () => {
+      beforeEach(() => {
+        dataset = TABLE_ITEM_FIXTURE
+        expression = 'avera---age'
+        figure = service.compute(expression, dataset)
+      })
+      it('returns Nan', () => {
+        expect(figure).toBeNaN()
+      })
+    })
+  })
+})

--- a/libs/feature/dataviz/src/lib/figure/figure.service.ts
+++ b/libs/feature/dataviz/src/lib/figure/figure.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core'
+import { TableItemModel } from '@geonetwork-ui/ui/layout'
+
+type FigureOperationTypes = 'sum' | 'average'
+type FigureOperationsModel = Record<
+  FigureOperationTypes,
+  (data: number[]) => number
+>
+export const FIGURE_OPERATION_DELIMITER = '|'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FigureService {
+  private operations: FigureOperationsModel = {
+    sum: (data) => data.reduce((sum, value) => (sum += value), 0),
+    average: (data) => this.operations.sum(data) / data.length,
+  }
+
+  compute(expression: string, dataset: TableItemModel[]): number {
+    try {
+      const computing = expression.split(FIGURE_OPERATION_DELIMITER)[0]
+      const column = expression.split(FIGURE_OPERATION_DELIMITER)[1]
+      const data = dataset.map((row) => row[column])
+      return this.operations[computing](data)
+    } catch (e) {
+      return NaN
+    }
+  }
+}

--- a/libs/feature/dataviz/src/lib/geo-table-view/geo-table-view.component.spec.ts
+++ b/libs/feature/dataviz/src/lib/geo-table-view/geo-table-view.component.spec.ts
@@ -150,7 +150,7 @@ describe('GeoTableViewComponent', () => {
   })
 
   describe('#onMapFeatureSelect', () => {
-    let tableEntry, features
+    let features
     beforeEach(() => {
       features = [
         component['vectorSource']

--- a/libs/feature/dataviz/src/lib/geo-table-view/geo-table-view.component.stories.ts
+++ b/libs/feature/dataviz/src/lib/geo-table-view/geo-table-view.component.stories.ts
@@ -1,5 +1,7 @@
 import { HttpClientModule } from '@angular/common/http'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+import { FeatureMapModule } from '@geonetwork-ui/feature/map'
+import { UiLayoutModule } from '@geonetwork-ui/ui/layout'
 import { UiMapModule } from '@geonetwork-ui/ui/map'
 import { FEATURE_COLLECTION_POINT_FIXTURE_4326 } from '@geonetwork-ui/util/shared'
 import {
@@ -9,12 +11,6 @@ import {
   Story,
 } from '@storybook/angular'
 import { GeoTableViewComponent } from './geo-table-view.component'
-import {
-  defaultMapOptions,
-  FEATURE_MAP_OPTIONS,
-  FeatureMapModule,
-} from '@geonetwork-ui/feature/map'
-import { UiLayoutModule } from '@geonetwork-ui/ui/layout'
 
 export default {
   title: 'Map/GeoTable',

--- a/libs/ui/layout/src/index.ts
+++ b/libs/ui/layout/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/ui-layout.module'
 export * from './lib/table/table.component'
+export * from './lib/table/table.fixtures'
 export * from './lib/metadata-page/metadata-page.component'

--- a/libs/ui/layout/src/lib/figure/figure.component.css
+++ b/libs/ui/layout/src/lib/figure/figure.component.css
@@ -1,0 +1,3 @@
+.icon {
+    font-size: 36px;
+}

--- a/libs/ui/layout/src/lib/figure/figure.component.css
+++ b/libs/ui/layout/src/lib/figure/figure.component.css
@@ -1,3 +1,7 @@
 .icon {
-    font-size: 36px;
+  font-size: 36px;
+}
+mat-icon {
+  width: 48px;
+  height: 48px;
 }

--- a/libs/ui/layout/src/lib/figure/figure.component.html
+++ b/libs/ui/layout/src/lib/figure/figure.component.html
@@ -1,0 +1,9 @@
+<div class="mx-auto text-center">
+  <mat-icon class="text-5xl text-main">{{ icon }}</mat-icon>
+
+  <div class="figure-block text-primary text-3xl">
+    <span class="figure fw-bold mr-2">{{ figure }}</span>
+    <span class="unit text-sm">{{ unit }}</span>
+  </div>
+  <div class="title">{{ title }}</div>
+</div>

--- a/libs/ui/layout/src/lib/figure/figure.component.spec.ts
+++ b/libs/ui/layout/src/lib/figure/figure.component.spec.ts
@@ -20,7 +20,7 @@ describe('FigureComponent', () => {
     component = fixture.componentInstance
     component.title = 'Average population in European countries'
     component.icon = 'group'
-    component.figure = 1020500
+    component.figure = '1020500'
     component.unit = 'hab.'
     fixture.detectChanges()
     compiled = fixture.nativeElement as HTMLElement

--- a/libs/ui/layout/src/lib/figure/figure.component.spec.ts
+++ b/libs/ui/layout/src/lib/figure/figure.component.spec.ts
@@ -1,0 +1,52 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { FigureComponent } from './figure.component'
+
+describe('FigureComponent', () => {
+  let component: FigureComponent
+  let fixture: ComponentFixture<FigureComponent>
+  let compiled: HTMLElement
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FigureComponent],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents()
+  })
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FigureComponent)
+    component = fixture.componentInstance
+    component.title = 'Average population in European countries'
+    component.icon = 'group'
+    component.figure = 1020500
+    component.unit = 'hab.'
+    fixture.detectChanges()
+    compiled = fixture.nativeElement as HTMLElement
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('should render figure', () => {
+    expect(compiled.querySelector('.figure')?.textContent).toContain('1020500')
+  })
+  it('should render unit', () => {
+    expect(compiled.querySelector('.unit')?.textContent).toContain('hab.')
+  })
+  it('should render title', () => {
+    expect(compiled.querySelector('.title')?.textContent).toContain(
+      'Average population in European countries'
+    )
+  })
+  it('should render icon', () => {
+    expect(compiled.querySelector('mat-icon')?.textContent).toContain('group')
+  })
+  it('icon is primary color', () => {
+    expect(compiled.querySelector('.figure-block')?.className).toContain(
+      'text-primary'
+    )
+  })
+})

--- a/libs/ui/layout/src/lib/figure/figure.component.stories.ts
+++ b/libs/ui/layout/src/lib/figure/figure.component.stories.ts
@@ -16,7 +16,10 @@ export default {
       imports: [UiLayoutModule, BrowserAnimationsModule],
     }),
     componentWrapperDecorator(
-      (story) => `<div style="max-width: 700px">${story}</div>`
+      (story) => `
+<div class="border border-gray-300 p-2" style="width: 300px; resize: both; overflow: auto">
+  ${story}
+</div>`
     ),
   ],
 } as Meta<FigureComponent>

--- a/libs/ui/layout/src/lib/figure/figure.component.stories.ts
+++ b/libs/ui/layout/src/lib/figure/figure.component.stories.ts
@@ -1,0 +1,35 @@
+import {
+  moduleMetadata,
+  Story,
+  Meta,
+  componentWrapperDecorator,
+} from '@storybook/angular'
+import { FigureComponent } from './figure.component'
+import { UiLayoutModule } from '../ui-layout.module'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+
+export default {
+  title: 'Layout/FigureComponent',
+  component: FigureComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [UiLayoutModule, BrowserAnimationsModule],
+    }),
+    componentWrapperDecorator(
+      (story) => `<div style="max-width: 700px">${story}</div>`
+    ),
+  ],
+} as Meta<FigureComponent>
+
+const Template: Story<FigureComponent> = (args: FigureComponent) => ({
+  component: FigureComponent,
+  props: args,
+})
+
+export const Primary = Template.bind({})
+Primary.args = {
+  title: 'Average population in European countries',
+  icon: 'group',
+  figure: 1020500,
+  unit: 'hab.',
+}

--- a/libs/ui/layout/src/lib/figure/figure.component.ts
+++ b/libs/ui/layout/src/lib/figure/figure.component.ts
@@ -14,6 +14,6 @@ import {
 export class FigureComponent {
   @Input() icon: string
   @Input() title: string
-  @Input() figure: number
+  @Input() figure: string
   @Input() unit: string
 }

--- a/libs/ui/layout/src/lib/figure/figure.component.ts
+++ b/libs/ui/layout/src/lib/figure/figure.component.ts
@@ -1,0 +1,19 @@
+import {
+  Component,
+  OnInit,
+  ChangeDetectionStrategy,
+  Input,
+} from '@angular/core'
+
+@Component({
+  selector: 'gn-ui-figure',
+  templateUrl: './figure.component.html',
+  styleUrls: ['./figure.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FigureComponent {
+  @Input() icon: string
+  @Input() title: string
+  @Input() figure: number
+  @Input() unit: string
+}

--- a/libs/ui/layout/src/lib/table/table.component.spec.ts
+++ b/libs/ui/layout/src/lib/table/table.component.spec.ts
@@ -3,26 +3,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { MatSortModule } from '@angular/material/sort'
 import { MatTableModule } from '@angular/material/table'
 import { NoopAnimationsModule } from '@angular/platform-browser/animations'
+import { TABLE_ITEM_FIXTURE } from './table.fixtures'
 
 import { TableComponent } from './table.component'
 
-const data = [
-  {
-    name: 'name 1',
-    id: 'id 1',
-    age: 15,
-  },
-  {
-    name: 'name 2',
-    id: 'id 2',
-    age: 10,
-  },
-  {
-    name: 'name 3',
-    id: 'id 3',
-    age: 55,
-  },
-]
+const data = TABLE_ITEM_FIXTURE
+
 describe('TableComponent', () => {
   let component: TableComponent
   let fixture: ComponentFixture<TableComponent>

--- a/libs/ui/layout/src/lib/table/table.fixtures.ts
+++ b/libs/ui/layout/src/lib/table/table.fixtures.ts
@@ -1,0 +1,40 @@
+export const TABLE_ITEM_FIXTURE = [
+  {
+    name: 'name 1',
+    id: 'id 1',
+    age: 15,
+  },
+  {
+    name: 'name 2',
+    id: 'id 2',
+    age: 10,
+  },
+  {
+    name: 'name 3',
+    id: 'id 3',
+    age: 55,
+  },
+]
+
+export const TABLE_ITEM_FIXTURE_HAB = [
+  {
+    name: 'France',
+    id: '1',
+    pop: 50500000,
+  },
+  {
+    name: 'Italy',
+    id: '2',
+    pop: 155878789655,
+  },
+  {
+    name: 'UK',
+    id: '3',
+    pop: 31522456,
+  },
+  {
+    name: 'US',
+    id: '4',
+    pop: 3215448888,
+  },
+]

--- a/libs/ui/layout/src/lib/ui-layout.module.ts
+++ b/libs/ui/layout/src/lib/ui-layout.module.ts
@@ -1,14 +1,26 @@
 import { NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
+import { MatIconModule } from '@angular/material/icon'
 import { MatSortModule } from '@angular/material/sort'
 import { MatTableModule } from '@angular/material/table'
 import { TableComponent } from './table/table.component'
 import { MetadataPageComponent } from './metadata-page/metadata-page.component'
 import { ContentGhostComponent } from './content-ghost/content-ghost.component'
+import { FigureComponent } from './figure/figure.component'
 
 @NgModule({
-  imports: [CommonModule, MatTableModule, MatSortModule],
-  declarations: [TableComponent, MetadataPageComponent, ContentGhostComponent],
-  exports: [TableComponent, MetadataPageComponent, ContentGhostComponent],
+  imports: [CommonModule, MatTableModule, MatSortModule, MatIconModule],
+  declarations: [
+    TableComponent,
+    MetadataPageComponent,
+    ContentGhostComponent,
+    FigureComponent,
+  ],
+  exports: [
+    TableComponent,
+    MetadataPageComponent,
+    ContentGhostComponent,
+    FigureComponent,
+  ],
 })
 export class UiLayoutModule {}


### PR DESCRIPTION
Add dataviz components to display figures from a dataset.

- icon
- figure + unit
- text

![Screenshot from 2021-08-25 17-24-00](https://user-images.githubusercontent.com/1491924/130931868-e26cf0d1-ff03-43b0-bb3d-5cbd4dd932bd.png)

The figure is computed from an expression over a dataset.
Tha dataset is an array of objects.
The expression is something like operation|column (eg sum|pop)
Only average and sum are available for now, on a single column.

Web component stuff will be part of another PR, as the extraction of the dataset from the metadata is not done.

Contains:
- [x] Dumb component
- [x] Storybook
- [x] Smart component
- [x] figure computation from expression
- [ ] ~~Extract dataset from metadata~~
- [ ] ~~Web component~~

