### PR TITLE
Recognize JPG type to display in download list

### DIFF
--- a/libs/feature/search/src/lib/utils/links/link-classifier.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/links/link-classifier.service.spec.ts
@@ -1,77 +1,7 @@
 import { LinkClassifierService, LinkUsage } from './link-classifier.service'
+import { LINK_FIXTURES } from './link.fixtures'
 
 describe('LinkClassifierService', () => {
-  const readmeLink = {
-    protocol: 'WWW:LINK',
-    description: 'Readme page',
-    url: 'http://envlit.ifremer.fr/resultats/quadrige',
-  }
-  const doiLink = {
-    protocol: 'WWW:DOI',
-    description: 'DOI for the resource',
-    url: 'http://doi.org/123-456-678',
-  }
-  const dataCsv = {
-    protocol: 'WWW:DOWNLOAD',
-    description: 'Data in CSV format',
-    name: 'abc.csv',
-    url: 'http://my.server/files/abc.csv',
-  }
-  const dataXls = {
-    protocol: 'WWW:DOWNLOAD',
-    description: 'Data in XLS format',
-    name: 'abc.xls',
-    url: 'https://my.server/files/abc.xls',
-  }
-  const dataXlsx = {
-    protocol: 'WWW:DOWNLOAD',
-    description: 'Data in XLSX format',
-    name: 'abc.XLSX',
-    url: 'https://my.server/files/abc.XLSX',
-  }
-  const dataJson = {
-    protocol: 'WWW:DOWNLOAD',
-    description: 'Data in JSON format',
-    name: 'abc.json',
-    url: 'https://my.server/files/abc.json',
-  }
-  const geodataJson = {
-    protocol: 'WWW:DOWNLOAD',
-    description: 'Geographic data in GeoJSON format',
-    format: 'geojson',
-    name: 'mylayer',
-    url: 'http://my.server/files/geographic/dataset',
-  }
-  const geodataWms = {
-    protocol: 'OGC:WMS',
-    name: 'mylayer',
-    url: 'https://my.ogc.server/wms',
-  }
-  const geodataWfs = {
-    protocol: 'OGC:WFS',
-    name: 'mylayer',
-    url: 'https://my.ogc.server/wfs',
-  }
-  const geodataWms2 = {
-    protocol: 'OGC:WMS',
-    name: 'myotherlayer',
-    url: 'https://my.ogc.server/wms',
-  }
-  const geodataWfs2 = {
-    protocol: 'OGC:WFS',
-    name: 'myotherlayer',
-    url: 'https://my.ogc.server/wfs',
-  }
-  const geodataRest = {
-    protocol: 'ESRI:REST',
-    name: 'myrestlayer',
-    url: 'https://my.esri.server/FeatureServer',
-  }
-  const maplayerRest = {
-    protocol: 'ESRI:REST',
-    name: 'myotherrestlayer',
-    url: 'https://my.esri.server/MapServer',
-  }
   let service: LinkClassifierService
 
   beforeEach(() => {
@@ -85,7 +15,7 @@ describe('LinkClassifierService', () => {
   describe('#getUsagesForLink', () => {
     describe('for a WMS link', () => {
       it('returns map API  and API usage', () => {
-        expect(service.getUsagesForLink(geodataWms)).toEqual([
+        expect(service.getUsagesForLink(LINK_FIXTURES.geodataWms)).toEqual([
           LinkUsage.API,
           LinkUsage.MAPAPI,
         ])
@@ -93,7 +23,7 @@ describe('LinkClassifierService', () => {
     })
     describe('for a WFS link', () => {
       it('returns download, data and API usage', () => {
-        expect(service.getUsagesForLink(geodataWfs)).toEqual([
+        expect(service.getUsagesForLink(LINK_FIXTURES.geodataWfs)).toEqual([
           LinkUsage.API,
           LinkUsage.DOWNLOAD,
           LinkUsage.DATA,
@@ -102,7 +32,7 @@ describe('LinkClassifierService', () => {
     })
     describe('for a ESRI REST feature service link', () => {
       it('returns download and API usage', () => {
-        expect(service.getUsagesForLink(geodataRest)).toEqual([
+        expect(service.getUsagesForLink(LINK_FIXTURES.geodataRest)).toEqual([
           LinkUsage.API,
           LinkUsage.DOWNLOAD,
         ])
@@ -110,12 +40,12 @@ describe('LinkClassifierService', () => {
     })
     describe('for a ESRI REST map service link', () => {
       it('returns no usage', () => {
-        expect(service.getUsagesForLink(maplayerRest)).toEqual([])
+        expect(service.getUsagesForLink(LINK_FIXTURES.maplayerRest)).toEqual([])
       })
     })
     describe('for a link to a CSV file', () => {
       it('returns a download usage', () => {
-        expect(service.getUsagesForLink(dataCsv)).toEqual([
+        expect(service.getUsagesForLink(LINK_FIXTURES.dataCsv)).toEqual([
           LinkUsage.DOWNLOAD,
           LinkUsage.DATA,
         ])
@@ -123,7 +53,7 @@ describe('LinkClassifierService', () => {
     })
     describe('for a link to a XLSX file', () => {
       it('returns a download usage', () => {
-        expect(service.getUsagesForLink(dataXlsx)).toEqual([
+        expect(service.getUsagesForLink(LINK_FIXTURES.dataXlsx)).toEqual([
           LinkUsage.DOWNLOAD,
           LinkUsage.DATA,
         ])
@@ -131,7 +61,7 @@ describe('LinkClassifierService', () => {
     })
     describe('for a link to a geojson file', () => {
       it('returns download and data usage', () => {
-        expect(service.getUsagesForLink(geodataJson)).toEqual([
+        expect(service.getUsagesForLink(LINK_FIXTURES.geodataJson)).toEqual([
           LinkUsage.DOWNLOAD,
           LinkUsage.DATA,
         ])
@@ -139,7 +69,7 @@ describe('LinkClassifierService', () => {
     })
     describe('for a link to a simple page', () => {
       it('returns null', () => {
-        expect(service.getUsagesForLink(readmeLink)).toEqual([])
+        expect(service.getUsagesForLink(LINK_FIXTURES.readmeLink)).toEqual([])
       })
     })
   })

--- a/libs/feature/search/src/lib/utils/links/link-utils.spec.ts
+++ b/libs/feature/search/src/lib/utils/links/link-utils.spec.ts
@@ -4,26 +4,88 @@ import {
   checkFileFormat,
   getLinksWithEsriRestFormats,
 } from './link-utils'
+import { LINK_FIXTURES } from './link.fixtures'
 
 describe('link utils', () => {
   describe('#getDownloadFormat', () => {
-    describe('for a FILE link', () => {
-      it('returns download format', () => {
+    describe('for a csv FILE link', () => {
+      it('returns csv format', () => {
         expect(
-          getDownloadFormat(
-            {
-              description: 'Test file',
-              name: 'file.geojson',
-              protocol: 'WWW:DOWNLOAD',
-              url: 'http://example.com',
-            },
-            DownloadFormatType.FILE
-          )
-        ).toEqual('geojson')
+          getDownloadFormat(LINK_FIXTURES.dataCsv, DownloadFormatType.FILE)
+        ).toEqual('csv')
       })
     }),
-      describe('for a WFS link', () => {
-        it('returns download format', () => {
+      describe('for a geojson FILE link', () => {
+        it('returns geojson format', () => {
+          expect(
+            getDownloadFormat(
+              LINK_FIXTURES.geodataJson,
+              DownloadFormatType.FILE
+            )
+          ).toEqual('geojson')
+        })
+      }),
+      describe('for a json FILE link', () => {
+        it('returns json format', () => {
+          expect(
+            getDownloadFormat(LINK_FIXTURES.dataJson, DownloadFormatType.FILE)
+          ).toEqual('json')
+        })
+      }),
+      describe('for a shapefile link', () => {
+        it('returns shp format', () => {
+          expect(
+            getDownloadFormat(LINK_FIXTURES.geodataShp, DownloadFormatType.FILE)
+          ).toEqual('shp')
+        })
+      }),
+      describe('for a kml FILE link', () => {
+        it('returns kml format', () => {
+          expect(
+            getDownloadFormat(LINK_FIXTURES.geodataKml, DownloadFormatType.FILE)
+          ).toEqual('kml')
+        })
+      }),
+      describe('for a geopackage FILE link', () => {
+        it('returns gpkg format', () => {
+          expect(
+            getDownloadFormat(
+              LINK_FIXTURES.geodataGpkg,
+              DownloadFormatType.FILE
+            )
+          ).toEqual('gpkg')
+        })
+      }),
+      describe('for an excel FILE link', () => {
+        it('returns excel format', () => {
+          expect(
+            getDownloadFormat(LINK_FIXTURES.dataXlsx, DownloadFormatType.FILE)
+          ).toEqual('excel')
+        })
+      }),
+      describe('for a pdf FILE link', () => {
+        it('returns pdf format', () => {
+          expect(
+            getDownloadFormat(LINK_FIXTURES.dataPdf, DownloadFormatType.FILE)
+          ).toEqual('pdf')
+        })
+      }),
+      describe('for a jpg FILE link', () => {
+        it('returns jpg format', () => {
+          expect(
+            getDownloadFormat(LINK_FIXTURES.dataJpg, DownloadFormatType.FILE)
+          ).toEqual('jpg')
+        })
+      }),
+      describe('for a zip FILE link', () => {
+        it('returns zip format', () => {
+          expect(
+            getDownloadFormat(LINK_FIXTURES.dataZip, DownloadFormatType.FILE)
+          ).toEqual('zip')
+        })
+      }),
+      describe('for a WFS link with geojson format', () => {
+        it('returns WFS:geojson format', () => {
           expect(
             getDownloadFormat(
               {

--- a/libs/feature/search/src/lib/utils/links/link-utils.ts
+++ b/libs/feature/search/src/lib/utils/links/link-utils.ts
@@ -19,6 +19,7 @@ export function getDownloadFormat(
     gpkg: ['gpkg', 'geopackage'],
     excel: ['xls', 'xlsx', 'ms-excel', 'openxmlformats-officedocument'],
     pdf: ['pdf'],
+    jpg: ['jpg', 'jpeg', 'jfif', 'pjpeg', 'pjp'],
     zip: ['zip'],
   }
   for (const format in formats) {

--- a/libs/feature/search/src/lib/utils/links/link.fixtures.ts
+++ b/libs/feature/search/src/lib/utils/links/link.fixtures.ts
@@ -1,0 +1,108 @@
+export const LINK_FIXTURES = {
+  readmeLink: {
+    protocol: 'WWW:LINK',
+    description: 'Readme page',
+    url: 'http://envlit.ifremer.fr/resultats/quadrige',
+  },
+  doiLink: {
+    protocol: 'WWW:DOI',
+    description: 'DOI for the resource',
+    url: 'http://doi.org/123-456-678',
+  },
+  dataCsv: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Data in CSV format',
+    name: 'abc.csv',
+    url: 'http://my.server/files/abc.csv',
+  },
+  dataPdf: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Data in PDF format',
+    name: 'abc.pdf',
+    url: 'https://my.server/files/abc.pdf',
+  },
+  dataJpg: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Data in JPG format',
+    name: 'abc.jpg',
+    url: 'https://my.server/files/abc.jpg',
+  },
+  dataZip: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Data in ZIP format',
+    name: 'abc.zip',
+    url: 'https://my.server/files/abc.zip',
+  },
+  dataXls: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Data in XLS format',
+    name: 'abc.xls',
+    url: 'https://my.server/files/abc.xls',
+  },
+  dataXlsx: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Data in XLSX format',
+    name: 'abc.XLSX',
+    url: 'https://my.server/files/abc.XLSX',
+  },
+  dataJson: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Data in JSON format',
+    name: 'abc.json',
+    url: 'https://my.server/files/abc.json',
+  },
+  geodataJson: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Geographic data in GeoJSON format',
+    name: 'dataset.geojson',
+    url: 'http://my.server/files/geographic/dataset.geojson',
+  },
+  geodataKml: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Geographic data in KML format',
+    name: 'dataset.kml',
+    url: 'http://my.server/files/geographic/dataset.kml',
+  },
+  geodataGpkg: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Geographic data in geopackage format',
+    name: 'dataset.gpkg',
+    url: 'http://my.server/files/geographic/dataset.gpkg',
+  },
+  geodataShp: {
+    protocol: 'WWW:DOWNLOAD',
+    description: 'Geographic data in shapefile format',
+    name: 'dataset.shp',
+    url: 'http://my.server/files/geographic/dataset.zip',
+  },
+  geodataWms: {
+    protocol: 'OGC:WMS',
+    name: 'mylayer',
+    url: 'https://my.ogc.server/wms',
+  },
+  geodataWfs: {
+    protocol: 'OGC:WFS',
+    name: 'mylayer',
+    url: 'https://my.ogc.server/wfs',
+  },
+  geodataWms2: {
+    protocol: 'OGC:WMS',
+    name: 'myotherlayer',
+    url: 'https://my.ogc.server/wms',
+  },
+  geodataWfs2: {
+    protocol: 'OGC:WFS',
+    name: 'myotherlayer',
+    url: 'https://my.ogc.server/wfs',
+  },
+  geodataRest: {
+    protocol: 'ESRI:REST',
+    name: 'myrestlayer',
+    url: 'https://my.esri.server/FeatureServer',
+  },
+  maplayerRest: {
+    protocol: 'ESRI:REST',
+    name: 'myotherrestlayer',
+    url: 'https://my.esri.server/MapServer',
+  },
+}


### PR DESCRIPTION
PR recognizes JPG file type in links with protocol `WWW:DOWNLOAD` and displays it in the download list, which is currently not the case ("unknown"). To test this behavior, search for entry "Schémas de cohérence territoriale dans l'Oise" (471011ac-b927-4c8d-9589-ce3c530ea08d) for example.