### PR TITLE
Restore docker build with the new config system

### DIFF
--- a/apps/datahub/README.md
+++ b/apps/datahub/README.md
@@ -54,3 +54,17 @@ Notice how the `GN4_API_URL` and `PROXY_PATH` variables are used to override any
 **This override will happen everytime the docker container is started.**
 
 The application will be available on http://localhost:8080/datahub/.
+
+### Specifying a custom configuration file
+
+If the `GN4_API_URL` and `PROXY_PATH` environment variables are not enough and you want to specify a full configuration file,
+you can do so like this:
+
+```bash
+# this assumes a custom `default.toml` file is located in the /home/user/custom-conf directory:
+$ docker run -p 8080:80 \
+             -v /home/user/custom-conf:/conf \
+             geonetwork-ui/datahub
+```
+
+If a `default.toml` file is found in the `/conf` folder of the app container at startup, it will be used instead of the default one.

--- a/apps/datahub/README.md
+++ b/apps/datahub/README.md
@@ -61,10 +61,10 @@ If the `GN4_API_URL` and `PROXY_PATH` environment variables are not enough and y
 you can do so like this:
 
 ```bash
-# this assumes a custom `default.toml` file is located in the /home/user/custom-conf directory:
+# this assumes a file named `default.toml` is located in the /home/user/custom-conf directory:
 $ docker run -p 8080:80 \
              -v /home/user/custom-conf:/conf \
              geonetwork-ui/datahub
 ```
 
-If a `default.toml` file is found in the `/conf` folder of the app container at startup, it will be used instead of the default one.
+If a file named `default.toml` is found in the `/conf` folder _of the app container_ at startup, it will be used by the application.

--- a/apps/datahub/README.md
+++ b/apps/datahub/README.md
@@ -16,11 +16,7 @@ will run `datahub` as an Angular application available on localhost:4200.
 
 ## Configuration
 
-### API url
-
-By default it uses GN4 API `/geonetwork/srv/api`.
-
-You can override this URL with the ENV variable `${GN4_API_URL}`.
+See the [main README section for more info](../../README.md#application-configuration).
 
 ### Proxy
 
@@ -29,24 +25,11 @@ CORS limitations).
 
 By default it is disabled in order not to hide those issues to the user.
 
-You can specify a custom proxy path using the ENV variable `${PROXY_PATH}`. The proxy is disabled when
+You can specify a custom proxy path using the `proxy_path` setting in the `[global]` section of the app configuration file. The proxy is disabled when
 no path is defined.
 
 Please note that during development a proxy is provided by webpack on the `/dev-proxy?` url path. **It is
 not used by default in the Datahub app, you will have to set it up yourself.**
-
-### Applying configuration
-
-Once you have set up the above parameters using environment variables, you can then automatically
-generate an `assets/env.js` file using the following commands from the app directory:
-
-```
-# Set environment variable
-export GN4_API_URL="https://my.gn4.instance/geonetwork/srv/api"
-export PROXY_PATH="https://my.gn4.instance/proxy?url="
-# Replace variables in env.js
-envsubst < src/assets/env.template.js > src/assets/env.js
-```
 
 ## Using with Docker
 
