### PR TITLE
Update ogc-client to 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@angular/router": "12.2.0",
         "@biesbjerg/ngx-translate-extract": "^7.0.4",
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-        "@camptocamp/ogc-client": "^0.3.1",
+        "@camptocamp/ogc-client": "^0.3.2",
         "@ngrx/router-store": "^12.2.0",
         "@nguniversal/express-engine": "^12.0.1",
         "@ngx-translate/core": "^13.0.0",
@@ -2736,9 +2736,9 @@
       }
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.1.tgz",
-      "integrity": "sha512-bj7pQrkYVCCONeQB7LGpwCOWzLZwbkskMbaa/vbSlDc04LoR12wcsTySzoF71DIq7hxy9thHmX65380kBIvvvQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.2.tgz",
+      "integrity": "sha512-Tsk3Mbf8qZ9v01nsRJKCVbmfloRChFR/8HjECtEn1jBI2rvQZIiUUVCWNWT7m+rHBEqSg5o8dRd27W5EZNr+9g==",
       "dependencies": {
         "@rgrove/parse-xml": "^3.0.0"
       }
@@ -44072,9 +44072,9 @@
       }
     },
     "@camptocamp/ogc-client": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.1.tgz",
-      "integrity": "sha512-bj7pQrkYVCCONeQB7LGpwCOWzLZwbkskMbaa/vbSlDc04LoR12wcsTySzoF71DIq7hxy9thHmX65380kBIvvvQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.2.tgz",
+      "integrity": "sha512-Tsk3Mbf8qZ9v01nsRJKCVbmfloRChFR/8HjECtEn1jBI2rvQZIiUUVCWNWT7m+rHBEqSg5o8dRd27W5EZNr+9g==",
       "requires": {
         "@rgrove/parse-xml": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@angular/router": "12.2.0",
     "@biesbjerg/ngx-translate-extract": "^7.0.4",
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-    "@camptocamp/ogc-client": "^0.3.1",
+    "@camptocamp/ogc-client": "^0.3.2",
     "@ngrx/router-store": "^12.2.0",
     "@nguniversal/express-engine": "^12.0.1",
     "@ngx-translate/core": "^13.0.0",


### PR DESCRIPTION
This provides clearer error messages, and finer detection of CORS issues