### PR TITLE
Fix: Rename empty string property ids to 'unknown'

### DIFF
--- a/libs/util/data-fetcher/src/parsers/json.spec.ts
+++ b/libs/util/data-fetcher/src/parsers/json.spec.ts
@@ -1,4 +1,4 @@
-import { parseJson } from './json'
+import { jsonToGeojsonFeature, parseJson } from './json'
 
 describe('parseJson', () => {
   describe('valid JSON with id', () => {
@@ -109,6 +109,29 @@ describe('parseJson', () => {
       ],
       "nom_dep": "ARIEGE",`)
       ).toThrowError('Unexpected end')
+    })
+  })
+  describe('empty string column name', () => {
+    it('is renamed to unknown', () => {
+      expect(
+        jsonToGeojsonFeature({
+          '': '',
+          code_region: '76',
+          nom_region: 'OCCITANIE',
+          geo_point_2d: [42.9178728416, 1.17961253606],
+          nom_dep: 'ARIEGE',
+        })
+      ).toEqual({
+        geometry: null,
+        properties: {
+          unknown: undefined,
+          code_region: '76',
+          nom_region: 'OCCITANIE',
+          geo_point_2d: [42.9178728416, 1.17961253606],
+          nom_dep: 'ARIEGE',
+        },
+        type: 'Feature',
+      })
     })
   })
 })

--- a/libs/util/data-fetcher/src/parsers/json.ts
+++ b/libs/util/data-fetcher/src/parsers/json.ts
@@ -13,16 +13,21 @@ export function parseJson(text: string): Feature[] {
 }
 
 export function jsonToGeojsonFeature(object: { [key: string]: any }): Feature {
-  const { id, properties } = Object.keys(object).reduce(
-    (prev, curr) =>
-      curr.toLowerCase().endsWith('id')
-        ? {
-            ...prev,
-            id: object[curr],
-          }
-        : { ...prev, properties: { ...prev.properties, [curr]: object[curr] } },
-    { id: undefined, properties: {} }
-  )
+  const { id, properties } = Object.keys(object)
+    .map((property) => (property ? property : 'unknown')) //prevent empty strings
+    .reduce(
+      (prev, curr) =>
+        curr.toLowerCase().endsWith('id')
+          ? {
+              ...prev,
+              id: object[curr],
+            }
+          : {
+              ...prev,
+              properties: { ...prev.properties, [curr]: object[curr] },
+            },
+      { id: undefined, properties: {} }
+    )
   return {
     type: 'Feature',
     geometry: null,


### PR DESCRIPTION
PR adds a small fix, renaming column names that consist of an empty string to "unknown" which currently creates a `properties` object with a missing key which breaks the table.

Can be tested with "Accroches vélos MEL" once its data formats will be harvested and available in the datahub.