@@ -66,5 +49,8 @@ $ docker run -p 8080:80 \
              -e PROXY_PATH=/proxy?url= \
              geonetwork-ui/datahub
 ```
+
+Notice how the `GN4_API_URL` and `PROXY_PATH` variables are used to override any values present in the app configuration file.
+**This override will happen everytime the docker container is started.**
 
 The application will be available on http://localhost:8080/datahub/.

--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -91,7 +91,8 @@ export class AppModule {
       getThemeConfig().MAIN_COLOR,
       getThemeConfig().BACKGROUND_COLOR,
       getThemeConfig().MAIN_FONT,
-      getThemeConfig().TITLE_FONT
+      getThemeConfig().TITLE_FONT,
+      getThemeConfig().FONTS_STYLESHEET_URL
     )
   }
 }

--- a/apps/datahub/src/index.html
+++ b/apps/datahub/src/index.html
@@ -6,11 +6,8 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap"
-      rel="stylesheet"
-    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"

--- a/apps/datahub/src/styles.css
+++ b/apps/datahub/src/styles.css
@@ -5,6 +5,7 @@
 html,
 body {
   height: 100%;
+  color: var(--color-main);
 }
 body {
   margin: 0;

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -36,17 +36,12 @@ background_color = "#fdfbff"
 # [translations.fr]
 # "results.sortBy.dateStamp" = "Dernière fois que quelqu'un a modifié quelque chose"
 #
-# Note 1:
+# Note:
 #   translation keys ending with ".html" _can_ contain HTML markup, including inline CSS:
 #     "catalog.welcome.html" = """
 #     Welcome to <span class="text-primary">Organization</span>'s<br>
 #     wonderful <span style="font-size: 1.2em;">data catalogue</span>
 #     """
-#
-# Note 2:
-#   translation keys _have_ to be written in quotes:
-#     "results.sortBy": OK
-#     results.sortBy: not OK
 
 [translations.en]
-"datahub.header.title.html" = '<div class="text-white">Toutes les <span class="text-primary">données<br>publiques</span> de mon organisation</div>'
+datahub.header.title.html = '<div class="text-white">Toutes les <span class="text-primary">données<br>publiques</span> de mon organisation</div>'

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -1,5 +1,7 @@
-# Common configuration for all GeoNetwork-UI applications
+# GeoNetwork-UI configuration
 # Note: this file's syntax is TOML (https://toml.io/)
+
+### GLOBAL SETTINGS
 
 [global]
 # This URL (relative or absolute) must point to the API endpoint of a GeoNetwork4 instance
@@ -9,7 +11,8 @@ geonetwork4_api_url = "/geonetwork/srv/api"
 # This is an optional parameter: leave empty to disable proxy usage
 proxy_path = ""
 
-# Theme parameters, used to customize appearance
+### VISUAL THEME
+
 # All parameters are expressed in CSS format, see:
 #  - for color: https://developer.mozilla.org/en-US/docs/Web/CSS/color
 #  - for font families: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family
@@ -18,24 +21,31 @@ primary_color = "#0f4395"
 secondary_color = "#c2e9dc"
 main_color = "#212029" # All-purpose text color
 background_color = "#fdfbff"
-# custom fonts are optional
-#main_font = "My Custom Font", fallback-font
-#title_font = "My Custom Title Font", fallback-font-title
+# main_font = "My Custom Font", fallback-font
+# title_font = "My Custom Title Font", fallback-font-title
+
+### TRANSLATIONS
 
 # To override translations in a specific language, use a 'translations.xx' section where 'xx' is a language code.
 # Language codes are expressed in ISO 639-1 codes, see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-#
 # Example:
+#
 # [translations.en]
 # "results.sortBy.dateStamp" = "Last time someone changed something"
 # [translations.fr]
 # "results.sortBy.dateStamp" = "Dernière fois que quelqu'un a modifié quelque chose"
 #
-# Note that translation keys ending with ".html" _can_ contain HTML markup, including inline CSS:
-# "catalog.welcome.html" = """
-# Welcome to <span class="text-primary">Organization</span>'s<br>
-# wonderful <span style="font-size: 1.2em;">data catalogue</span>
-# """
+# Note 1:
+#   translation keys ending with ".html" _can_ contain HTML markup, including inline CSS:
+#     "catalog.welcome.html" = """
+#     Welcome to <span class="text-primary">Organization</span>'s<br>
+#     wonderful <span style="font-size: 1.2em;">data catalogue</span>
+#     """
+#
+# Note 2:
+#   translation keys _have_ to be written in quotes:
+#     "results.sortBy": OK
+#     results.sortBy: not OK
 
 [translations.en]
 "datahub.header.title.html" = '<div class="text-white">Toutes les <span class="text-primary">données<br>publiques</span> de mon organisation</div>'

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -32,13 +32,13 @@ background_color = "#fdfbff"
 # Example:
 #
 # [translations.en]
-# "results.sortBy.dateStamp" = "Last time someone changed something"
+# results.sortBy.dateStamp = "Last time someone changed something"
 # [translations.fr]
-# "results.sortBy.dateStamp" = "Dernière fois que quelqu'un a modifié quelque chose"
+# results.sortBy.dateStamp = "Dernière fois que quelqu'un a modifié quelque chose"
 #
 # Note:
 #   translation keys ending with ".html" _can_ contain HTML markup, including inline CSS:
-#     "catalog.welcome.html" = """
+#     catalog.welcome.html = """
 #     Welcome to <span class="text-primary">Organization</span>'s<br>
 #     wonderful <span style="font-size: 1.2em;">data catalogue</span>
 #     """

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -23,6 +23,7 @@ main_color = "#212029" # All-purpose text color
 background_color = "#fdfbff"
 # main_font = "My Custom Font", fallback-font
 # title_font = "My Custom Title Font", fallback-font-title
+# fonts_stylesheet_url = "https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Permanent+Marker&display=swap"
 
 ### TRANSLATIONS
 

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -143,6 +143,8 @@ describe('app config utils', () => {
           PRIMARY_COLOR: '#093564',
           SECONDARY_COLOR: '#c2e9dc',
           TITLE_FONT: 'serif',
+          FONTS_STYLESHEET_URL:
+            'https://fonts.googleapis.com/css2?family=Open+Sans',
         })
       })
     })

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -157,6 +157,10 @@ describe('app config utils', () => {
         expect(getCustomTranslations('de')).toEqual({
           'my.first.key': 'Erste Etikett.',
         })
+        expect(getCustomTranslations('fr')).toEqual({
+          'my.sample.text': 'Un bon exemple de texte.',
+          'my.quoted.text': 'du texte entre guillements.',
+        })
       })
       it('returns an empty object if no translation defined', () => {
         expect(getCustomTranslations('nl')).toEqual({})

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -21,8 +21,9 @@ interface ThemeConfig {
   SECONDARY_COLOR: string
   MAIN_COLOR: string
   BACKGROUND_COLOR: string
-  MAIN_FONT: string
-  TITLE_FONT: string
+  MAIN_FONT?: string
+  TITLE_FONT?: string
+  FONTS_STYLESHEET_URL?: string
 }
 let themeConfig: ThemeConfig = null
 
@@ -97,7 +98,7 @@ export function loadAppConfig() {
       const themeCheck = checkKeys(
         theme || {},
         ['primary_color', 'secondary_color', 'main_color', 'background_color'],
-        ['main_font', 'title_font']
+        ['main_font', 'title_font', 'fonts_stylesheet_url']
       )
       if (themeCheck.missing.length) {
         errors.push(`In the [theme] section: ${themeCheck.missing.join(', ')}`)
@@ -125,6 +126,7 @@ ${warnings.join('\n')}`)
         BACKGROUND_COLOR: theme.background_color,
         TITLE_FONT: theme.title_font,
         MAIN_FONT: theme.main_font,
