### PR TITLE
Record info: sanitize HTML for abstract

### DIFF
--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -17,23 +17,27 @@
       </gn-ui-content-ghost>
     </div>
 
-    <p class="mb-4 font-medium text-primary" translate>
-      record.metadata.keywords
-    </p>
-    <div class="mb-4">
-      <gn-ui-badge
-        class="inline-block mr-2 mb-2"
-        *ngFor="let keyword of metadata.keywords"
-        >{{ keyword }}</gn-ui-badge
-      >
-    </div>
+    <ng-container *ngIf="metadata.keywords">
+      <p class="mb-4 font-medium text-primary" translate>
+        record.metadata.keywords
+      </p>
+      <div class="mb-4">
+        <gn-ui-badge
+          class="inline-block mr-2 mb-2"
+          *ngFor="let keyword of metadata.keywords"
+          >{{ keyword }}</gn-ui-badge
+        >
+      </div>
+    </ng-container>
 
-    <p class="mb-4 font-medium text-primary" translate>
-      record.metadata.origin
-    </p>
-    <p class="mb-4 whitespace-pre-line">
-      {{ metadata.lineage }}
-    </p>
+    <ng-container *ngIf="metadata.lineage">
+      <p class="mb-4 font-medium text-primary" translate>
+        record.metadata.origin
+      </p>
+      <p class="mb-4 whitespace-pre-line">
+        {{ metadata.lineage }}
+      </p>
+    </ng-container>
     <div
       class="
         py-4
@@ -46,26 +50,30 @@
         text-gray-800
       "
     >
-      <div class="border-b border-gray-300">
+      <div class="border-b border-gray-300" *ngIf="metadata.updatedOn">
         <p translate>record.metadata.updatedOn</p>
         <p class="text-primary my-2">
           {{ metadata.updatedOn && metadata.updatedOn.toLocaleString() }}
         </p>
       </div>
-      <div class="border-b border-gray-300">
+      <div class="border-b border-gray-300" *ngIf="metadata.updateFrequency">
         <p translate>record.metadata.updateFrequency</p>
         <p class="text-primary my-2">{{ metadata.updateFrequency }}</p>
       </div>
-      <div>
+      <div *ngIf="metadata.updateStatus">
         <p translate>record.metadata.updateStatus</p>
         <p class="text-primary my-2">{{ metadata.updateStatus }}</p>
       </div>
     </div>
 
-    <p class="mb-4 font-medium text-primary" translate>record.metadata.usage</p>
-    <p class="mb-4 whitespace-pre-line">
-      {{ metadata.usageConstraints }}
-    </p>
+    <ng-container *ngIf="metadata.usageConstraints">
+      <p class="mb-4 font-medium text-primary" translate>
+        record.metadata.usage
+      </p>
+      <p class="mb-4 whitespace-pre-line">
+        {{ metadata.usageConstraints }}
+      </p>
+    </ng-container>
   </div>
 
   <div *ngIf="metadata.contact">

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -10,7 +10,10 @@
         ghostClass="h-32"
         [showContent]="fieldReady('abstract')"
       >
-        <p class="whitespace-pre-line">{{ metadata.abstract }}</p>
+        <p
+          class="whitespace-pre-line"
+          [innerHTML]="metadata.abstract | safe: 'html'"
+        ></p>
       </gn-ui-content-ghost>
     </div>
 

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.spec.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { UtilSharedModule } from '@geonetwork-ui/util/shared'
 import { MetadataInfoComponent } from './metadata-info.component'
 import { ContentGhostComponent } from '../content-ghost/content-ghost.component'
 import { RECORDS_FULL_FIXTURE } from '@geonetwork-ui/ui/search'
@@ -10,7 +11,7 @@ describe('MetadataInfoComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot(), UtilSharedModule],
       declarations: [MetadataInfoComponent, ContentGhostComponent],
     }).compileComponents()
   })

--- a/libs/ui/elements/src/lib/ui-elements.module.ts
+++ b/libs/ui/elements/src/lib/ui-elements.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { MatIconModule } from '@angular/material/icon'
 import { MatTooltipModule } from '@angular/material/tooltip'
+import { UtilSharedModule } from '@geonetwork-ui/util/shared'
 import { MetadataInfoComponent } from './metadata-info/metadata-info.component'
 import { ContentGhostComponent } from './content-ghost/content-ghost.component'
 import { DownloadsListItemComponent } from './downloads-list-item/downloads-list-item.component'
@@ -20,6 +21,7 @@ import { TranslateModule } from '@ngx-translate/core'
     UiWidgetsModule,
     UiLayoutModule,
     TranslateModule.forChild(),
+    UtilSharedModule,
   ],
   declarations: [
     MetadataInfoComponent,


### PR DESCRIPTION
Some opendata catalogs (even GN catalogs) format the abstract of a record in HTML.

- Handle that to have a better display for now.
- Also hide empty elements in the record info panel

![Screenshot from 2021-11-08 15-40-23](https://user-images.githubusercontent.com/1491924/140761840-505790fd-6297-46cd-af93-f658c8005311.png)


