### PR TITLE
Datahub: use ENV to set API_BASE_PATH

### DIFF
--- a/apps/datafeeder/README.md
+++ b/apps/datafeeder/README.md
@@ -1,0 +1,32 @@
+# Datafeeder
+UI of the web application `datafeeder`.
+
+`datafeeder` is for now a georchestra web application. Its purpose is to ease data and metadata publication.
+
+Basically, it invites the user to upload a SHP file and ask few questions about the data. 
+
+At the end, the data is published in GeoServer, and an INSPIRE compliant metadata is published in GeoNetwork.
+
+## Dev
+```
+npm start datafeeder
+```
+will run `datafeeder` as an Angular application available on localhost:4200.
+
+## Configuration
+### API url
+By default the api url is `/datafeeder`.
+
+A proxy configuration in dev mode redirects to `localhost:8080/import`
+
+You can override this URL with an ENV variable `${DATAFEEDER_API_URL}`.
+You can override this ENV from your docker entrypoint using the `assets/env.template.js`
+```
+# Set environment variable
+export DATAFEEDER_API_URL="/my-datafeeder";
+# Replace variables in env.js
+envsubst < assets/env.template.js > assets/env.js
+```
+
+### Other settings
+Other settings are fetched as a second step from the API `/datafeeder/config/frontend`

--- a/apps/datafeeder/README.md
+++ b/apps/datafeeder/README.md
@@ -1,26 +1,32 @@
 # Datafeeder
+
 UI of the web application `datafeeder`.
 
 `datafeeder` is for now a georchestra web application. Its purpose is to ease data and metadata publication.
 
-Basically, it invites the user to upload a SHP file and ask few questions about the data. 
+Basically, it invites the user to upload a SHP file and ask few questions about the data.
 
 At the end, the data is published in GeoServer, and an INSPIRE compliant metadata is published in GeoNetwork.
 
 ## Dev
+
 ```
 npm start datafeeder
 ```
+
 will run `datafeeder` as an Angular application available on localhost:4200.
 
 ## Configuration
+
 ### API url
+
 By default the api url is `/datafeeder`.
 
 A proxy configuration in dev mode redirects to `localhost:8080/import`
 
 You can override this URL with an ENV variable `${DATAFEEDER_API_URL}`.
 You can override this ENV from your docker entrypoint using the `assets/env.template.js`
+
 ```
 # Set environment variable
 export DATAFEEDER_API_URL="/my-datafeeder";
@@ -29,4 +35,5 @@ envsubst < assets/env.template.js > assets/env.js
 ```
 
 ### Other settings
+
 Other settings are fetched as a second step from the API `/datafeeder/config/frontend`

--- a/apps/datahub/README.md
+++ b/apps/datahub/README.md
@@ -1,0 +1,25 @@
+# Datahub
+UI of the web application `datahub`.
+
+`datahub` is an application to provide a default, pure and simple UI for metadata and dataset search.
+
+Inspire by Opendata catalogs (CKAN, Opendatasoft), the Hub will host geo and non-geo dataset. It will provide dataviz tool and focuses the experience on the dataset instead of on the metadata.
+
+## Dev
+```
+ng serve datahub
+```
+will run `datahub` as an Angular application available on localhost:4200.
+
+## Configuration
+### API url
+By default it uses GN4 API `/geonetwork/srv/api`.
+
+You can override this URL with an ENV variable `${GN4_API_URL}`.
+You can override this ENV from your docker entrypoint using the `assets/env.template.js`
+```
+# Set environment variable
+export GN4_API_URL="https://gn4.georchestra/...";
+# Replace variables in env.js
+envsubst < assets/env.template.js > assets/env.js
+```

--- a/apps/datahub/README.md
+++ b/apps/datahub/README.md
@@ -1,4 +1,5 @@
 # Datahub
+
 UI of the web application `datahub`.
 
 `datahub` is an application to provide a default, pure and simple UI for metadata and dataset search.
@@ -6,17 +7,22 @@ UI of the web application `datahub`.
 Inspire by Opendata catalogs (CKAN, Opendatasoft), the Hub will host geo and non-geo dataset. It will provide dataviz tool and focuses the experience on the dataset instead of on the metadata.
 
 ## Dev
+
 ```
 ng serve datahub
 ```
+
 will run `datahub` as an Angular application available on localhost:4200.
 
 ## Configuration
+
 ### API url
+
 By default it uses GN4 API `/geonetwork/srv/api`.
 
 You can override this URL with an ENV variable `${GN4_API_URL}`.
 You can override this ENV from your docker entrypoint using the `assets/env.template.js`
+
 ```
 # Set environment variable
 export GN4_API_URL="https://gn4.georchestra/...";

--- a/apps/datahub/src/assets/env.js
+++ b/apps/datahub/src/assets/env.js
@@ -1,0 +1,4 @@
+;((window) => {
+  window['env'] = window['env'] || {}
+  window['env']['apiUrl'] = 'https://gn4.georchestra.org/geonetwork/srv/api'
+})(this)

--- a/apps/datahub/src/assets/env.template.js
+++ b/apps/datahub/src/assets/env.template.js
@@ -1,0 +1,4 @@
+;((window) => {
+  window['env'] = window['env'] || {}
+  window['env']['apiUrl'] = '${GN4_API_URL}'
+})(this)

--- a/apps/datahub/src/environments/environment.prod.ts
+++ b/apps/datahub/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  API_BASE_PATH: 'https://apps.titellus.net/geonetwork/srv/api',
+  API_BASE_PATH: window['env']['apiUrl'],
 }

--- a/apps/datahub/src/environments/environment.ts
+++ b/apps/datahub/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  API_BASE_PATH: '/geonetwork/srv/api',
+  API_BASE_PATH: window['env']['apiUrl'],
 }
 
 /*

--- a/apps/datahub/src/index.html
+++ b/apps/datahub/src/index.html
@@ -15,6 +15,7 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
     />
+    <script src="assets/env.js"></script>
   </head>
   <body>
     <gn-ui-root></gn-ui-root>


### PR DESCRIPTION
Set up API base url from ENV var, to be customizable for production.

Follow the followings:
```
# Set environment variable
export GN4_API_URL="https://gn4.georchestra/...";
# Replace variables in env.js
envsubst < assets/env.template.js > assets/env.js
```

