### PR TITLE
Expand map preview to work with WFS and GeoJSON files

### DIFF
--- a/libs/feature/map/src/lib/map-context/map-context.model.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.model.ts
@@ -3,6 +3,7 @@ import type { FeatureCollection } from 'geojson'
 export enum MapContextLayerTypeEnum {
   XYZ = 'xyz',
   WMS = 'wms',
+  WFS = 'wfs',
   GEOJSON = 'geojson',
 }
 

--- a/libs/feature/map/src/lib/map-context/map-context.service.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.ts
@@ -14,6 +14,8 @@ import TileLayer from 'ol/layer/Tile'
 import XYZ from 'ol/source/XYZ'
 import VectorSource from 'ol/source/Vector'
 import { MapUtilsService } from '../utils/map-utils.service'
+import { bbox as bboxStrategy } from 'ol/loadingstrategy'
+import GeoJSON from 'ol/format/GeoJSON'
 
 @Injectable({
   providedIn: 'root',
@@ -31,7 +33,7 @@ export class MapContextService {
   }
 
   createLayer(layerModel: MapContextLayerModel): Layer {
-    const { type, url } = layerModel
+    const { type, url, name } = layerModel
     switch (type) {
       case MapContextLayerTypeEnum.XYZ:
         return new TileLayer({
@@ -43,7 +45,19 @@ export class MapContextService {
         return new TileLayer({
           source: new TileWMS({
             url,
-            params: { LAYERS: layerModel.name },
+            params: { LAYERS: name },
+          }),
+        })
+      case MapContextLayerTypeEnum.WFS:
+        return new VectorLayer({
+          source: new VectorSource({
+            format: new GeoJSON(),
+            url: function (extent) {
+              return `${url}?service=WFS&version=1.1.0&request=GetFeature&outputFormat=application/json&typename=${name}&srsname=EPSG:3857&bbox=${extent.join(
+                ','
+              )},EPSG:3857`
+            },
+            strategy: bboxStrategy,
           }),
         })
       case MapContextLayerTypeEnum.GEOJSON: {

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.css
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.css
@@ -3,3 +3,10 @@ gn-ui-dropdown-selector {
   left: 0;
   right: 0;
 }
+
+gn-ui-loading-mask {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.css
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.css
@@ -10,3 +10,10 @@ gn-ui-loading-mask {
   left: 0;
   right: 0;
 }
+
+gn-ui-popup-alert {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.html
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.html
@@ -5,6 +5,9 @@
     class="absolute"
     message="map.loading.data"
   ></gn-ui-loading-mask>
+  <gn-ui-popup-alert *ngIf="error" icon="error_outline" class="absolute m-2">
+    <span translate>{{ error }}</span>
+  </gn-ui-popup-alert>
   <gn-ui-dropdown-selector
     title="available layers"
     class="absolute m-2"

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.html
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.html
@@ -1,5 +1,10 @@
 <div class="relative w-full h-full">
   <gn-ui-map-context [context]="mapContext$ | async"></gn-ui-map-context>
+  <gn-ui-loading-mask
+    *ngIf="loading"
+    class="absolute"
+    message="map.loading.data"
+  ></gn-ui-loading-mask>
   <gn-ui-dropdown-selector
     title="available layers"
     class="absolute m-2"

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
@@ -12,6 +12,15 @@ import { DropdownSelectorComponent } from '@geonetwork-ui/ui/inputs'
 import { Subject } from 'rxjs'
 import { DataViewMapComponent } from './data-view-map.component'
 
+jest.mock('@camptocamp/ogc-client', () => ({
+  WfsEndpoint: class {
+    isReady() {
+      return Promise.resolve({
+        getFeatureUrl: () => '',
+      })
+    }
+  },
+}))
 jest.mock('@geonetwork-ui/data-fetcher', () => ({
   readDataset: (url) => Promise.resolve(SAMPLE_GEOJSON.features),
 }))
@@ -207,7 +216,7 @@ describe('DataViewMapComponent', () => {
     })
 
     describe('with a link using WFS protocol', () => {
-      beforeEach(() => {
+      beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
         mdViewFacade.dataLinks$.next([
           {
@@ -216,16 +225,16 @@ describe('DataViewMapComponent', () => {
             protocol: 'OGC:WFS',
           },
         ])
+        tick()
         fixture.detectChanges()
-      })
-      it('emits a map context with the base layer and the WFS link', () => {
+      }))
+      it('emits a map context with the base layer and the downloaded data from WFS', () => {
         expect(mapComponent.context).toEqual({
           layers: [
             component.getBackgroundLayer(),
             {
-              url: 'http://abcd.com/wfs',
-              name: 'featuretype',
-              type: 'wfs',
+              type: 'geojson',
+              data: SAMPLE_GEOJSON,
             },
           ],
           view: expect.any(Object),

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -94,7 +94,9 @@ export class DataViewMapComponent {
       return fromPromise(
         new WfsEndpoint(link.url).isReady().then((endpoint) =>
           readDataset(
-            endpoint.getFeatureUrl(link.name, undefined, 'application/json')
+            endpoint.getFeatureUrl(link.name, undefined, 'application/json') +
+              '&srsname=EPSG:4326',
+            'geojson'
           ).then((features) => ({
             type: MapContextLayerTypeEnum.GEOJSON,
             data: {
@@ -106,7 +108,7 @@ export class DataViewMapComponent {
       )
     } else if (link.protocol.startsWith('WWW:DOWNLOAD')) {
       return fromPromise(
-        readDataset(link.url).then((features) => ({
+        readDataset(link.url, 'geojson').then((features) => ({
           type: MapContextLayerTypeEnum.GEOJSON,
           data: {
             type: 'FeatureCollection',

--- a/libs/feature/record/src/lib/feature-record.module.ts
+++ b/libs/feature/record/src/lib/feature-record.module.ts
@@ -17,6 +17,7 @@ import { DataDownloadsComponent } from './data-downloads/data-downloads.componen
 import { RecordMetadataComponent } from './record-metadata/record-metadata.component'
 import { MatTabsModule } from '@angular/material/tabs'
 import { MatIconModule } from '@angular/material/icon'
+import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
 
 @NgModule({
   declarations: [
@@ -37,6 +38,7 @@ import { MatIconModule } from '@angular/material/icon'
     UiElementsModule,
     MatTabsModule,
     MatIconModule,
+    UiWidgetsModule,
   ],
   providers: [MdViewFacade],
   exports: [

--- a/libs/ui/widgets/src/index.ts
+++ b/libs/ui/widgets/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/ui-widgets.module'
+export * from './lib/loading-mask/loading-mask.component'

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.css
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.css
@@ -1,17 +1,17 @@
 /* this overrides the spinner color with a CSS variable to match the theme */
 ::ng-deep .mat-spinner circle {
-    stroke: var(--color-gray-300);
+  stroke: var(--color-gray-300);
 }
 
 .backdrop {
-    backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
 }
 
 .background {
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    opacity: 0.6;
-    z-index: -10;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  opacity: 0.6;
+  z-index: -10;
 }

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.css
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.css
@@ -1,0 +1,17 @@
+/* this overrides the spinner color with a CSS variable to match the theme */
+::ng-deep .mat-spinner circle {
+    stroke: var(--color-gray-300);
+}
+
+.backdrop {
+    backdrop-filter: blur(4px);
+}
+
+.background {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    opacity: 0.6;
+    z-index: -10;
+}

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.html
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.html
@@ -1,1 +1,5 @@
-<p>loading-mask works!</p>
+<div class="h-full flex flex-col justify-center items-center relative backdrop">
+  <div class="absolute background bg-white"></div>
+  <mat-spinner [diameter]="28"></mat-spinner>
+  <span class="text-sm text-gray-700 mt-3" translate>{{ message }}</span>
+</div>

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.html
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.html
@@ -1,0 +1,1 @@
+<p>loading-mask works!</p>

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.spec.ts
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoadingMaskComponent } from './loading-mask.component';
+
+describe('LoadingMaskComponent', () => {
+  let component: LoadingMaskComponent;
+  let fixture: ComponentFixture<LoadingMaskComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LoadingMaskComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoadingMaskComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.spec.ts
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.spec.ts
@@ -1,25 +1,24 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing'
 
-import { LoadingMaskComponent } from './loading-mask.component';
+import { LoadingMaskComponent } from './loading-mask.component'
 
 describe('LoadingMaskComponent', () => {
-  let component: LoadingMaskComponent;
-  let fixture: ComponentFixture<LoadingMaskComponent>;
+  let component: LoadingMaskComponent
+  let fixture: ComponentFixture<LoadingMaskComponent>
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ LoadingMaskComponent ]
-    })
-    .compileComponents();
-  });
+      declarations: [LoadingMaskComponent],
+    }).compileComponents()
+  })
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(LoadingMaskComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(LoadingMaskComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.stories.ts
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.stories.ts
@@ -5,17 +5,18 @@ import {
   componentWrapperDecorator,
 } from '@storybook/angular'
 import { LoadingMaskComponent } from './loading-mask.component'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 
 export default {
   title: 'Widgets/LoadingMaskComponent',
   component: LoadingMaskComponent,
   decorators: [
     moduleMetadata({
-      imports: [],
+      imports: [MatProgressSpinnerModule],
     }),
     componentWrapperDecorator(
       (story) => `
-<div class="border border-gray-300 p-2" style="width: 300px; resize: both; overflow: auto">
+<div class="border border-gray-300 p-2" style="width: 600px; height:400px; resize: both; overflow: auto">
   ${story}
 </div>`
     ),
@@ -29,5 +30,5 @@ const Template: Story<LoadingMaskComponent> = (args: LoadingMaskComponent) => ({
 
 export const Primary = Template.bind({})
 Primary.args = {
-  message: '',
+  message: 'Loading some data, please wait...',
 }

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.stories.ts
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.stories.ts
@@ -1,0 +1,33 @@
+import {
+  moduleMetadata,
+  Story,
+  Meta,
+  componentWrapperDecorator,
+} from '@storybook/angular'
+import { LoadingMaskComponent } from './loading-mask.component'
+
+export default {
+  title: 'Widgets/LoadingMaskComponent',
+  component: LoadingMaskComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [],
+    }),
+    componentWrapperDecorator(
+      (story) => `
+<div class="border border-gray-300 p-2" style="width: 300px; resize: both; overflow: auto">
+  ${story}
+</div>`
+    ),
+  ],
+} as Meta<LoadingMaskComponent>
+
+const Template: Story<LoadingMaskComponent> = (args: LoadingMaskComponent) => ({
+  component: LoadingMaskComponent,
+  props: args,
+})
+
+export const Primary = Template.bind({})
+Primary.args = {
+  message: '',
+}

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.ts
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.ts
@@ -1,16 +1,16 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  ChangeDetectionStrategy,
+  Input,
+} from '@angular/core'
 
 @Component({
   selector: 'gn-ui-loading-mask',
   templateUrl: './loading-mask.component.html',
   styleUrls: ['./loading-mask.component.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LoadingMaskComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
+export class LoadingMaskComponent {
+  @Input() message: string
 }

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.ts
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+
+@Component({
+  selector: 'gn-ui-loading-mask',
+  templateUrl: './loading-mask.component.html',
+  styleUrls: ['./loading-mask.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class LoadingMaskComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.css
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.css
@@ -1,0 +1,33 @@
+:host {
+    pointer-events: none;
+}
+.container {
+    filter: drop-shadow(0px 4px 3px rgba(0, 0, 0, 0.2));
+}
+.message {
+    transition: clip-path 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+.message.expanded {
+    clip-path: circle(100%);
+}
+.position-top {
+    clip-path: circle(19px at 20px 20px);
+    align-items: start;
+    top: 0;
+    left: 0
+}
+.position-bottom {
+    clip-path: circle(19px at 20px calc(100% - 20px));
+    align-items: end;
+    bottom: 0;
+    left: 0
+}
+
+/* style links inside message */
+.container ::ng-deep a {
+    text-decoration: underline;
+    font-weight: bold;
+}
+.container ::ng-deep a:hover {
+    opacity: 0.85;
+}

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.css
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.css
@@ -1,33 +1,33 @@
 :host {
-    pointer-events: none;
+  pointer-events: none;
 }
 .container {
-    filter: drop-shadow(0px 4px 3px rgba(0, 0, 0, 0.2));
+  filter: drop-shadow(0px 4px 3px rgba(0, 0, 0, 0.2));
 }
 .message {
-    transition: clip-path 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: clip-path 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 .message.expanded {
-    clip-path: circle(100%);
+  clip-path: circle(100%);
 }
 .position-top {
-    clip-path: circle(19px at 20px 20px);
-    align-items: start;
-    top: 0;
-    left: 0
+  clip-path: circle(19px at 20px 20px);
+  align-items: start;
+  top: 0;
+  left: 0;
 }
 .position-bottom {
-    clip-path: circle(19px at 20px calc(100% - 20px));
-    align-items: end;
-    bottom: 0;
-    left: 0
+  clip-path: circle(19px at 20px calc(100% - 20px));
+  align-items: end;
+  bottom: 0;
+  left: 0;
 }
 
 /* style links inside message */
 .container ::ng-deep a {
-    text-decoration: underline;
-    font-weight: bold;
+  text-decoration: underline;
+  font-weight: bold;
 }
 .container ::ng-deep a:hover {
-    opacity: 0.85;
+  opacity: 0.85;
 }

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.html
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.html
@@ -1,0 +1,1 @@
+<p>popup-alert works!</p>

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.html
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.html
@@ -1,1 +1,27 @@
-<p>popup-alert works!</p>
+<div class="h-full relative container">
+  <div
+    class="
+      pointer-events-auto
+      absolute
+      bg-red-500
+      text-white
+      flex flex-row
+      p-2
+      rounded
+      message
+    "
+    role="alert"
+    [ngClass]="{
+      'position-bottom': position === 'bottom',
+      'position-top': position === 'top',
+      expanded
+    }"
+    (mouseenter)="expand()"
+    (mouseleave)="expandAndClose()"
+  >
+    <mat-icon class="mr-2 flex-shrink-0 select-none">{{ icon }}</mat-icon>
+    <div class="flex-grow" #content [ngClass]="{ invisible: !expanded }">
+      <ng-content></ng-content>
+    </div>
+  </div>
+</div>

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.spec.ts
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.spec.ts
@@ -1,24 +1,70 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { PopupAlertComponent } from './popup-alert.component'
+import { Component, Input } from '@angular/core'
+import { By } from '@angular/platform-browser'
+import { MatIconModule } from '@angular/material/icon'
+
+@Component({
+  template: '<gn-ui-popup-alert>{{message}}</gn-ui-popup-alert>',
+})
+class PopupAlertWrapperComponent {
+  @Input() message
+}
 
 describe('PopupAlertComponent', () => {
+  let wrapper: PopupAlertWrapperComponent
   let component: PopupAlertComponent
-  let fixture: ComponentFixture<PopupAlertComponent>
+  let fixture: ComponentFixture<PopupAlertWrapperComponent>
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [PopupAlertComponent],
+      declarations: [PopupAlertComponent, PopupAlertWrapperComponent],
+      imports: [MatIconModule],
     }).compileComponents()
   })
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(PopupAlertComponent)
-    component = fixture.componentInstance
-    fixture.detectChanges()
+    fixture = TestBed.createComponent(PopupAlertWrapperComponent)
+    wrapper = fixture.componentInstance
+    component = fixture.debugElement.query(
+      By.directive(PopupAlertComponent)
+    ).componentInstance
   })
 
   it('should create', () => {
-    expect(component).toBeTruthy()
+    fixture.detectChanges()
+    expect(wrapper).toBeTruthy()
+  })
+
+  describe('#showDuration', () => {
+    describe('with empty content', () => {
+      beforeEach(() => {
+        wrapper.message = ''
+        fixture.detectChanges()
+      })
+      it('returns 3 seconds', () => {
+        expect(component.showDuration).toEqual(3000)
+      })
+    })
+    describe('with small content', () => {
+      beforeEach(() => {
+        wrapper.message = 'abcdefg'
+        fixture.detectChanges()
+      })
+      it('returns 3 seconds', () => {
+        expect(component.showDuration).toEqual(3000)
+      })
+    })
+    describe('with long content', () => {
+      beforeEach(() => {
+        wrapper.message =
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse semper massa condimentum tortor auctor, vitae rhoncus nibh fringilla. Mauris ut volutpat purus. Mauris sed posuere quam. In ac ligula ut massa fermentum ornare. Pellentesque dignissim ex rutrum condimentum maximus. Ut placerat eleifend erat vel sodales. Sed nec lacus sodales, maximus mauris at, mollis libero. Nam vel ultricies metus. In sed placerat sem.'
+        fixture.detectChanges()
+      })
+      it('returns more that 8 seconds', () => {
+        expect(component.showDuration).toBeGreaterThan(8000)
+      })
+    })
   })
 })

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.spec.ts
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { PopupAlertComponent } from './popup-alert.component'
+
+describe('PopupAlertComponent', () => {
+  let component: PopupAlertComponent
+  let fixture: ComponentFixture<PopupAlertComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [PopupAlertComponent],
+    }).compileComponents()
+  })
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PopupAlertComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.stories.ts
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.stories.ts
@@ -1,20 +1,48 @@
-import { moduleMetadata, Story, Meta } from '@storybook/angular'
+import {
+  componentWrapperDecorator,
+  Meta,
+  moduleMetadata,
+  Story,
+} from '@storybook/angular'
 import { PopupAlertComponent } from './popup-alert.component'
+import { MatIconModule } from '@angular/material/icon'
 
 export default {
   title: 'Widgets/PopupAlertComponent',
   component: PopupAlertComponent,
   decorators: [
     moduleMetadata({
-      imports: [],
+      imports: [MatIconModule],
     }),
+    componentWrapperDecorator(
+      (story) => `
+<div class="border border-gray-300 p-2" style="width: 600px; height:300px; resize: both; overflow: auto">
+  ${story}
+</div>`
+    ),
   ],
+  argTypes: {
+    position: {
+      control: 'radio',
+      options: ['top', 'bottom'],
+    },
+  },
 } as Meta<PopupAlertComponent>
 
-const Template: Story<PopupAlertComponent> = (args: PopupAlertComponent) => ({
+type PopupAlertComponentWithContent = PopupAlertComponent & { content: string }
+
+const Template: Story<PopupAlertComponentWithContent> = (
+  args: PopupAlertComponentWithContent
+) => ({
   component: PopupAlertComponent,
   props: args,
+  template: `<gn-ui-popup-alert [icon]='icon' [position]='position'>${args.content}</gn-ui-popup-alert>`,
 })
 
 export const Primary = Template.bind({})
-Primary.args = {}
+Primary.args = {
+  icon: 'error_outline',
+  content:
+    'Something went wrong during a task that was probably too complicated, you should probably <a href="https://www.google.com">look for answers</a> and come back!',
+  position: 'top',
+}

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.stories.ts
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.stories.ts
@@ -1,0 +1,20 @@
+import { moduleMetadata, Story, Meta } from '@storybook/angular'
+import { PopupAlertComponent } from './popup-alert.component'
+
+export default {
+  title: 'Widgets/PopupAlertComponent',
+  component: PopupAlertComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [],
+    }),
+  ],
+} as Meta<PopupAlertComponent>
+
+const Template: Story<PopupAlertComponent> = (args: PopupAlertComponent) => ({
+  component: PopupAlertComponent,
+  props: args,
+})
+
+export const Primary = Template.bind({})
+Primary.args = {}

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.ts
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.ts
@@ -1,4 +1,12 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Input,
+  OnInit,
+  ViewChild,
+} from '@angular/core'
 
 @Component({
   selector: 'gn-ui-popup-alert',
@@ -7,7 +15,36 @@ import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PopupAlertComponent implements OnInit {
-  constructor() {}
+  @Input() icon: string
+  @Input() position: 'top' | 'bottom' = 'top'
+  @ViewChild('content') content: ElementRef
+  expanded = false
+  timeout = null
 
-  ngOnInit(): void {}
+  constructor(private changeDetector: ChangeDetectorRef) {}
+
+  get showDuration() {
+    const chars = this.content.nativeElement.innerHTML.length
+    return Math.max(3000, chars * 20)
+  }
+
+  ngOnInit() {
+    this.expandAndClose()
+  }
+
+  expand() {
+    this.expanded = true
+    this.changeDetector.detectChanges()
+    clearTimeout(this.timeout)
+  }
+
+  expandAndClose() {
+    this.expanded = true
+    this.changeDetector.detectChanges()
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(() => {
+      this.expanded = false
+      this.changeDetector.detectChanges()
+    }, this.showDuration)
+  }
 }

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.ts
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.ts
@@ -1,0 +1,13 @@
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
+
+@Component({
+  selector: 'gn-ui-popup-alert',
+  templateUrl: './popup-alert.component.html',
+  styleUrls: ['./popup-alert.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PopupAlertComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/libs/ui/widgets/src/lib/ui-widgets.module.ts
+++ b/libs/ui/widgets/src/lib/ui-widgets.module.ts
@@ -10,7 +10,8 @@ import { TagInputModule } from 'ngx-chips'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { LoadingMaskComponent } from './loading-mask/loading-mask.component'
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { PopupAlertComponent } from './popup-alert/popup-alert.component'
 
 @NgModule({
   declarations: [
@@ -18,6 +19,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
     ProgressBarComponent,
     StepBarComponent,
     LoadingMaskComponent,
+    PopupAlertComponent,
   ],
   imports: [
     BrowserModule,
@@ -30,6 +32,6 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
     UtilSharedModule,
     MatProgressSpinnerModule,
   ],
-  exports: [ProgressBarComponent, StepBarComponent, LoadingMaskComponent],
+  exports: [ProgressBarComponent, StepBarComponent, LoadingMaskComponent, PopupAlertComponent],
 })
 export class UiWidgetsModule {}

--- a/libs/ui/widgets/src/lib/ui-widgets.module.ts
+++ b/libs/ui/widgets/src/lib/ui-widgets.module.ts
@@ -8,11 +8,17 @@ import { ProgressBarComponent } from './progress-bar/progress-bar.component'
 import { StepBarComponent } from './step-bar/step-bar.component'
 import { TagInputModule } from 'ngx-chips'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { LoadingMaskComponent } from './loading-mask/loading-mask.component'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 
 @NgModule({
-  declarations: [ColorScaleComponent, ProgressBarComponent, StepBarComponent, LoadingMaskComponent],
+  declarations: [
+    ColorScaleComponent,
+    ProgressBarComponent,
+    StepBarComponent,
+    LoadingMaskComponent,
+  ],
   imports: [
     BrowserModule,
     TranslateModule.forChild(),
@@ -22,6 +28,7 @@ import { LoadingMaskComponent } from './loading-mask/loading-mask.component'
     ReactiveFormsModule,
     TagInputModule,
     UtilSharedModule,
+    MatProgressSpinnerModule,
   ],
   exports: [ProgressBarComponent, StepBarComponent, LoadingMaskComponent],
 })

--- a/libs/ui/widgets/src/lib/ui-widgets.module.ts
+++ b/libs/ui/widgets/src/lib/ui-widgets.module.ts
@@ -10,8 +10,9 @@ import { TagInputModule } from 'ngx-chips'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { LoadingMaskComponent } from './loading-mask/loading-mask.component'
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 import { PopupAlertComponent } from './popup-alert/popup-alert.component'
+import { MatIconModule } from '@angular/material/icon'
 
 @NgModule({
   declarations: [
@@ -31,7 +32,13 @@ import { PopupAlertComponent } from './popup-alert/popup-alert.component'
     TagInputModule,
     UtilSharedModule,
     MatProgressSpinnerModule,
+    MatIconModule,
   ],
-  exports: [ProgressBarComponent, StepBarComponent, LoadingMaskComponent, PopupAlertComponent],
+  exports: [
+    ProgressBarComponent,
+    StepBarComponent,
+    LoadingMaskComponent,
+    PopupAlertComponent,
+  ],
 })
 export class UiWidgetsModule {}

--- a/libs/ui/widgets/src/lib/ui-widgets.module.ts
+++ b/libs/ui/widgets/src/lib/ui-widgets.module.ts
@@ -8,10 +8,11 @@ import { ProgressBarComponent } from './progress-bar/progress-bar.component'
 import { StepBarComponent } from './step-bar/step-bar.component'
 import { TagInputModule } from 'ngx-chips'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
-import { FormsModule, ReactiveFormsModule } from '@angular/forms'
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { LoadingMaskComponent } from './loading-mask/loading-mask.component'
 
 @NgModule({
-  declarations: [ColorScaleComponent, ProgressBarComponent, StepBarComponent],
+  declarations: [ColorScaleComponent, ProgressBarComponent, StepBarComponent, LoadingMaskComponent],
   imports: [
     BrowserModule,
     TranslateModule.forChild(),
@@ -22,6 +23,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms'
     TagInputModule,
     UtilSharedModule,
   ],
-  exports: [ProgressBarComponent, StepBarComponent],
+  exports: [ProgressBarComponent, StepBarComponent, LoadingMaskComponent],
 })
 export class UiWidgetsModule {}

--- a/libs/util/data-fetcher/src/lib/data-fetcher.spec.ts
+++ b/libs/util/data-fetcher/src/lib/data-fetcher.spec.ts
@@ -2,6 +2,7 @@ import fetchMock from 'fetch-mock-jest'
 import fs from 'fs/promises'
 import path from 'path'
 import { readDataset } from './data-fetcher'
+import * as csv from '../parsers/csv'
 
 describe('data-fetcher', () => {
   beforeEach(() => {
@@ -41,9 +42,11 @@ describe('data-fetcher', () => {
         }
       }
     )
+    jest.spyOn(csv, 'parseCsv')
   })
   afterEach(() => {
     fetchMock.reset()
+    jest.clearAllMocks()
   })
   describe('readDataset', () => {
     describe('network error occurs', () => {
@@ -268,6 +271,17 @@ describe('data-fetcher', () => {
           },
           type: 'Feature',
         })
+      })
+    })
+    describe('specifying a type hint', () => {
+      it('ignores the advertised content type and follow the type hint instead', async () => {
+        try {
+          await readDataset(
+            'http://localfile/fixtures/perimetre-des-epci-concernes-par-un-contrat-de-ville.geojson',
+            'csv'
+          )
+        } catch {}
+        expect(csv.parseCsv).toHaveBeenCalled()
       })
     })
   })

--- a/libs/util/data-fetcher/src/lib/data-fetcher.spec.ts
+++ b/libs/util/data-fetcher/src/lib/data-fetcher.spec.ts
@@ -280,7 +280,7 @@ describe('data-fetcher', () => {
             'http://localfile/fixtures/perimetre-des-epci-concernes-par-un-contrat-de-ville.geojson',
             'csv'
           )
-        } catch {}
+        } catch {} // eslint-disable-line
         expect(csv.parseCsv).toHaveBeenCalled()
       })
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@angular/router": "12.2.0",
         "@biesbjerg/ngx-translate-extract": "^7.0.4",
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-        "@camptocamp/ogc-client": "^0.2.1",
+        "@camptocamp/ogc-client": "^0.2.2",
         "@ngrx/router-store": "^12.2.0",
         "@nguniversal/express-engine": "^12.0.1",
         "@ngx-translate/core": "^13.0.0",
@@ -2733,9 +2733,9 @@
       }
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.2.1.tgz",
-      "integrity": "sha512-7UezGkJQcCiJ3l2Spd+se/3mZmBqutg1nxULd0OB4UWU36UVhriusw5XHVRdC57z+ohu3iSHOLP2I9HWou+4lQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.2.2.tgz",
+      "integrity": "sha512-TG1eMqYchNr5v78GeDP1adjDWKgd9Xq6lqKNyHuLHewyogtPBi4uhpJ+FqJKB7fddLrlksLmvVrU0nl4V9OMLw==",
       "dependencies": {
         "@rgrove/parse-xml": "^3.0.0"
       }
@@ -28307,7 +28307,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -28342,7 +28342,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -43884,9 +43884,9 @@
       }
     },
     "@camptocamp/ogc-client": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.2.1.tgz",
-      "integrity": "sha512-7UezGkJQcCiJ3l2Spd+se/3mZmBqutg1nxULd0OB4UWU36UVhriusw5XHVRdC57z+ohu3iSHOLP2I9HWou+4lQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.2.2.tgz",
+      "integrity": "sha512-TG1eMqYchNr5v78GeDP1adjDWKgd9Xq6lqKNyHuLHewyogtPBi4uhpJ+FqJKB7fddLrlksLmvVrU0nl4V9OMLw==",
       "requires": {
         "@rgrove/parse-xml": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/router": "12.2.0",
     "@biesbjerg/ngx-translate-extract": "^7.0.4",
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-    "@camptocamp/ogc-client": "^0.2.1",
+    "@camptocamp/ogc-client": "^0.2.2",
     "@ngrx/router-store": "^12.2.0",
     "@nguniversal/express-engine": "^12.0.1",
     "@ngx-translate/core": "^13.0.0",


### PR DESCRIPTION
This PR expands on the data-view-map component to make it work with WFS layers as well as geojson files provided in the metadata record.

* `data-fetcher` is used to download all data (either from files or WFS) as geojson
* a loading mask component was added to handle the time where the dataset is being downloaded
* use ogc-client 0.2.2 to resolve an issue with output formats not parsed in the WFS

Remaining:
- [x] show errors/warnings when something goes wrong (CORS, parse error etc.)

![image](https://user-images.githubusercontent.com/10629150/138178989-8bf32ade-6b14-45e7-8264-96c854e3019b.png)
![popup-alert](https://user-images.githubusercontent.com/10629150/138271805-db1a7750-2558-4e02-a439-d8e80f9d55bd.gif)


