### PR TITLE
Loading mask / improve appearance, fix in Firefox

### DIFF
--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.css
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.css
@@ -1,10 +1,18 @@
 /* this overrides the spinner color with a CSS variable to match the theme */
 ::ng-deep .mat-spinner circle {
-  stroke: var(--color-gray-300);
+  stroke: var(--color-gray-700);
+  opacity: 0.5;
 }
 
 .backdrop {
-  backdrop-filter: blur(4px);
+  background-color: rgba(255, 255, 255, 0.4);
+}
+
+@supports (-webkit-backdrop-filter: blur()) or (backdrop-filter: blur()) {
+  .backdrop {
+    background-color: transparent;
+    backdrop-filter: blur(4px);
+  }
 }
 
 .background {
@@ -12,6 +20,5 @@
   bottom: 0;
   left: 0;
   right: 0;
-  opacity: 0.6;
-  z-index: -10;
+  opacity: 0.7;
 }

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.html
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.html
@@ -1,5 +1,7 @@
 <div class="h-full flex flex-col justify-center items-center relative backdrop">
   <div class="absolute background bg-white"></div>
-  <mat-spinner [diameter]="28"></mat-spinner>
-  <span class="text-sm text-gray-700 mt-3" translate>{{ message }}</span>
+  <mat-spinner [diameter]="28" class="relative"></mat-spinner>
+  <span class="text-sm text-gray-700 mt-3 relative" translate>{{
+    message
+  }}</span>
 </div>

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.spec.ts
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-
 import { LoadingMaskComponent } from './loading-mask.component'
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 
 describe('LoadingMaskComponent', () => {
   let component: LoadingMaskComponent
@@ -9,6 +9,7 @@ describe('LoadingMaskComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [LoadingMaskComponent],
+      imports: [MatProgressSpinnerModule],
     }).compileComponents()
   })
 

--- a/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.stories.ts
+++ b/libs/ui/widgets/src/lib/loading-mask/loading-mask.component.stories.ts
@@ -7,6 +7,9 @@ import {
 import { LoadingMaskComponent } from './loading-mask.component'
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 
+const sampleBackground =
+  'url(https://geonetwork-opensource.org/_images/gn-map.png)'
+
 export default {
   title: 'Widgets/LoadingMaskComponent',
   component: LoadingMaskComponent,
@@ -16,7 +19,7 @@ export default {
     }),
     componentWrapperDecorator(
       (story) => `
-<div class="border border-gray-300 p-2" style="width: 600px; height:400px; resize: both; overflow: auto">
+<div class="border border-gray-300 p-2" style="width: 600px; height:400px; resize: both; overflow: auto; background: ${sampleBackground}">
   ${story}
 </div>`
     ),


### PR DESCRIPTION
Firefox does not support CSS backdrop-filter so we just use a brighter background instead.

![image](https://user-images.githubusercontent.com/10629150/138439743-34eadec9-961b-4b3b-a4be-7f1ea5b14693.png)
