### PR TITLE
Define formats and urls for ESRI REST links

### DIFF
--- a/libs/feature/record/src/lib/data-apis/data-apis.component.spec.ts
+++ b/libs/feature/record/src/lib/data-apis/data-apis.component.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
-import { RECORDS_FULL_FIXTURE } from '@geonetwork-ui/ui/search'
 import { Subject } from 'rxjs'
 import { MdViewFacade } from '../state'
 

--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
@@ -4,7 +4,6 @@ import {
   TestBed,
   tick,
 } from '@angular/core/testing'
-import { RECORDS_FULL_FIXTURE } from '@geonetwork-ui/ui/search'
 import { Subject } from 'rxjs'
 import { MdViewFacade } from '../state'
 import { DataDownloadsComponent } from './data-downloads.component'

--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
@@ -110,6 +110,14 @@ describe('DataDownloadsComponent', () => {
             protocol: 'OGC:WFS',
             url: 'https://www.ifremer.fr/services/wfs/surveillance_littorale',
           },
+          {
+            protocol: 'ESRI:REST',
+            name: 'mes_hdf_journalier_poll_princ',
+            format: 'arcgis geoservices rest api',
+            description: 'ArcGIS GeoService',
+            mediaType: 'application/json',
+            url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf_journalier_poll_princ/FeatureServer/0',
+          },
         ])
         tick()
         fixture.detectChanges()
@@ -143,6 +151,22 @@ describe('DataDownloadsComponent', () => {
             format: 'WFS:csv',
             protocol: 'OGC:WFS',
             url: 'https://www.ifremer.fr/services/wfs/surveillance_littorale',
+          },
+          {
+            protocol: 'ESRI:REST',
+            name: 'mes_hdf_journalier_poll_princ',
+            format: 'REST:json',
+            description: 'ArcGIS GeoService',
+            mediaType: 'application/json',
+            url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf_journalier_poll_princ/FeatureServer/0/query?f=json&where=1=1',
+          },
+          {
+            protocol: 'ESRI:REST',
+            name: 'mes_hdf_journalier_poll_princ',
+            format: 'REST:geojson',
+            description: 'ArcGIS GeoService',
+            mediaType: 'application/json',
+            url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf_journalier_poll_princ/FeatureServer/0/query?f=geojson&where=1=1',
           },
         ])
       })

--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
@@ -2,10 +2,11 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { MetadataLink, MetadataLinkValid } from '@geonetwork-ui/util/shared'
 import { map, startWith, switchMap } from 'rxjs/operators'
 import { MdViewFacade } from '../state'
-import { combineLatest, from, of } from 'rxjs'
+import { combineLatest, from } from 'rxjs'
 import {
   DownloadFormatType,
   getDownloadFormat,
+  getLinksWithEsriRestFormats,
   getLinksWithWfsFormats,
 } from '../links/link-utils'
 
@@ -20,11 +21,12 @@ export class DataDownloadsComponent {
 
   links$ = this.facade.downloadLinks$.pipe(
     switchMap((links) => {
-      const wfsLinks = links.filter((link) =>
-        link.protocol.startsWith('OGC:WFS')
-      )
+      const wfsLinks = links.filter((link) => /^OGC:WFS/.test(link.protocol))
+      const esriRestLinks = links
+        .filter((link) => /^ESRI:REST/.test(link.protocol))
+        .flatMap((link) => getLinksWithEsriRestFormats(link))
       const otherLinks = links
-        .filter((link) => !link.protocol.startsWith('OGC:WFS'))
+        .filter((link) => !/^OGC:WFS|ESRI:REST/.test(link.protocol))
         .map((link) =>
           'format' in link
             ? link
@@ -50,7 +52,11 @@ export class DataDownloadsComponent {
             }))
             .filter((link) => link.format !== 'unknown')
         ),
-        map((wfsDownloadLinks) => [...otherLinks, ...wfsDownloadLinks]),
+        map((wfsDownloadLinks) => [
+          ...otherLinks,
+          ...wfsDownloadLinks,
+          ...esriRestLinks,
+        ]),
         startWith(otherLinks)
       )
     })

--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
-import { MetadataLink, MetadataLinkValid } from '@geonetwork-ui/util/shared'
 import { map, startWith, switchMap } from 'rxjs/operators'
 import { MdViewFacade } from '../state'
 import { combineLatest, from } from 'rxjs'

