### PR TITLE
Implement basic dataset visualization

### DIFF
--- a/apps/datafeeder/src/app/app.module.ts
+++ b/apps/datafeeder/src/app/app.module.ts
@@ -1,10 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser'
 import { NgModule } from '@angular/core'
-import {
-  ApiModule,
-  BASE_PATH,
-  Configuration,
-} from '@geonetwork-ui/data-access/datafeeder'
+import { ApiModule, Configuration } from '@geonetwork-ui/data-access/datafeeder'
 import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
 import { StoreModule } from '@ngrx/store'
 import { StoreDevtoolsModule } from '@ngrx/store-devtools'
@@ -16,8 +12,8 @@ import { UploadDataComponent } from './presentation/components/upload-data/uploa
 import {
   getLangFromBrowser,
   getLangFromHtml,
-  UtilI18nModule,
   TRANSLATE_DEFAULT_CONFIG,
+  UtilI18nModule,
 } from '@geonetwork-ui/util/i18n'
 import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
 import { UploadDataPageComponent } from './presentation/pages/upload-data-page/upload-data.page'
@@ -45,6 +41,7 @@ import { DATAFEEDER_STATE_KEY, reducer } from './store/datafeeder.reducer'
 export function apiConfigurationFactory() {
   return new Configuration({
     withCredentials: true,
+    basePath: environment.apiUrl,
   })
 }
 
@@ -84,12 +81,6 @@ export function apiConfigurationFactory() {
       [DATAFEEDER_STATE_KEY]: reducer,
     }),
     !environment.production ? StoreDevtoolsModule.instrument() : [],
