### PR TITLE
Proxy service now encodes urls

### DIFF
--- a/libs/util/shared/src/lib/services/proxy.service.spec.ts
+++ b/libs/util/shared/src/lib/services/proxy.service.spec.ts
@@ -35,7 +35,7 @@ describe('ProxyService', () => {
       })
       it('applies the proxy', () => {
         expect(service.getProxiedUrl('http://anotherhost/abcd')).toEqual(
-          `https://proxy.org/abc?url=http://anotherhost/abcd`
+          `https://proxy.org/abc?url=http%3A%2F%2Fanotherhost%2Fabcd`
         )
       })
     })
@@ -46,7 +46,7 @@ describe('ProxyService', () => {
       })
       it('applies the proxy and return a fully qualified url', () => {
         expect(service.getProxiedUrl('http://anotherhost/abcd')).toEqual(
-          `http://myhost:1234/proxy?http://anotherhost/abcd`
+          `http://myhost:1234/proxy?http%3A%2F%2Fanotherhost%2Fabcd`
         )
       })
     })

--- a/libs/util/shared/src/lib/services/proxy.service.ts
+++ b/libs/util/shared/src/lib/services/proxy.service.ts
@@ -16,7 +16,7 @@ export class ProxyService {
   getProxiedUrl(url: string): string {
     if (!this.proxyPath) return url
     return new URL(
-      `${this.proxyPath}${url}`,
+      `${this.proxyPath}${encodeURIComponent(url)}`,
       window.location.toString()
     ).toString()
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "geonetwork-ui",
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -23,7 +24,7 @@
         "@angular/router": "12.2.0",
         "@biesbjerg/ngx-translate-extract": "^7.0.4",
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-        "@camptocamp/ogc-client": "^0.3.2",
+        "@camptocamp/ogc-client": "^0.3.3",
         "@ngrx/router-store": "^12.2.0",
         "@nguniversal/express-engine": "^12.0.1",
         "@ngx-translate/core": "^13.0.0",
@@ -2736,9 +2737,9 @@
       }
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.2.tgz",
-      "integrity": "sha512-Tsk3Mbf8qZ9v01nsRJKCVbmfloRChFR/8HjECtEn1jBI2rvQZIiUUVCWNWT7m+rHBEqSg5o8dRd27W5EZNr+9g==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.3.tgz",
+      "integrity": "sha512-Up+elu5lxEOKWOT+odWn9pmGt0iAi3T48xWHbY/6c9/jRnsjdrhzXaqxExq5OLjS36PovKWVGYB4rDkt3feeFQ==",
       "dependencies": {
         "@rgrove/parse-xml": "^3.0.0"
       }
@@ -44021,9 +44022,9 @@
       }
     },
     "@camptocamp/ogc-client": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.2.tgz",
-      "integrity": "sha512-Tsk3Mbf8qZ9v01nsRJKCVbmfloRChFR/8HjECtEn1jBI2rvQZIiUUVCWNWT7m+rHBEqSg5o8dRd27W5EZNr+9g==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.3.tgz",
+      "integrity": "sha512-Up+elu5lxEOKWOT+odWn9pmGt0iAi3T48xWHbY/6c9/jRnsjdrhzXaqxExq5OLjS36PovKWVGYB4rDkt3feeFQ==",
       "requires": {
         "@rgrove/parse-xml": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@angular/router": "12.2.0",
     "@biesbjerg/ngx-translate-extract": "^7.0.4",
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-    "@camptocamp/ogc-client": "^0.3.2",
+    "@camptocamp/ogc-client": "^0.3.3",
     "@ngrx/router-store": "^12.2.0",
     "@nguniversal/express-engine": "^12.0.1",
     "@ngx-translate/core": "^13.0.0",


### PR DESCRIPTION
This required an adaptation in ogc-client, see: https://github.com/camptocamp/ogc-client/commit/7813e712b230699d3f53f2a3e35813f64fccf89f