+        FONTS_STYLESHEET_URL: theme.fonts_stylesheet_url,
       }
       customTranslations = translations || {}
 

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -10,6 +10,7 @@ main_color = "#212029" # All-purpose text color
 background_color = "#fdfbff"
 main_font = 'sans-serif'
 title_font = 'serif'
+fonts_stylesheet_url = "https://fonts.googleapis.com/css2?family=Open+Sans"
 
 [translations.en]
 "my.first.key" = 'First label.'

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -19,8 +19,9 @@ Second label,
 on two lines."""
 
 [translations.de]
-"my.first.key" = 'Erste Etikett.'
+my.first.key = 'Erste Etikett.'
 
 [translations.fr]
-"my.sample.text" = "Un bon exemple de texte."
+my.sample.text = "Un bon exemple de texte."
+"my.quoted.text" = 'du texte entre guillements.'
 `

--- a/libs/util/i18n/src/lib/file.translate.loader.spec.ts
+++ b/libs/util/i18n/src/lib/file.translate.loader.spec.ts
@@ -76,6 +76,7 @@ describe('FileTranslateLoader', () => {
         expect(translations).toEqual({
           'second.label': 'Deuxième libellé.',
           'my.sample.text': 'Un bon exemple de texte.',
+          'my.quoted.text': 'du texte entre guillements.',
         })
       })
     })

--- a/libs/util/shared/src/lib/services/theme.service.ts
+++ b/libs/util/shared/src/lib/services/theme.service.ts
@@ -16,7 +16,8 @@ export class ThemeService {
     mainColor: string,
     backgroundColor: string,
     mainFont?: string,
-    titleFont?: string
+    titleFont?: string,
+    fontsStylesheetUrl?: string
   ) {
     const applyColor = (name: string, color) => {
       document.documentElement.style.setProperty(`--color-${name}`, color.css())
@@ -80,6 +81,14 @@ export class ThemeService {
         `--font-family-title`,
         titleFont
       )
+    }
+
+    if (fontsStylesheetUrl) {
+      const link = document.createElement('link')
+      link.href = fontsStylesheetUrl
+      link.rel = 'stylesheet'
+      link.type = 'text/css'
+      document.head.append(link)
     }
   }
 

--- a/tools/docker/Dockerfile.apps
+++ b/tools/docker/Dockerfile.apps
@@ -1,7 +1,7 @@
 # This dockerfile should work for all traditional apps,
 # i.e. it only sets up a nginx server with the app dist folder
 
-FROM nginx
+FROM nginx:1.21.4-alpine
 
 ARG APP_NAME="search"
 ENV APP_NAME=${APP_NAME}
@@ -10,9 +10,11 @@ ENV PROXY_PATH ""
 
 COPY dist/apps/${APP_NAME} /usr/share/nginx/html/${APP_NAME}
 COPY tools/docker/docker-entrypoint.sh /
+
+# copy default NGINX conf & put the app name in it
 COPY tools/docker/nginx.apps.conf /etc/nginx/conf.d/default.conf
 RUN sed -i "s/APP_NAME/${APP_NAME}/" /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 
-ENTRYPOINT ["/docker-entrypoint.sh", "nginx", "-g", "daemon off;"]
+ENTRYPOINT ["sh", "/docker-entrypoint.sh", "nginx", "-g", "daemon off;"]

--- a/tools/docker/docker-entrypoint.sh
+++ b/tools/docker/docker-entrypoint.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
 
-CONFIG_FILE=assets/configuration/default.toml
+CONFIG_FILE_PATH=assets/configuration/
+CONFIG_FILE_NAME=default.toml
 
-# Modify the GN4 url and proxy path based on env variables (if defined)
-if [ ! -z "${GN4_API_URL}" ]
+# copy the conf file from /conf if present
+if [ -f "/conf/${CONFIG_FILE_NAME}" ]
 then
-  sed -i "s%geonetwork4_api_url = \".*\"%geonetwork4_api_url = \"${GN4_API_URL}\"%" /usr/share/nginx/html/${APP_NAME}/${CONFIG_FILE}
-  echo "[INFO] Replaced GN4 url in conf with: ${GN4_API_URL}"
+  cp /conf/${CONFIG_FILE_NAME} /usr/share/nginx/html/${APP_NAME}/${CONFIG_FILE_PATH}${CONFIG_FILE_NAME}
+  echo "[INFO] Copied custom configuration file located in /conf/${CONFIG_FILE_NAME}"
+else
+  # Modify the GN4 url and proxy path based on env variables (if defined)
+  if [ ! -z "${GN4_API_URL}" ]
+  then
+    sed -i "s%geonetwork4_api_url = \".*\"%geonetwork4_api_url = \"${GN4_API_URL}\"%" /usr/share/nginx/html/${APP_NAME}/${CONFIG_FILE_PATH}${CONFIG_FILE_NAME}
+    echo "[INFO] Replaced GN4 url in conf with: ${GN4_API_URL}"
+  fi
+  if [ ! -z "${PROXY_PATH}" ]
+  then
+    sed -i "s%proxy_path = \".*\"%proxy_path = \"${PROXY_PATH}\"%" /usr/share/nginx/html/${APP_NAME}/${CONFIG_FILE_PATH}${CONFIG_FILE_NAME}
+    echo "[INFO] Replaced proxy path in conf with: ${PROXY_PATH}"
+  fi
 fi
-if [ ! -z "${PROXY_PATH}" ]
-then
-  sed -i "s%proxy_path = \".*\"%proxy_path = \"${PROXY_PATH}\"%" /usr/share/nginx/html/${APP_NAME}/${CONFIG_FILE}
-  echo "[INFO] Replaced proxy path in conf with: ${PROXY_PATH}"
-fi
+
 
 exec "$@"

--- a/tools/docker/docker-entrypoint.sh
+++ b/tools/docker/docker-entrypoint.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
-envsubst < /usr/share/nginx/html/${APP_NAME}/assets/env.template.js > /usr/share/nginx/html/${APP_NAME}/assets/env.js
+CONFIG_FILE=assets/configuration/default.toml
+
+# Modify the GN4 url and proxy path based on env variables (if defined)
+if [ ! -z "${GN4_API_URL}" ]
+then
+  sed -i "s%geonetwork4_api_url = \".*\"%geonetwork4_api_url = \"${GN4_API_URL}\"%" /usr/share/nginx/html/${APP_NAME}/${CONFIG_FILE}
+  echo "[INFO] Replaced GN4 url in conf with: ${GN4_API_URL}"
+fi
+if [ ! -z "${PROXY_PATH}" ]
+then
+  sed -i "s%proxy_path = \".*\"%proxy_path = \"${PROXY_PATH}\"%" /usr/share/nginx/html/${APP_NAME}/${CONFIG_FILE}
+  echo "[INFO] Replaced proxy path in conf with: ${PROXY_PATH}"
+fi
 
 exec "$@"


### PR DESCRIPTION
This PR reworks the generic dockerfile for apps and associated docker-entrypoint.sh to work with the new config file. It is still possible to specify a GN4 url and proxy path using env var, or a full config file can be given to the docker container at startup.

Also:
* apply "main" color to all text by default (in the datahub only for now)
* allow specifying custom translations without quotes in the TOML file; this is a workaround for a quirk of the TOML syntax
* allow specifying a stylesheet link for fonts (e.g. google fonts) in config

Rebased on #199 