-  ],
-  providers: [
-    {
-      provide: BASE_PATH,
-      useFactory: () => environment.apiUrl,
-    },
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
 import { RouterModule } from '@angular/router'
-import { BASE_PATH } from '@geonetwork-ui/data-access/gn4'
 import {
   FeatureSearchModule,
   MdViewModule,
@@ -20,6 +19,7 @@ import { environment } from '../environments/environment'
 
 import { AppComponent } from './app.component'
 import { MainSearchComponent } from './main-search/main-search.component'
+import { Configuration } from '@geonetwork-ui/data-access/gn4'
 
 export const metaReducers: MetaReducer[] = !environment.production
   ? [storeFreeze]
@@ -39,7 +39,14 @@ export const metaReducers: MetaReducer[] = !environment.production
     SearchRouterModule,
     MdViewModule,
   ],
-  providers: [{ provide: BASE_PATH, useValue: environment.API_BASE_PATH }],
+  providers: [
+    {
+      provide: Configuration,
+      useValue: new Configuration({
+        basePath: environment.API_BASE_PATH,
+      }),
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {

--- a/apps/search/src/app/app.module.ts
+++ b/apps/search/src/app/app.module.ts
@@ -11,7 +11,7 @@ import {
   UtilI18nModule,
   TRANSLATE_GEONETWORK_CONFIG,
 } from '@geonetwork-ui/util/i18n'
-import { BASE_PATH } from '@geonetwork-ui/data-access/gn4'
+import { Configuration } from '@geonetwork-ui/data-access/gn4'
 import { FeatureSearchModule } from '@geonetwork-ui/feature/search'
 import { EffectsModule } from '@ngrx/effects'
 import { MetaReducer, StoreModule } from '@ngrx/store'
@@ -47,7 +47,14 @@ export const metaReducers: MetaReducer<any>[] = !environment.production
     EffectsModule.forRoot(),
     NoopAnimationsModule,
   ],
-  providers: [{ provide: BASE_PATH, useValue: environment.API_BASE_PATH }],
+  providers: [
+    {
+      provide: Configuration,
+      useValue: new Configuration({
+        basePath: environment.API_BASE_PATH,
+      }),
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {

--- a/libs/data-access/gn4/src/README.md
+++ b/libs/data-access/gn4/src/README.md
@@ -12,10 +12,34 @@ npm run generate-api:gn4
 The api `baseUrl` is stored in the api specification document, and overwritten via Angular injection:
 
 ```typescript
+import { Configuration } from '@geonetwork-ui/data-access/gn4'
+
+// ...
+
+@NgModule({
+  exports: [
+    // ...
+  ],
+  declarations: [
+    // ...
+  ],
+  imports: [
+    // ...
+  ],
+  providers: [
     {
-      provide: BASE_PATH,
-      useValue: '/geonetwork/srv/api',
+      provide: Configuration,
+      useValue: new Configuration({
+        basePath: '/geonetwork/srv/api'
+      }),
     },
+    // ...
+  ],
+})
+export class MyModule {
 ```
 
 This might need to be changed for further deployment, it is used in dev mode environment only for the moment.
+
+> Note: libs should **not** rely on the `BASE_PATH` token as it will not be available in Web Components! Use the `Configuration`
+> injectable class from the `@geonetwork-ui/data-access/gn4` module instead.

--- a/libs/feature/dataviz/src/index.ts
+++ b/libs/feature/dataviz/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/feature-dataviz.module'
+export * from './lib/dataset-finder.service'

--- a/libs/feature/dataviz/src/lib/dataset-finder.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/dataset-finder.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing'
+
+import { DatasetFinderService } from './dataset-finder.service'
+
+describe('DatasetFinderService', () => {
+  let service: DatasetFinderService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+    service = TestBed.inject(DatasetFinderService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+})

--- a/libs/feature/dataviz/src/lib/dataset-finder.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/dataset-finder.service.spec.ts
@@ -1,16 +1,137 @@
-import { TestBed } from '@angular/core/testing'
-
-import { DatasetFinderService } from './dataset-finder.service'
+import { DatasetFinderService, LinkUsage } from './dataset-finder.service'
+import { MetadataRecord } from '@geonetwork-ui/util/shared'
+import { RECORDS_SUMMARY_FIXTURE } from '@geonetwork-ui/ui/search'
 
 describe('DatasetFinderService', () => {
+  const readmeLink = {
+    protocol: 'WWW:LINK',
+    description: 'Readme page',
+    url: 'http://envlit.ifremer.fr/resultats/quadrige',
+  }
+  const doiLink = {
+    protocol: 'WWW:DOI',
+    description: 'DOI for the resource',
+    url: 'http://doi.org/123-456-678',
+  }
+  const dataCsv = {
+    protocol: 'HTTP',
+    description: 'Data in CSV format',
+    name: 'abc.csv',
+    url: 'http://my.server/files/abc.csv',
+  }
+  const dataXls = {
+    protocol: 'HTTP',
+    description: 'Data in XLS format',
+    name: 'abc.xls',
+    url: 'https://my.server/files/abc.xls',
+  }
+  const dataXlsx = {
+    protocol: 'HTTP',
+    description: 'Data in XLSX format',
+    name: 'abc.XLSX',
+    url: 'https://my.server/files/abc.XLSX',
+  }
+  const dataJson = {
+    protocol: 'HTTP',
+    description: 'Data in JSON format',
+    name: 'abc.json',
+    url: 'https://my.server/files/abc.json',
+  }
+  const geodataJson = {
+    protocol: 'HTTP',
+    description: 'Geographic data in GeoJSON format',
+    name: 'mylayer',
+    url: 'http://my.server/files/geographic/dataset.geojson',
+  }
+  const geodataWms = {
+    protocol: 'OGC:WMS',
+    name: 'mylayer',
+    url: 'https://my.ogc.server/wms',
+  }
+  const geodataWfs = {
+    protocol: 'OGC:WFS',
+    name: 'mylayer',
+    url: 'https://my.ogc.server/wfs',
+  }
+  const geodataWms2 = {
+    protocol: 'OGC:WMS',
+    name: 'myotherlayer',
+    url: 'https://my.ogc.server/wms',
+  }
+  const geodataWfs2 = {
+    protocol: 'OGC:WFS',
+    name: 'myotherlayer',
+    url: 'https://my.ogc.server/wfs',
+  }
   let service: DatasetFinderService
 
   beforeEach(() => {
-    TestBed.configureTestingModule({})
-    service = TestBed.inject(DatasetFinderService)
+    service = new DatasetFinderService()
   })
 
   it('should be created', () => {
     expect(service).toBeTruthy()
+  })
+
+  describe('#getDistinctLinksByUsage', () => {
+    const record: MetadataRecord = {
+      ...RECORDS_SUMMARY_FIXTURE[0],
+      links: [
+        readmeLink,
+        doiLink,
+        dataCsv,
+        dataXls,
+        dataXlsx,
+        dataJson,
+        geodataJson,
+        geodataWms,
+        geodataWfs,
+        geodataWms2,
+        geodataWfs2,
+      ],
+    }
+    describe('for download', () => {
+      it('returns the downloadable resources', () => {
+        expect(
+          service.getDistinctLinksByUsage(record, LinkUsage.DOWNLOAD)
+        ).toEqual([dataCsv, geodataWfs, geodataWfs2])
+      })
+      it('returns the resources renderable on a map', () => {
+        expect(service.getDistinctLinksByUsage(record, LinkUsage.MAP)).toEqual([
+          dataCsv,
+          geodataWms,
+          geodataWms2,
+        ])
+      })
+    })
+  })
+
+  describe('#getLinkUsages', () => {
+    describe('for a WMS link', () => {
+      it('returns a MAP usage', () => {
+        expect(service.getLinkUsages(geodataWms)).toEqual([LinkUsage.MAP])
+      })
+    })
+    describe('for a link to a CSV file', () => {
+      it('returns a download usage', () => {
+        expect(service.getLinkUsages(dataCsv)).toEqual([
+          LinkUsage.DOWNLOAD,
+          LinkUsage.MAP,
+        ])
+      })
+    })
+    describe('for a link to a XLSX file', () => {
+      it('returns a download usage', () => {
+        expect(service.getLinkUsages(dataXlsx)).toEqual([
+          LinkUsage.DOWNLOAD,
+          LinkUsage.MAP,
+        ])
+      })
+    })
+    describe('for a link to a simple page', () => {
+      it('returns null', () => {
+        expect(service.getLinkUsages(readmeLink)).toEqual([])
+      })
+    })
   })
 })

--- a/libs/feature/dataviz/src/lib/dataset-finder.service.ts
+++ b/libs/feature/dataviz/src/lib/dataset-finder.service.ts
@@ -1,8 +1,83 @@
 import { Injectable } from '@angular/core'
+import { MetadataLink, MetadataRecord } from '@geonetwork-ui/util/shared'
+
+export enum LinkUsage {
+  DOWNLOAD = 'download',
+  MAP = 'map',
+}
+
+/**
+ * Evaluates the priority for a given link.
+ * Higher return value means this link will be preferred above others
+ * -1 means this link will not be used
+ */
+type LinkPrioritizer = (link: MetadataLink) => number
 
 @Injectable({
   providedIn: 'root',
 })
 export class DatasetFinderService {
-  constructor() {}
+  protected getLinkPriorityByUsage: Record<LinkUsage, LinkPrioritizer> = {
+    [LinkUsage.DOWNLOAD]: (link) => {
+      if ('name' in link && link.name.match(/\.csv/i)) return 3
+      if ('name' in link && link.name.match(/\.(?:geo)?json/i)) return 2
+      if ('name' in link && link.name.match(/\.xlsx?/i)) return 1
+      if ('protocol' in link && link.protocol === 'OGC:WFS') return 0
+      return -1
+    },
+    [LinkUsage.MAP]: (link) => {
+      if ('protocol' in link && link.protocol === 'OGC:WMTS') return 6
+      if ('protocol' in link && link.protocol === 'OGC:WMS') return 5
+      if ('protocol' in link && link.protocol === 'OGC:WFS') return 4
+      return this.getLinkPriorityByUsage[LinkUsage.DOWNLOAD](link) // fallback on download priorities
+    },
+  }
+
+  /**
+   * Returns all *distinct* links, in the preferred format/protocol as
+   * evaluated by the functions in `getLinkPriorityByUsage`
+   * Distinct links are links with different names
+   */
+  getDistinctLinksByUsage(
+    record: MetadataRecord,
+    usage: LinkUsage
+  ): MetadataLink[] {
+    if (!('links' in record)) return []
+    const getFilenameWithoutExtension = (filename: string) => {
+      const matches = filename.match(/^(.*)\.\w+$/)
+      return (matches && matches[1]) || filename
+    }
+    const linksByName = record.links.reduce((prev, curr) => {
+      const name =
+        'name' in curr ? getFilenameWithoutExtension(curr.name) : undefined
+      const existingLinks = name in prev ? prev[name] : []
+      return {
+        ...prev,
+        [name]: [...existingLinks, curr],
+      }
+    }, {})
+    const prioritizer = this.getLinkPriorityByUsage[usage]
+    return (
+      Object.keys(linksByName)
+        .map(
+          (name) =>
+            // this selects the link with the highest priority
+            linksByName[name].sort(
+              (linkA, linkB) => prioritizer(linkB) - prioritizer(linkA)
+            )[0]
+        )
+        // exclude link not compatible with the usage
+        .filter((link) => !!link && prioritizer(link) >= 0)
+    )
+  }
+
+  /**
+   * Returns null if no usage found for link
+   * @param link
+   */
+  getLinkUsages(link: MetadataLink): LinkUsage[] {
+    return Object.keys(this.getLinkPriorityByUsage).filter(
+      (usage) => this.getLinkPriorityByUsage[usage](link) > -1
+    ) as LinkUsage[]
+  }
 }

--- a/libs/feature/dataviz/src/lib/dataset-finder.service.ts
+++ b/libs/feature/dataviz/src/lib/dataset-finder.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DatasetFinderService {
+  constructor() {}
+}

--- a/libs/feature/search/src/lib/metadata-view/metadata-full-view/metadata-full-view.component.html
+++ b/libs/feature/search/src/lib/metadata-view/metadata-full-view/metadata-full-view.component.html
@@ -10,5 +10,7 @@
   *ngIf="(isPresent$ | async) === true"
   [metadata]="metadata$ | async"
   [incomplete]="isIncomplete$ | async"
+  [dataLinks]="mdDataLinks$ | async"
+  [otherLinks]="mdOtherLinks$ | async"
 >
 </gn-ui-metadata-page>

--- a/libs/feature/search/src/lib/metadata-view/metadata-full-view/metadata-full-view.component.spec.ts
+++ b/libs/feature/search/src/lib/metadata-view/metadata-full-view/metadata-full-view.component.spec.ts
@@ -2,7 +2,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { MetadataFullViewComponent } from './metadata-full-view.component'
 import { MdViewFacade } from '../state/mdview.facade'
 import { BehaviorSubject } from 'rxjs'
-import { RECORDS_SUMMARY_FIXTURE } from '@geonetwork-ui/ui/search'
+import {
+  RECORDS_FULL_FIXTURE,
+  RECORDS_SUMMARY_FIXTURE,
+} from '@geonetwork-ui/ui/search'
 import { By } from '@angular/platform-browser'
 import { MetadataPageComponent, UiLayoutModule } from '@geonetwork-ui/ui/layout'
 
@@ -63,6 +66,100 @@ describe('MetadataFullViewComponent', () => {
       ).componentInstance
       expect(dumb.metadata).not.toHaveProperty('abstract')
       expect(dumb.incomplete).toBeTruthy()
+    })
+  })
+
+  describe('metadata links', () => {
+    let mdPageComponent: MetadataPageComponent
+    describe('full metadata', () => {
+      beforeEach(() => {
+        facade.isPresent$.next(true)
+        facade.metadata$.next(RECORDS_FULL_FIXTURE[0])
+        fixture.detectChanges()
+        mdPageComponent = fixture.debugElement.query(
+          By.directive(MetadataPageComponent)
+        ).componentInstance
+      })
+      it('filters out links with and without usage', () => {
+        expect(mdPageComponent.dataLinks).toEqual([
+          {
+            description: 'Lieu de surveillance (point)',
+            name: 'surval_parametre_point',
+            protocol: 'OGC:WMS',
+            url: 'https://www.ifremer.fr/services/wms/surveillance_littorale',
+          },
+          {
+            description: 'Lieu de surveillance (point)',
+            name: 'surval_parametre_point',
+            protocol: 'OGC:WFS',
+            url: 'https://www.ifremer.fr/services/wfs/surveillance_littorale',
+          },
+          {
+            description: 'Lieu de surveillance (polygone)',
+            name: 'surval_parametre_polygone',
+            protocol: 'OGC:WMS',
+            url: 'https://www.ifremer.fr/services/wms/surveillance_littorale',
+          },
+          {
+            description: 'Lieu de surveillance (polygone)',
+            name: 'surval_parametre_polygone',
+            protocol: 'OGC:WFS',
+            url: 'https://www.ifremer.fr/services/wfs/surveillance_littorale',
+          },
+        ])
+        expect(mdPageComponent.otherLinks).toEqual([
+          {
+            description: "Extraction des données d'observation",
+            name: 'r:survalextraction',
+            protocol: 'OGC:WPS',
+            url: 'https://www.ifremer.fr/services/wps/surval',
+          },
+          {
+            description: "Extraction des données d'observation",
+            name: 'r:survalextraction',
+            protocol: 'OGC:WPS',
+            url: 'https://www.ifremer.fr/services/wps/surval',
+          },
+          {
+            description: '',
+            name: 'La base de données Quadrige',
+            protocol: 'WWW:LINK',
+            url: 'http://envlit.ifremer.fr/resultats/quadrige',
+          },
+          {
+            description: '',
+            name: 'La surveillance du milieu marin et côtier',
+            protocol: 'WWW:LINK-1.0-http--link',
+            url: 'http://envlit.ifremer.fr/surveillance/presentation',
+          },
+          {
+            description:
+              'Manuel pour l’utilisation des données REPHY. Informations destinées à améliorer la compréhension des fichiers de données REPHY mis à disposition des scientifiques et du public. ODE/VIGIES/17-15. Ifremer, ODE/VIGIES, Coordination REPHY & Cellule Quadrige (2017).',
+            name: 'Manuel pour l’utilisation des données REPHY',
+            protocol: 'WWW:LINK',
+            url: 'http://archimer.ifremer.fr/doc/00409/52016/',
+          },
+          {
+            description: 'DOI du jeu de données',
+            name: 'DOI du jeu de données',
+            protocol: 'WWW:LINK-1.0-http--metadata-URL',
+            url: 'https://doi.org/10.12770/cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
+          },
+        ])
+      })
+    })
+    describe('summary metadata', () => {
+      beforeEach(() => {
+        facade.isPresent$.next(true)
+        fixture.detectChanges()
+        mdPageComponent = fixture.debugElement.query(
+          By.directive(MetadataPageComponent)
+        ).componentInstance
+      })
+      it('leaves links as empty arrays', () => {
+        expect(mdPageComponent.dataLinks).toEqual([])
+        expect(mdPageComponent.otherLinks).toEqual([])
+      })
     })
   })
 })

--- a/libs/feature/search/src/lib/metadata-view/metadata-full-view/metadata-full-view.component.ts
+++ b/libs/feature/search/src/lib/metadata-view/metadata-full-view/metadata-full-view.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { MdViewFacade } from '../state/mdview.facade'
+import { map } from 'rxjs/operators'
+import { DatasetFinderService } from '@geonetwork-ui/feature/dataviz'
 
 @Component({
   selector: 'gn-ui-metadata-full-view',
@@ -12,5 +14,24 @@ export class MetadataFullViewComponent {
   metadata$ = this.mdViewFacade.metadata$
   isIncomplete$ = this.mdViewFacade.isIncomplete$
 
-  constructor(private mdViewFacade: MdViewFacade) {}
+  mdLinks = this.metadata$.pipe(
+    map((metadata) => ('links' in metadata ? metadata.links : []))
+  )
+  mdDataLinks$ = this.mdLinks.pipe(
+    map((links) =>
+      links.filter((link) => this.datasetFinder.getLinkUsages(link).length > 0)
+    )
+  )
+  mdOtherLinks$ = this.mdLinks.pipe(
+    map((links) =>
+      links.filter(
+        (link) => this.datasetFinder.getLinkUsages(link).length === 0
+      )
+    )
+  )
+
+  constructor(
+    private mdViewFacade: MdViewFacade,
+    private datasetFinder: DatasetFinderService
+  ) {}
 }

--- a/libs/ui/layout/src/lib/metadata-page/metadata-page.component.html
+++ b/libs/ui/layout/src/lib/metadata-page/metadata-page.component.html
@@ -21,15 +21,15 @@
 <p class="mb-4">
   <gn-ui-content-ghost
     ghostClass="h-24"
-    [showContent]="fieldReady('otherLinks')"
+    [showContent]="!incomplete || !!otherLinks"
   >
     <ul>
-      <li *ngFor="let link of metadata.otherLinks" [title]="link.description">
+      <li *ngFor="let link of otherLinks" [title]="link.name">
         <a
           href="{{ link.url }}"
           class="my-2 p-2 border border-gray-400 rounded block"
         >
-          {{ link.name }}
+          {{ link.description || link.name }}
           <br />
           <span class="text-sm text-gray-500 mr-3">
             {{ link.url }}
@@ -46,15 +46,15 @@
 <p class="mb-4">
   <gn-ui-content-ghost
     ghostClass="h-24"
-    [showContent]="fieldReady('dataLinks')"
+    [showContent]="!incomplete || !!dataLinks"
   >
     <ul>
-      <li *ngFor="let link of metadata.dataLinks" [title]="link.description">
+      <li *ngFor="let link of dataLinks" [title]="link.name">
         <a
           href="{{ link.url }}"
           class="my-2 p-2 border border-gray-400 rounded block"
         >
-          {{ link.name }}
+          {{ link.description || link.name }}
           <br />
           <span class="text-sm text-gray-500 mr-3">
             {{ link.url }}

--- a/libs/ui/layout/src/lib/metadata-page/metadata-page.component.ts
+++ b/libs/ui/layout/src/lib/metadata-page/metadata-page.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
-import { MetadataRecord } from '@geonetwork-ui/util/shared'
+import { MetadataLink, MetadataRecord } from '@geonetwork-ui/util/shared'
 
 @Component({
   selector: 'gn-ui-metadata-page',
@@ -9,6 +9,8 @@ import { MetadataRecord } from '@geonetwork-ui/util/shared'
 })
 export class MetadataPageComponent {
   @Input() metadata: MetadataRecord
+  @Input() dataLinks: MetadataLink[] = []
+  @Input() otherLinks: MetadataLink[] = []
   @Input() incomplete: boolean
 
   fieldReady(propName: string) {

--- a/libs/ui/search/src/lib/facets/fixtures/records.ts
+++ b/libs/ui/search/src/lib/facets/fixtures/records.ts
@@ -70,7 +70,7 @@ export const RECORDS_FULL_FIXTURE = [
     createdOn: new Date('2021-03-31T12:17:38.105Z'),
     dataCreatedOn: new Date('2012-01-01T00:00:00.000Z'),
     id: '10420',
-    dataLinks: [
+    links: [
       {
         description: 'Lieu de surveillance (point)',
         name: 'surval_parametre_point',
@@ -107,8 +107,6 @@ export const RECORDS_FULL_FIXTURE = [
         protocol: 'OGC:WPS',
         url: 'https://www.ifremer.fr/services/wps/surval',
       },
-    ],
-    otherLinks: [
       {
         description: '',
         name: 'La base de données Quadrige',

--- a/libs/util/shared/src/lib/models/search.model.ts
+++ b/libs/util/shared/src/lib/models/search.model.ts
@@ -18,20 +18,21 @@ export interface MetadataRecord {
   downloadable?: boolean
   viewable?: boolean
   updateFrequency?: string
-  dataLinks?: MetadataLink[]
-  otherLinks?: MetadataLink[]
+  links?: MetadataLink[]
   updatedOn?: Date
   createdOn?: Date
   dataUpdatedOn?: Date
   dataCreatedOn?: Date
 }
 
-export interface MetadataLink {
-  protocol?: string
-  name: string
-  description?: string
+interface MetadataLinkValid {
   url: string
+  // either a file name, a layer name or any other resource identifier
+  name?: string
+  protocol?: string
+  description?: string
 }
+export type MetadataLink = MetadataLinkValid | { invalid: true; reason: string }
 
 export interface RecordMetric {
   value: string

--- a/libs/util/shared/src/lib/services/metadata-url.service.spec.ts
+++ b/libs/util/shared/src/lib/services/metadata-url.service.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed } from '@angular/core/testing'
-import { BASE_PATH } from '@geonetwork-ui/data-access/gn4'
 import { TranslateService } from '@ngx-translate/core'
 
 import { MetadataUrlService } from './metadata-url.service'
+import { Configuration } from '@geonetwork-ui/data-access/gn4'
 
 const translateServiceMock = {
   currentLang: 'en',
@@ -18,8 +18,8 @@ describe('MetadataUrlService', () => {
           useValue: translateServiceMock,
         },
         {
-          provide: BASE_PATH,
-          useValue: '/geonetwork/srv/api',
+          provide: Configuration,
+          useValue: new Configuration({ basePath: '/geonetwork/srv/api' }),
         },
       ],
     })

--- a/libs/util/shared/src/lib/services/metadata-url.service.ts
+++ b/libs/util/shared/src/lib/services/metadata-url.service.ts
@@ -1,5 +1,5 @@
-import { Inject, Injectable } from '@angular/core'
-import { BASE_PATH } from '@geonetwork-ui/data-access/gn4'
+import { Inject, Injectable, Optional } from '@angular/core'
+import { Configuration } from '@geonetwork-ui/data-access/gn4'
 import { TranslateService } from '@ngx-translate/core'
 import { LANG_2_TO_3_MAPPER } from '@geonetwork-ui/util/i18n'
 
@@ -9,10 +9,10 @@ import { LANG_2_TO_3_MAPPER } from '@geonetwork-ui/util/i18n'
 export class MetadataUrlService {
   constructor(
     private translate: TranslateService,
-    @Inject(BASE_PATH) private basePath: string
+    @Inject(Configuration) private apiConfiguration: Configuration
   ) {}
 
-  getUrl(uuid: string, apiPath: string = this.basePath) {
+  getUrl(uuid: string, apiPath: string = this.apiConfiguration.basePath) {
     const prefix = `${apiPath}/../`
     return `${prefix}${
       LANG_2_TO_3_MAPPER[this.translate.currentLang]


### PR DESCRIPTION
Currently rebased on #146 

This PR aims at providing foundations for smart components to be able, when given a metadata UUID, to fetch and render part of a dataset in different forms. The following steps are made to achieve this result:

* Introduces a `DatasetFinderService` used for determining the usage of each link in a metadata record (render on a map, download); this can be overridden with custom logic using Angular injection
* ~(WIP) Adds a `data-fetcher` lib in `libs/util` for downloading and parsing data in various formats, and apply expressions to filter/aggregate data~
  * ~This lib is **not** an angular library but in typescript only, also it is marked as buildable and publishable in Nx, meaning that it can eventually be published as a NPM package under the name `@geonetwork-ui/data-fetcher`~
  * ~Currently only reads a CSV file using a dedicated parser~