### PR TITLE
datahub: fix state conflicts between search and mdview

### DIFF
--- a/apps/datahub/src/app/app.component.html
+++ b/apps/datahub/src/app/app.component.html
@@ -15,6 +15,7 @@
         <gn-ui-fuzzy-search
           [displayWithFn]="autocompleteDisplayWithFn"
           (itemSelected)="onFuzzySearchSelection($event)"
+          (inputSubmited)="onFuzzySearchSubmission()"
         ></gn-ui-fuzzy-search>
       </div>
     </div>
@@ -30,7 +31,7 @@
           cursor-pointer
         "
         translate
-        (click)="resetSearch()"
+        (click)="onBCDatahubClick()"
         >datahub.route.home</a
       >
       > {{ breadcrumb$ | async }}

--- a/apps/datahub/src/app/app.component.spec.ts
+++ b/apps/datahub/src/app/app.component.spec.ts
@@ -2,6 +2,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { TestBed } from '@angular/core/testing'
 import { RouterTestingModule } from '@angular/router/testing'
 import { MdViewFacade } from '@geonetwork-ui/feature/record'
+import { RouterFacade } from '@geonetwork-ui/feature/router'
 import { AppComponent } from './app.component'
 import { of } from 'rxjs'
 
@@ -10,6 +11,9 @@ class MdViewFacadeMock {
   isPresent$ = of()
   isLoading$ = of()
   metadata$ = of()
+}
+class RouterFacadeMock {
+  goToMetadata = jest.fn()
 }
 
 describe('AppComponent', () => {
@@ -22,6 +26,10 @@ describe('AppComponent', () => {
         {
           provide: MdViewFacade,
           useClass: MdViewFacadeMock,
+        },
+        {
+          provide: RouterFacade,
+          useClass: RouterFacadeMock,
         },
       ],
     }).compileComponents()

--- a/apps/datahub/src/app/app.component.ts
+++ b/apps/datahub/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component, ViewChild } from '@angular/core'
 import { MdViewFacade } from '@geonetwork-ui/feature/record'
+import { RouterFacade } from '@geonetwork-ui/feature/router'
 import { ColorService, MetadataRecord } from '@geonetwork-ui/util/shared'
 import { combineLatest, of } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
@@ -33,15 +34,23 @@ export class AppComponent {
   )
   autocompleteDisplayWithFn = () => ''
 
