### PR TITLE
Datahub / navigation and user experience improvements

### DIFF
--- a/apps/datahub/src/app/app.component.html
+++ b/apps/datahub/src/app/app.component.html
@@ -31,7 +31,7 @@
   </div>
   <div class="container-lg mx-auto py-4">
     <gn-ui-main-search
-      *ngIf="(isRecordOpened$ | async) === false"
+      [ngClass]="{ hidden: (isRecordOpened$ | async) }"
     ></gn-ui-main-search>
     <gn-ui-record-metadata *ngIf="isRecordOpened$ | async">
     </gn-ui-record-metadata>

--- a/apps/datahub/src/app/main-search/main-search.component.spec.ts
+++ b/apps/datahub/src/app/main-search/main-search.component.spec.ts
@@ -2,11 +2,15 @@ import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { MainSearchComponent } from './main-search.component'
-import { RouterFacade } from '@geonetwork-ui/feature/search'
+import { RouterFacade, SearchFacade } from '@geonetwork-ui/feature/search'
 import { UiLayoutModule } from '@geonetwork-ui/ui/layout'
 
 class RouterFacadeMock {
   goToMetadata = jest.fn()
+}
+
+class SearchFacadeMock {
+  setFilters = jest.fn()
 }
 
 describe('MainSearchComponent', () => {
@@ -22,6 +26,10 @@ describe('MainSearchComponent', () => {
         {
           provide: RouterFacade,
           useClass: RouterFacadeMock,
+        },
+        {
+          provide: SearchFacade,
+          useClass: SearchFacadeMock,
         },
       ],
     }).compileComponents()

--- a/apps/datahub/src/app/main-search/main-search.component.ts
+++ b/apps/datahub/src/app/main-search/main-search.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core'
-import { RouterFacade } from '@geonetwork-ui/feature/search'
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core'
+import { RouterFacade, SearchFacade } from '@geonetwork-ui/feature/search'
 import { MetadataRecord } from '@geonetwork-ui/util/shared'
 
 @Component({
@@ -8,8 +8,17 @@ import { MetadataRecord } from '@geonetwork-ui/util/shared'
   styleUrls: ['./main-search.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MainSearchComponent {
-  constructor(private searchRouter: RouterFacade) {}
+export class MainSearchComponent implements OnInit {
+  constructor(
+    private searchRouter: RouterFacade,
+    private searchFacade: SearchFacade
+  ) {}
+
+  ngOnInit() {
+    this.searchFacade.setFilters({
+      any: '',
+    })
+  }
 
   onMetadataSelection(metadata: MetadataRecord): void {
     this.searchRouter.goToMetadata(metadata)

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
@@ -160,12 +160,12 @@ describe('DataViewMapComponent', () => {
           {
             url: 'http://abcd.com/',
             name: 'layer1',
-            protocol: 'OGC:WMS',
+            protocol: 'OGC:WMS--1-3-0',
           },
           {
             url: 'http://abcd.com/',
             name: 'layer2',
-            protocol: 'OGC:WMS',
+            protocol: 'OGC:WMS--1-1-0',
           },
         ])
         mdViewFacade.dataLinks$.next([])
@@ -188,11 +188,11 @@ describe('DataViewMapComponent', () => {
         expect(dropdownComponent.choices).toEqual([
           {
             value: 0,
-            label: 'layer1 (OGC:WMS)',
+            label: 'layer1 (OGC:WMS--1-3-0)',
           },
           {
             value: 1,
-            label: 'layer2 (OGC:WMS)',
+            label: 'layer2 (OGC:WMS--1-1-0)',
           },
         ])
       })
@@ -211,7 +211,7 @@ describe('DataViewMapComponent', () => {
           {
             url: 'http://abcd.com/wfs',
             name: 'featuretype',
-            protocol: 'OGC:WFS',
+            protocol: 'OGC:WFS--2-0-0',
           },
           {
             url: 'http://abcd.com/data.geojson',
@@ -230,7 +230,7 @@ describe('DataViewMapComponent', () => {
           },
           {
             value: 1,
-            label: 'featuretype (OGC:WFS)',
+            label: 'featuretype (OGC:WFS--2-0-0)',
           },
           {
             value: 2,

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -89,13 +89,13 @@ export class DataViewMapComponent {
   }
 
   getLayerFromLink(link: MetadataLinkValid): Observable<MapContextLayerModel> {
-    if (link.protocol === 'OGC:WMS') {
+    if (link.protocol.startsWith('OGC:WMS')) {
       return of({
         url: link.url,
         type: MapContextLayerTypeEnum.WMS,
         name: link.name,
       })
-    } else if (link.protocol === 'OGC:WFS') {
+    } else if (link.protocol.startsWith('OGC:WFS')) {
       return fromPromise(
         new WfsEndpoint(link.url).isReady().then((endpoint) => {
           if (!endpoint.supportsJson(link.name)) {

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.html
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.html
@@ -16,7 +16,7 @@
   <gn-ui-loading-mask
     *ngIf="loading"
     class="absolute"
-    message="map.loading.data"
+    message="table.loading.data"
   ></gn-ui-loading-mask>
   <gn-ui-popup-alert *ngIf="error" icon="error_outline" class="absolute m-2">
     <span translate>{{ error }}</span>

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
@@ -74,6 +74,7 @@ export class DataViewTableComponent {
           }
           return readDataset(
             endpoint.getFeatureUrl(link.name, {
+              outputCrs: 'EPSG:4326',
               asJson: true,
             }),
             'geojson'

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
@@ -21,6 +21,7 @@
       *ngIf="(facade.isPresent$ | async) === true"
       [metadata]="facade.metadata$ | async"
       [incomplete]="facade.isIncomplete$ | async"
+      [otherLinks]="facade.otherLinks$ | async"
     >
     </gn-ui-metadata-info>
   </mat-tab>

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
@@ -45,14 +45,15 @@
     </div>
   </mat-tab>
 
-  <mat-tab>
+  <mat-tab [disabled]="(displayDownload$ | async) === false">
     <ng-template mat-tab-label>
       <mat-icon class="mr-3">download</mat-icon>
       <span translate="">mdview.tab.exports</span>
     </ng-template>
     <gn-ui-data-downloads class="block mt-4"></gn-ui-data-downloads>
   </mat-tab>
-  <mat-tab>
+
+  <mat-tab [disabled]="(displayApi$ | async) === false">
     <ng-template mat-tab-label>
       <mat-icon class="mr-3">api</mat-icon>
       <span translate="">mdview.tab.api</span>

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
@@ -1,10 +1,14 @@
-<mat-tab-group (selectedIndexChange)="onTabIndexChange()">
+<mat-tab-group
+  (selectedIndexChange)="onTabIndexChange()"
+  animationDuration="200ms"
+>
   <mat-tab>
     <ng-template mat-tab-label>
       <mat-icon class="mr-3">info</mat-icon>
       <span translate="">mdview.tab.info</span>
     </ng-template>
     <gn-ui-metadata-info
+      class="block mt-4"
       *ngIf="(facade.isPresent$ | async) === false"
       [metadata]="{
         title: 'Loading...'
@@ -13,6 +17,7 @@
     >
     </gn-ui-metadata-info>
     <gn-ui-metadata-info
+      class="block mt-4"
       *ngIf="(facade.isPresent$ | async) === true"
       [metadata]="facade.metadata$ | async"
       [incomplete]="facade.isIncomplete$ | async"
@@ -25,7 +30,7 @@
       <mat-icon class="mr-3">list</mat-icon>
       <span translate="">mdview.tab.data</span>
     </ng-template>
-    <div style="height: 500px" *ngIf="displayData$ | async">
+    <div class="block mt-4" style="height: 500px" *ngIf="displayData$ | async">
       <gn-ui-data-view-table></gn-ui-data-view-table>
     </div>
   </mat-tab>
@@ -35,7 +40,7 @@
       <mat-icon class="mr-3">map</mat-icon>
       <span translate="">mdview.tab.map</span>
     </ng-template>
-    <div style="height: 500px" *ngIf="displayMap$ | async">
+    <div class="block mt-4" style="height: 500px" *ngIf="displayMap$ | async">
       <gn-ui-data-view-map></gn-ui-data-view-map>
     </div>
   </mat-tab>
@@ -45,13 +50,13 @@
       <mat-icon class="mr-3">download</mat-icon>
       <span translate="">mdview.tab.exports</span>
     </ng-template>
-    <gn-ui-data-downloads></gn-ui-data-downloads>
+    <gn-ui-data-downloads class="block mt-4"></gn-ui-data-downloads>
   </mat-tab>
   <mat-tab>
     <ng-template mat-tab-label>
       <mat-icon class="mr-3">api</mat-icon>
       <span translate="">mdview.tab.api</span>
     </ng-template>
-    <gn-ui-data-apis></gn-ui-data-apis>
+    <gn-ui-data-apis class="block mt-4"></gn-ui-data-apis>
   </mat-tab>
 </mat-tab-group>

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.spec.ts
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.spec.ts
@@ -16,6 +16,8 @@ class MdViewFacadeMock {
   metadata$ = new BehaviorSubject(RECORDS_SUMMARY_FIXTURE[0])
   mapApiLinks$ = new Subject()
   dataLinks$ = new Subject()
+  downloadLinks$ = new Subject()
+  apiLinks$ = new Subject()
 }
 
 describe('RecordMetadataComponent', () => {

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.ts
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.ts
@@ -16,6 +16,12 @@ export class RecordMetadataComponent {
   displayData$ = this.facade.dataLinks$.pipe(
     map((links) => !!links && links.length > 0)
   )
+  displayDownload$ = this.facade.downloadLinks$.pipe(
+    map((links) => !!links && links.length > 0)
+  )
+  displayApi$ = this.facade.apiLinks$.pipe(
+    map((links) => !!links && links.length > 0)
+  )
 
   constructor(
     public facade: MdViewFacade,

--- a/libs/feature/search/README.md
+++ b/libs/feature/search/README.md
@@ -127,3 +127,6 @@ export class MainSearchComponent {
 ```
 
 This is required otherwise the URL won't reflect the user actions and will not be in sync with the application state.
+
+Also please note that when using routing **it is assumed that displaying search results and displaying a catalog record
+are mutually exclusive**: triggering a search will close the current record.

--- a/libs/feature/search/src/lib/router/state/router.effects.spec.ts
+++ b/libs/feature/search/src/lib/router/state/router.effects.spec.ts
@@ -8,6 +8,7 @@ import { Location } from '@angular/common'
 
 import * as fromActions from './router.actions'
 import { RouterGoActionPayload } from './router.actions'
+import * as fromSearchActions from '../../state/actions'
 import * as fromEffects from './router.effects'
 import { Action } from '@ngrx/store'
 import { routerNavigationAction } from '@ngrx/router-store'
@@ -50,7 +51,7 @@ describe('RouterEffects', () => {
     location = TestBed.inject(Location)
   })
 
-  describe('loadMetadata$', () => {
+  describe('navigateToMetadata$', () => {
     it('should dispatch a loadFullMetadata action', () => {
       actions = hot('-a', {
         a: routerNavigationAction({
@@ -71,11 +72,11 @@ describe('RouterEffects', () => {
       const expected = hot('-a', {
         a: MdViewActions.loadFullMetadata({ uuid: 'abcdef' }),
       })
-      expect(effects.loadMetadata$).toBeObservable(expected)
+      expect(effects.navigateToMetadata$).toBeObservable(expected)
     })
   })
 
-  describe('closeMetadata$', () => {
+  describe('navigateToSearch$', () => {
     it('should dispatch a loadFullMetadata action', () => {
       actions = hot('-a', {
         a: routerNavigationAction({
@@ -94,7 +95,19 @@ describe('RouterEffects', () => {
       const expected = hot('-a', {
         a: MdViewActions.close(),
       })
-      expect(effects.closeMetadata$).toBeObservable(expected)
+      expect(effects.navigateToSearch$).toBeObservable(expected)
+    })
+  })
+
+  describe('setSearchFilters$', () => {
+    it('should dispatch a closeMetadata action', () => {
+      actions = hot('-a', {
+        a: new fromSearchActions.SetFilters({ any: 'changed filter' }),
+      })
+      const expected = hot('-a', {
+        a: MdViewActions.close(),
+      })
+      expect(effects.setSearchFilters$).toBeObservable(expected)
     })
   })
 

--- a/libs/feature/search/src/lib/router/state/router.effects.ts
+++ b/libs/feature/search/src/lib/router/state/router.effects.ts
@@ -2,9 +2,10 @@ import { Location } from '@angular/common'
 import { Injectable } from '@angular/core'
 import { ActivatedRouteSnapshot, Router } from '@angular/router'
 import { Actions, createEffect, ofType } from '@ngrx/effects'
-import { tap } from 'rxjs/operators'
+import { map, tap } from 'rxjs/operators'
 
 import * as RouterActions from './router.actions'
+import * as SearchActions from '../../state/actions'
 import { MdViewActions } from '@geonetwork-ui/feature/record'
 import { navigation } from '@nrwl/angular'
 import { MetadataRouteComponent, SearchRouteComponent } from '../constants'
@@ -28,7 +29,11 @@ export class RouterEffects {
     { dispatch: false }
   )
 
-  loadMetadata$ = createEffect(() =>
+  /**
+   * This effect will load the metadata when a navigation to
+   * a metadata record happens
+   */
+  navigateToMetadata$ = createEffect(() =>
     this._actions$.pipe(
       navigation(MetadataRouteComponent, {
         run: (activatedRouteSnapshot: ActivatedRouteSnapshot) =>
@@ -42,11 +47,26 @@ export class RouterEffects {
     )
   )
 
-  closeMetadata$ = createEffect(() =>
+  /**
+   * This effect will close the metadata when a navigation to
+   * the search results happens
+   */
+  navigateToSearch$ = createEffect(() =>
     this._actions$.pipe(
       navigation(SearchRouteComponent, {
         run: () => MdViewActions.close(),
       })
+    )
+  )
+
+  /**
+   * This effect will close the metadata when new search filters
+   * are entered, thus triggering a new search
+   */
+  setSearchFilters$ = createEffect(() =>
+    this._actions$.pipe(
+      ofType(SearchActions.SET_FILTERS),
+      map(() => MdViewActions.close())
     )
   )
 

--- a/libs/ui/elements/src/lib/apis-list/apis-list.component.html
+++ b/libs/ui/elements/src/lib/apis-list/apis-list.component.html
@@ -1,3 +1,3 @@
-<div class="pt-4" *ngFor="let link of links">
+<div class="pb-4" *ngFor="let link of links">
   <gn-ui-apis-list-item [link]="link"></gn-ui-apis-list-item>
 </div>

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
@@ -1,3 +1,3 @@
-<div class="pt-4" *ngFor="let link of links">
+<div class="pb-4" *ngFor="let link of links">
   <gn-ui-downloads-list-item [link]="link"></gn-ui-downloads-list-item>
 </div>

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -1,19 +1,107 @@
-<p class="text-lg font-medium text-primary mb-3">{{ metadata.title }}</p>
-<p class="text-gray-700 mb-4">
-  <gn-ui-content-ghost
-    [showContent]="fieldReady('createdOn') && fieldReady('updatedOn')"
+<div class="grid grid-cols-3 gap-6">
+  <div class="col-span-2">
+    <p class="text-2xl font-medium text-primary my-6">{{ metadata.title }}</p>
+
+    <p class="text-lg font-medium mb-4" translate>
+      record.metadata.description
+    </p>
+    <div class="mb-6">
+      <gn-ui-content-ghost
+        ghostClass="h-32"
+        [showContent]="fieldReady('abstract')"
+      >
+        <p class="whitespace-pre-line">{{ metadata.abstract }}</p>
+      </gn-ui-content-ghost>
+    </div>
+
+    <p class="mb-4 font-medium text-primary" translate>
+      record.metadata.keywords
+    </p>
+    <div class="mb-4">
+      <gn-ui-badge
+        class="inline-block mr-2 mb-2"
+        *ngFor="let keyword of metadata.keywords"
+        >{{ keyword }}</gn-ui-badge
+      >
+    </div>
+
+    <p class="mb-4 font-medium text-primary" translate>
+      record.metadata.origin
+    </p>
+    <p class="mb-4 whitespace-pre-line">
+      {{ metadata.lineage }}
+    </p>
+    <div
+      class="
+        py-4
+        px-6
+        mb-6
+        rounded
+        bg-gray-100
+        grid grid-cols-2 grid-rows-2
+        gap-6
+        text-gray-800
+      "
+    >
+      <div class="border-b border-gray-300">
+        <p translate>record.metadata.updatedOn</p>
+        <p class="text-primary my-2">
+          {{ metadata.updatedOn && metadata.updatedOn.toLocaleString() }}
+        </p>
+      </div>
+      <div class="border-b border-gray-300">
+        <p translate>record.metadata.updateFrequency</p>
+        <p class="text-primary my-2">{{ metadata.updateFrequency }}</p>
+      </div>
+      <div>
+        <p translate>record.metadata.updateStatus</p>
+        <p class="text-primary my-2">{{ metadata.updateStatus }}</p>
+      </div>
+    </div>
+
+    <p class="mb-4 font-medium text-primary" translate>record.metadata.usage</p>
+    <p class="mb-4 whitespace-pre-line">
+      {{ metadata.usageConstraints }}
+    </p>
+  </div>
+
+  <div *ngIf="metadata.contact">
+    <p class="text-gray-600 my-6 uppercase" translate>
+      record.metadata.contact
+    </p>
+    <img
+      class="w-full mb-4 border border-gray-400 rounded"
+      [src]="metadata.contact.logoUrl"
+      [alt]="metadata.contact.name"
+    />
+    <p class="text-primary text-lg mb-2">{{ metadata.contact.name }}</p>
+    <p class="text-gray-600 mb-2">{{ metadata.contact.email }}</p>
+    <p class="text-gray-600 mb-4">
+      <a [href]="metadata.contact.website">{{ metadata.contact.website }}</a>
+    </p>
+  </div>
+</div>
+
+<div *ngIf="otherLinks && otherLinks.length">
+  <p class="mb-4 font-medium text-primary" translate>
+    record.metadata.otherLinks
+  </p>
+  <div
+    class="mb-4 flex flex-row items-stretch overflow-x-auto overflow-y-visible"
   >
-    <span *ngIf="metadata.createdOn"
-      >created on {{ metadata.createdOn.toLocaleString() }} |
-    </span>
-    <span *ngIf="metadata.updatedOn"
-      >updated on {{ metadata.updatedOn.toLocaleString() }} |
-    </span>
-    {{ metadata.updateFrequency }}
-  </gn-ui-content-ghost>
-</p>
-<p class="mb-4">
-  <gn-ui-content-ghost ghostClass="h-32" [showContent]="fieldReady('abstract')">
-    {{ metadata.abstract }}
-  </gn-ui-content-ghost>
-</p>
+    <gn-ui-card-link
+      *ngFor="let link of otherLinks"
+      class="flex-shrink-0 mr-4 my-2"
+      [linkHref]="link.url"
+      [title]="link.description || link.name"
+    >
+      <div class="flex flex-col h-40 w-64">
+        <p class="mb-2 text-lg font-medium">{{ link.name }}</p>
+        <p class="mb-3 flex-grow overflow-hidden">
+          {{ link.description }}
+        </p>
+        <mat-icon class="opacity-40">ios_share</mat-icon>
+      </div>
+    </gn-ui-card-link>
+  </div>
+</div>

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
-import { MetadataRecord } from '@geonetwork-ui/util/shared'
+import { MetadataLinkValid, MetadataRecord } from '@geonetwork-ui/util/shared'
 
 @Component({
   selector: 'gn-ui-metadata-info',
@@ -10,6 +10,7 @@ import { MetadataRecord } from '@geonetwork-ui/util/shared'
 export class MetadataInfoComponent {
   @Input() metadata: MetadataRecord
   @Input() incomplete: boolean
+  @Input() otherLinks: MetadataLinkValid[]
 
   fieldReady(propName: string) {
     return !this.incomplete || propName in this.metadata

--- a/libs/ui/elements/src/lib/ui-elements.module.ts
+++ b/libs/ui/elements/src/lib/ui-elements.module.ts
@@ -8,9 +8,17 @@ import { DownloadsListItemComponent } from './downloads-list-item/downloads-list
 import { DownloadsListComponent } from './downloads-list/downloads-list.component'
 import { ApisListItemComponent } from './apis-list-item/apis-list-item.component'
 import { ApisListComponent } from './apis-list/apis-list.component'
+import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
+import { UiLayoutModule } from '@geonetwork-ui/ui/layout'
 
 @NgModule({
-  imports: [CommonModule, MatIconModule, MatTooltipModule],
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatTooltipModule,
+    UiWidgetsModule,
+    UiLayoutModule,
+  ],
   declarations: [
     MetadataInfoComponent,
     ContentGhostComponent,

--- a/libs/ui/layout/src/lib/card-link/card-link.component.html
+++ b/libs/ui/layout/src/lib/card-link/card-link.component.html
@@ -1,0 +1,1 @@
+<p>card-link works!</p>

--- a/libs/ui/layout/src/lib/card-link/card-link.component.html
+++ b/libs/ui/layout/src/lib/card-link/card-link.component.html
@@ -1,1 +1,24 @@
-<p>card-link works!</p>
+<a
+  [href]="linkHref"
+  [target]="newTab ? '_blank' : '_self'"
+  class="
+    block
+    h-full
+    py-3
+    px-4
+    border
+    bg-white
+    rounded
+    transition
+    duration-150
+    transform
+    hover:scale-105 hover:bg-gray-50
+    border-gray-300
+    hover:border-primary hover:text-primary
+    filter
+    drop-shadow-sm
+    hover:drop-shadow-lg
+  "
+>
+  <ng-content></ng-content>
+</a>

--- a/libs/ui/layout/src/lib/card-link/card-link.component.spec.ts
+++ b/libs/ui/layout/src/lib/card-link/card-link.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { CardLinkComponent } from './card-link.component'
+
+describe('CardLinkComponent', () => {
+  let component: CardLinkComponent
+  let fixture: ComponentFixture<CardLinkComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CardLinkComponent],
+    }).compileComponents()
+  })
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CardLinkComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/ui/layout/src/lib/card-link/card-link.component.stories.ts
+++ b/libs/ui/layout/src/lib/card-link/card-link.component.stories.ts
@@ -1,0 +1,37 @@
+import {
+  componentWrapperDecorator,
+  Meta,
+  moduleMetadata,
+  Story,
+} from '@storybook/angular'
+import { CardLinkComponent } from './card-link.component'
+
+export default {
+  title: 'Layout/CardLinkComponent',
+  component: CardLinkComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [],
+    }),
+    componentWrapperDecorator(
+      (story) => `<div style="max-width: 300px">${story}</div>`
+    ),
+  ],
+} as Meta<CardLinkComponent>
+
+type CardLinkComponentWithContent = CardLinkComponent & { content: string }
+
+const Template: Story<CardLinkComponentWithContent> = (args) => ({
+  component: CardLinkComponent,
+  props: args,
+  template:
+    '<gn-ui-card-link [linkHref]="linkHref" [newTab]="newTab">{{content}}</gn-ui-card-link>',
+})
+
+export const Primary = Template.bind({})
+Primary.args = {
+  linkHref: 'http://archimer.ifremer.fr/doc/00409/52016/',
+  newTab: false,
+  content:
+    'Manuel pour l’utilisation des données REPHY. Informations destinées à améliorer la compréhension des fichiers de données REPHY mis à disposition des scientifiques et du public.',
+}

--- a/libs/ui/layout/src/lib/card-link/card-link.component.ts
+++ b/libs/ui/layout/src/lib/card-link/card-link.component.ts
@@ -1,0 +1,13 @@
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
+
+@Component({
+  selector: 'gn-ui-card-link',
+  templateUrl: './card-link.component.html',
+  styleUrls: ['./card-link.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CardLinkComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/libs/ui/layout/src/lib/card-link/card-link.component.ts
+++ b/libs/ui/layout/src/lib/card-link/card-link.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 
 @Component({
   selector: 'gn-ui-card-link',
@@ -6,8 +6,7 @@ import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
   styleUrls: ['./card-link.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CardLinkComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit(): void {}
+export class CardLinkComponent {
+  @Input() linkHref: string
+  @Input() newTab = true
 }

--- a/libs/ui/layout/src/lib/table/table.component.html
+++ b/libs/ui/layout/src/lib/table/table.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="border border-gray-300 rounded overflow-hidden">
   <cdk-virtual-scroll-viewport
     tvsItemSize="48"
     headerHeight="56"
@@ -30,8 +30,8 @@
       ></tr>
     </table>
   </cdk-virtual-scroll-viewport>
-  <div class="mt-2">
-    <span class="count">{{ count }}</span
-    >&nbsp;<span translate>table.object.count</span>
+  <div class="text-gray-900 border-t border-gray-300 px-4 py-2">
+    <span class="count font-extrabold text-primary">{{ count }}</span
+    >&nbsp;<span translate>table.object.count</span>.
   </div>
 </div>

--- a/libs/ui/layout/src/lib/ui-layout.module.ts
+++ b/libs/ui/layout/src/lib/ui-layout.module.ts
@@ -7,6 +7,7 @@ import { TableComponent } from './table/table.component'
 import { FigureComponent } from './figure/figure.component'
 import { ScrollingModule } from '@angular/cdk/scrolling'
 import { TableVirtualScrollModule } from 'ng-table-virtual-scroll'
+import { CardLinkComponent } from './card-link/card-link.component'
 
 @NgModule({
   imports: [
@@ -17,7 +18,7 @@ import { TableVirtualScrollModule } from 'ng-table-virtual-scroll'
     TableVirtualScrollModule,
     ScrollingModule,
   ],
-  declarations: [TableComponent, FigureComponent],
-  exports: [TableComponent, FigureComponent],
+  declarations: [TableComponent, FigureComponent, CardLinkComponent],
+  exports: [TableComponent, FigureComponent, CardLinkComponent],
 })
 export class UiLayoutModule {}

--- a/libs/ui/search/src/lib/facets/fixtures/records.ts
+++ b/libs/ui/search/src/lib/facets/fixtures/records.ts
@@ -9,8 +9,6 @@ export const RECORDS_SUMMARY_FIXTURE = [
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',
-    logoUrl:
-      'https://www.geograndest.fr/geonetwork/images/logos/b1b10881-2a33-472f-b99b-7576a6f84025.png',
     viewable: true,
     downloadable: true,
   },
@@ -25,8 +23,6 @@ export const RECORDS_SUMMARY_FIXTURE = [
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',
-    logoUrl:
-      'https://www.geograndest.fr/geonetwork/images/logos/b1b10881-2a33-472f-b99b-7576a6f84025.png',
     viewable: true,
     downloadable: true,
   },
@@ -40,8 +36,6 @@ export const RECORDS_SUMMARY_FIXTURE = [
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',
-    logoUrl:
-      'https://www.geograndest.fr/geonetwork/images/logos/b1b10881-2a33-472f-b99b-7576a6f84025.png',
     viewable: true,
     downloadable: true,
   },
@@ -55,8 +49,6 @@ export const RECORDS_SUMMARY_FIXTURE = [
     thumbnailUrl:
       'https://sextant.ifremer.fr/var/storage/images/_aliases/listitem_thumbnail/medias-ifremer/medias-sextant/accueil/cartes-thematiques/adcp/1595636-3-fre-FR/ADCP.png',
     updateFrequency: 'Final',
-    logoUrl:
-      'https://www.geograndest.fr/geonetwork/images/logos/b1b10881-2a33-472f-b99b-7576a6f84025.png',
     viewable: true,
     downloadable: true,
   },
@@ -133,8 +125,6 @@ export const RECORDS_FULL_FIXTURE = [
         url: 'https://doi.org/10.12770/cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
       },
     ],
-    logoUrl:
-      '/geonetwork/images/logos/cea9bf9f-329a-4583-9092-2dfc7efdcce2.png',
     mainLanguage: 'fre',
     metadataUrl: 'url',
     thumbnailUrl:

--- a/libs/ui/widgets/src/lib/badge/badge.component.html
+++ b/libs/ui/widgets/src/lib/badge/badge.component.html
@@ -1,0 +1,1 @@
+<p>badge works!</p>

--- a/libs/ui/widgets/src/lib/badge/badge.component.html
+++ b/libs/ui/widgets/src/lib/badge/badge.component.html
@@ -1,1 +1,14 @@
-<p>badge works!</p>
+<div
+  class="
+    inline-block
+    bg-gray-900
+    py-2
+    px-3
+    rounded
+    font-medium
+    text-gray-50
+    leading-none
+  "
+>
+  <ng-content></ng-content>
+</div>

--- a/libs/ui/widgets/src/lib/badge/badge.component.spec.ts
+++ b/libs/ui/widgets/src/lib/badge/badge.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { BadgeComponent } from './badge.component'
+
+describe('BadgeComponent', () => {
+  let component: BadgeComponent
+  let fixture: ComponentFixture<BadgeComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BadgeComponent],
+    }).compileComponents()
+  })
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BadgeComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/ui/widgets/src/lib/badge/badge.component.stories.ts
+++ b/libs/ui/widgets/src/lib/badge/badge.component.stories.ts
@@ -1,0 +1,25 @@
+import { Meta, moduleMetadata, Story } from '@storybook/angular'
+import { BadgeComponent } from './badge.component'
+
+export default {
+  title: 'Widgets/BadgeComponent',
+  component: BadgeComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [],
+    }),
+  ],
+} as Meta<BadgeComponent>
+
+type BadgeComponentWithContent = { content: string }
+
+const Template: Story<BadgeComponentWithContent> = (args: BadgeComponent) => ({
+  component: BadgeComponent,
+  props: args,
+  template: '<gn-ui-badge>{{content}}</gn-ui-badge>',
+})
+
+export const Primary = Template.bind({})
+Primary.args = {
+  content: 'My badge!',
+}

--- a/libs/ui/widgets/src/lib/badge/badge.component.ts
+++ b/libs/ui/widgets/src/lib/badge/badge.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
+import { ChangeDetectionStrategy, Component } from '@angular/core'
 
 @Component({
   selector: 'gn-ui-badge',
@@ -6,8 +6,4 @@ import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
   styleUrls: ['./badge.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class BadgeComponent implements OnInit {
-  constructor() {}
-
-  ngOnInit(): void {}
-}
+export class BadgeComponent {}

--- a/libs/ui/widgets/src/lib/badge/badge.component.ts
+++ b/libs/ui/widgets/src/lib/badge/badge.component.ts
@@ -1,0 +1,13 @@
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
+
+@Component({
+  selector: 'gn-ui-badge',
+  templateUrl: './badge.component.html',
+  styleUrls: ['./badge.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BadgeComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/libs/ui/widgets/src/lib/ui-widgets.module.ts
+++ b/libs/ui/widgets/src/lib/ui-widgets.module.ts
@@ -12,7 +12,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { LoadingMaskComponent } from './loading-mask/loading-mask.component'
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 import { PopupAlertComponent } from './popup-alert/popup-alert.component'
-import { MatIconModule } from '@angular/material/icon'
+import { MatIconModule } from '@angular/material/icon';
+import { BadgeComponent } from './badge/badge.component'
 
 @NgModule({
   declarations: [
@@ -21,6 +22,7 @@ import { MatIconModule } from '@angular/material/icon'
     StepBarComponent,
     LoadingMaskComponent,
     PopupAlertComponent,
+    BadgeComponent,
   ],
   imports: [
     BrowserModule,

--- a/libs/ui/widgets/src/lib/ui-widgets.module.ts
+++ b/libs/ui/widgets/src/lib/ui-widgets.module.ts
@@ -12,8 +12,8 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { LoadingMaskComponent } from './loading-mask/loading-mask.component'
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
 import { PopupAlertComponent } from './popup-alert/popup-alert.component'
-import { MatIconModule } from '@angular/material/icon';
 import { BadgeComponent } from './badge/badge.component'
+import { MatIconModule } from '@angular/material/icon'
 
 @NgModule({
   declarations: [
@@ -41,6 +41,7 @@ import { BadgeComponent } from './badge/badge.component'
     StepBarComponent,
     LoadingMaskComponent,
     PopupAlertComponent,
+    BadgeComponent,
   ],
 })
 export class UiWidgetsModule {}

--- a/libs/util/shared/src/lib/elasticsearch/fixtures/full-response.ts
+++ b/libs/util/shared/src/lib/elasticsearch/fixtures/full-response.ts
@@ -11,6 +11,11 @@ export const ES_FIXTURE_FULL_RESPONSE = {
         _type: '_doc',
         _id: 'cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
         _score: 1.0,
+        _ignored: [
+          'resourceAbstractObject.default.keyword',
+          'resourceAbstractObject.langfre.keyword',
+          'link.applicationProfile.keyword',
+        ],
         _source: {
           docType: 'metadata',
           document: '',
@@ -20,8 +25,8 @@ export const ES_FIXTURE_FULL_RESPONSE = {
             langfre: 'ISO 19115:2003/19139 - SEXTANT',
           },
           standardVersionObject: { default: '1.0', langfre: '1.0' },
-          indexingDate: '2021-08-25T07:36:44Z',
-          dateStamp: '2021-04-01T17:38:51.866Z',
+          indexingDate: '2021-10-29T08:41:42.537Z',
+          dateStamp: '2021-09-09T10:41:12.000Z',
           mainLanguage: 'fre',
           cl_characterSet: [
             {
@@ -39,7 +44,7 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               organisation: 'Ifremer',
               role: 'pointOfContact',
               email: 'q2suppor@ifremer.fr',
-              website: '',
+              website: 'https://www.ifremer.fr',
               logo: '',
               individual: "Cellule d'administration Quadrige",
               position: "Cellule d'administration Quadrige",
@@ -103,9 +108,9 @@ export const ES_FIXTURE_FULL_RESPONSE = {
           ],
           cl_accessConstraints: [
             {
-              key: 'otherRestrictions',
-              default: 'Autres restrictions',
-              langfre: 'Autres restrictions',
+              key: 'copyright',
+              default: 'Droit d’auteur / Droit moral (copyright)',
+              langfre: 'Droit d’auteur / Droit moral (copyright)',
               link: 'http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode',
             },
           ],
@@ -124,12 +129,15 @@ export const ES_FIXTURE_FULL_RESPONSE = {
           creationDateForResource: ['2012-01-01T00:00:00.000Z'],
           creationYearForResource: '2012',
           creationMonthForResource: '2012-01',
-          publicationDateForResource: ['2018-01-01T00:00:00.000Z'],
-          publicationYearForResource: '2018',
-          publicationMonthForResource: '2018-01',
+          publicationDateForResource: ['2021-04-01T00:00:00.000Z'],
+          publicationYearForResource: '2021',
+          publicationMonthForResource: '2021-04',
           resourceDate: [
             { type: 'creation', date: '2012-01-01T00:00:00.000Z' },
-            { type: 'publication', date: '2018-01-01T00:00:00.000Z' },
+            {
+              type: 'publication',
+              date: '2021-04-01T00:00:00.000Z',
+            },
           ],
           resourceTemporalDateRange: [
             {
@@ -137,9 +145,10 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               lte: '2012-01-01T00:00:00.000Z',
             },
             {
-              gte: '2018-01-01T00:00:00.000Z',
-              lte: '2018-01-01T00:00:00.000Z',
+              gte: '2021-04-01T00:00:00.000Z',
+              lte: '2021-04-01T00:00:00.000Z',
             },
+            { gte: '1974-01-01T00:00:00.000Z' },
           ],
           resourceIdentifier: [
             {
@@ -150,9 +159,9 @@ export const ES_FIXTURE_FULL_RESPONSE = {
           ],
           resourceAbstractObject: {
             default:
-              "Le produit Surval \"Données par paramètre\" met à disposition les données d'observation et de surveillance bancarisées dans Quadrige.\n\nCe produit contient des résultats sur la plupart des paramètres physiques, chimiques et biologiques de description de l'environnement. Les premières données datent par exemple de 1974 pour les paramètres de la qualité générale des eaux et les contaminants, 1987 pour le phytoplancton et les phycotoxines, 1989 pour la microbiologie, du début des années 2000 pour le benthos. \n\nLes données sous moratoire ou les données qualifiées \"Faux\" sont exclues de la diffusion Surval.\nUne donnée validée dans Quadrige aujourd’hui sera disponible dans Surval demain.\n\nL'accès aux données d'observation se réalise par lieu.\nUn lieu de surveillance est un lieu géographique où des observations, des mesures et/ou des prélèvements sont effectués. Il est localisé de façon unique par son emprise cartographique (surface, ligne ou point). Un lieu de mesure peut être utilisé par plusieurs programmes.\n\nAujourd’hui, ce produit met à disposition des données issues d'une sélection de thématiques.\n\nThématiques suivies :\n- Benthos dont récifs coralliens\n- Contaminants chimiques et Écotoxicologie\n- Déchets\n- Microbiologie\n- Phytoplancton et Hydrologie\n- Ressources aquacoles\n- Zooplancton\n- Autres\n\nL'emprise géographique est nationale : la métropole et les départements et régions d'outre-mer (DROM).",
+              "Le produit Surval \"Données par paramètre\" met à disposition les données d'observation et de surveillance bancarisées dans Quadrige, validées et qui ne sont pas sous moratoire.\n\nCe système d'information contient des résultats sur la plupart des paramètres physiques, chimiques et biologiques de description de l'environnement. Les premières données datent par exemple de 1974 pour les paramètres de la qualité générale des eaux et les contaminants, 1987 pour le phytoplancton et les phycotoxines, 1989 pour la microbiologie, du début des années 2000 pour le benthos. \n\nCe produit contient des résultats sur la plupart des paramètres physiques, chimiques et biologiques de description de l'environnement. Les premières données datent par exemple de 1974 pour les paramètres de la qualité générale des eaux et les contaminants.\n\nLes données sous moratoire ou les données qualifiées \"Faux\" sont exclus de la diffusion Surval. Une donnée validée dans Quadrige aujourd’hui sera disponible dans Surval demain.\n\nL'accès aux données d'observation se fait par lieu. Un lieu de surveillance est un lieu géographique où des observations, des mesures et/ou des prélèvements sont effectués. Il est localisé de façon unique par son emprise cartographique (surface, ligne ou point). Un lieu de mesure peut être utilisé par plusieurs programmes d'observation et de surveillance.\n\nA compter du 29 avril 2021, conformément aux obligations de l’ « Open data », toutes les données validées sans moratoire sont diffusées à J+1 et sans traitement. Ainsi tous les paramètres et tous les programmes Quadrige sont diffusés, et regroupés sous forme de thème :\n- Benthos dont récifs coralliens\n- Contaminants chimiques et Écotoxicologie\n- Déchets\n- Microbiologie\n- Phytoplancton et Hydrologie\n- Ressources aquacoles\n- Zooplancton\n- Autres\nUn thème regroupe un ou plusieurs programmes d'acquisition. Un programme correspond à une mise en œuvre d'un protocole, sur une période et un ensemble de lieux. Chaque programme est placé sous la responsabilité d'un animateur. \n\nPour accompagner le résultat, de nombreuses données sont diffusées (téléchargeables en tant que données d’observation), comme :\n- la description complète du « Paramètre-Support-Fraction-Méthode-Unité »;\n- la description complète des « Passages », « Prélèvements » et « Échantillons »;\n- le niveau de qualification du résultat;\n- une proposition de citation, afin d’identifier tous les organismes contribuant à cette observation.\n\nL'emprise géographique est nationale : la métropole et les départements et régions d'outre-mer (DROM).\n\nL'accès au téléchargement direct du jeu de données complet (~ 220 Mo) en date du 9 juillet 2021 s'effectue par ce lien : https://www.ifremer.fr/sextant_doc/surveillance_littorale/surval/data/surval.zip \nL'accès par la carte permet de configurer des extractions et des graphes de visualisation sur demande (email demandé pour le téléchargement).",
             langfre:
-              "Le produit Surval \"Données par paramètre\" met à disposition les données d'observation et de surveillance bancarisées dans Quadrige.\n\nCe produit contient des résultats sur la plupart des paramètres physiques, chimiques et biologiques de description de l'environnement. Les premières données datent par exemple de 1974 pour les paramètres de la qualité générale des eaux et les contaminants, 1987 pour le phytoplancton et les phycotoxines, 1989 pour la microbiologie, du début des années 2000 pour le benthos. \n\nLes données sous moratoire ou les données qualifiées \"Faux\" sont exclues de la diffusion Surval.\nUne donnée validée dans Quadrige aujourd’hui sera disponible dans Surval demain.\n\nL'accès aux données d'observation se réalise par lieu.\nUn lieu de surveillance est un lieu géographique où des observations, des mesures et/ou des prélèvements sont effectués. Il est localisé de façon unique par son emprise cartographique (surface, ligne ou point). Un lieu de mesure peut être utilisé par plusieurs programmes.\n\nAujourd’hui, ce produit met à disposition des données issues d'une sélection de thématiques.\n\nThématiques suivies :\n- Benthos dont récifs coralliens\n- Contaminants chimiques et Écotoxicologie\n- Déchets\n- Microbiologie\n- Phytoplancton et Hydrologie\n- Ressources aquacoles\n- Zooplancton\n- Autres\n\nL'emprise géographique est nationale : la métropole et les départements et régions d'outre-mer (DROM).",
+              "Le produit Surval \"Données par paramètre\" met à disposition les données d'observation et de surveillance bancarisées dans Quadrige, validées et qui ne sont pas sous moratoire.\n\nCe système d'information contient des résultats sur la plupart des paramètres physiques, chimiques et biologiques de description de l'environnement. Les premières données datent par exemple de 1974 pour les paramètres de la qualité générale des eaux et les contaminants, 1987 pour le phytoplancton et les phycotoxines, 1989 pour la microbiologie, du début des années 2000 pour le benthos. \n\nCe produit contient des résultats sur la plupart des paramètres physiques, chimiques et biologiques de description de l'environnement. Les premières données datent par exemple de 1974 pour les paramètres de la qualité générale des eaux et les contaminants.\n\nLes données sous moratoire ou les données qualifiées \"Faux\" sont exclus de la diffusion Surval. Une donnée validée dans Quadrige aujourd’hui sera disponible dans Surval demain.\n\nL'accès aux données d'observation se fait par lieu. Un lieu de surveillance est un lieu géographique où des observations, des mesures et/ou des prélèvements sont effectués. Il est localisé de façon unique par son emprise cartographique (surface, ligne ou point). Un lieu de mesure peut être utilisé par plusieurs programmes d'observation et de surveillance.\n\nA compter du 29 avril 2021, conformément aux obligations de l’ « Open data », toutes les données validées sans moratoire sont diffusées à J+1 et sans traitement. Ainsi tous les paramètres et tous les programmes Quadrige sont diffusés, et regroupés sous forme de thème :\n- Benthos dont récifs coralliens\n- Contaminants chimiques et Écotoxicologie\n- Déchets\n- Microbiologie\n- Phytoplancton et Hydrologie\n- Ressources aquacoles\n- Zooplancton\n- Autres\nUn thème regroupe un ou plusieurs programmes d'acquisition. Un programme correspond à une mise en œuvre d'un protocole, sur une période et un ensemble de lieux. Chaque programme est placé sous la responsabilité d'un animateur. \n\nPour accompagner le résultat, de nombreuses données sont diffusées (téléchargeables en tant que données d’observation), comme :\n- la description complète du « Paramètre-Support-Fraction-Méthode-Unité »;\n- la description complète des « Passages », « Prélèvements » et « Échantillons »;\n- le niveau de qualification du résultat;\n- une proposition de citation, afin d’identifier tous les organismes contribuant à cette observation.\n\nL'emprise géographique est nationale : la métropole et les départements et régions d'outre-mer (DROM).\n\nL'accès au téléchargement direct du jeu de données complet (~ 220 Mo) en date du 9 juillet 2021 s'effectue par ce lien : https://www.ifremer.fr/sextant_doc/surveillance_littorale/surval/data/surval.zip \nL'accès par la carte permet de configurer des extractions et des graphes de visualisation sur demande (email demandé pour le téléchargement).",
           },
           cl_resourceCharacterSet: [
             {
@@ -224,47 +233,97 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               default: 'Lieux de surveillance',
               langfre: 'Lieux de surveillance',
             },
-            { default: 'Observation', langfre: 'Observation' },
+            {
+              default: 'Observation',
+              langfre: 'Observation',
+            },
             { default: 'Surveillance', langfre: 'Surveillance' },
-            { default: 'Environnement', langfre: 'Environnement' },
+            {
+              default: 'Environnement',
+              langfre: 'Environnement',
+            },
             { default: 'Littoral', langfre: 'Littoral' },
-            { default: 'Quadrige', langfre: 'Quadrige' },
+            {
+              default: 'Quadrige',
+              langfre: 'Quadrige',
+            },
             { default: 'DCE', langfre: 'DCE' },
             { default: 'DCSMM', langfre: 'DCSMM' },
-            { default: 'OSPAR', langfre: 'OSPAR' },
+            {
+              default: 'OSPAR',
+              langfre: 'OSPAR',
+            },
             { default: 'MEDPOL', langfre: 'MEDPOL' },
+            {
+              default: 'Données ouvertes',
+              langfre: 'Données ouvertes',
+            },
+            { default: 'Open Data', langfre: 'Open Data' },
+            {
+              default: 'Surval',
+              langfre: 'Surval',
+            },
             {
               default: 'Installations de suivi environnemental',
               langfre: 'Installations de suivi environnemental',
             },
-            { default: 'D5: Eutrophisation', langfre: 'D5: Eutrophisation' },
+            { default: 'D8: Contaminants', langfre: 'D8: Contaminants' },
+            {
+              default: 'D1: Biodiversité',
+              langfre: 'D1: Biodiversité',
+            },
+            {
+              default: 'D7: Changements hydrographiques',
+              langfre: 'D7: Changements hydrographiques',
+            },
             {
               default: 'D4: Réseaux trophiques',
               langfre: 'D4: Réseaux trophiques',
             },
             {
-              default: 'D8: Contaminants chimiques',
-              langfre: 'D8: Contaminants chimiques',
-            },
-            { default: 'D1: Biodiversité', langfre: 'D1: Biodiversité' },
-            {
-              default: 'D2: Espèces non indigènes',
-              langfre: 'D2: Espèces non indigènes',
-            },
-            {
-              default: 'D7: Conditions hydrographiques',
-              langfre: 'D7: Conditions hydrographiques',
+              default: 'D5: Eutrophisation',
+              langfre: 'D5: Eutrophisation',
             },
             {
               default: 'D9: Questions sanitaires',
               langfre: 'D9: Questions sanitaires',
             },
-            { default: 'D10: Déchets marins', langfre: 'D10: Déchets marins' },
+            {
+              default: 'D10: Déchets marins',
+              langfre: 'D10: Déchets marins',
+            },
+            {
+              default: 'D1: Biodiversité - Habitats benthiques',
+              langfre: 'D1: Biodiversité - Habitats benthiques',
+            },
+            {
+              default: 'D1: Biodiversité - Habitats pélagiques',
+              langfre: 'D1: Biodiversité - Habitats pélagiques',
+            },
+            {
+              default: 'D1: Biodiversité - Poissons',
+              langfre: 'D1: Biodiversité - Poissons',
+            },
+            {
+              default: 'D1: Biodiversité - Mammifères',
+              langfre: 'D1: Biodiversité - Mammifères',
+            },
+            {
+              default: 'D1: Biodiversité - Tortues',
+              langfre: 'D1: Biodiversité - Tortues',
+            },
+            {
+              default: 'D1: Biodiversité - Céphalopodes',
+              langfre: 'D1: Biodiversité - Céphalopodes',
+            },
             { default: 'National', langfre: 'National' },
-            { default: 'Observation directe', langfre: 'Observation directe' },
             {
               default: 'Observation par point',
               langfre: 'Observation par point',
+            },
+            {
+              default: 'Observation directe',
+              langfre: 'Observation directe',
             },
             {
               default:
@@ -289,58 +348,62 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               langfre: '/Biologie marine/Bivalves',
             },
             {
-              default: '/Biogéochimie marine/Pigments',
-              langfre: '/Biogéochimie marine/Pigments',
-            },
-            {
               default:
                 '/Biogéochimie marine/Eléments chimiques et contaminants',
               langfre:
                 '/Biogéochimie marine/Eléments chimiques et contaminants',
             },
             {
-              default: '/Biologie marine/Habitats benthiques',
-              langfre: '/Biologie marine/Habitats benthiques',
+              default: "/Physique de l'Océan/Turbidité",
+              langfre: "/Physique de l'Océan/Turbidité",
             },
             {
-              default: '/Biologie marine/Organismes pathogènes',
-              langfre: '/Biologie marine/Organismes pathogènes',
-            },
-            {
-              default: '/Biologie marine/Phytoplancton',
-              langfre: '/Biologie marine/Phytoplancton',
-            },
-            {
-              default: '/Biogéochimie marine/Nutriments (sels nutritifs)',
-              langfre: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+              default: '/Biogéochimie marine/Pigments',
+              langfre: '/Biogéochimie marine/Pigments',
             },
             {
               default: '/Biologie marine/Toxines',
               langfre: '/Biologie marine/Toxines',
             },
             {
-              default: "/Physique de l'Océan/Turbidité",
-              langfre: "/Physique de l'Océan/Turbidité",
+              default: '/Biologie marine/Phytoplancton',
+              langfre: '/Biologie marine/Phytoplancton',
             },
             {
-              default: '/Biologie marine/Matière en suspension',
-              langfre: '/Biologie marine/Matière en suspension',
-            },
-            {
-              default: '/Biogéochimie marine/Oxygène dissous',
-              langfre: '/Biogéochimie marine/Oxygène dissous',
-            },
-            {
-              default: "/Physique de l'Océan/Salinité",
-              langfre: "/Physique de l'Océan/Salinité",
+              default: '/Biologie marine/Zooplancton',
+              langfre: '/Biologie marine/Zooplancton',
             },
             {
               default: "/Physique de l'Océan/Température",
               langfre: "/Physique de l'Océan/Température",
             },
             {
-              default: '/Biologie marine/Zooplancton',
-              langfre: '/Biologie marine/Zooplancton',
+              default: "/Physique de l'Océan/Salinité",
+              langfre: "/Physique de l'Océan/Salinité",
+            },
+            {
+              default: '/Biogéochimie marine/Oxygène dissous',
+              langfre: '/Biogéochimie marine/Oxygène dissous',
+            },
+            {
+              default: '/Biologie marine/Organismes pathogènes',
+              langfre: '/Biologie marine/Organismes pathogènes',
+            },
+            {
+              default: '/Biologie marine/Organismes marins tropicaux',
+              langfre: '/Biologie marine/Organismes marins tropicaux',
+            },
+            {
+              default: '/Biologie marine/Matière en suspension',
+              langfre: '/Biologie marine/Matière en suspension',
+            },
+            {
+              default: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+              langfre: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+            },
+            {
+              default: '/Biologie marine/Habitats benthiques',
+              langfre: '/Biologie marine/Habitats benthiques',
             },
             {
               default: '/Etat du Milieu/Biogéochimie',
@@ -350,53 +413,131 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               default: '/Etat du Milieu/Pollutions',
               langfre: '/Etat du Milieu/Pollutions',
             },
+            {
+              default: '/Etat du Milieu/Littoral',
+              langfre: '/Etat du Milieu/Littoral',
+            },
+            {
+              default: '/Etat du Milieu/Habitats',
+              langfre: '/Etat du Milieu/Habitats',
+            },
+            {
+              default: '/Etat du Milieu/Espèces',
+              langfre: '/Etat du Milieu/Espèces',
+            },
+            {
+              default: 'Brest',
+              langfre: 'Brest',
+            },
+            { default: 'Fort-de-France', langfre: 'Fort-de-France' },
+            {
+              default: 'Boulogne-sur-Mer',
+              langfre: 'Boulogne-sur-Mer',
+            },
+            { default: 'Nouméa', langfre: 'Nouméa' },
+            {
+              default: 'Toulon',
+              langfre: 'Toulon',
+            },
+            { default: 'Sète', langfre: 'Sète' },
+            { default: 'La Rochelle', langfre: 'La Rochelle' },
           ],
-          isOpenData: 'false',
+          isOpenData: 'true',
           'keywordType-theme': [
             {
               default: 'Lieux de surveillance',
               langfre: 'Lieux de surveillance',
             },
             { default: 'Observation', langfre: 'Observation' },
-            { default: 'Surveillance', langfre: 'Surveillance' },
+            {
+              default: 'Surveillance',
+              langfre: 'Surveillance',
+            },
             { default: 'Environnement', langfre: 'Environnement' },
-            { default: 'Littoral', langfre: 'Littoral' },
+            {
+              default: 'Littoral',
+              langfre: 'Littoral',
+            },
             { default: 'Quadrige', langfre: 'Quadrige' },
-            { default: 'DCE', langfre: 'DCE' },
+            {
+              default: 'DCE',
+              langfre: 'DCE',
+            },
             { default: 'DCSMM', langfre: 'DCSMM' },
-            { default: 'OSPAR', langfre: 'OSPAR' },
+            {
+              default: 'OSPAR',
+              langfre: 'OSPAR',
+            },
             { default: 'MEDPOL', langfre: 'MEDPOL' },
+            {
+              default: 'Données ouvertes',
+              langfre: 'Données ouvertes',
+            },
+            { default: 'Open Data', langfre: 'Open Data' },
+            {
+              default: 'Surval',
+              langfre: 'Surval',
+            },
             {
               default: 'Installations de suivi environnemental',
               langfre: 'Installations de suivi environnemental',
             },
-            { default: 'D5: Eutrophisation', langfre: 'D5: Eutrophisation' },
+            { default: 'D8: Contaminants', langfre: 'D8: Contaminants' },
+            {
+              default: 'D1: Biodiversité',
+              langfre: 'D1: Biodiversité',
+            },
+            {
+              default: 'D7: Changements hydrographiques',
+              langfre: 'D7: Changements hydrographiques',
+            },
             {
               default: 'D4: Réseaux trophiques',
               langfre: 'D4: Réseaux trophiques',
             },
             {
-              default: 'D8: Contaminants chimiques',
-              langfre: 'D8: Contaminants chimiques',
-            },
-            { default: 'D1: Biodiversité', langfre: 'D1: Biodiversité' },
-            {
-              default: 'D2: Espèces non indigènes',
-              langfre: 'D2: Espèces non indigènes',
-            },
-            {
-              default: 'D7: Conditions hydrographiques',
-              langfre: 'D7: Conditions hydrographiques',
+              default: 'D5: Eutrophisation',
+              langfre: 'D5: Eutrophisation',
             },
             {
               default: 'D9: Questions sanitaires',
               langfre: 'D9: Questions sanitaires',
             },
-            { default: 'D10: Déchets marins', langfre: 'D10: Déchets marins' },
-            { default: 'Observation directe', langfre: 'Observation directe' },
+            {
+              default: 'D10: Déchets marins',
+              langfre: 'D10: Déchets marins',
+            },
+            {
+              default: 'D1: Biodiversité - Habitats benthiques',
+              langfre: 'D1: Biodiversité - Habitats benthiques',
+            },
+            {
+              default: 'D1: Biodiversité - Habitats pélagiques',
+              langfre: 'D1: Biodiversité - Habitats pélagiques',
+            },
+            {
+              default: 'D1: Biodiversité - Poissons',
+              langfre: 'D1: Biodiversité - Poissons',
+            },
+            {
+              default: 'D1: Biodiversité - Mammifères',
+              langfre: 'D1: Biodiversité - Mammifères',
+            },
+            {
+              default: 'D1: Biodiversité - Tortues',
+              langfre: 'D1: Biodiversité - Tortues',
+            },
+            {
+              default: 'D1: Biodiversité - Céphalopodes',
+              langfre: 'D1: Biodiversité - Céphalopodes',
+            },
             {
               default: 'Observation par point',
               langfre: 'Observation par point',
+            },
+            {
+              default: 'Observation directe',
+              langfre: 'Observation directe',
             },
             {
               default:
@@ -421,58 +562,62 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               langfre: '/Biologie marine/Bivalves',
             },
             {
-              default: '/Biogéochimie marine/Pigments',
-              langfre: '/Biogéochimie marine/Pigments',
-            },
-            {
               default:
                 '/Biogéochimie marine/Eléments chimiques et contaminants',
               langfre:
                 '/Biogéochimie marine/Eléments chimiques et contaminants',
             },
             {
-              default: '/Biologie marine/Habitats benthiques',
-              langfre: '/Biologie marine/Habitats benthiques',
+              default: "/Physique de l'Océan/Turbidité",
+              langfre: "/Physique de l'Océan/Turbidité",
             },
             {
-              default: '/Biologie marine/Organismes pathogènes',
-              langfre: '/Biologie marine/Organismes pathogènes',
-            },
-            {
-              default: '/Biologie marine/Phytoplancton',
-              langfre: '/Biologie marine/Phytoplancton',
-            },
-            {
-              default: '/Biogéochimie marine/Nutriments (sels nutritifs)',
-              langfre: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+              default: '/Biogéochimie marine/Pigments',
+              langfre: '/Biogéochimie marine/Pigments',
             },
             {
               default: '/Biologie marine/Toxines',
               langfre: '/Biologie marine/Toxines',
             },
             {
-              default: "/Physique de l'Océan/Turbidité",
-              langfre: "/Physique de l'Océan/Turbidité",
+              default: '/Biologie marine/Phytoplancton',
+              langfre: '/Biologie marine/Phytoplancton',
             },
             {
-              default: '/Biologie marine/Matière en suspension',
-              langfre: '/Biologie marine/Matière en suspension',
-            },
-            {
-              default: '/Biogéochimie marine/Oxygène dissous',
-              langfre: '/Biogéochimie marine/Oxygène dissous',
-            },
-            {
-              default: "/Physique de l'Océan/Salinité",
-              langfre: "/Physique de l'Océan/Salinité",
+              default: '/Biologie marine/Zooplancton',
+              langfre: '/Biologie marine/Zooplancton',
             },
             {
               default: "/Physique de l'Océan/Température",
               langfre: "/Physique de l'Océan/Température",
             },
             {
-              default: '/Biologie marine/Zooplancton',
-              langfre: '/Biologie marine/Zooplancton',
+              default: "/Physique de l'Océan/Salinité",
+              langfre: "/Physique de l'Océan/Salinité",
+            },
+            {
+              default: '/Biogéochimie marine/Oxygène dissous',
+              langfre: '/Biogéochimie marine/Oxygène dissous',
+            },
+            {
+              default: '/Biologie marine/Organismes pathogènes',
+              langfre: '/Biologie marine/Organismes pathogènes',
+            },
+            {
+              default: '/Biologie marine/Organismes marins tropicaux',
+              langfre: '/Biologie marine/Organismes marins tropicaux',
+            },
+            {
+              default: '/Biologie marine/Matière en suspension',
+              langfre: '/Biologie marine/Matière en suspension',
+            },
+            {
+              default: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+              langfre: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+            },
+            {
+              default: '/Biologie marine/Habitats benthiques',
+              langfre: '/Biologie marine/Habitats benthiques',
             },
             {
               default: '/Etat du Milieu/Biogéochimie',
@@ -482,79 +627,94 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               default: '/Etat du Milieu/Pollutions',
               langfre: '/Etat du Milieu/Pollutions',
             },
+            {
+              default: '/Etat du Milieu/Littoral',
+              langfre: '/Etat du Milieu/Littoral',
+            },
+            {
+              default: '/Etat du Milieu/Habitats',
+              langfre: '/Etat du Milieu/Habitats',
+            },
+            {
+              default: '/Etat du Milieu/Espèces',
+              langfre: '/Etat du Milieu/Espèces',
+            },
           ],
-          'keywordType-place': [{ default: 'National', langfre: 'National' }],
+          'keywordType-place': [
+            { default: 'National', langfre: 'National' },
+            {
+              default: 'Brest',
+              langfre: 'Brest',
+            },
+            { default: 'Fort-de-France', langfre: 'Fort-de-France' },
+            {
+              default: 'Boulogne-sur-Mer',
+              langfre: 'Boulogne-sur-Mer',
+            },
+            { default: 'Nouméa', langfre: 'Nouméa' },
+            {
+              default: 'Toulon',
+              langfre: 'Toulon',
+            },
+            { default: 'Sète', langfre: 'Sète' },
+            { default: 'La Rochelle', langfre: 'La Rochelle' },
+          ],
           'th_httpinspireeceuropaeutheme-themeNumber': '1',
           'th_httpinspireeceuropaeutheme-theme': [
             {
               default: 'Installations de suivi environnemental',
               langfre: 'Installations de suivi environnemental',
-              link: 'http://inspire.ec.europa.eu/theme/ef',
             },
-          ],
-          'th_httpinspireeceuropaeutheme-theme_tree': {
-            default: ['Installations de suivi environnemental'],
-            key: ['http://inspire.ec.europa.eu/theme/ef'],
-          },
-          'th_dcsmm-descripteurNumber': '8',
-          'th_dcsmm-descripteur': [
-            { default: 'D5: Eutrophisation', langfre: 'D5: Eutrophisation' },
-            {
-              default: 'D4: Réseaux trophiques',
-              langfre: 'D4: Réseaux trophiques',
-            },
-            {
-              default: 'D8: Contaminants chimiques',
-              langfre: 'D8: Contaminants chimiques',
-            },
-            { default: 'D1: Biodiversité', langfre: 'D1: Biodiversité' },
-            {
-              default: 'D2: Espèces non indigènes',
-              langfre: 'D2: Espèces non indigènes',
-            },
-            {
-              default: 'D7: Conditions hydrographiques',
-              langfre: 'D7: Conditions hydrographiques',
-            },
-            {
-              default: 'D9: Questions sanitaires',
-              langfre: 'D9: Questions sanitaires',
-            },
-            { default: 'D10: Déchets marins', langfre: 'D10: Déchets marins' },
           ],
           indexingErrorMsg: [
-            'Warning / Keyword D5: Eutrophisation not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
-            'Warning / Keyword D4: Réseaux trophiques not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
-            'Warning / Keyword D8: Contaminants chimiques not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
+            'Warning / Keyword Installations de suivi environnemental not found in geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme.',
+            'Warning / Keyword D8: Contaminants not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
             'Warning / Keyword D1: Biodiversité not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
-            'Warning / Keyword D2: Espèces non indigènes not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
-            'Warning / Keyword D7: Conditions hydrographiques not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
+            'Warning / Keyword D7: Changements hydrographiques not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
+            'Warning / Keyword D4: Réseaux trophiques not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
+            'Warning / Keyword D5: Eutrophisation not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
             'Warning / Keyword D9: Questions sanitaires not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
             'Warning / Keyword D10: Déchets marins not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
+            'Warning / Keyword D1: Biodiversité - Habitats benthiques not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
+            'Warning / Keyword D1: Biodiversité - Habitats pélagiques not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
+            'Warning / Keyword D1: Biodiversité - Poissons not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
+            'Warning / Keyword D1: Biodiversité - Mammifères not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
+            'Warning / Keyword D1: Biodiversité - Tortues not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
+            'Warning / Keyword D1: Biodiversité - Céphalopodes not found in geonetwork.thesaurus.local.theme.dcsmm-descripteur.',
             'Warning / Keyword National not found in geonetwork.thesaurus.local.place.dcsmm.area.',
-            'Warning / Keyword Observation directe not found in geonetwork.thesaurus.local.theme.dcsmm-methode.',
             'Warning / Keyword Observation par point not found in geonetwork.thesaurus.local.theme.dcsmm-methode.',
+            'Warning / Keyword Observation directe not found in geonetwork.thesaurus.local.theme.dcsmm-methode.',
             "Warning / Keyword /Activités humaines/Réseaux d'observation et de surveillance du littoral not found in geonetwork.thesaurus.local.theme.sextant-theme.",
             'Warning / Keyword /Observations in-situ/Réseaux not found in geonetwork.thesaurus.local.theme.type_jeux_donnee.',
             'Warning / Keyword Base de données de recherche not found in geonetwork.thesaurus.local.theme.odatis_thematiques.',
             'Warning / Keyword Dispositifs de surveillance not found in geonetwork.thesaurus.local.theme.odatis_thematiques.',
             'Warning / Keyword /Biologie marine/Bivalves not found in geonetwork.thesaurus.local.theme.odatis_variables.',
-            'Warning / Keyword /Biogéochimie marine/Pigments not found in geonetwork.thesaurus.local.theme.odatis_variables.',
             'Warning / Keyword /Biogéochimie marine/Eléments chimiques et contaminants not found in geonetwork.thesaurus.local.theme.odatis_variables.',
-            'Warning / Keyword /Biologie marine/Habitats benthiques not found in geonetwork.thesaurus.local.theme.odatis_variables.',
-            'Warning / Keyword /Biologie marine/Organismes pathogènes not found in geonetwork.thesaurus.local.theme.odatis_variables.',
-            'Warning / Keyword /Biologie marine/Phytoplancton not found in geonetwork.thesaurus.local.theme.odatis_variables.',
-            'Warning / Keyword /Biogéochimie marine/Nutriments (sels nutritifs) not found in geonetwork.thesaurus.local.theme.odatis_variables.',
-            'Warning / Keyword /Biologie marine/Toxines not found in geonetwork.thesaurus.local.theme.odatis_variables.',
             "Warning / Keyword /Physique de l'Océan/Turbidité not found in geonetwork.thesaurus.local.theme.odatis_variables.",
-            'Warning / Keyword /Biologie marine/Matière en suspension not found in geonetwork.thesaurus.local.theme.odatis_variables.',
-            'Warning / Keyword /Biogéochimie marine/Oxygène dissous not found in geonetwork.thesaurus.local.theme.odatis_variables.',
-            "Warning / Keyword /Physique de l'Océan/Salinité not found in geonetwork.thesaurus.local.theme.odatis_variables.",
-            "Warning / Keyword /Physique de l'Océan/Température not found in geonetwork.thesaurus.local.theme.odatis_variables.",
+            'Warning / Keyword /Biogéochimie marine/Pigments not found in geonetwork.thesaurus.local.theme.odatis_variables.',
+            'Warning / Keyword /Biologie marine/Toxines not found in geonetwork.thesaurus.local.theme.odatis_variables.',
+            'Warning / Keyword /Biologie marine/Phytoplancton not found in geonetwork.thesaurus.local.theme.odatis_variables.',
             'Warning / Keyword /Biologie marine/Zooplancton not found in geonetwork.thesaurus.local.theme.odatis_variables.',
+            "Warning / Keyword /Physique de l'Océan/Température not found in geonetwork.thesaurus.local.theme.odatis_variables.",
+            "Warning / Keyword /Physique de l'Océan/Salinité not found in geonetwork.thesaurus.local.theme.odatis_variables.",
+            'Warning / Keyword /Biogéochimie marine/Oxygène dissous not found in geonetwork.thesaurus.local.theme.odatis_variables.',
+            'Warning / Keyword /Biologie marine/Organismes pathogènes not found in geonetwork.thesaurus.local.theme.odatis_variables.',
+            'Warning / Keyword /Biologie marine/Organismes marins tropicaux not found in geonetwork.thesaurus.local.theme.odatis_variables.',
+            'Warning / Keyword /Biologie marine/Matière en suspension not found in geonetwork.thesaurus.local.theme.odatis_variables.',
+            'Warning / Keyword /Biogéochimie marine/Nutriments (sels nutritifs) not found in geonetwork.thesaurus.local.theme.odatis_variables.',
+            'Warning / Keyword /Biologie marine/Habitats benthiques not found in geonetwork.thesaurus.local.theme.odatis_variables.',
             'Warning / Keyword /Etat du Milieu/Biogéochimie not found in geonetwork.thesaurus.local.theme.simm.thematiques.',
             'Warning / Keyword /Etat du Milieu/Pollutions not found in geonetwork.thesaurus.local.theme.simm.thematiques.',
-            "Warning / Field resourceTemporalDateRange /\n                Lower range bound '\n                  1974-01-01T00:00:00\n                  \n                ' can not be\n                greater than upper bound ''.\n                Date range not indexed.",
+            'Warning / Keyword /Etat du Milieu/Littoral not found in geonetwork.thesaurus.local.theme.simm.thematiques.',
+            'Warning / Keyword /Etat du Milieu/Habitats not found in geonetwork.thesaurus.local.theme.simm.thematiques.',
+            'Warning / Keyword /Etat du Milieu/Espèces not found in geonetwork.thesaurus.local.theme.simm.thematiques.',
+            'Warning / Keyword Brest not found in geonetwork.thesaurus.local.place.oh_ville.',
+            'Warning / Keyword Fort-de-France not found in geonetwork.thesaurus.local.place.oh_ville.',
+            'Warning / Keyword Boulogne-sur-Mer not found in geonetwork.thesaurus.local.place.oh_ville.',
+            'Warning / Keyword Nouméa not found in geonetwork.thesaurus.local.place.oh_ville.',
+            'Warning / Keyword Toulon not found in geonetwork.thesaurus.local.place.oh_ville.',
+            'Warning / Keyword Sète not found in geonetwork.thesaurus.local.place.oh_ville.',
+            'Warning / Keyword La Rochelle not found in geonetwork.thesaurus.local.place.oh_ville.',
           ],
           indexingError: [
             'true',
@@ -588,16 +748,88 @@ export const ES_FIXTURE_FULL_RESPONSE = {
             'true',
             'true',
             'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+            'true',
+          ],
+          'th_dcsmm-descripteurNumber': '13',
+          'th_dcsmm-descripteur': [
+            {
+              default: 'D8: Contaminants',
+              langfre: 'D8: Contaminants',
+            },
+            {
+              default: 'D1: Biodiversité',
+              langfre: 'D1: Biodiversité',
+            },
+            {
+              default: 'D7: Changements hydrographiques',
+              langfre: 'D7: Changements hydrographiques',
+            },
+            {
+              default: 'D4: Réseaux trophiques',
+              langfre: 'D4: Réseaux trophiques',
+            },
+            {
+              default: 'D5: Eutrophisation',
+              langfre: 'D5: Eutrophisation',
+            },
+            {
+              default: 'D9: Questions sanitaires',
+              langfre: 'D9: Questions sanitaires',
+            },
+            {
+              default: 'D10: Déchets marins',
+              langfre: 'D10: Déchets marins',
+            },
+            {
+              default: 'D1: Biodiversité - Habitats benthiques',
+              langfre: 'D1: Biodiversité - Habitats benthiques',
+            },
+            {
+              default: 'D1: Biodiversité - Habitats pélagiques',
+              langfre: 'D1: Biodiversité - Habitats pélagiques',
+            },
+            {
+              default: 'D1: Biodiversité - Poissons',
+              langfre: 'D1: Biodiversité - Poissons',
+            },
+            {
+              default: 'D1: Biodiversité - Mammifères',
+              langfre: 'D1: Biodiversité - Mammifères',
+            },
+            {
+              default: 'D1: Biodiversité - Tortues',
+              langfre: 'D1: Biodiversité - Tortues',
+            },
+            {
+              default: 'D1: Biodiversité - Céphalopodes',
+              langfre: 'D1: Biodiversité - Céphalopodes',
+            },
           ],
           th_areaNumber: '1',
           th_area: [{ default: 'National', langfre: 'National' }],
           'th_dcsmm-methodeNumber': '2',
           'th_dcsmm-methode': [
-            { default: 'Observation directe', langfre: 'Observation directe' },
             {
               default: 'Observation par point',
               langfre: 'Observation par point',
             },
+            { default: 'Observation directe', langfre: 'Observation directe' },
           ],
           'th_sextant-themeNumber': '1',
           'th_sextant-theme': [
@@ -626,15 +858,11 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               langfre: 'Dispositifs de surveillance',
             },
           ],
-          th_odatis_variablesNumber: '14',
+          th_odatis_variablesNumber: '15',
           th_odatis_variables: [
             {
               default: '/Biologie marine/Bivalves',
               langfre: '/Biologie marine/Bivalves',
-            },
-            {
-              default: '/Biogéochimie marine/Pigments',
-              langfre: '/Biogéochimie marine/Pigments',
             },
             {
               default:
@@ -643,51 +871,59 @@ export const ES_FIXTURE_FULL_RESPONSE = {
                 '/Biogéochimie marine/Eléments chimiques et contaminants',
             },
             {
-              default: '/Biologie marine/Habitats benthiques',
-              langfre: '/Biologie marine/Habitats benthiques',
+              default: "/Physique de l'Océan/Turbidité",
+              langfre: "/Physique de l'Océan/Turbidité",
             },
             {
-              default: '/Biologie marine/Organismes pathogènes',
-              langfre: '/Biologie marine/Organismes pathogènes',
-            },
-            {
-              default: '/Biologie marine/Phytoplancton',
-              langfre: '/Biologie marine/Phytoplancton',
-            },
-            {
-              default: '/Biogéochimie marine/Nutriments (sels nutritifs)',
-              langfre: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+              default: '/Biogéochimie marine/Pigments',
+              langfre: '/Biogéochimie marine/Pigments',
             },
             {
               default: '/Biologie marine/Toxines',
               langfre: '/Biologie marine/Toxines',
             },
             {
-              default: "/Physique de l'Océan/Turbidité",
-              langfre: "/Physique de l'Océan/Turbidité",
+              default: '/Biologie marine/Phytoplancton',
+              langfre: '/Biologie marine/Phytoplancton',
             },
             {
-              default: '/Biologie marine/Matière en suspension',
-              langfre: '/Biologie marine/Matière en suspension',
-            },
-            {
-              default: '/Biogéochimie marine/Oxygène dissous',
-              langfre: '/Biogéochimie marine/Oxygène dissous',
-            },
-            {
-              default: "/Physique de l'Océan/Salinité",
-              langfre: "/Physique de l'Océan/Salinité",
+              default: '/Biologie marine/Zooplancton',
+              langfre: '/Biologie marine/Zooplancton',
             },
             {
               default: "/Physique de l'Océan/Température",
               langfre: "/Physique de l'Océan/Température",
             },
             {
-              default: '/Biologie marine/Zooplancton',
-              langfre: '/Biologie marine/Zooplancton',
+              default: "/Physique de l'Océan/Salinité",
+              langfre: "/Physique de l'Océan/Salinité",
+            },
+            {
+              default: '/Biogéochimie marine/Oxygène dissous',
+              langfre: '/Biogéochimie marine/Oxygène dissous',
+            },
+            {
+              default: '/Biologie marine/Organismes pathogènes',
+              langfre: '/Biologie marine/Organismes pathogènes',
+            },
+            {
+              default: '/Biologie marine/Organismes marins tropicaux',
+              langfre: '/Biologie marine/Organismes marins tropicaux',
+            },
+            {
+              default: '/Biologie marine/Matière en suspension',
+              langfre: '/Biologie marine/Matière en suspension',
+            },
+            {
+              default: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+              langfre: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+            },
+            {
+              default: '/Biologie marine/Habitats benthiques',
+              langfre: '/Biologie marine/Habitats benthiques',
             },
           ],
-          th_thematiquesNumber: '2',
+          th_thematiquesNumber: '5',
           th_thematiques: [
             {
               default: '/Etat du Milieu/Biogéochimie',
@@ -697,6 +933,37 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               default: '/Etat du Milieu/Pollutions',
               langfre: '/Etat du Milieu/Pollutions',
             },
+            {
+              default: '/Etat du Milieu/Littoral',
+              langfre: '/Etat du Milieu/Littoral',
+            },
+            {
+              default: '/Etat du Milieu/Habitats',
+              langfre: '/Etat du Milieu/Habitats',
+            },
+            {
+              default: '/Etat du Milieu/Espèces',
+              langfre: '/Etat du Milieu/Espèces',
+            },
+          ],
+          th_oh_villeNumber: '7',
+          th_oh_ville: [
+            { default: 'Brest', langfre: 'Brest' },
+            {
+              default: 'Fort-de-France',
+              langfre: 'Fort-de-France',
+            },
+            { default: 'Boulogne-sur-Mer', langfre: 'Boulogne-sur-Mer' },
+            {
+              default: 'Nouméa',
+              langfre: 'Nouméa',
+            },
+            { default: 'Toulon', langfre: 'Toulon' },
+            {
+              default: 'Sète',
+              langfre: 'Sète',
+            },
+            { default: 'La Rochelle', langfre: 'La Rochelle' },
           ],
           allKeywords: {
             geonetworkthesauruslocalthemedcsmmdescripteur: {
@@ -706,25 +973,24 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               link: '',
               keywords: [
                 {
-                  default: 'D5: Eutrophisation',
-                  langfre: 'D5: Eutrophisation',
+                  default: 'D8: Contaminants',
+                  langfre: 'D8: Contaminants',
+                },
+                {
+                  default: 'D1: Biodiversité',
+                  langfre: 'D1: Biodiversité',
+                },
+                {
+                  default: 'D7: Changements hydrographiques',
+                  langfre: 'D7: Changements hydrographiques',
                 },
                 {
                   default: 'D4: Réseaux trophiques',
                   langfre: 'D4: Réseaux trophiques',
                 },
                 {
-                  default: 'D8: Contaminants chimiques',
-                  langfre: 'D8: Contaminants chimiques',
-                },
-                { default: 'D1: Biodiversité', langfre: 'D1: Biodiversité' },
-                {
-                  default: 'D2: Espèces non indigènes',
-                  langfre: 'D2: Espèces non indigènes',
-                },
-                {
-                  default: 'D7: Conditions hydrographiques',
-                  langfre: 'D7: Conditions hydrographiques',
+                  default: 'D5: Eutrophisation',
+                  langfre: 'D5: Eutrophisation',
                 },
                 {
                   default: 'D9: Questions sanitaires',
@@ -733,6 +999,30 @@ export const ES_FIXTURE_FULL_RESPONSE = {
                 {
                   default: 'D10: Déchets marins',
                   langfre: 'D10: Déchets marins',
+                },
+                {
+                  default: 'D1: Biodiversité - Habitats benthiques',
+                  langfre: 'D1: Biodiversité - Habitats benthiques',
+                },
+                {
+                  default: 'D1: Biodiversité - Habitats pélagiques',
+                  langfre: 'D1: Biodiversité - Habitats pélagiques',
+                },
+                {
+                  default: 'D1: Biodiversité - Poissons',
+                  langfre: 'D1: Biodiversité - Poissons',
+                },
+                {
+                  default: 'D1: Biodiversité - Mammifères',
+                  langfre: 'D1: Biodiversité - Mammifères',
+                },
+                {
+                  default: 'D1: Biodiversité - Tortues',
+                  langfre: 'D1: Biodiversité - Tortues',
+                },
+                {
+                  default: 'D1: Biodiversité - Céphalopodes',
+                  langfre: 'D1: Biodiversité - Céphalopodes',
                 },
               ],
             },
@@ -743,12 +1033,12 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               link: '',
               keywords: [
                 {
-                  default: 'Observation directe',
-                  langfre: 'Observation directe',
-                },
-                {
                   default: 'Observation par point',
                   langfre: 'Observation par point',
+                },
+                {
+                  default: 'Observation directe',
+                  langfre: 'Observation directe',
                 },
               ],
             },
@@ -762,6 +1052,30 @@ export const ES_FIXTURE_FULL_RESPONSE = {
                   default: 'Installations de suivi environnemental',
                   langfre: 'Installations de suivi environnemental',
                 },
+              ],
+            },
+            geonetworkthesauruslocalplaceohville: {
+              id: 'geonetwork.thesaurus.local.place.oh_ville',
+              title: 'Ocean Hackathon - Ville',
+              theme: 'place',
+              link: '',
+              keywords: [
+                { default: 'Brest', langfre: 'Brest' },
+                {
+                  default: 'Fort-de-France',
+                  langfre: 'Fort-de-France',
+                },
+                { default: 'Boulogne-sur-Mer', langfre: 'Boulogne-sur-Mer' },
+                {
+                  default: 'Nouméa',
+                  langfre: 'Nouméa',
+                },
+                { default: 'Toulon', langfre: 'Toulon' },
+                {
+                  default: 'Sète',
+                  langfre: 'Sète',
+                },
+                { default: 'La Rochelle', langfre: 'La Rochelle' },
               ],
             },
             geonetworkthesauruslocalplacedcsmmarea: {
@@ -815,6 +1129,18 @@ export const ES_FIXTURE_FULL_RESPONSE = {
                   default: '/Etat du Milieu/Pollutions',
                   langfre: '/Etat du Milieu/Pollutions',
                 },
+                {
+                  default: '/Etat du Milieu/Littoral',
+                  langfre: '/Etat du Milieu/Littoral',
+                },
+                {
+                  default: '/Etat du Milieu/Habitats',
+                  langfre: '/Etat du Milieu/Habitats',
+                },
+                {
+                  default: '/Etat du Milieu/Espèces',
+                  langfre: '/Etat du Milieu/Espèces',
+                },
               ],
             },
             geonetworkthesauruslocalthemetypejeuxdonnee: {
@@ -840,58 +1166,62 @@ export const ES_FIXTURE_FULL_RESPONSE = {
                   langfre: '/Biologie marine/Bivalves',
                 },
                 {
-                  default: '/Biogéochimie marine/Pigments',
-                  langfre: '/Biogéochimie marine/Pigments',
-                },
-                {
                   default:
                     '/Biogéochimie marine/Eléments chimiques et contaminants',
                   langfre:
                     '/Biogéochimie marine/Eléments chimiques et contaminants',
                 },
                 {
-                  default: '/Biologie marine/Habitats benthiques',
-                  langfre: '/Biologie marine/Habitats benthiques',
+                  default: "/Physique de l'Océan/Turbidité",
+                  langfre: "/Physique de l'Océan/Turbidité",
                 },
                 {
-                  default: '/Biologie marine/Organismes pathogènes',
-                  langfre: '/Biologie marine/Organismes pathogènes',
-                },
-                {
-                  default: '/Biologie marine/Phytoplancton',
-                  langfre: '/Biologie marine/Phytoplancton',
-                },
-                {
-                  default: '/Biogéochimie marine/Nutriments (sels nutritifs)',
-                  langfre: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+                  default: '/Biogéochimie marine/Pigments',
+                  langfre: '/Biogéochimie marine/Pigments',
                 },
                 {
                   default: '/Biologie marine/Toxines',
                   langfre: '/Biologie marine/Toxines',
                 },
                 {
-                  default: "/Physique de l'Océan/Turbidité",
-                  langfre: "/Physique de l'Océan/Turbidité",
+                  default: '/Biologie marine/Phytoplancton',
+                  langfre: '/Biologie marine/Phytoplancton',
                 },
                 {
-                  default: '/Biologie marine/Matière en suspension',
-                  langfre: '/Biologie marine/Matière en suspension',
-                },
-                {
-                  default: '/Biogéochimie marine/Oxygène dissous',
-                  langfre: '/Biogéochimie marine/Oxygène dissous',
-                },
-                {
-                  default: "/Physique de l'Océan/Salinité",
-                  langfre: "/Physique de l'Océan/Salinité",
+                  default: '/Biologie marine/Zooplancton',
+                  langfre: '/Biologie marine/Zooplancton',
                 },
                 {
                   default: "/Physique de l'Océan/Température",
                   langfre: "/Physique de l'Océan/Température",
                 },
                 {
-                  default: '/Biologie marine/Zooplancton',
-                  langfre: '/Biologie marine/Zooplancton',
+                  default: "/Physique de l'Océan/Salinité",
+                  langfre: "/Physique de l'Océan/Salinité",
+                },
+                {
+                  default: '/Biogéochimie marine/Oxygène dissous',
+                  langfre: '/Biogéochimie marine/Oxygène dissous',
+                },
+                {
+                  default: '/Biologie marine/Organismes pathogènes',
+                  langfre: '/Biologie marine/Organismes pathogènes',
+                },
+                {
+                  default: '/Biologie marine/Organismes marins tropicaux',
+                  langfre: '/Biologie marine/Organismes marins tropicaux',
+                },
+                {
+                  default: '/Biologie marine/Matière en suspension',
+                  langfre: '/Biologie marine/Matière en suspension',
+                },
+                {
+                  default: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+                  langfre: '/Biogéochimie marine/Nutriments (sels nutritifs)',
+                },
+                {
+                  default: '/Biologie marine/Habitats benthiques',
+                  langfre: '/Biologie marine/Habitats benthiques',
                 },
               ],
             },
@@ -902,41 +1232,43 @@ export const ES_FIXTURE_FULL_RESPONSE = {
                   langfre: 'Lieux de surveillance',
                 },
                 { default: 'Observation', langfre: 'Observation' },
-                { default: 'Surveillance', langfre: 'Surveillance' },
+                {
+                  default: 'Surveillance',
+                  langfre: 'Surveillance',
+                },
                 { default: 'Environnement', langfre: 'Environnement' },
-                { default: 'Littoral', langfre: 'Littoral' },
+                {
+                  default: 'Littoral',
+                  langfre: 'Littoral',
+                },
                 { default: 'Quadrige', langfre: 'Quadrige' },
-                { default: 'DCE', langfre: 'DCE' },
+                {
+                  default: 'DCE',
+                  langfre: 'DCE',
+                },
                 { default: 'DCSMM', langfre: 'DCSMM' },
-                { default: 'OSPAR', langfre: 'OSPAR' },
+                {
+                  default: 'OSPAR',
+                  langfre: 'OSPAR',
+                },
                 { default: 'MEDPOL', langfre: 'MEDPOL' },
+                {
+                  default: 'Données ouvertes',
+                  langfre: 'Données ouvertes',
+                },
+                { default: 'Open Data', langfre: 'Open Data' },
+                { default: 'Surval', langfre: 'Surval' },
               ],
             },
           },
           cl_topic: [{ key: 'oceans', default: 'Océans', langfre: 'Océans' }],
           resolutionScaleDenominator: ['5000'],
-          MD_LegalConstraintsOtherConstraintsObject: [
+          MD_ConstraintsUseLimitationObject: [
             {
-              default:
-                'Proposition de citation : "Quadrige (2019). Surval - Données par paramètre. Ifremer. https://doi.org/10.12770/cf5048f6-5bbf-4e44-ba74-e6f429af51ea", la date du téléchargement des données, la liste des programmes dont les données sont utilisées.',
-              langfre:
-                'Proposition de citation : "Quadrige (2019). Surval - Données par paramètre. Ifremer. https://doi.org/10.12770/cf5048f6-5bbf-4e44-ba74-e6f429af51ea", la date du téléchargement des données, la liste des programmes dont les données sont utilisées.',
+              default: 'Restriction lié à l’exercice du droit moral',
+              langfre: 'Restriction lié à l’exercice du droit moral',
             },
           ],
-          MD_LegalConstraintsUseLimitationObject: [
-            {
-              default:
-                'Données sous Licence ouverte / Open licence : http://www.etalab.gouv.fr/pages/licence-ouverte-open-licence-5899923.html',
-              langfre:
-                'Données sous Licence ouverte / Open licence : http://www.etalab.gouv.fr/pages/licence-ouverte-open-licence-5899923.html',
-            },
-          ],
-          licenseObject: {
-            default:
-              'Proposition de citation : "Quadrige (2019). Surval - Données par paramètre. Ifremer. https://doi.org/10.12770/cf5048f6-5bbf-4e44-ba74-e6f429af51ea", la date du téléchargement des données, la liste des programmes dont les données sont utilisées.',
-            langfre:
-              'Proposition de citation : "Quadrige (2019). Surval - Données par paramètre. Ifremer. https://doi.org/10.12770/cf5048f6-5bbf-4e44-ba74-e6f429af51ea", la date du téléchargement des données, la liste des programmes dont les données sont utilisées.',
-          },
           geom: {
             type: 'Polygon',
             coordinates: [
@@ -950,21 +1282,26 @@ export const ES_FIXTURE_FULL_RESPONSE = {
             ],
           },
           location: '0,0',
+          resourceTemporalExtentDateRange: [
+            { gte: '1974-01-01T00:00:00.000Z' },
+          ],
           coordinateSystem: ['WGS 84 (EPSG:4326)'],
           crsDetails: [
             {
               code: 'WGS 84 (EPSG:4326)',
               codeSpace: 'EPSG',
-              name: '',
+              name: 'WGS 84 (EPSG:4326)',
               url: '',
             },
           ],
-          specificationConformance: {
-            title: 'Inspire specifications',
-            date: '2012-01-16',
-            explanation: 'Non évalué',
-            pass: 'false',
-          },
+          specificationConformance: [
+            {
+              title: 'Inspire specifications',
+              date: '2012-01-16',
+              explanation: 'Non évalué',
+              pass: 'false',
+            },
+          ],
           lineageObject: {
             default:
               'Les données sont bancarisées dans la base de données Quadrige.',
@@ -973,15 +1310,18 @@ export const ES_FIXTURE_FULL_RESPONSE = {
           },
           format: [''],
           linkUrl: [
-            'http://envlit.ifremer.fr/resultats/quadrige',
-            'http://envlit.ifremer.fr/surveillance/presentation',
+            'https://wwz.ifremer.fr/envlit/Quadrige-la-base-de-donnees',
+            'https://wwz.ifremer.fr/envlit/Surveillance-du-littoral',
             'http://archimer.ifremer.fr/doc/00409/52016/',
-            'https://www.ifremer.fr/services/wms/surveillance_littorale',
-            'https://www.ifremer.fr/services/wfs/surveillance_littorale',
-            'https://www.ifremer.fr/services/wps/surval',
-            'https://www.ifremer.fr/services/wms/surveillance_littorale',
-            'https://www.ifremer.fr/services/wfs/surveillance_littorale',
-            'https://www.ifremer.fr/services/wps/surval',
+            'http://www.ifremer.fr/services/wms/surveillance_littorale',
+            'http://www.ifremer.fr/services/wfs/surveillance_littorale',
+            'https://www.ifremer.fr/services/wps3/surval',
+            'http://www.ifremer.fr/services/wms/surveillance_littorale',
+            'http://www.ifremer.fr/services/wfs/surveillance_littorale',
+            'https://www.ifremer.fr/services/wps3/surval',
+            'http://www.ifremer.fr/services/wms/surveillance_littorale',
+            'http://www.ifremer.fr/services/wfs/surveillance_littorale',
+            'https://www.ifremer.fr/services/wps3/surval',
             'https://doi.org/10.12770/cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
           ],
           linkProtocol: [
@@ -994,16 +1334,19 @@ export const ES_FIXTURE_FULL_RESPONSE = {
             'OGC:WMS',
             'OGC:WFS',
             'OGC:WPS',
+            'OGC:WMS',
+            'OGC:WFS',
+            'OGC:WPS',
             'WWW:LINK-1.0-http--metadata-URL',
           ],
           linkUrlProtocolWWWLINK: [
-            'http://envlit.ifremer.fr/resultats/quadrige',
+            'https://wwz.ifremer.fr/envlit/Quadrige-la-base-de-donnees',
             'http://archimer.ifremer.fr/doc/00409/52016/',
           ],
           link: [
             {
               protocol: 'WWW:LINK',
-              url: 'http://envlit.ifremer.fr/resultats/quadrige',
+              url: 'https://wwz.ifremer.fr/envlit/Quadrige-la-base-de-donnees',
               name: 'La base de données Quadrige',
               description: '',
               function: '',
@@ -1012,7 +1355,7 @@ export const ES_FIXTURE_FULL_RESPONSE = {
             },
             {
               protocol: 'WWW:LINK-1.0-http--link',
-              url: 'http://envlit.ifremer.fr/surveillance/presentation',
+              url: 'https://wwz.ifremer.fr/envlit/Surveillance-du-littoral',
               name: 'La surveillance du milieu marin et côtier',
               description: '',
               function: '',
@@ -1031,7 +1374,7 @@ export const ES_FIXTURE_FULL_RESPONSE = {
             },
             {
               protocol: 'OGC:WMS',
-              url: 'https://www.ifremer.fr/services/wms/surveillance_littorale',
+              url: 'http://www.ifremer.fr/services/wms/surveillance_littorale',
               name: 'surval_parametre_point',
               description: 'Lieu de surveillance (point)',
               function: '',
@@ -1040,52 +1383,81 @@ export const ES_FIXTURE_FULL_RESPONSE = {
             },
             {
               protocol: 'OGC:WFS',
-              url: 'https://www.ifremer.fr/services/wfs/surveillance_littorale',
+              url: 'http://www.ifremer.fr/services/wfs/surveillance_littorale',
               name: 'surval_parametre_point',
               description: 'Lieu de surveillance (point)',
               function: '',
               applicationProfile:
-                '{ "tokenizedFields":{ "PROGRAMME":";", "PARAMETRE":";", "SUPPORT_NIVEAUPRELEVEMENT":";" }, "fields":[ { "name":"PROGRAMME", "label":{ "fr":"Programme de suivi", "en":"Programme de suivi" } },{ "name":"PARAMETRE", "label":{ "fr":"Paramètre", "en":"Paramètre" } },{ "name": "range_Date", "type": "rangeDate", "minField": "DATEMIN", "maxField": "DATEMAX", "label":{ "fr":"Date", "en":"Date" }, "display": "graph" },{ "name":"QUADRIGE_ZONEMARINE", "label":{ "fr":"Zone marine Quadrige", "en":"Zone marine Quadrige" } },{ "name":"DCSMM_SOUS_REGION", "label":{ "fr":"Sous-région marine DCSMM", "en":"Sous-région marine DCSMM" } },{ "name":"DCE_MASSE_EAU", "label":{ "fr":"Masse d’eau DCE", "en":"Masse d’eau DCE" } },{ "name":"SUPPORT_NIVEAUPRELEVEMENT", "label":{ "fr":"Support d’analyse et niveau de prélèvement", "en":"Support d’analyse et niveau de prélèvement" } },{ "name":"LIEU_LIBELLE", "label":{ "fr":"Lieu", "en":"Lieu" } },{ "name":"GRAPHES", "hidden": true, "suffix":"&from=${filtre_range_Date.from}&to=${filtre_range_Date.to}&typeParam=${filtre_PARAMETRE}&support=${filtre_SUPPORT_NIVEAUPRELEVEMENT}" } ], "treeFields": [ "PARAMETRE" ]}',
+                '{\n\t\t\t\t\t\t\t"tokenizedFields":{\n\t\t\t\t\t\t\t   "THEME":";",\n\t\t\t\t\t\t\t\t"PROGRAMME":";",\n\t\t\t\t\t\t\t\t"PARAMETRE":";"\n\t\t\t\t\t\t\t},\t\t\t\n\t\t\t\t\t\t\t"fields":[\n\t\t\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\t\t"name":"THEME",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Thème",\n\t\t\t\t\t\t\t\t\t\t"en":"Thème"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t    "name":"PROGRAMME",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Programme de suivi",\n\t\t\t\t\t\t\t\t\t\t"en":"Programme de suivi"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"PARAMETRE",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Paramètre",\n\t\t\t\t\t\t\t\t\t\t"en":"Paramètre"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name": "range_Date",\n\t\t\t\t\t\t\t\t\t"type": "rangeDate",\n\t\t\t\t\t\t\t\t\t"minField": "DATEMIN",\n\t\t\t\t\t\t\t\t\t"maxField": "DATEMAX",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Date",\n\t\t\t\t\t\t\t\t\t\t"en":"Date"\n\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t"display": "graph"\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"LIEU_LIBELLE",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Lieu",\n\t\t\t\t\t\t\t\t\t\t"en":"Lieu"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t"name":"QUADRIGE_ZONEMARINE",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Zone marine Quadrige",\n\t\t\t\t\t\t\t\t\t\t"en":"Zone marine Quadrige"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"DCSMM_SOUS_REGION",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Sous-région marine DCSMM",\n\t\t\t\t\t\t\t\t\t\t"en":"Sous-région marine DCSMM"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"DCE_MASSE_EAU",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Masse d’eau DCE",\n\t\t\t\t\t\t\t\t\t\t"en":"Masse d’eau DCE"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"GRAPHES", \n\t\t\t\t\t\t\t\t\t"hidden": true,\n\t\t\t\t\t\t\t\t\t"suffix":"from=${filtre_range_Date.from}&to=${filtre_range_Date.to}&typeParam=${filtre_PARAMETRE}"\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t],\n\t\t\t\t\t\t\t"treeFields": [\n\t\t\t\t\t\t\t\t"PARAMETRE"\n\t\t\t\t\t\t\t]}',
               group: 2,
             },
             {
               protocol: 'OGC:WPS',
-              url: 'https://www.ifremer.fr/services/wps/surval',
-              name: 'r:survalextraction',
+              url: 'https://www.ifremer.fr/services/wps3/surval',
+              name: 'r:survalextraction30140',
               description: "Extraction des données d'observation",
               function: '',
               applicationProfile:
-                '{\n                               "inputs":[\n                                  {\n                                     "identifier":"produit_id",\n                                     "defaultValue":"30140",\n                                     "hidden":true\n                                  },\n                                  {\n                                     "identifier":"programme_suivi",\n                                     "linkedWfsFilter":"PROGRAMME",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"parametres",\n                                     "linkedWfsFilter":"PARAMETRE",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"date_min",\n                                     "linkedWfsFilter":"range_Date.from",\n                                     "hidden":true\n                                  },\n                                  {\n                                     "identifier":"date_max",\n                                     "linkedWfsFilter":"range_Date.to",\n                                     "hidden":true\n                                  },\n                                  {\n                                     "identifier":"zone_marine_quadrige",\n                                     "linkedWfsFilter":"QUADRIGE_ZONEMARINE",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"sous_region_marine_dcsmm",\n                                     "linkedWfsFilter":"DCSMM_SOUS_REGION",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"masse_eau_dce",\n                                     "linkedWfsFilter":"DCE_MASSE_EAU",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"supports_niveaux_prelevement",\n                                     "linkedWfsFilter":"SUPPORT_NIVEAUPRELEVEMENT",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"entity_id",\n                                     "hidden":true\n                                  },\n                                  {\n                                     "identifier":"entity_label",\n                                     "linkedWfsFilter":"LIEU_LIBELLE",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"limits",\n                                     "linkedWfsFilter":"geometry",\n                                     "hidden":true\n                                  },\n                                  {\n                                     "identifier":"geometry_type",\n                                     "defaultValue":"POINT",\n                            \t\t "hidden": true\n                                  }                \n                               ]\n                            }',
+                '{\n                           "inputs":[\n                              {\n                                 "identifier":"theme",\n                                 "linkedWfsFilter":"THEME",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },      {\n                                 "identifier":"programme_suivi",\n                                 "linkedWfsFilter":"PROGRAMME",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                             {\n                               "identifier":"parametres",\n                               "linkedWfsFilter":"PARAMETRE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\n                             },\n                              {\n                                 "identifier":"date_min",\n                                 "linkedWfsFilter":"range_Date.from",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"date_max",\n                                 "linkedWfsFilter":"range_Date.to",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"zone_marine_quadrige",\n                                 "linkedWfsFilter":"ZONE_MARINE_QUADRIGE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                              {\n                                 "identifier":"sous_region_marine_dcsmm",\n                                 "linkedWfsFilter":"SOUS_REGION_MARINE_DCSMM",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                              {\n                                 "identifier":"masse_eau_dce",\n                                 "linkedWfsFilter":"MASSE_EAU_DCE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                              {\n                                 "identifier":"supports_niveaux_prelevement",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"taxon",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"taxon_group",\n                               "hidden": true\n                              },      \n                              {\n                                 "identifier":"entity_id",\n                               "hidden": true\t\t \n                              },\n                              {\n                                 "identifier":"entity_label",\n                                 "linkedWfsFilter":"LIEU_LIBELLE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\t  \n                              {\n                                 "identifier":"limits",\n                                 "linkedWfsFilter":"geometry",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"geometry_type",\n                                 "defaultValue":"POINT",\n                               "hidden": true\n                              }      \n                           ]\n                        }',
               group: 2,
             },
             {
               protocol: 'OGC:WMS',
-              url: 'https://www.ifremer.fr/services/wms/surveillance_littorale',
-              name: 'surval_parametre_polygone',
-              description: 'Lieu de surveillance (polygone)',
+              url: 'http://www.ifremer.fr/services/wms/surveillance_littorale',
+              name: 'surval_parametre_ligne',
+              description: 'Lieu de surveillance (ligne)',
               function: '',
               applicationProfile: '',
               group: 3,
             },
             {
               protocol: 'OGC:WFS',
-              url: 'https://www.ifremer.fr/services/wfs/surveillance_littorale',
-              name: 'surval_parametre_polygone',
-              description: 'Lieu de surveillance (polygone)',
+              url: 'http://www.ifremer.fr/services/wfs/surveillance_littorale',
+              name: 'surval_parametre_ligne',
+              description: 'Lieu de surveillance (ligne)',
               function: '',
               applicationProfile:
-                '{ "tokenizedFields":{ "PROGRAMME":";", "PARAMETRE":";", "SUPPORT_NIVEAUPRELEVEMENT":";" }, "fields":[ { "name":"PROGRAMME", "label":{ "fr":"Programme de suivi", "en":"Programme de suivi" } },{ "name":"PARAMETRE", "label":{ "fr":"Paramètre", "en":"Paramètre" } },{ "name": "range_Date", "type": "rangeDate", "minField": "DATEMIN", "maxField": "DATEMAX", "label":{ "fr":"Date", "en":"Date" }, "display": "graph" },{ "name":"QUADRIGE_ZONEMARINE", "label":{ "fr":"Zone marine Quadrige", "en":"Zone marine Quadrige" } },{ "name":"DCSMM_SOUS_REGION", "label":{ "fr":"Sous-région marine DCSMM", "en":"Sous-région marine DCSMM" } },{ "name":"DCE_MASSE_EAU", "label":{ "fr":"Masse d’eau DCE", "en":"Masse d’eau DCE" } },{ "name":"SUPPORT_NIVEAUPRELEVEMENT", "label":{ "fr":"Support d’analyse et niveau de prélèvement", "en":"Support d’analyse et niveau de prélèvement" } },{ "name":"LIEU_LIBELLE", "label":{ "fr":"Lieu", "en":"Lieu" } },{ "name":"GRAPHES", "hidden": true, "suffix":"&from=${filtre_range_Date.from}&to=${filtre_range_Date.to}&typeParam=${filtre_PARAMETRE}&support=${filtre_SUPPORT_NIVEAUPRELEVEMENT}" } ], "treeFields": [ "PARAMETRE" ]}',
+                '{\n\t\t\t\t\t\t\t"tokenizedFields":{\n\t\t\t\t\t\t\t   "THEME":";",\n\t\t\t\t\t\t\t\t"PROGRAMME":";",\n\t\t\t\t\t\t\t\t"PARAMETRE":";"\n\t\t\t\t\t\t\t},\t\t\t\n\t\t\t\t\t\t\t"fields":[\n\t\t\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\t\t"name":"THEME",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Thème",\n\t\t\t\t\t\t\t\t\t\t"en":"Thème"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t    "name":"PROGRAMME",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Programme de suivi",\n\t\t\t\t\t\t\t\t\t\t"en":"Programme de suivi"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"PARAMETRE",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Paramètre",\n\t\t\t\t\t\t\t\t\t\t"en":"Paramètre"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name": "range_Date",\n\t\t\t\t\t\t\t\t\t"type": "rangeDate",\n\t\t\t\t\t\t\t\t\t"minField": "DATEMIN",\n\t\t\t\t\t\t\t\t\t"maxField": "DATEMAX",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Date",\n\t\t\t\t\t\t\t\t\t\t"en":"Date"\n\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t"display": "graph"\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"LIEU_LIBELLE",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Lieu",\n\t\t\t\t\t\t\t\t\t\t"en":"Lieu"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t"name":"QUADRIGE_ZONEMARINE",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Zone marine Quadrige",\n\t\t\t\t\t\t\t\t\t\t"en":"Zone marine Quadrige"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"DCSMM_SOUS_REGION",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Sous-région marine DCSMM",\n\t\t\t\t\t\t\t\t\t\t"en":"Sous-région marine DCSMM"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"DCE_MASSE_EAU",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Masse d’eau DCE",\n\t\t\t\t\t\t\t\t\t\t"en":"Masse d’eau DCE"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"GRAPHES", \n\t\t\t\t\t\t\t\t\t"hidden": true,\n\t\t\t\t\t\t\t\t\t"suffix":"from=${filtre_range_Date.from}&to=${filtre_range_Date.to}&typeParam=${filtre_PARAMETRE}"\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t],\n\t\t\t\t\t\t\t"treeFields": [\n\t\t\t\t\t\t\t\t"PARAMETRE"\n\t\t\t\t\t\t\t]}',
               group: 3,
             },
             {
               protocol: 'OGC:WPS',
-              url: 'https://www.ifremer.fr/services/wps/surval',
-              name: 'r:survalextraction',
+              url: 'https://www.ifremer.fr/services/wps3/surval',
+              name: 'r:survalextraction30140',
               description: "Extraction des données d'observation",
               function: '',
               applicationProfile:
-                '{\n                               "inputs":[\n                                  {\n                                     "identifier":"produit_id",\n                                     "defaultValue":"30140",\n                                     "hidden":true\n                                  },\n                                  {\n                                     "identifier":"programme_suivi",\n                                     "linkedWfsFilter":"PROGRAMME",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"parametres",\n                                     "linkedWfsFilter":"PARAMETRE",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"date_min",\n                                     "linkedWfsFilter":"range_Date.from",\n                                     "hidden":true\n                                  },\n                                  {\n                                     "identifier":"date_max",\n                                     "linkedWfsFilter":"range_Date.to",\n                                     "hidden":true\n                                  },\n                                  {\n                                     "identifier":"zone_marine_quadrige",\n                                     "linkedWfsFilter":"QUADRIGE_ZONEMARINE",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"sous_region_marine_dcsmm",\n                                     "linkedWfsFilter":"DCSMM_SOUS_REGION",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"masse_eau_dce",\n                                     "linkedWfsFilter":"DCE_MASSE_EAU",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"supports_niveaux_prelevement",\n                                     "linkedWfsFilter":"SUPPORT_NIVEAUPRELEVEMENT",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"entity_id",\n                                     "hidden":true\n                                  },\n                                  {\n                                     "identifier":"entity_label",\n                                     "linkedWfsFilter":"LIEU_LIBELLE",\n                                     "hidden":true,\n                                     "tokenizeWfsFilterValues":true,\n                                     "wfsFilterValuesDelimiter":";"\n                                  },\n                                  {\n                                     "identifier":"limits",\n                                     "linkedWfsFilter":"geometry",\n                                     "hidden":true\n                                  },\n                                  {\n                                     "identifier":"geometry_type",\n                                     "defaultValue":"AREA",\n                            \t\t "hidden": true\n                                  }       \n                               ]\n                            }',
+                '{\n                           "inputs":[\n                              {\n                                 "identifier":"theme",\n                                 "linkedWfsFilter":"THEME",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },      {\n                                 "identifier":"programme_suivi",\n                                 "linkedWfsFilter":"PROGRAMME",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                             {\n                               "identifier":"parametres",\n                               "linkedWfsFilter":"PARAMETRE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\n                             },\n                              {\n                                 "identifier":"date_min",\n                                 "linkedWfsFilter":"range_Date.from",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"date_max",\n                                 "linkedWfsFilter":"range_Date.to",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"zone_marine_quadrige",\n                                 "linkedWfsFilter":"ZONE_MARINE_QUADRIGE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                              {\n                                 "identifier":"sous_region_marine_dcsmm",\n                                 "linkedWfsFilter":"SOUS_REGION_MARINE_DCSMM",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                              {\n                                 "identifier":"masse_eau_dce",\n                                 "linkedWfsFilter":"MASSE_EAU_DCE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                              {\n                                 "identifier":"supports_niveaux_prelevement",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"taxon",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"taxon_group",\n                               "hidden": true\n                              },      \n                              {\n                                 "identifier":"entity_id",\n                               "hidden": true\t\t \n                              },\n                              {\n                                 "identifier":"entity_label",\n                                 "linkedWfsFilter":"LIEU_LIBELLE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\t  \n                              {\n                                 "identifier":"limits",\n                                 "linkedWfsFilter":"geometry",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"geometry_type",\n                                 "defaultValue":"LINE",\n                               "hidden": true\n                              }      \n                           ]\n                        }',
               group: 3,
+            },
+            {
+              protocol: 'OGC:WMS',
+              url: 'http://www.ifremer.fr/services/wms/surveillance_littorale',
+              name: 'surval_parametre_polygone',
+              description: 'Lieu de surveillance (polygone)',
+              function: '',
+              applicationProfile: '',
+              group: 4,
+            },
+            {
+              protocol: 'OGC:WFS',
+              url: 'http://www.ifremer.fr/services/wfs/surveillance_littorale',
+              name: 'surval_parametre_polygone',
+              description: 'Lieu de surveillance (polygone)',
+              function: '',
+              applicationProfile:
+                '{\n\t\t\t\t\t\t\t"tokenizedFields":{\n\t\t\t\t\t\t\t   "THEME":";",\n\t\t\t\t\t\t\t\t"PROGRAMME":";",\n\t\t\t\t\t\t\t\t"PARAMETRE":";"\n\t\t\t\t\t\t\t},\t\t\t\n\t\t\t\t\t\t\t"fields":[\n\t\t\t\t\t\t\t\t{\n\t\t\t\t\t\t\t\t\t"name":"THEME",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Thème",\n\t\t\t\t\t\t\t\t\t\t"en":"Thème"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t    "name":"PROGRAMME",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Programme de suivi",\n\t\t\t\t\t\t\t\t\t\t"en":"Programme de suivi"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"PARAMETRE",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Paramètre",\n\t\t\t\t\t\t\t\t\t\t"en":"Paramètre"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name": "range_Date",\n\t\t\t\t\t\t\t\t\t"type": "rangeDate",\n\t\t\t\t\t\t\t\t\t"minField": "DATEMIN",\n\t\t\t\t\t\t\t\t\t"maxField": "DATEMAX",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Date",\n\t\t\t\t\t\t\t\t\t\t"en":"Date"\n\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t\t"display": "graph"\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"LIEU_LIBELLE",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Lieu",\n\t\t\t\t\t\t\t\t\t\t"en":"Lieu"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t"name":"QUADRIGE_ZONEMARINE",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Zone marine Quadrige",\n\t\t\t\t\t\t\t\t\t\t"en":"Zone marine Quadrige"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"DCSMM_SOUS_REGION",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Sous-région marine DCSMM",\n\t\t\t\t\t\t\t\t\t\t"en":"Sous-région marine DCSMM"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"DCE_MASSE_EAU",\n\t\t\t\t\t\t\t\t\t"label":{\n\t\t\t\t\t\t\t\t\t\t"fr":"Masse d’eau DCE",\n\t\t\t\t\t\t\t\t\t\t"en":"Masse d’eau DCE"\n\t\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t\t},{\n\t\t\t\t\t\t\t\t\t"name":"GRAPHES", \n\t\t\t\t\t\t\t\t\t"hidden": true,\n\t\t\t\t\t\t\t\t\t"suffix":"from=${filtre_range_Date.from}&to=${filtre_range_Date.to}&typeParam=${filtre_PARAMETRE}"\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t],\n\t\t\t\t\t\t\t"treeFields": [\n\t\t\t\t\t\t\t\t"PARAMETRE"\n\t\t\t\t\t\t\t]}',
+              group: 4,
+            },
+            {
+              protocol: 'OGC:WPS',
+              url: 'https://www.ifremer.fr/services/wps3/surval',
+              name: 'r:survalextraction30140',
+              description: "Extraction des données d'observation",
+              function: '',
+              applicationProfile:
+                '{\n                           "inputs":[\n                              {\n                                 "identifier":"theme",\n                                 "linkedWfsFilter":"THEME",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },      {\n                                 "identifier":"programme_suivi",\n                                 "linkedWfsFilter":"PROGRAMME",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                             {\n                               "identifier":"parametres",\n                               "linkedWfsFilter":"PARAMETRE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\n                             },\n                              {\n                                 "identifier":"date_min",\n                                 "linkedWfsFilter":"range_Date.from",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"date_max",\n                                 "linkedWfsFilter":"range_Date.to",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"zone_marine_quadrige",\n                                 "linkedWfsFilter":"ZONE_MARINE_QUADRIGE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                              {\n                                 "identifier":"sous_region_marine_dcsmm",\n                                 "linkedWfsFilter":"SOUS_REGION_MARINE_DCSMM",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                              {\n                                 "identifier":"masse_eau_dce",\n                                 "linkedWfsFilter":"MASSE_EAU_DCE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\n                              {\n                                 "identifier":"supports_niveaux_prelevement",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"taxon",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"taxon_group",\n                               "hidden": true\n                              },      \n                              {\n                                 "identifier":"entity_id",\n                               "hidden": true\t\t \n                              },\n                              {\n                                 "identifier":"entity_label",\n                                 "linkedWfsFilter":"LIEU_LIBELLE",\n                               "hidden": true,\n                               "tokenizeWfsFilterValues": true,\n                               "wfsFilterValuesDelimiter": ";"\t\t \n                              },\t  \n                              {\n                                 "identifier":"limits",\n                                 "linkedWfsFilter":"geometry",\n                               "hidden": true\n                              },\n                              {\n                                 "identifier":"geometry_type",\n                                 "defaultValue":"AREA",\n                               "hidden": true\n                              }      \n                           ]\n                        }',
+              group: 4,
             },
             {
               protocol: 'WWW:LINK-1.0-http--metadata-URL',
@@ -1094,42 +1466,45 @@ export const ES_FIXTURE_FULL_RESPONSE = {
               description: 'DOI du jeu de données',
               function: '',
               applicationProfile: '',
-              group: 4,
+              group: 5,
             },
           ],
           linkUrlProtocolWWWLINK10httplink:
-            'http://envlit.ifremer.fr/surveillance/presentation',
+            'https://wwz.ifremer.fr/envlit/Surveillance-du-littoral',
           linkUrlProtocolOGCWMS: [
-            'https://www.ifremer.fr/services/wms/surveillance_littorale',
-            'https://www.ifremer.fr/services/wms/surveillance_littorale',
+            'http://www.ifremer.fr/services/wms/surveillance_littorale',
+            'http://www.ifremer.fr/services/wms/surveillance_littorale',
+            'http://www.ifremer.fr/services/wms/surveillance_littorale',
           ],
           linkUrlProtocolOGCWFS: [
-            'https://www.ifremer.fr/services/wfs/surveillance_littorale',
-            'https://www.ifremer.fr/services/wfs/surveillance_littorale',
+            'http://www.ifremer.fr/services/wfs/surveillance_littorale',
+            'http://www.ifremer.fr/services/wfs/surveillance_littorale',
+            'http://www.ifremer.fr/services/wfs/surveillance_littorale',
           ],
           linkUrlProtocolOGCWPS: [
-            'https://www.ifremer.fr/services/wps/surval',
-            'https://www.ifremer.fr/services/wps/surval',
+            'https://www.ifremer.fr/services/wps3/surval',
+            'https://www.ifremer.fr/services/wps3/surval',
+            'https://www.ifremer.fr/services/wps3/surval',
           ],
           linkUrlProtocolWWWLINK10httpmetadataURL:
             'https://doi.org/10.12770/cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
           recordGroup: 'cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
           isPublishedToAll: 'true',
-          recordOwner: 'admin admin',
+          recordOwner: 'Test ADMIN',
           uuid: 'cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
           displayOrder: '0',
-          popularity: '15',
-          userinfo: 'admin|admin|admin|Administrator',
+          popularity: 2,
+          userinfo: 'testadmin|ADMIN|Test|Administrator',
           record: 'record',
           draft: 'n',
-          changeDate: '2021-04-01T17:38:51.895Z',
-          id: '10420',
-          createDate: '2021-03-31T12:17:38.105Z',
-          owner: '1',
+          changeDate: '2021-10-05T12:48:57.678Z',
+          id: '11700',
+          createDate: '2021-10-05T12:48:57.678Z',
+          owner: '100',
           groupOwner: '2',
-          logo: '/images/logos/cea9bf9f-329a-4583-9092-2dfc7efdcce2.png',
+          logo: '/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
           hasxlinks: 'false',
-          groupPublished: ['all', 'sample'],
+          groupPublished: ['sample', 'all'],
           featureOfRecord: 'record',
           extra: 'null',
           documentStandard: 'iso19139',
@@ -1138,7 +1513,7 @@ export const ES_FIXTURE_FULL_RESPONSE = {
           feedbackCount: '0',
           rating: '0',
           isHarvested: 'false',
-          sourceCatalogue: 'cea9bf9f-329a-4583-9092-2dfc7efdcce2',
+          sourceCatalogue: '81e8a591-7815-4d2f-a7da-5673192e74c9',
         },
         edit: false,
         owner: false,

--- a/libs/util/shared/src/lib/elasticsearch/mapper/atomic-operations.ts
+++ b/libs/util/shared/src/lib/elasticsearch/mapper/atomic-operations.ts
@@ -1,4 +1,4 @@
-import { MetadataLink } from '../../models'
+import { MetadataContact, MetadataLink } from '../../models'
 
 export type SourceWithUnknownProps = { [key: string]: unknown }
 
@@ -20,10 +20,14 @@ export const selectFallbackFields = <T>(
 export const selectFallback = <T, U>(field: T, fallback: U): T | U =>
   field === null ? fallback : field
 
+export const selectTranslatedValue = <T>(
+  source: SourceWithUnknownProps
+): T | null => selectField(source, 'default')
+
 export const selectTranslatedField = <T>(
   source: SourceWithUnknownProps,
   fieldName: string
-): T | null => selectField(selectField(source, fieldName), 'default')
+): T | null => selectTranslatedValue(selectField(source, fieldName))
 
 export const toDate = (field) => new Date(field)
 
@@ -73,5 +77,23 @@ export const mapLink = (sourceLink: SourceWithUnknownProps): MetadataLink => {
     ...(name !== null && { name }),
     ...(description !== null && { description }),
     ...(protocol !== null && { protocol }),
+  }
+}
+
+export const mapContact = (
+  sourceContact: SourceWithUnknownProps,
+  sourceRecord: SourceWithUnknownProps
+): MetadataContact => {
+  const website = selectField<string>(sourceContact, 'website')
+  const logoUrl = getAsUrl(`/geonetwork${selectField(sourceRecord, 'logo')}`)
+  const address = selectField<string>(sourceContact, 'address')
+  const phone = selectField<string>(sourceContact, 'phone')
+  return {
+    name: selectField<string>(sourceContact, 'organisation'),
+    email: selectField<string>(sourceContact, 'email'),
+    ...(website !== null && { website }),
+    ...(logoUrl !== null && { logoUrl }),
+    ...(address !== null && { address }),
+    ...(phone !== null && { phone }),
   }
 }

--- a/libs/util/shared/src/lib/elasticsearch/mapper/elasticsearch.mapper.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/mapper/elasticsearch.mapper.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing'
 import { ElasticsearchMapper } from './elasticsearch.mapper'
 import { hitsOnly, ES_FIXTURE_FULL_RESPONSE } from '../fixtures'
 import { MetadataUrlService } from '../../services'
+import { MetadataRecord } from '../../models'
 
 const metadataUrlServiceMock = {
   translate: undefined,
@@ -34,8 +35,6 @@ describe('ElasticsearchMapper', () => {
           abstract: 'The grid is based on proposal ',
           downloadable: false,
           id: '12456',
-          logoUrl:
-            'http://localhost/geonetwork/images/logos/e6826118-7280-4638-b1f9-d898e9efe281.png',
           metadataUrl: 'url',
           thumbnailUrl: 'data:image/png;base64,',
           title: 'EEA reference grid for Germany (10km), May 2013',
@@ -46,8 +45,6 @@ describe('ElasticsearchMapper', () => {
           abstract: 'Reference layer of the rivers sensitive areas, ',
           downloadable: false,
           id: '12442',
-          logoUrl:
-            'http://localhost/geonetwork/images/logos/e6826118-7280-4638-b1f9-d898e9efe281.png',
           metadataUrl: 'url',
           thumbnailUrl: 'data:image/png;base64,',
           title:
@@ -191,23 +188,23 @@ describe('ElasticsearchMapper', () => {
         const record = service.toRecord(ES_FIXTURE_FULL_RESPONSE.hits.hits[0])
         expect(record).toMatchObject({
           abstract:
-            "Le produit Surval \"Données par paramètre\" met à disposition les données d'observation et de surveillance bancarisées dans Quadrige.\n\nCe produit contient des résultats sur la plupart des paramètres physiques, chimiques et biologiques de description de l'environnement. Les premières données datent par exemple de 1974 pour les paramètres de la qualité générale des eaux et les contaminants, 1987 pour le phytoplancton et les phycotoxines, 1989 pour la microbiologie, du début des années 2000 pour le benthos. \n\nLes données sous moratoire ou les données qualifiées \"Faux\" sont exclues de la diffusion Surval.\nUne donnée validée dans Quadrige aujourd’hui sera disponible dans Surval demain.\n\nL'accès aux données d'observation se réalise par lieu.\nUn lieu de surveillance est un lieu géographique où des observations, des mesures et/ou des prélèvements sont effectués. Il est localisé de façon unique par son emprise cartographique (surface, ligne ou point). Un lieu de mesure peut être utilisé par plusieurs programmes.\n\nAujourd’hui, ce produit met à disposition des données issues d'une sélection de thématiques.\n\nThématiques suivies :\n- Benthos dont récifs coralliens\n- Contaminants chimiques et Écotoxicologie\n- Déchets\n- Microbiologie\n- Phytoplancton et Hydrologie\n- Ressources aquacoles\n- Zooplancton\n- Autres\n\nL'emprise géographique est nationale : la métropole et les départements et régions d'outre-mer (DROM).",
-          updatedOn: new Date('2021-04-01T17:38:51.895Z'),
-          createdOn: new Date('2021-03-31T12:17:38.105Z'),
+            "Le produit Surval \"Données par paramètre\" met à disposition les données d'observation et de surveillance bancarisées dans Quadrige, validées et qui ne sont pas sous moratoire.\n\nCe système d'information contient des résultats sur la plupart des paramètres physiques, chimiques et biologiques de description de l'environnement. Les premières données datent par exemple de 1974 pour les paramètres de la qualité générale des eaux et les contaminants, 1987 pour le phytoplancton et les phycotoxines, 1989 pour la microbiologie, du début des années 2000 pour le benthos. \n\nCe produit contient des résultats sur la plupart des paramètres physiques, chimiques et biologiques de description de l'environnement. Les premières données datent par exemple de 1974 pour les paramètres de la qualité générale des eaux et les contaminants.\n\nLes données sous moratoire ou les données qualifiées \"Faux\" sont exclus de la diffusion Surval. Une donnée validée dans Quadrige aujourd’hui sera disponible dans Surval demain.\n\nL'accès aux données d'observation se fait par lieu. Un lieu de surveillance est un lieu géographique où des observations, des mesures et/ou des prélèvements sont effectués. Il est localisé de façon unique par son emprise cartographique (surface, ligne ou point). Un lieu de mesure peut être utilisé par plusieurs programmes d'observation et de surveillance.\n\nA compter du 29 avril 2021, conformément aux obligations de l’ « Open data », toutes les données validées sans moratoire sont diffusées à J+1 et sans traitement. Ainsi tous les paramètres et tous les programmes Quadrige sont diffusés, et regroupés sous forme de thème :\n- Benthos dont récifs coralliens\n- Contaminants chimiques et Écotoxicologie\n- Déchets\n- Microbiologie\n- Phytoplancton et Hydrologie\n- Ressources aquacoles\n- Zooplancton\n- Autres\nUn thème regroupe un ou plusieurs programmes d'acquisition. Un programme correspond à une mise en œuvre d'un protocole, sur une période et un ensemble de lieux. Chaque programme est placé sous la responsabilité d'un animateur. \n\nPour accompagner le résultat, de nombreuses données sont diffusées (téléchargeables en tant que données d’observation), comme :\n- la description complète du « Paramètre-Support-Fraction-Méthode-Unité »;\n- la description complète des « Passages », « Prélèvements » et « Échantillons »;\n- le niveau de qualification du résultat;\n- une proposition de citation, afin d’identifier tous les organismes contribuant à cette observation.\n\nL'emprise géographique est nationale : la métropole et les départements et régions d'outre-mer (DROM).\n\nL'accès au téléchargement direct du jeu de données complet (~ 220 Mo) en date du 9 juillet 2021 s'effectue par ce lien : https://www.ifremer.fr/sextant_doc/surveillance_littorale/surval/data/surval.zip \nL'accès par la carte permet de configurer des extractions et des graphes de visualisation sur demande (email demandé pour le téléchargement).",
+          updatedOn: new Date('2021-10-05T12:48:57.678Z'),
+          createdOn: new Date('2021-10-05T12:48:57.678Z'),
           dataCreatedOn: new Date('2012-01-01T00:00:00.000Z'),
-          id: '10420',
+          id: '11700',
           links: [
             {
               description: '',
               name: 'La base de données Quadrige',
               protocol: 'WWW:LINK',
-              url: 'http://envlit.ifremer.fr/resultats/quadrige',
+              url: 'https://wwz.ifremer.fr/envlit/Quadrige-la-base-de-donnees',
             },
             {
               description: '',
               name: 'La surveillance du milieu marin et côtier',
               protocol: 'WWW:LINK-1.0-http--link',
-              url: 'http://envlit.ifremer.fr/surveillance/presentation',
+              url: 'https://wwz.ifremer.fr/envlit/Surveillance-du-littoral',
             },
             {
               description:
@@ -220,37 +217,55 @@ describe('ElasticsearchMapper', () => {
               description: 'Lieu de surveillance (point)',
               name: 'surval_parametre_point',
               protocol: 'OGC:WMS',
-              url: 'https://www.ifremer.fr/services/wms/surveillance_littorale',
+              url: 'http://www.ifremer.fr/services/wms/surveillance_littorale',
             },
             {
               description: 'Lieu de surveillance (point)',
               name: 'surval_parametre_point',
               protocol: 'OGC:WFS',
-              url: 'https://www.ifremer.fr/services/wfs/surveillance_littorale',
+              url: 'http://www.ifremer.fr/services/wfs/surveillance_littorale',
             },
             {
               description: "Extraction des données d'observation",
-              name: 'r:survalextraction',
+              name: 'r:survalextraction30140',
               protocol: 'OGC:WPS',
-              url: 'https://www.ifremer.fr/services/wps/surval',
+              url: 'https://www.ifremer.fr/services/wps3/surval',
+            },
+            {
+              description: 'Lieu de surveillance (ligne)',
+              name: 'surval_parametre_ligne',
+              protocol: 'OGC:WMS',
+              url: 'http://www.ifremer.fr/services/wms/surveillance_littorale',
+            },
+            {
+              description: 'Lieu de surveillance (ligne)',
+              name: 'surval_parametre_ligne',
+              protocol: 'OGC:WFS',
+              url: 'http://www.ifremer.fr/services/wfs/surveillance_littorale',
+            },
+            {
+              description: "Extraction des données d'observation",
+              name: 'r:survalextraction30140',
+              protocol: 'OGC:WPS',
+              url: 'https://www.ifremer.fr/services/wps3/surval',
             },
             {
               description: 'Lieu de surveillance (polygone)',
               name: 'surval_parametre_polygone',
               protocol: 'OGC:WMS',
-              url: 'https://www.ifremer.fr/services/wms/surveillance_littorale',
+              url: 'http://www.ifremer.fr/services/wms/surveillance_littorale',
             },
             {
               description: 'Lieu de surveillance (polygone)',
               name: 'surval_parametre_polygone',
               protocol: 'OGC:WFS',
-              url: 'https://www.ifremer.fr/services/wfs/surveillance_littorale',
+              url: 'http://www.ifremer.fr/services/wfs/surveillance_littorale',
             },
             {
               description: "Extraction des données d'observation",
-              name: 'r:survalextraction',
+              name: 'r:survalextraction30140',
               protocol: 'OGC:WPS',
-              url: 'https://www.ifremer.fr/services/wps/surval',
+              url: 'https://www.ifremer.fr/services/wps3/surval',
             },
             {
               description: 'DOI du jeu de données',
@@ -259,9 +274,6 @@ describe('ElasticsearchMapper', () => {
               url: 'https://doi.org/10.12770/cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
             },
           ],
-          logoUrl:
-            'http://localhost/geonetwork/images/logos/cea9bf9f-329a-4583-9092-2dfc7efdcce2.png',
-          mainLanguage: 'fre',
           metadataUrl: 'url',
           thumbnailUrl:
             'https://sextant.ifremer.fr/geonetwork/srv/api/records/cf5048f6-5bbf-4e44-ba74-e6f429af51ea/attachments/parametres.gif',
@@ -269,7 +281,82 @@ describe('ElasticsearchMapper', () => {
           uuid: 'cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
           viewable: true,
           downloadable: true,
-        })
+          contact: {
+            name: 'Ifremer',
+            email: 'q2suppor@ifremer.fr',
+            website: 'https://www.ifremer.fr',
+            logoUrl:
+              'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
+          },
+          updateStatus: 'Mise à jour continue',
+          updateFrequency: 'Journalière',
+          keywords: [
+            'Lieux de surveillance',
+            'Observation',
+            'Surveillance',
+            'Environnement',
+            'Littoral',
+            'Quadrige',
+            'DCE',
+            'DCSMM',
+            'OSPAR',
+            'MEDPOL',
+            'Données ouvertes',
+            'Open Data',
+            'Surval',
+            'Installations de suivi environnemental',
+            'D8: Contaminants',
+            'D1: Biodiversité',
+            'D7: Changements hydrographiques',
+            'D4: Réseaux trophiques',
+            'D5: Eutrophisation',
+            'D9: Questions sanitaires',
+            'D10: Déchets marins',
+            'D1: Biodiversité - Habitats benthiques',
+            'D1: Biodiversité - Habitats pélagiques',
+            'D1: Biodiversité - Poissons',
+            'D1: Biodiversité - Mammifères',
+            'D1: Biodiversité - Tortues',
+            'D1: Biodiversité - Céphalopodes',
+            'National',
+            'Observation par point',
+            'Observation directe',
+            "/Activités humaines/Réseaux d'observation et de surveillance du littoral",
+            '/Observations in-situ/Réseaux',
+            'Base de données de recherche',
+            'Dispositifs de surveillance',
+            '/Biologie marine/Bivalves',
+            '/Biogéochimie marine/Eléments chimiques et contaminants',
+            "/Physique de l'Océan/Turbidité",
+            '/Biogéochimie marine/Pigments',
+            '/Biologie marine/Toxines',
+            '/Biologie marine/Phytoplancton',
+            '/Biologie marine/Zooplancton',
+            "/Physique de l'Océan/Température",
+            "/Physique de l'Océan/Salinité",
+            '/Biogéochimie marine/Oxygène dissous',
+            '/Biologie marine/Organismes pathogènes',
+            '/Biologie marine/Organismes marins tropicaux',
+            '/Biologie marine/Matière en suspension',
+            '/Biogéochimie marine/Nutriments (sels nutritifs)',
+            '/Biologie marine/Habitats benthiques',
+            '/Etat du Milieu/Biogéochimie',
+            '/Etat du Milieu/Pollutions',
+            '/Etat du Milieu/Littoral',
+            '/Etat du Milieu/Habitats',
+            '/Etat du Milieu/Espèces',
+            'Brest',
+            'Fort-de-France',
+            'Boulogne-sur-Mer',
+            'Nouméa',
+            'Toulon',
+            'Sète',
+            'La Rochelle',
+          ],
+          lineage:
+            'Les données sont bancarisées dans la base de données Quadrige.',
+          usageConstraints: 'Restriction lié à l’exercice du droit moral',
+        } as MetadataRecord)
       })
     })
   })

--- a/libs/util/shared/src/lib/elasticsearch/mapper/elasticsearch.mapper.ts
+++ b/libs/util/shared/src/lib/elasticsearch/mapper/elasticsearch.mapper.ts
@@ -21,7 +21,7 @@ export class ElasticsearchMapper {
 
     return Object.keys(_source).reduce(
       (prev, fieldName) =>
-        this.fieldMapper.getMappingFn(fieldName)(prev, _source, fieldName),
+        this.fieldMapper.getMappingFn(fieldName)(prev, _source),
       record
     ) as MetadataRecord
   }

--- a/libs/util/shared/src/lib/models/search.model.ts
+++ b/libs/util/shared/src/lib/models/search.model.ts
@@ -7,6 +7,16 @@ export interface StateConfigFilters {
   custom?: SearchFilters
   elastic?: any
 }
+
+export interface MetadataContact {
+  name: string
+  email: string
+  website?: string
+  logoUrl?: string
+  address?: string
+  phone?: string
+}
+
 export interface MetadataRecord {
   id: string
   uuid: string
@@ -14,15 +24,19 @@ export interface MetadataRecord {
   metadataUrl: string
   abstract?: string
   thumbnailUrl?: string
-  logoUrl?: string
   downloadable?: boolean
   viewable?: boolean
+  updateStatus?: string
   updateFrequency?: string
   links?: MetadataLink[]
   updatedOn?: Date
   createdOn?: Date
   dataUpdatedOn?: Date
   dataCreatedOn?: Date
+  lineage?: string
+  keywords?: string[]
+  contact?: MetadataContact
+  usageConstraints?: string
 }
 
 export interface MetadataLinkValid {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@angular/router": "12.2.0",
         "@biesbjerg/ngx-translate-extract": "^7.0.4",
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-        "@camptocamp/ogc-client": "^0.2.4",
+        "@camptocamp/ogc-client": "^0.3.0",
         "@ngrx/router-store": "^12.2.0",
         "@nguniversal/express-engine": "^12.0.1",
         "@ngx-translate/core": "^13.0.0",
@@ -2735,9 +2735,9 @@
       }
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.2.4.tgz",
-      "integrity": "sha512-UKNzF1aHEUpSCuOyf0AzOlhQYrhyJaTRrWeYVP3e0zPQqfNX+p+2C+AuxrV7sjRighLIaiey9FYPaPF3GpjsWA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.0.tgz",
+      "integrity": "sha512-pKDhk9PQ7JXWN4+BPGG8M6w0nceULaeoitHxtWsTSKl2KpnJg2xaZuuOkc8G1WeXddtmSa2wb0AvhBgFxgUzdA==",
       "dependencies": {
         "@rgrove/parse-xml": "^3.0.0"
       }
@@ -44071,9 +44071,9 @@
       }
     },
     "@camptocamp/ogc-client": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.2.4.tgz",
-      "integrity": "sha512-UKNzF1aHEUpSCuOyf0AzOlhQYrhyJaTRrWeYVP3e0zPQqfNX+p+2C+AuxrV7sjRighLIaiey9FYPaPF3GpjsWA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.0.tgz",
+      "integrity": "sha512-pKDhk9PQ7JXWN4+BPGG8M6w0nceULaeoitHxtWsTSKl2KpnJg2xaZuuOkc8G1WeXddtmSa2wb0AvhBgFxgUzdA==",
       "requires": {
         "@rgrove/parse-xml": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/router": "12.2.0",
     "@biesbjerg/ngx-translate-extract": "^7.0.4",
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-    "@camptocamp/ogc-client": "^0.2.4",
+    "@camptocamp/ogc-client": "^0.3.0",
     "@ngrx/router-store": "^12.2.0",
     "@nguniversal/express-engine": "^12.0.1",
     "@ngx-translate/core": "^13.0.0",


### PR DESCRIPTION
* Search view:
  * Adds a bit more logic in the search router: the router will close the current metadata if new search filters are sent (e.g. when pressing <kbd>enter</kbd> on the search input)
  * The datahub app will trigger a search with no filters at initialization
* Record view :
  * disable download and api tabs if no link available
  * fix a bug where links with a protocol such as `OGC:WMS-http-getmap-etc` would not render on the map
  * improve layout of the tabs content
  * added keywords, lineage, usage constraints, contact info, other links
Misc:
* use ogc-client v0.3.0 which have better cache! (not limited in size anymore)
* better style for the record count under the table

![image](https://user-images.githubusercontent.com/10629150/139707232-0e331159-df08-49b2-a3ef-228b0042d62a.png)
