### PR TITLE
Prevent duplicates in wfs download formats

### DIFF
--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
@@ -20,6 +20,10 @@ jest.spyOn(utils, 'getLinksWithWfsFormats').mockImplementation((link) =>
     },
     {
       ...link,
+      format: 'geojson',
+    },
+    {
+      ...link,
       format: 'csv',
     },
     {
@@ -121,7 +125,7 @@ describe('DataDownloadsComponent', () => {
         tick()
         fixture.detectChanges()
       }))
-      it('emits download links', () => {
+      it('emits download links once per format', () => {
         expect(downloadsListComponent.links).toEqual([
           {
             description: 'Lieu de surveillance (point)',

--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
@@ -50,6 +50,14 @@ export class DataDownloadsComponent {
               format: getDownloadFormat(link, DownloadFormatType.WFS),
             }))
             .filter((link) => link.format !== 'unknown')
+            .filter(
+              (link, i, links) =>
+                links.findIndex(
+                  (firstLink) =>
+                    firstLink.format === link.format &&
+                    firstLink.name === link.name
+                ) === i
+            )
         ),
         map((wfsDownloadLinks) => [
           ...otherLinks,


### PR DESCRIPTION
PR prevents format duplicates for WFS in download list for the case that the WFS provides one format with several mime types. This problem has become clear with ogc-client update to version 0.2.2. which detects outputFormats in a very complete way.