### PR TITLE
Display data from ESRI:REST services in table and map

### DIFF
--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
@@ -4,6 +4,7 @@ import {
   getDownloadFormat,
   getLinksWithEsriRestFormats,
   getLinksWithWfsFormats,
+  LinkHelperService,
 } from '@geonetwork-ui/feature/search'
 import { map, startWith, switchMap } from 'rxjs/operators'
 import { MdViewFacade } from '../state'
@@ -16,22 +17,18 @@ import { combineLatest, from } from 'rxjs'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataDownloadsComponent {
-  constructor(public facade: MdViewFacade) {}
+  constructor(
+    public facade: MdViewFacade,
+    private linkHelper: LinkHelperService
+  ) {}
 
   error: string = null
 
   links$ = this.facade.downloadLinks$.pipe(
     switchMap((links) => {
-      const wfsLinks = links.filter(
-        (link) =>
-          /^OGC:WFS/.test(link.protocol) ||
-          (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
-      )
+      const wfsLinks = links.filter((link) => this.linkHelper.isWfsLink(link))
       const esriRestLinks = links
-        .filter(
-          (link) =>
-            /^ESRI:REST/.test(link.protocol) && /FeatureServer/.test(link.url)
-        )
+        .filter((link) => this.linkHelper.isEsriRestFeatureServer(link))
         .flatMap((link) => getLinksWithEsriRestFormats(link))
       const otherLinks = links
         .filter((link) => !/^OGC:WFS|ESRI:REST/.test(link.protocol))

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -26,6 +26,7 @@ import { MetadataLinkValid } from '@geonetwork-ui/util/shared'
 import { readDataset } from '@geonetwork-ui/data-fetcher'
 import { fromPromise } from 'rxjs/internal-compatibility'
 import { WfsEndpoint } from '@camptocamp/ogc-client'
+import { getEsriRestDataUrl } from '@geonetwork-ui/feature/search'
 
 @Component({
   selector: 'gn-ui-data-view-map',
@@ -144,6 +145,20 @@ export class DataViewMapComponent {
     } else if (link.protocol.startsWith('WWW:DOWNLOAD')) {
       return fromPromise(
         readDataset(link.url, 'geojson').then((features) => ({
+          type: MapContextLayerTypeEnum.GEOJSON,
+          data: {
+            type: 'FeatureCollection',
+            features,
+          },
+        }))
+      )
+    } else if (
+      /^ESRI:REST/.test(link.protocol) &&
+      /FeatureServer/.test(link.url)
+    ) {
+      const url = getEsriRestDataUrl(link, 'geojson')
+      return fromPromise(
+        readDataset(url, 'geojson').then((features) => ({
           type: MapContextLayerTypeEnum.GEOJSON,
           data: {
             type: 'FeatureCollection',

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -121,7 +121,10 @@ export class DataViewMapComponent {
         type: MapContextLayerTypeEnum.WMS,
         name: link.name,
       })
-    } else if (link.protocol.startsWith('OGC:WFS')) {
+    } else if (
+      link.protocol.startsWith('OGC:WFS') ||
+      (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
+    ) {
       return fromPromise(
         new WfsEndpoint(link.url).isReady().then((endpoint) => {
           if (!endpoint.supportsJson(link.name)) {

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
@@ -70,7 +70,10 @@ export class DataViewTableComponent {
   constructor(private mdViewFacade: MdViewFacade) {}
 
   fetchData(link: MetadataLinkValid): Observable<{ id: string | number }[]> {
-    if (link.protocol.startsWith('OGC:WFS')) {
+    if (
+      link.protocol.startsWith('OGC:WFS') ||
+      (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
+    ) {
       return fromPromise(
         new WfsEndpoint(link.url).isReady().then((endpoint) => {
           if (!endpoint.supportsJson(link.name)) {

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
@@ -21,6 +21,7 @@ import {
 import { MdViewFacade } from '../state'
 import { WfsEndpoint } from '@camptocamp/ogc-client'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
+import { getEsriRestDataUrl } from '@geonetwork-ui/feature/search'
 
 marker('map.wfs.geojson.not.supported')
 
@@ -92,6 +93,19 @@ export class DataViewTableComponent {
     } else if (link.protocol.startsWith('WWW:DOWNLOAD')) {
       return fromPromise(
         readDataset(link.url).then((features) =>
+          features.map((f) => ({
+            id: f.id,
+            ...f.properties,
+          }))
+        )
+      )
+    } else if (
+      /^ESRI:REST/.test(link.protocol) &&
+      /FeatureServer/.test(link.url)
+    ) {
+      const url = getEsriRestDataUrl(link, 'geojson')
+      return fromPromise(
+        readDataset(url, 'geojson').then((features) =>
           features.map((f) => ({
             id: f.id,
             ...f.properties,

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
@@ -36,12 +36,20 @@
     </div>
   </mat-tab>
 
-  <mat-tab [disabled]="(displayMap$ | async) === false">
+  <mat-tab
+    [disabled]="
+      (displayMap$ | async) === false && (displayData$ | async) === false
+    "
+  >
     <ng-template mat-tab-label>
       <mat-icon class="mr-3">map</mat-icon>
       <span translate>record.tab.map</span>
     </ng-template>
-    <div class="block mt-4" style="height: 500px" *ngIf="displayMap$ | async">
+    <div
+      class="block mt-4"
+      style="height: 500px"
+      *ngIf="(displayMap$ | async) || (displayData$ | async)"
+    >
       <gn-ui-data-view-map></gn-ui-data-view-map>
     </div>
   </mat-tab>

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
@@ -36,20 +36,12 @@
     </div>
   </mat-tab>
 
-  <mat-tab
-    [disabled]="
-      (displayMap$ | async) === false && (displayData$ | async) === false
-    "
-  >
+  <mat-tab [disabled]="(displayMap$ | async) === false">
     <ng-template mat-tab-label>
       <mat-icon class="mr-3">map</mat-icon>
       <span translate>record.tab.map</span>
     </ng-template>
-    <div
-      class="block mt-4"
-      style="height: 500px"
-      *ngIf="(displayMap$ | async) || (displayData$ | async)"
-    >
+    <div class="block mt-4" style="height: 500px" *ngIf="displayMap$ | async">
       <gn-ui-data-view-map></gn-ui-data-view-map>
     </div>
   </mat-tab>

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.spec.ts
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.spec.ts
@@ -82,9 +82,11 @@ describe('RecordMetadataComponent', () => {
   })
   describe('Map', () => {
     let mapTab
-    describe('when no MAPAPI link', () => {
+    describe('when no MAPAPI and no DATA link', () => {
       beforeEach(() => {
         facade.mapApiLinks$.next(null)
+        fixture.detectChanges()
+        facade.dataLinks$.next(null)
         fixture.detectChanges()
         mapTab = fixture.debugElement.queryAll(By.css('mat-tab'))[2]
       })

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.ts
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { MapManagerService } from '@geonetwork-ui/feature/map'
 import { MdViewFacade } from '../state/mdview.facade'
 import { map } from 'rxjs/operators'
+import { combineLatest } from 'rxjs'
 
 @Component({
   selector: 'gn-ui-record-metadata',
@@ -10,8 +11,15 @@ import { map } from 'rxjs/operators'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RecordMetadataComponent {
-  displayMap$ = this.facade.mapApiLinks$.pipe(
-    map((links) => !!links && links.length > 0)
+  displayMap$ = combineLatest([
+    this.facade.mapApiLinks$,
+    this.facade.dataLinks$,
+  ]).pipe(
+    map(
+      ([mapLinks, dataLinks]) =>
+        (!!mapLinks && mapLinks.length > 0) ||
+        (!!dataLinks && dataLinks.length > 0)
+    )
   )
   displayData$ = this.facade.dataLinks$.pipe(
     map((links) => !!links && links.length > 0)

--- a/libs/feature/search/src/lib/utils/links/link-classifier.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/links/link-classifier.service.spec.ts
@@ -35,6 +35,7 @@ describe('LinkClassifierService', () => {
         expect(service.getUsagesForLink(LINK_FIXTURES.geodataRest)).toEqual([
           LinkUsage.API,
           LinkUsage.DOWNLOAD,
+          LinkUsage.DATA,
         ])
       })
     })

--- a/libs/feature/search/src/lib/utils/links/link-classifier.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/links/link-classifier.service.spec.ts
@@ -44,6 +44,7 @@ describe('LinkClassifierService', () => {
         expect(service.getUsagesForLink(LINK_FIXTURES.geodataRestWfs)).toEqual([
           LinkUsage.API,
           LinkUsage.DOWNLOAD,
+          LinkUsage.DATA,
         ])
       })
     })

--- a/libs/feature/search/src/lib/utils/links/link-classifier.service.ts
+++ b/libs/feature/search/src/lib/utils/links/link-classifier.service.ts
@@ -35,7 +35,7 @@ export class LinkClassifierService {
       if (/^OGC:WFS/.test(link.protocol))
         return [LinkUsage.API, LinkUsage.DOWNLOAD, LinkUsage.DATA]
       if (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
-        return [LinkUsage.API, LinkUsage.DOWNLOAD]
+        return [LinkUsage.API, LinkUsage.DOWNLOAD, LinkUsage.DATA]
       if (/^ESRI:REST/.test(link.protocol) && /FeatureServer/.test(link.url))
         return [LinkUsage.API, LinkUsage.DOWNLOAD, LinkUsage.DATA]
       if (/^OGC:WMS/.test(link.protocol))

--- a/libs/feature/search/src/lib/utils/links/link-classifier.service.ts
+++ b/libs/feature/search/src/lib/utils/links/link-classifier.service.ts
@@ -37,7 +37,7 @@ export class LinkClassifierService {
       if (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
         return [LinkUsage.API, LinkUsage.DOWNLOAD]
       if (/^ESRI:REST/.test(link.protocol) && /FeatureServer/.test(link.url))
-        return [LinkUsage.API, LinkUsage.DOWNLOAD]
+        return [LinkUsage.API, LinkUsage.DOWNLOAD, LinkUsage.DATA]
       if (/^OGC:WMS/.test(link.protocol))
         return [LinkUsage.API, LinkUsage.MAPAPI]
       if (/^OGC:WMTS/.test(link.protocol))

--- a/libs/feature/search/src/lib/utils/links/link-helper.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/links/link-helper.service.spec.ts
@@ -11,6 +11,7 @@ import {
 import { LinkClassifierService, LinkUsage } from './link-classifier.service'
 
 import { LinkHelperService } from './link-helper.service'
+import { LINK_FIXTURES } from './link.fixtures'
 
 let linkUsage: LinkUsage[]
 const linkClassifierMock = {
@@ -233,6 +234,45 @@ describe('LinkHelperService', () => {
           true
         )
       })
+    })
+  })
+  describe('#isWmsLink', () => {
+    it('returns true for a WMS link', () => {
+      expect(service.isWmsLink(LINK_FIXTURES.geodataWms)).toBeTruthy()
+    })
+    it('returns false for a WFS link', () => {
+      expect(service.isWmsLink(LINK_FIXTURES.geodataWfs)).toBeFalsy()
+    })
+  })
+  describe('#isWfsLink', () => {
+    it('returns true for a WFS link', () => {
+      expect(service.isWfsLink(LINK_FIXTURES.geodataWfs)).toBeTruthy()
+    })
+    it('returns true for a ESRI WFS link', () => {
+      expect(service.isWfsLink(LINK_FIXTURES.geodataRestWfs)).toBeTruthy()
+    })
+    it('returns false for a WFS link', () => {
+      expect(service.isWfsLink(LINK_FIXTURES.geodataWms)).toBeFalsy()
+    })
+  })
+  describe('#isEsriRestFeatureServer', () => {
+    it('returns true for a ESRI:REST FeatureServer link', () => {
+      expect(
+        service.isEsriRestFeatureServer(LINK_FIXTURES.geodataRest)
+      ).toBeTruthy()
+    })
+    it('returns false for a ESRI:REST WFSServer link', () => {
+      expect(
+        service.isEsriRestFeatureServer(LINK_FIXTURES.geodataRestWfs)
+      ).toBeFalsy()
+    })
+  })
+  describe('#hasProtocolDownload', () => {
+    it('returns true for a CSV link', () => {
+      expect(service.hasProtocolDownload(LINK_FIXTURES.dataCsv)).toBeTruthy()
+    })
+    it('returns false for a WFS link', () => {
+      expect(service.hasProtocolDownload(LINK_FIXTURES.geodataWfs)).toBeFalsy()
     })
   })
 })

--- a/libs/feature/search/src/lib/utils/links/link-helper.service.ts
+++ b/libs/feature/search/src/lib/utils/links/link-helper.service.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@angular/core'
-import { MetadataLink, MetadataRecord } from '@geonetwork-ui/util/shared'
+import {
+  MetadataLink,
+  MetadataLinkValid,
+  MetadataRecord,
+} from '@geonetwork-ui/util/shared'
 import { LinkClassifierService, LinkUsage } from './link-classifier.service'
 
 @Injectable({
@@ -55,5 +59,20 @@ export class LinkHelperService {
   }
   isOtherLink(link: MetadataLink): boolean {
     return this.linkClassifier.getUsagesForLink(link).length === 0
+  }
+  isWmsLink(link: MetadataLinkValid): boolean {
+    return /^OGC:WMS/.test(link.protocol)
+  }
+  isWfsLink(link: MetadataLinkValid): boolean {
+    return (
+      /^OGC:WFS/.test(link.protocol) ||
+      (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
+    )
+  }
+  isEsriRestFeatureServer(link: MetadataLinkValid): boolean {
+    return /^ESRI:REST/.test(link.protocol) && /FeatureServer/.test(link.url)
+  }
+  hasProtocolDownload(link: MetadataLinkValid): boolean {
+    return /^WWW:DOWNLOAD/.test(link.protocol)
   }
 }

--- a/libs/feature/search/src/lib/utils/links/link-utils.spec.ts
+++ b/libs/feature/search/src/lib/utils/links/link-utils.spec.ts
@@ -4,6 +4,7 @@ import {
   checkFileFormat,
   getLinksWithEsriRestFormats,
   getLinksWithWfsFormats,
+  getEsriRestDataUrl,
 } from './link-utils'
 import { LINK_FIXTURES } from './link.fixtures'
 
@@ -176,6 +177,23 @@ describe('link utils', () => {
             url: 'https://my.esri.server/FeatureServer/query?f=geojson&where=1=1&outFields=*',
           },
         ])
+      })
+    }),
+    describe('#getEsriRestDataUrl', () => {
+      it('returns data url for ESRI:REST FeatureServer in requested format', () => {
+        expect(
+          getEsriRestDataUrl(
+            {
+              protocol: 'ESRI:REST',
+              name: 'myrestlayer',
+              format: 'arcgis geoservices rest api',
+              url: 'https://my.esri.server/FeatureServer',
+            },
+            'geojson'
+          )
+        ).toEqual(
+          'https://my.esri.server/FeatureServer/query?f=geojson&where=1=1&outFields=*'
+        )
       })
     }),
     describe('#getLinksWithWfsFormats', () => {

--- a/libs/feature/search/src/lib/utils/links/link-utils.ts
+++ b/libs/feature/search/src/lib/utils/links/link-utils.ts
@@ -70,7 +70,14 @@ export function getLinksWithEsriRestFormats(
   const formats = ['json', 'geojson']
   return formats.map((format) => ({
     ...link,
-    url: `${link.url}/query?f=${format}&where=1=1&outFields=*`,
+    url: getEsriRestDataUrl(link, format),
     format: `REST:${format}`,
   }))
+}
+
+export function getEsriRestDataUrl(
+  link: MetadataLinkValid,
+  format: string
+): string {
+  return `${link.url}/query?f=${format}&where=1=1&outFields=*`
 }


### PR DESCRIPTION
PR displays data from ESRI:REST services in table and on map. This includes `FeatureServers` and `WFSServers`. The tested `WFSServers` responded with errors however, as their `FeatureType` names did not match the link names indicated in the metadata.
Can be tested on the datahub with any service found in https://data-atmo-hdf.opendata.arcgis.com/data.json (eg. "emi hdf region 2012").
I had to enable the map for data-links to display the data on the map (which should have already been the case for a WFS without WMS before), hoping this is not a big drawback if there are only non-geographic data-links and no map-api-link.