-  constructor(private mdViewFacade: MdViewFacade) {
+  constructor(
+    private mdViewFacade: MdViewFacade,
+    private searchRouter: RouterFacade
+  ) {
     ColorService.applyCssVariables('#093564', '#c2e9dc', '#212029', '#fdfbff')
   }
 
-  resetSearch() {
+  onFuzzySearchSelection(record: MetadataRecord) {
+    this.searchRouter.goToMetadata(record)
+  }
+
+  onBCDatahubClick() {
+    this.searchRouter.goToSearch()
     this.searchComponent.resetSearch()
   }
 
-  onFuzzySearchSelection(record: MetadataRecord) {
-    this.searchComponent.onMetadataSelection(record)
+  onFuzzySearchSubmission() {
+    this.searchRouter.goToSearch()
   }
 }

--- a/libs/feature/router/src/lib/default/state/router.effects.spec.ts
+++ b/libs/feature/router/src/lib/default/state/router.effects.spec.ts
@@ -3,7 +3,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { TestBed } from '@angular/core/testing'
 import { Router } from '@angular/router'
 import { MdViewActions } from '@geonetwork-ui/feature/record'
-import { RequestMoreResults } from '@geonetwork-ui/feature/search'
 import { provideMockActions } from '@ngrx/effects/testing'
 import { routerNavigationAction } from '@ngrx/router-store'
 import { Action } from '@ngrx/store'
@@ -13,7 +12,7 @@ import { MetadataRouteComponent, SearchRouteComponent } from '../constants'
 import { ROUTER_CONFIG } from '../router.module'
 
 import * as fromActions from './router.actions'
-import { goAction, RouterGoActionPayload } from './router.actions'
+import { RouterGoActionPayload } from './router.actions'
 import * as fromEffects from './router.effects'
 
 describe('RouterEffects', () => {
@@ -141,42 +140,6 @@ describe('RouterEffects', () => {
 
       effects.navigate$.subscribe(() => {
         expect(location.forward).toHaveBeenCalled()
-      })
-    })
-  })
-
-  describe('search$', () => {
-    let searchStateId
-    describe('when RequestMore on config search', () => {
-      beforeEach(() => {
-        searchStateId = 'main'
-      })
-      it('moves to search route', () => {
-        actions = hot('-a', { a: new RequestMoreResults(searchStateId) })
-
-        const expected = hot('-b', {
-          b: goAction({
-            path: 'search',
-          }),
-        })
-
-        expect(effects.search$).toBeObservable(expected)
-      })
-    })
-    describe('when RequestMore on another search', () => {
-      beforeEach(() => {
-        searchStateId = 'extra'
-      })
-      it('does nothing', () => {
-        actions = hot('-a', { a: new RequestMoreResults(searchStateId) })
-
-        const expected = hot('-b', {
-          b: goAction({
-            path: 'search',
-          }),
-        })
-
-        expect(effects.search$).not.toBeObservable(expected)
       })
     })
   })

--- a/libs/feature/router/src/lib/default/state/router.effects.ts
+++ b/libs/feature/router/src/lib/default/state/router.effects.ts
@@ -2,17 +2,12 @@ import { Location } from '@angular/common'
 import { Inject, Injectable } from '@angular/core'
 import { ActivatedRouteSnapshot, Router } from '@angular/router'
 import { MdViewActions } from '@geonetwork-ui/feature/record'
-import {
-  REQUEST_MORE_RESULTS,
-  RequestMoreResults,
-} from '@geonetwork-ui/feature/search'
 import { Actions, createEffect, ofType } from '@ngrx/effects'
 import { navigation } from '@nrwl/angular'
-import { filter, map, tap } from 'rxjs/operators'
+import { tap } from 'rxjs/operators'
 import { MetadataRouteComponent, SearchRouteComponent } from '../constants'
 import { ROUTER_CONFIG, RouterConfigModel } from '../router.module'
 import * as RouterActions from './router.actions'
-import { goAction } from './router.actions'
 
 @Injectable()
 export class RouterEffects {
@@ -61,25 +56,6 @@ export class RouterEffects {
       navigation(SearchRouteComponent, {
         run: () => MdViewActions.close(),
       })
-    )
-  )
-
-  /**
-   * This effect will navigate to the search page when a new
-   * search is launched
-   */
-  search$ = createEffect(() =>
-    this._actions$.pipe(
-      ofType(REQUEST_MORE_RESULTS),
-      filter(
-        (action: RequestMoreResults) =>
-          action.id === this.routerConfig.searchStateId
-      ),
-      map((action) =>
-        goAction({
-          path: 'search',
-        })
-      )
     )
   )
 

--- a/libs/feature/router/src/lib/default/state/router.facade.ts
+++ b/libs/feature/router/src/lib/default/state/router.facade.ts
@@ -33,15 +33,19 @@ export class RouterFacade {
         filter((params) => params.metadataUuid !== metadata.uuid)
       )
       .subscribe(() => {
-        this.store.dispatch(
-          goAction({
-            path: `metadata/${metadata.uuid}`,
-          })
-        )
+        this.go({
+          path: `metadata/${metadata.uuid}`,
+        })
         this.store.dispatch(
           MdViewActions.setIncompleteMetadata({ incomplete: metadata })
         )
       })
+  }
+
+  goToSearch() {
+    this.go({
+      path: `search/`,
+    })
   }
 
   go(payload: RouterGoActionPayload) {

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
@@ -110,11 +110,16 @@ describe('FuzzySearchComponent', () => {
   })
 
   describe('search enter key press', () => {
+    let outputValue
     beforeEach(() => {
+      component.inputSubmited.subscribe((event) => (outputValue = event))
       component.handleInputSubmission('blarg')
     })
     it('changes the search filters', () => {
       expect(searchFacadeMock.setFilters).toHaveBeenCalledWith({ any: 'blarg' })
+    })
+    it('emits inputSubmited event', () => {
+      expect(outputValue).toEqual('blarg')
     })
   })
 

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
@@ -27,6 +27,7 @@ import { ElasticsearchMapper } from '../utils/mapper'
 export class FuzzySearchComponent implements AfterViewInit {
   @ViewChild(AutocompleteComponent) autocomplete: AutocompleteComponent
   @Output() itemSelected = new EventEmitter<MetadataRecord>()
+  @Output() inputSubmited = new EventEmitter<string>()
   @Input() displayWithFn: (MetadataRecord) => string = (record) => record?.title
   itemToStringFn = (record: MetadataRecord) => record?.title
 
@@ -70,5 +71,6 @@ export class FuzzySearchComponent implements AfterViewInit {
 
   handleInputSubmission(any: string) {
     this.searchFacade.setFilters({ any })
+    this.inputSubmited.emit(any)
   }
 }

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
@@ -29,7 +29,7 @@
 </div>
 <mat-autocomplete
   #auto="matAutocomplete"
-  (optionSelected)="handleSelection($event.option.value)"
+  (optionSelected)="handleSelection($event)"
   [displayWith]="displayWithFn"
 >
   <mat-option

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
@@ -1,24 +1,31 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
   EventEmitter,
   Input,
+  OnDestroy,
   OnInit,
   Output,
   ViewChild,
 } from '@angular/core'
-import { Observable } from 'rxjs'
+import { FormControl } from '@angular/forms'
+import {
+  MatAutocomplete,
+  MatAutocompleteSelectedEvent,
+  MatAutocompleteTrigger,
+} from '@angular/material/autocomplete'
+import { Observable, ReplaySubject, Subscription } from 'rxjs'
 import {
   debounceTime,
   distinctUntilChanged,
   filter,
   finalize,
   switchMap,
+  take,
   tap,
 } from 'rxjs/operators'
-import { MatAutocompleteTrigger } from '@angular/material/autocomplete'
-import { FormControl } from '@angular/forms'
 
 export type AutcompleteItem = unknown
 
@@ -28,17 +35,21 @@ export type AutcompleteItem = unknown
   styleUrls: ['./autocomplete.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AutocompleteComponent implements OnInit {
+export class AutocompleteComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() placeholder: string
   @Input() action: (value: string) => Observable<AutcompleteItem[]>
   @Output() itemSelected = new EventEmitter<AutcompleteItem>()
   @Output() inputSubmited = new EventEmitter<string>()
   @ViewChild(MatAutocompleteTrigger) triggerRef: MatAutocompleteTrigger
+  @ViewChild(MatAutocomplete) autocomplete: MatAutocomplete
   @ViewChild('searchInput') inputRef: ElementRef<HTMLInputElement>
+  selectionSubject = new ReplaySubject<MatAutocompleteSelectedEvent>(1)
 
   searching: boolean
   suggestions$: Observable<AutcompleteItem[]>
   control = new FormControl()
+  subscription = new Subscription()
+  cancelEnter = true
 
   @Input() itemToStringFn: (AutcompleteItem) => string = (item) => item
   @Input() displayWithFn: (AutcompleteItem) => string = (item) => item
@@ -52,18 +63,38 @@ export class AutocompleteComponent implements OnInit {
       switchMap((value) => this.action(value)),
       finalize(() => (this.searching = false))
     )
+    this.subscription = this.control.valueChanges.subscribe((any) => {
+      if (any !== '') {
+        this.cancelEnter = false
+      }
+    })
+  }
+
+  ngAfterViewInit(): void {
+    this.autocomplete.optionSelected.subscribe(this.selectionSubject)
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe()
   }
 
   clear(): void {
     this.inputRef.nativeElement.value = ''
+    this.selectionSubject
+      .pipe(take(1))
+      .subscribe((selection) => selection && selection.option.deselect())
     this.inputRef.nativeElement.focus()
     this.triggerRef.closePanel()
   }
 
-  handleEnter(value: string) {
-    this.inputSubmited.emit(value)
+  handleEnter(any: string) {
+    if (!this.cancelEnter) {
+      this.inputSubmited.emit(any)
+      this.triggerRef.closePanel()
+    }
   }
-  handleSelection(item: AutcompleteItem) {
-    this.itemSelected.emit(item)
+  handleSelection(event: MatAutocompleteSelectedEvent) {
+    this.cancelEnter = true
+    this.itemSelected.emit(event.option.value)
   }
 }


### PR DESCRIPTION
The router effect which navigates to `/search` on `RequestMoreResults` action was too eager and has been removed.
It was causing several issues
- scrolling on record view page triggers a search (infinite scrolling bug) so it goes back to search page
- race condition on record view relaoding page, the full metadata comes after the search results list so it goes back to /search and then display the record view while on `/search` route

So we manually redirects to` /search` when desired in the datahub application.

- on fuzzy search input submission
- on datahub click from the breadcrumb