--- a/libs/feature/record/src/lib/links/link-classifier.service.spec.ts
+++ b/libs/feature/record/src/lib/links/link-classifier.service.spec.ts
@@ -63,6 +63,16 @@ describe('LinkClassifierService', () => {
     name: 'myotherlayer',
     url: 'https://my.ogc.server/wfs',
   }
+  const geodataRest = {
+    protocol: 'ESRI:REST',
+    name: 'myrestlayer',
+    url: 'https://my.esri.server/FeatureServer',
+  }
+  const maplayerRest = {
+    protocol: 'ESRI:REST',
+    name: 'myotherrestlayer',
+    url: 'https://my.esri.server/MapServer',
+  }
   let service: LinkClassifierService
 
   beforeEach(() => {
@@ -75,7 +85,7 @@ describe('LinkClassifierService', () => {
 
   describe('#getUsagesForLink', () => {
     describe('for a WMS link', () => {
-      it('returns map API usage', () => {
+      it('returns map API  and API usage', () => {
         expect(service.getUsagesForLink(geodataWms)).toEqual([
           LinkUsage.API,
           LinkUsage.MAPAPI,
@@ -83,12 +93,25 @@ describe('LinkClassifierService', () => {
       })
     })
     describe('for a WFS link', () => {
-      it('returns download and API usage', () => {
+      it('returns download, data and API usage', () => {
         expect(service.getUsagesForLink(geodataWfs)).toEqual([
           LinkUsage.API,
           LinkUsage.DOWNLOAD,
           LinkUsage.DATA,
         ])
+      })
+    })
+    describe('for a ESRI REST feature service link', () => {
+      it('returns download and API usage', () => {
+        expect(service.getUsagesForLink(geodataRest)).toEqual([
+          LinkUsage.API,
+          LinkUsage.DOWNLOAD,
+        ])
+      })
+    })
+    describe('for a ESRI REST map service link', () => {
+      it('returns no usage', () => {
+        expect(service.getUsagesForLink(maplayerRest)).toEqual([])
       })
     })
     describe('for a link to a CSV file', () => {

--- a/libs/feature/record/src/lib/links/link-classifier.service.spec.ts
+++ b/libs/feature/record/src/lib/links/link-classifier.service.spec.ts
@@ -1,4 +1,3 @@
-import { TestBed } from '@angular/core/testing'
 import { LinkClassifierService, LinkUsage } from './link-classifier.service'
 
 describe('LinkClassifierService', () => {

--- a/libs/feature/record/src/lib/links/link-classifier.service.ts
+++ b/libs/feature/record/src/lib/links/link-classifier.service.ts
@@ -33,7 +33,7 @@ export class LinkClassifierService {
       }
       if (/^OGC:WFS/.test(link.protocol))
         return [LinkUsage.API, LinkUsage.DOWNLOAD, LinkUsage.DATA]
-      if (/^ESRI:REST/.test(link.protocol))
+      if (/^ESRI:REST/.test(link.protocol) && /FeatureServer/.test(link.url))
         return [LinkUsage.API, LinkUsage.DOWNLOAD]
       if (/^OGC:WMS/.test(link.protocol))
         return [LinkUsage.API, LinkUsage.MAPAPI]

--- a/libs/feature/record/src/lib/links/link-utils.spec.ts
+++ b/libs/feature/record/src/lib/links/link-utils.spec.ts
@@ -3,6 +3,7 @@ import {
   getDownloadFormat,
   DownloadFormatType,
   checkFileFormat,
+  getLinksWithEsriRestFormats,
 } from './link-utils'
 
 describe('link utils', () => {
@@ -70,5 +71,30 @@ describe('link utils', () => {
             ).toEqual(false)
           })
         })
+    }),
+    describe('#getLinksWithEsriRestFormats', () => {
+      it('returns links with formats for link', () => {
+        expect(
+          getLinksWithEsriRestFormats({
+            protocol: 'ESRI:REST',
+            name: 'myrestlayer',
+            format: 'arcgis geoservices rest api',
+            url: 'https://my.esri.server/FeatureServer',
+          })
+        ).toEqual([
+          {
+            protocol: 'ESRI:REST',
+            name: 'myrestlayer',
+            format: 'REST:json',
+            url: 'https://my.esri.server/FeatureServer/query?f=json&where=1=1',
+          },
+          {
+            protocol: 'ESRI:REST',
+            name: 'myrestlayer',
+            format: 'REST:geojson',
+            url: 'https://my.esri.server/FeatureServer/query?f=geojson&where=1=1',
+          },
+        ])
+      })
     })
 })

--- a/libs/feature/record/src/lib/links/link-utils.spec.ts
+++ b/libs/feature/record/src/lib/links/link-utils.spec.ts
@@ -1,4 +1,3 @@
-import { TestBed } from '@angular/core/testing'
 import {
   getDownloadFormat,
   DownloadFormatType,

--- a/libs/feature/record/src/lib/links/link-utils.ts
+++ b/libs/feature/record/src/lib/links/link-utils.ts
@@ -55,3 +55,14 @@ export function getLinksWithWfsFormats(
     }))
   })
 }
+
+export function getLinksWithEsriRestFormats(
+  link: MetadataLinkValid
+): MetadataLinkValid[] {
+  const formats = ['json', 'geojson']
+  return formats.map((format) => ({
+    ...link,
+    url: `${link.url}/query?f=${format}&where=1=1`,
+    format: `REST:${format}`,
+  }))
+}

--- a/libs/feature/record/src/lib/state/fixture.ts
+++ b/libs/feature/record/src/lib/state/fixture.ts
@@ -1,0 +1,27 @@
+export const LINKS_FIXTURE = [
+  //ESRI
+  {
+    protocol: 'WWW:LINK',
+    name: 'ArcGIS Hub Dataset',
+    format: 'web page',
+    description: 'ArcGIS Hub Dataset',
+    mediaType: 'text/html',
+    url: 'https://data-atmo-hdf.opendata.arcgis.com/datasets/4ee9ddcfc11c4d0cb92d54d825534ff9_0',
+  },
+  {
+    protocol: 'ESRI:REST',
+    name: 'mes_hdf_journalier_poll_princ',
+    format: 'arcgis geoservices rest api',
+    description: 'ArcGIS GeoService',
+    mediaType: 'application/json',
+    url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf_journalier_poll_princ/FeatureServer/0',
+  },
+  {
+    protocol: 'ESRI:REST',
+    name: 'emi_hdf_epci',
+    format: 'arcgis geoservices rest api',
+    description: 'ArcGIS GeoService',
+    mediaType: 'application/json',
+    url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/emi_hdf_epci/FeatureServer/1',
+  },
+]

--- a/libs/feature/record/src/lib/state/mdview.effects.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.ts
@@ -9,6 +9,7 @@ import { Actions, createEffect, ofType } from '@ngrx/effects'
 import { of } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
 import * as MdViewActions from './mdview.actions'
+import { LINKS_FIXTURE } from './fixture'
 
 @Injectable()
 export class MdViewEffects {
@@ -31,6 +32,12 @@ export class MdViewEffects {
       map((response: EsSearchResponse) => {
         const records = this.esMapper.toRecords(response)
         const full = records[0]
+        //ADD FIXTURE FOR DEV
+        full.links = full.links
+          ? [...full.links, ...LINKS_FIXTURE]
+          : LINKS_FIXTURE
+        console.log(full.links)
+        //END FIXTURE
         return MdViewActions.loadFullSuccess({ full })
       }),
       catchError((error) => of(MdViewActions.loadFullFailure({ error })))

--- a/libs/ui/elements/src/lib/apis-list/apis-list.component.html
+++ b/libs/ui/elements/src/lib/apis-list/apis-list.component.html
@@ -1,8 +1,3 @@
-<div class="mb-2">
-  <h3 class="text-lg text-gray-900" *ngIf="links && links[0]">
-    {{ links[0].description || links[0].name }}
-  </h3>
-</div>
-<div class="pb-4" *ngFor="let link of links">
+<div class="pt-4" *ngFor="let link of links">
   <gn-ui-apis-list-item [link]="link"></gn-ui-apis-list-item>
 </div>

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
@@ -1,8 +1,3 @@
-<div class="mb-2">
-  <h3 class="text-lg text-gray-900" *ngIf="links && links[0]">
-    {{ links[0].description || links[0].name }}
-  </h3>
-</div>
-<div class="pb-4" *ngFor="let link of links">
+<div class="pt-4" *ngFor="let link of links">
   <gn-ui-downloads-list-item [link]="link"></gn-ui-downloads-list-item>
 </div>


### PR DESCRIPTION
PR generates urls to download data from ESRI REST FeatureServer in `json` and `geojson` and displays links with according format.

The REST API is not called in this PR, since ESRI FeatureServer generally propose three output formats for the query operation (https://developers.arcgis.com/rest/services-reference/enterprise/output-formats.htm).