### PR TITLE
feat(datahub): breadcrumb datahub link reset the search

### DIFF
--- a/apps/datahub/src/app/app.component.html
+++ b/apps/datahub/src/app/app.component.html
@@ -24,9 +24,10 @@
           truncate
           no-underline
           hover:text-primary-lighter hover:underline
+          cursor-pointer
         "
-        routerLink="search"
         translate
+        (click)="resetSearch()"
         >datahub.route.home</a
       >
       > {{ breadcrumb$ | async }}

--- a/apps/datahub/src/app/app.component.ts
+++ b/apps/datahub/src/app/app.component.ts
@@ -1,8 +1,10 @@
-import { Component } from '@angular/core'
+import { Component, ViewChild } from '@angular/core'
+import { SearchFacade } from '@geonetwork-ui/feature/search'
 import { ColorService } from '@geonetwork-ui/util/shared'
 import { MdViewFacade } from '@geonetwork-ui/feature/record'
 import { map, switchMap } from 'rxjs/operators'
 import { combineLatest, of } from 'rxjs'
+import { MainSearchComponent } from './main-search/main-search.component'
 
 @Component({
   selector: 'gn-ui-root',
@@ -10,6 +12,8 @@ import { combineLatest, of } from 'rxjs'
   styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
+  @ViewChild(MainSearchComponent) searchComponent: MainSearchComponent
+
   isPresentOrLoading$ = combineLatest([
     this.mdViewFacade.isPresent$,
     this.mdViewFacade.isLoading$,
@@ -31,5 +35,9 @@ export class AppComponent {
 
   constructor(private mdViewFacade: MdViewFacade) {
     ColorService.applyCssVariables('#093564', '#c2e9dc', '#212029', '#fdfbff')
+  }
+
+  resetSearch() {
+    this.searchComponent.resetSearch()
   }
 }

--- a/apps/datahub/src/app/main-search/main-search.component.ts
+++ b/apps/datahub/src/app/main-search/main-search.component.ts
@@ -26,4 +26,8 @@ export class MainSearchComponent implements OnInit {
   onMetadataSelection(metadata: MetadataRecord): void {
     this.searchRouter.goToMetadata(metadata)
   }
+
+  resetSearch(): void {
+    this.searchFacade.setFilters({})
+  }
 }

--- a/libs/feature/router/README.md
+++ b/libs/feature/router/README.md
@@ -1,7 +1,56 @@
 # feature-router
 
+## Overview
+
 This library provides tools to handle routing within the applications.
 A defaut router is implemented to manage the search state and the record view state.
 
 - `/search` to be on search result page
 - `/metadata/cf5048f6-5bbf-4e44-ba74-e6f429af51ea` to be on the details of the record page.
+
+## Principle
+
+No library should import the router library, but the router library should implement the interactions between other libraries in the `feature-router` library itself.
+
+The router is based on a `RouterStore`, so it reacts on actions.
+
+The interactions with other libraries should be done in the `router.effects` class to react to or dispatch external actions.
+
+Examples of both direction interactions
+
+1. On a route change to a record uuid, the `DefaultRouter` dispatches an external load full record action.
+
+```ts
+navigateToMetadata$ = createEffect(() =>
+  this._actions$.pipe(
+    navigation(MetadataRouteComponent, {
+      run: (activatedRouteSnapshot: ActivatedRouteSnapshot) =>
+        MdViewActions.loadFullMetadata({
+          uuid: activatedRouteSnapshot.params.metadataUuid,
+        }),
+      onError(a: ActivatedRouteSnapshot, e) {
+        console.error('Navigation failed', e)
+      },
+    })
+  )
+)
+```
+
+2. On a dispatch of an external `RequestMoreResult` action, the router changes the route to `/search`
+
+```ts
+search$ = createEffect(() =>
+  this._actions$.pipe(
+    ofType(REQUEST_MORE_RESULTS),
+    filter(
+      (action: RequestMoreResults) =>
+        action.id === this.routerConfig.searchStateId
+    ),
+    map((action) =>
+      goAction({
+        path: 'search',
+      })
+    )
+  )
+)
+```


### PR DESCRIPTION
The `Data hub` link in the breadcrumb no longer set the route to `/search` but also reset the search, as a link to _home_.
Quick win implementation.
I don't want to create a RESET search action, neither to manage default search params in the config etc... Keeping it simple for now.

After implementing this, i figured out that we could refactor a bit to move all what is related to the search in the `main-search.component` of the `datahub` application, this would avoid to call a children method from the parent (this is mandatory cause the `app.component` can't inject the `searchFacade` as it's injected underneath from the `gnUiSearchStateContainer` directive ).