### PR TITLE
Handle landing page link in metadata record

### DIFF
--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
@@ -22,6 +22,7 @@
       [metadata]="facade.metadata$ | async"
       [incomplete]="facade.isIncomplete$ | async"
       [otherLinks]="facade.otherLinks$ | async"
+      [landingPages]="facade.landingPageLinks$ | async"
     >
     </gn-ui-metadata-info>
   </mat-tab>

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -60,6 +60,9 @@ export class MdViewFacade {
   geoDataLinks$ = this.validLinks$.pipe(
     map((links) => links.filter((link) => this.helper.isGeoDataLink(link)))
   )
+  landingPageLinks$ = this.validLinks$.pipe(
+    map((links) => links.filter((link) => this.helper.isLandingPage(link)))
+  )
   otherLinks$ = this.validLinks$.pipe(
     map((links) => links.filter((link) => this.helper.isOtherLink(link)))
   )

--- a/libs/feature/search/src/lib/utils/links/link-classifier.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/links/link-classifier.service.spec.ts
@@ -89,5 +89,12 @@ describe('LinkClassifierService', () => {
         expect(service.getUsagesForLink(LINK_FIXTURES.readmeLink)).toEqual([])
       })
     })
+    describe('for a landing page', () => {
+      it('returns landingpage usage', () => {
+        expect(service.getUsagesForLink(LINK_FIXTURES.landingPage)).toEqual([
+          LinkUsage.LANDINGPAGE,
+        ])
+      })
+    })
   })
 })

--- a/libs/feature/search/src/lib/utils/links/link-classifier.service.ts
+++ b/libs/feature/search/src/lib/utils/links/link-classifier.service.ts
@@ -7,7 +7,10 @@ export enum LinkUsage {
   DOWNLOAD = 'download',
   DATA = 'data',
   GEODATA = 'geodata',
+  LANDINGPAGE = 'landingpage',
 }
+
+const LANDINGPAGE_LINK_PROTOCOL = 'WWW:LINK:LANDING_PAGE'
 
 @Injectable({
   providedIn: 'root',
@@ -58,6 +61,9 @@ export class LinkClassifierService {
         return [LinkUsage.API, LinkUsage.MAPAPI]
       if (/^OGC:WMTS/.test(link.protocol))
         return [LinkUsage.API, LinkUsage.MAPAPI]
+      if (link.protocol === LANDINGPAGE_LINK_PROTOCOL) {
+        return [LinkUsage.LANDINGPAGE]
+      }
     }
     return []
   }

--- a/libs/feature/search/src/lib/utils/links/link-helper.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/links/link-helper.service.spec.ts
@@ -201,6 +201,30 @@ describe('LinkHelperService', () => {
     })
   })
 
+  describe('#isLandingPage', () => {
+    describe('LANDINGPAGE usage', () => {
+      beforeEach(() => {
+        linkUsage = [LinkUsage.LANDINGPAGE]
+        result = service.isLandingPage(link)
+      })
+      it('calls #getUsagesForLink', () => {
+        expect(linkClassifierMock.getUsagesForLink).toHaveBeenCalledWith(link)
+      })
+      it('returns true', () => {
+        expect(result).toBe(true)
+      })
+    })
+    describe('no MAP usage', () => {
+      beforeEach(() => {
+        linkUsage = [LinkUsage.MAPAPI]
+        result = service.isLandingPage(link)
+      })
+      it('returns false', () => {
+        expect(result).toBe(false)
+      })
+    })
+  })
+
   describe('#protocols', () => {
     describe('#hasDownloadProtocols', () => {
       beforeEach(() => {

--- a/libs/feature/search/src/lib/utils/links/link-helper.service.ts
+++ b/libs/feature/search/src/lib/utils/links/link-helper.service.ts
@@ -74,6 +74,11 @@ export class LinkHelperService {
       (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
     )
   }
+  isLandingPage(link: MetadataLink): boolean {
+    return this.linkClassifier
+      .getUsagesForLink(link)
+      .includes(LinkUsage.LANDINGPAGE)
+  }
   isEsriRestFeatureServer(link: MetadataLinkValid): boolean {
     return /^ESRI:REST/.test(link.protocol) && /FeatureServer/.test(link.url)
   }

--- a/libs/feature/search/src/lib/utils/links/link-helper.service.ts
+++ b/libs/feature/search/src/lib/utils/links/link-helper.service.ts
@@ -37,30 +37,23 @@ export class LinkHelperService {
     return !('invalid' in link)
   }
   isApiLink(link: MetadataLink): boolean {
-    return (
-      this.linkClassifier.getUsagesForLink(link).indexOf(LinkUsage.API) > -1
-    )
+    return this.linkClassifier.getUsagesForLink(link).includes(LinkUsage.API)
   }
   isMapApiLink(link: MetadataLink): boolean {
-    return (
-      this.linkClassifier.getUsagesForLink(link).indexOf(LinkUsage.MAPAPI) > -1
-    )
+    return this.linkClassifier.getUsagesForLink(link).includes(LinkUsage.MAPAPI)
   }
   isDownloadLink(link: MetadataLink): boolean {
-    return (
-      this.linkClassifier.getUsagesForLink(link).indexOf(LinkUsage.DOWNLOAD) >
-      -1
-    )
+    return this.linkClassifier
+      .getUsagesForLink(link)
+      .includes(LinkUsage.DOWNLOAD)
   }
   isDataLink(link: MetadataLink): boolean {
-    return (
-      this.linkClassifier.getUsagesForLink(link).indexOf(LinkUsage.DATA) > -1
-    )
+    return this.linkClassifier.getUsagesForLink(link).includes(LinkUsage.DATA)
   }
   isGeoDataLink(link: MetadataLink): boolean {
-    return (
-      this.linkClassifier.getUsagesForLink(link).indexOf(LinkUsage.GEODATA) > -1
-    )
+    return this.linkClassifier
+      .getUsagesForLink(link)
+      .includes(LinkUsage.GEODATA)
   }
   isOtherLink(link: MetadataLink): boolean {
     return this.linkClassifier.getUsagesForLink(link).length === 0

--- a/libs/feature/search/src/lib/utils/links/link.fixtures.ts
+++ b/libs/feature/search/src/lib/utils/links/link.fixtures.ts
@@ -122,4 +122,9 @@ export const LINK_FIXTURES = {
     name: 'myotherrestlayer',
     url: 'https://my.esri.server/MapServer',
   },
+  landingPage: {
+    protocol: 'WWW:LINK:LANDING_PAGE',
+    name: 'landingpage link',
+    url: 'https://landing.page',
+  },
 }

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
@@ -11,6 +11,7 @@ export class MetadataInfoComponent {
   @Input() metadata: MetadataRecord
   @Input() incomplete: boolean
   @Input() otherLinks: MetadataLinkValid[]
+  @Input() landingPages: MetadataLinkValid[]
 
   fieldReady(propName: string) {
     return !this.incomplete || propName in this.metadata


### PR DESCRIPTION
Ad a new `LinkUsage.LANDINGPAGE` if the link has the protocol equal to `WWW:LINK:LANDING_PAGE`.
The landing page link is added as an observable in the record state and passed to the `metadata-info-component`.

