### PR TITLE
Improve Elasticsearch mappers by using a functional approach

### DIFF
--- a/apps/datafeeder/jest.config.js
+++ b/apps/datafeeder/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/apps/datahub/jest.config.js
+++ b/apps/datahub/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/apps/demo/jest.config.js
+++ b/apps/demo/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/apps/search/jest.config.js
+++ b/apps/search/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/apps/webcomponents/jest.config.js
+++ b/apps/webcomponents/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/feature/auth/jest.config.js
+++ b/libs/feature/auth/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/feature/catalog/jest.config.js
+++ b/libs/feature/catalog/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/feature/dataviz/jest.config.js
+++ b/libs/feature/dataviz/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/feature/editor/jest.config.js
+++ b/libs/feature/editor/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/feature/map/jest.config.js
+++ b/libs/feature/map/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/feature/search/jest.config.js
+++ b/libs/feature/search/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/feature/search/src/lib/elasticsearch/mapper/atomic-operations.ts
+++ b/libs/feature/search/src/lib/elasticsearch/mapper/atomic-operations.ts
@@ -17,7 +17,7 @@ export const selectFallbackFields = <T>(
     null
   )
 
-export const selectFallback = (field, fallback) =>
+export const selectFallback = <T, U>(field: T, fallback: U): T | U =>
   field === null ? fallback : field
 
 export const selectTranslatedField = <T>(

--- a/libs/feature/search/src/lib/elasticsearch/mapper/atomic-operations.ts
+++ b/libs/feature/search/src/lib/elasticsearch/mapper/atomic-operations.ts
@@ -1,0 +1,47 @@
+import { MetadataLink } from '@geonetwork-ui/util/shared'
+
+export type SourceWithUnknownProps = { [key: string]: unknown }
+
+export const selectField = <T>(
+  source: SourceWithUnknownProps,
+  fieldName: string
+): T | null =>
+  source !== null && fieldName in source ? (source[fieldName] as T) : null
+
+export const selectFallbackFields = <T>(
+  source: SourceWithUnknownProps,
+  ...fieldNames: string[]
+): T | null =>
+  fieldNames.reduce<T>(
+    (prev, curr) => (prev === null ? selectField(source, curr) : prev),
+    null
+  )
+
+export const selectFallback = (field, fallback) =>
+  field === null ? fallback : field
+
+export const selectTranslatedField = <T>(
+  source: SourceWithUnknownProps,
+  fieldName: string
+): T | null => selectField(selectField(source, fieldName), 'default')
+
+export const toDate = (field) => new Date(field)
+
+export const getFirstValue = (field) =>
+  Array.isArray(field) ? field[0] : field
+
+export const getAsArray = (field) =>
+  Array.isArray(field) ? field : field !== null ? [field] : []
+
+export const mapLinks = (
+  sourceLinks: SourceWithUnknownProps[],
+  filter: (MetadataLink) => boolean
+): MetadataLink[] =>
+  getAsArray(sourceLinks)
+    .map((link) => ({
+      protocol: selectFallback(selectField<string>(link, 'protocol'), ''),
+      url: selectFallback(selectField<string>(link, 'url'), ''),
+      description: selectFallback(selectField<string>(link, 'description'), ''),
+      name: selectFallback(selectField<string>(link, 'name'), ''),
+    }))
+    .filter(filter)

--- a/libs/ui/catalog/jest.config.js
+++ b/libs/ui/catalog/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/ui/inputs/jest.config.js
+++ b/libs/ui/inputs/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/ui/layout/jest.config.js
+++ b/libs/ui/layout/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/ui/map/jest.config.js
+++ b/libs/ui/map/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/ui/search/jest.config.js
+++ b/libs/ui/search/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/ui/widgets/jest.config.js
+++ b/libs/ui/widgets/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/util/i18n/jest.config.js
+++ b/libs/util/i18n/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },

--- a/libs/util/shared/jest.config.js
+++ b/libs/util/shared/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
   globals: {
     'ts-jest': {
+      isolatedModules: true,
       tsconfig: '<rootDir>/tsconfig.spec.json',
       stringifyContentPathRegex: '\\.(html|svg)$',
     },


### PR DESCRIPTION
This PR refactors the Elasticsearch mapper service to have more of a functional style, i.e. not mutating objects while mapping.

The field mappers now rely on atomic operations that can be combined in different ways, and which provide a safe framework for parsing ES responses, handling missing and/or unexpected properties without crashing (hopefully).

Consumers can still extend the field mapper service and add or replace specific mappers according to their needs, eg:
```ts
class CustomMapper extends ElasticsearchFieldMapper {
  protected fields = {
    ...super.fields,
    toto: (source) =>
      ({
        ...source,
        newProp: selectField(source, 'toto')
      })
  }
}
```

Using pure functions for mapping instead of relying on mutating objects is a safeguard against bugs where objects end up being mutated incorrectly (which is very hard to track).

This PR also reduces the setup time for tests by approx. 50% by setting `isolatedModules: true` in ts-jest config.