### PR TITLE
Fix sort for component init when inside ngIf

### DIFF
--- a/libs/ui/layout/src/lib/table/table.component.ts
+++ b/libs/ui/layout/src/lib/table/table.component.ts
@@ -39,7 +39,7 @@ export class TableComponent implements AfterViewInit {
   @Input() activeId: TableItemId
   @Output() selected = new EventEmitter<any>()
 
-  @ViewChild(MatSort) sort: MatSort
+  @ViewChild(MatSort, { static: true }) sort: MatSort
   properties: string[]
   dataSource: MatTableDataSource<any>
   headerHeight: number


### PR DESCRIPTION
PR fixes that mat-sort currently does not work directly after the table component is rendered on an `ngIf` condition.