### PR TITLE
Display ESRI:REST WFS links in download component

### DIFF
--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
@@ -168,6 +168,14 @@ describe('DataDownloadsComponent', () => {
           },
           {
             protocol: 'ESRI:REST',
+            name: 'mes_hdf',
+            format: 'arcgis geoservices rest api',
+            description: 'ArcGIS GeoService Wfs',
+            mediaType: 'application/json',
+            url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf/WFSServer/0',
+          },
+          {
+            protocol: 'ESRI:REST',
             name: 'mes_hdf_journalier_poll_princ',
             format: 'arcgis geoservices rest api',
             description: 'ArcGIS GeoService',
@@ -207,6 +215,22 @@ describe('DataDownloadsComponent', () => {
             format: 'WFS:csv',
             protocol: 'OGC:WFS',
             url: 'https://www.ifremer.fr/services/wfs/surveillance_littorale',
+          },
+          {
+            protocol: 'ESRI:REST',
+            name: 'mes_hdf',
+            format: 'WFS:geojson',
+            description: 'ArcGIS GeoService Wfs',
+            mediaType: 'application/json',
+            url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf/WFSServer/0',
+          },
+          {
+            protocol: 'ESRI:REST',
+            name: 'mes_hdf',
+            format: 'WFS:csv',
+            description: 'ArcGIS GeoService Wfs',
+            mediaType: 'application/json',
+            url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf/WFSServer/0',
           },
           {
             protocol: 'ESRI:REST',

--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
@@ -22,9 +22,16 @@ export class DataDownloadsComponent {
 
   links$ = this.facade.downloadLinks$.pipe(
     switchMap((links) => {
-      const wfsLinks = links.filter((link) => /^OGC:WFS/.test(link.protocol))
+      const wfsLinks = links.filter(
+        (link) =>
+          /^OGC:WFS/.test(link.protocol) ||
+          (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
+      )
       const esriRestLinks = links
-        .filter((link) => /^ESRI:REST/.test(link.protocol))
+        .filter(
+          (link) =>
+            /^ESRI:REST/.test(link.protocol) && /FeatureServer/.test(link.url)
+        )
         .flatMap((link) => getLinksWithEsriRestFormats(link))
       const otherLinks = links
         .filter((link) => !/^OGC:WFS|ESRI:REST/.test(link.protocol))

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
@@ -69,7 +69,7 @@ export class DataViewTableComponent {
   constructor(private mdViewFacade: MdViewFacade) {}
 
   fetchData(link: MetadataLinkValid): Observable<{ id: string | number }[]> {
-    if (link.protocol === 'OGC:WFS') {
+    if (link.protocol.startsWith('OGC:WFS')) {
       return fromPromise(
         new WfsEndpoint(link.url).isReady().then((endpoint) => {
           if (!endpoint.supportsJson(link.name)) {

--- a/libs/feature/search/src/lib/utils/links/link-classifier.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/links/link-classifier.service.spec.ts
@@ -38,6 +38,14 @@ describe('LinkClassifierService', () => {
         ])
       })
     })
+    describe('for a ESRI REST WFS service link', () => {
+      it('returns download and API usage', () => {
+        expect(service.getUsagesForLink(LINK_FIXTURES.geodataRestWfs)).toEqual([
+          LinkUsage.API,
+          LinkUsage.DOWNLOAD,
+        ])
+      })
+    })
     describe('for a ESRI REST map service link', () => {
       it('returns no usage', () => {
         expect(service.getUsagesForLink(LINK_FIXTURES.maplayerRest)).toEqual([])

--- a/libs/feature/search/src/lib/utils/links/link-classifier.service.ts
+++ b/libs/feature/search/src/lib/utils/links/link-classifier.service.ts
@@ -34,6 +34,8 @@ export class LinkClassifierService {
       }
       if (/^OGC:WFS/.test(link.protocol))
         return [LinkUsage.API, LinkUsage.DOWNLOAD, LinkUsage.DATA]
+      if (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
+        return [LinkUsage.API, LinkUsage.DOWNLOAD]
       if (/^ESRI:REST/.test(link.protocol) && /FeatureServer/.test(link.url))
         return [LinkUsage.API, LinkUsage.DOWNLOAD]
       if (/^OGC:WMS/.test(link.protocol))

--- a/libs/feature/search/src/lib/utils/links/link-utils.ts
+++ b/libs/feature/search/src/lib/utils/links/link-utils.ts
@@ -1,5 +1,8 @@
 import { MetadataLink, MetadataLinkValid } from '@geonetwork-ui/util/shared'
 import { WfsEndpoint } from '@camptocamp/ogc-client'
+import { marker } from '@biesbjerg/ngx-translate-extract-marker'
+
+marker('downloads.wfs.featuretype.not.found')
 
 export enum DownloadFormatType {
   WFS = 'WFS',
@@ -49,11 +52,15 @@ export function getLinksWithWfsFormats(
 ): Promise<MetadataLinkValid[]> {
   return new WfsEndpoint(link.url).isReady().then((endpoint) => {
     const featureType = endpoint.getFeatureTypeSummary(link.name)
-    return featureType.outputFormats.map((format) => ({
-      ...link,
-      url: endpoint.getFeatureUrl(featureType.name, { outputFormat: format }),
-      format: format,
-    }))
+    if (featureType) {
+      return featureType.outputFormats.map((format) => ({
+        ...link,
+        url: endpoint.getFeatureUrl(featureType.name, { outputFormat: format }),
+        format: format,
+      }))
+    } else {
+      throw new Error('downloads.wfs.featuretype.not.found')
+    }
   })
 }
 

--- a/libs/feature/search/src/lib/utils/links/link.fixtures.ts
+++ b/libs/feature/search/src/lib/utils/links/link.fixtures.ts
@@ -100,6 +100,11 @@ export const LINK_FIXTURES = {
     name: 'myrestlayer',
     url: 'https://my.esri.server/FeatureServer',
   },
+  geodataRestWfs: {
+    protocol: 'ESRI:REST',
+    name: 'mywfsrestlayer',
+    url: 'https://my.esri.server/WFSServer',
+  },
   maplayerRest: {
     protocol: 'ESRI:REST',
     name: 'myotherrestlayer',

--- a/translations/de.json
+++ b/translations/de.json
@@ -76,6 +76,7 @@
   "datahub.app.title": "",
   "datahub.route.home": "",
   "downloads.wfs.error": "",
+  "downloads.wfs.featuretype.not.found": "",
   "dropFile": "",
   "facets.block.title.OrgForResource": "",
   "facets.block.title.availableInServices": "",

--- a/translations/en.json
+++ b/translations/en.json
@@ -76,6 +76,7 @@
   "datahub.app.title": "Data Hub",
   "datahub.route.home": "Data hub",
   "downloads.wfs.error": "Download options from the WFS service could not be fetched",
+  "downloads.wfs.featuretype.not.found": "The layer was not found",
   "dropFile": "drop file",
   "facets.block.title.OrgForResource": "Organisation",
   "facets.block.title.availableInServices": "Available for",

--- a/translations/es.json
+++ b/translations/es.json
@@ -76,6 +76,7 @@
   "datahub.app.title": "",
   "datahub.route.home": "",
   "downloads.wfs.error": "",
+  "downloads.wfs.featuretype.not.found": "",
   "dropFile": "",
   "facets.block.title.OrgForResource": "",
   "facets.block.title.availableInServices": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -76,6 +76,7 @@
   "datahub.app.title": "Data Hub",
   "datahub.route.home": "Data hub",
   "downloads.wfs.error": "Les options de téléchargement ne peuvent être obtenues depuis le service WFS",
+  "downloads.wfs.featuretype.not.found": "La couche n'a pas été retrouvée",
   "dropFile": "Faites glisser votre fichier",
   "facets.block.title.OrgForResource": "Organisation",
   "facets.block.title.availableInServices": "Disponible pour",

--- a/translations/it.json
+++ b/translations/it.json
@@ -76,6 +76,7 @@
   "datahub.app.title": "",
   "datahub.route.home": "",
   "downloads.wfs.error": "",
+  "downloads.wfs.featuretype.not.found": "",
   "dropFile": "",
   "facets.block.title.OrgForResource": "",
   "facets.block.title.availableInServices": "",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -76,6 +76,7 @@
   "datahub.app.title": "",
   "datahub.route.home": "",
   "downloads.wfs.error": "",
+  "downloads.wfs.featuretype.not.found": "",
   "dropFile": "",
   "facets.block.title.OrgForResource": "",
   "facets.block.title.availableInServices": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -76,6 +76,7 @@
   "datahub.app.title": "",
   "datahub.route.home": "",
   "downloads.wfs.error": "",
+  "downloads.wfs.featuretype.not.found": "",
   "dropFile": "",
   "facets.block.title.OrgForResource": "",
   "facets.block.title.availableInServices": "",


### PR DESCRIPTION
This PR displays ESRI:REST WFS links in the download component. Unfortunately, the metadata link names of the tested ESRI WFS servers did not match the layer/featuretype names, which does not allow inferring the available formats. An according error message is displayed.