### PR TITLE
datahub: add related record section

### DIFF
--- a/apps/datahub/src/app/header/header-record/header-record.component.ts
+++ b/apps/datahub/src/app/header/header-record/header-record.component.ts
@@ -13,6 +13,6 @@ export class HeaderRecordComponent {
 
   constructor(private searchRouter: RouterFacade) {}
   back() {
-    this.searchRouter.back()
+    this.searchRouter.goToSearch()
   }
 }

--- a/apps/datahub/src/app/record-preview-datahub/record-preview-datahub.component.html
+++ b/apps/datahub/src/app/record-preview-datahub/record-preview-datahub.component.html
@@ -13,7 +13,8 @@
   </div>
   <div class="content flex-grow mx-2 flex flex-col justify-between min-w-0">
     <div
-      class="py-2 text-primary font-medium text-xl truncate"
+      class="py-2 font-title text-xl truncate"
+      style="font-size: 21px"
       [title]="record.title"
     >
       {{ record.title }}

--- a/libs/feature/record/src/lib/feature-record.module.ts
+++ b/libs/feature/record/src/lib/feature-record.module.ts
@@ -19,7 +19,7 @@ import { MatTabsModule } from '@angular/material/tabs'
 import { MatIconModule } from '@angular/material/icon'
 import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
 import { TranslateModule } from '@ngx-translate/core'
-import { DataOtherlinksComponent } from './data-otherlinks/data-otherlinks.component';
+import { DataOtherlinksComponent } from './data-otherlinks/data-otherlinks.component'
 import { RelatedRecordsComponent } from './related-records/related-records.component'
 
 @NgModule({

--- a/libs/feature/record/src/lib/feature-record.module.ts
+++ b/libs/feature/record/src/lib/feature-record.module.ts
@@ -19,7 +19,8 @@ import { MatTabsModule } from '@angular/material/tabs'
 import { MatIconModule } from '@angular/material/icon'
 import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
 import { TranslateModule } from '@ngx-translate/core'
-import { DataOtherlinksComponent } from './data-otherlinks/data-otherlinks.component'
+import { DataOtherlinksComponent } from './data-otherlinks/data-otherlinks.component';
+import { RelatedRecordsComponent } from './related-records/related-records.component'
 
 @NgModule({
   declarations: [
@@ -29,6 +30,7 @@ import { DataOtherlinksComponent } from './data-otherlinks/data-otherlinks.compo
     DataDownloadsComponent,
     DataApisComponent,
     DataOtherlinksComponent,
+    RelatedRecordsComponent,
   ],
   imports: [
     CommonModule,

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
@@ -124,3 +124,21 @@
   </div>
   <!--FIXME: add related md record cards-->
 </div>
+
+<div id="related-records" *ngIf="facade.related$ | async">
+  <div>
+    <div class="h-48 overflow-visible">
+      <div class="container-lg mx-auto">
+        <p class="font-title text-3xl font-medium mt-12 mb-4" translate>
+          record.section.related
+        </p>
+        <gn-ui-related-records
+          [records]="facade.related$ | async"
+        ></gn-ui-related-records>
+      </div>
+    </div>
+  </div>
+  <div class="bg-primary">
+    <div class="container-lg mx-auto h-96"></div>
+  </div>
+</div>

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.spec.ts
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.spec.ts
@@ -21,6 +21,7 @@ class MdViewFacadeMock {
   downloadLinks$ = new BehaviorSubject([])
   apiLinks$ = new BehaviorSubject([])
   otherLinks$ = new BehaviorSubject([])
+  related$ = new BehaviorSubject(null)
 }
 
 @Component({
@@ -53,6 +54,12 @@ export class MockDataOtherlinksComponent {}
 })
 export class MockDataApisComponent {}
 
+@Component({
+  selector: 'gn-ui-related-records',
+  template: '<div></div>',
+})
+export class MockRelatedComponent {}
+
 describe('RecordMetadataComponent', () => {
   let component: RecordMetadataComponent
   let fixture: ComponentFixture<RecordMetadataComponent>
@@ -67,6 +74,7 @@ describe('RecordMetadataComponent', () => {
         MockDataDownloadsComponent,
         MockDataOtherlinksComponent,
         MockDataApisComponent,
+        MockRelatedComponent,
       ],
       schemas: [NO_ERRORS_SCHEMA],
       imports: [UiElementsModule, TranslateModule.forRoot()],
@@ -303,6 +311,33 @@ describe('RecordMetadataComponent', () => {
       })
       it('API component renders', () => {
         expect(apiComponent).toBeTruthy()
+      })
+    })
+  })
+
+  describe('related records', () => {
+    let relatedComponent
+    describe('when no related records', () => {
+      beforeEach(() => {
+        fixture.detectChanges()
+        relatedComponent = fixture.debugElement.query(
+          By.directive(MockRelatedComponent)
+        )
+      })
+      it('Related component does not render', () => {
+        expect(relatedComponent).toBeFalsy()
+      })
+    })
+    describe('when related records', () => {
+      beforeEach(() => {
+        facade.related$.next([{ title: 'title' }])
+        fixture.detectChanges()
+        relatedComponent = fixture.debugElement.query(
+          By.directive(MockRelatedComponent)
+        )
+      })
+      it('Related component renders', () => {
+        expect(relatedComponent).toBeTruthy()
       })
     })
   })

--- a/libs/feature/record/src/lib/related-records/related-records.component.html
+++ b/libs/feature/record/src/lib/related-records/related-records.component.html
@@ -1,0 +1,4 @@
+<div class="mb-4 pl-2 flex flex-wrap justify-between gap-y-6">
+  <gn-ui-related-record-card *ngFor="let record of records" [record]="record">
+  </gn-ui-related-record-card>
+</div>

--- a/libs/feature/record/src/lib/related-records/related-records.component.spec.ts
+++ b/libs/feature/record/src/lib/related-records/related-records.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RelatedRecordsComponent } from './related-records.component';
+
+describe('RelatedRecordsComponent', () => {
+  let component: RelatedRecordsComponent;
+  let fixture: ComponentFixture<RelatedRecordsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RelatedRecordsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RelatedRecordsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/feature/record/src/lib/related-records/related-records.component.spec.ts
+++ b/libs/feature/record/src/lib/related-records/related-records.component.spec.ts
@@ -1,25 +1,24 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing'
 
-import { RelatedRecordsComponent } from './related-records.component';
+import { RelatedRecordsComponent } from './related-records.component'
 
 describe('RelatedRecordsComponent', () => {
-  let component: RelatedRecordsComponent;
-  let fixture: ComponentFixture<RelatedRecordsComponent>;
+  let component: RelatedRecordsComponent
+  let fixture: ComponentFixture<RelatedRecordsComponent>
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ RelatedRecordsComponent ]
-    })
-    .compileComponents();
-  });
+      declarations: [RelatedRecordsComponent],
+    }).compileComponents()
+  })
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(RelatedRecordsComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+    fixture = TestBed.createComponent(RelatedRecordsComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/feature/record/src/lib/related-records/related-records.component.ts
+++ b/libs/feature/record/src/lib/related-records/related-records.component.ts
@@ -12,9 +12,6 @@ import { MetadataRecord } from '@geonetwork-ui/util/shared'
   styleUrls: ['./related-records.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RelatedRecordsComponent implements OnInit {
+export class RelatedRecordsComponent {
   @Input() records: MetadataRecord[]
-  constructor() {}
-
-  ngOnInit(): void {}
 }

--- a/libs/feature/record/src/lib/related-records/related-records.component.ts
+++ b/libs/feature/record/src/lib/related-records/related-records.component.ts
@@ -1,0 +1,20 @@
+import {
+  Component,
+  OnInit,
+  ChangeDetectionStrategy,
+  Input,
+} from '@angular/core'
+import { MetadataRecord } from '@geonetwork-ui/util/shared'
+
+@Component({
+  selector: 'gn-ui-related-records',
+  templateUrl: './related-records.component.html',
+  styleUrls: ['./related-records.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RelatedRecordsComponent implements OnInit {
+  @Input() records: MetadataRecord[]
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/libs/feature/record/src/lib/state/mdview.actions.ts
+++ b/libs/feature/record/src/lib/state/mdview.actions.ts
@@ -21,4 +21,9 @@ export const loadFullFailure = createAction(
   props<{ error: string }>()
 )
 
+export const setRelated = createAction(
+  '[Metadata view] Set related records',
+  props<{ related: MetadataRecord[] }>()
+)
+
 export const close = createAction('[Metadata view] close')

--- a/libs/feature/record/src/lib/state/mdview.effects.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.spec.ts
@@ -32,6 +32,7 @@ const esMapperMock = {
 }
 const esServiceMock = {
   getMetadataByIdPayload: jest.fn,
+  getRelatedRecordPaylod: jest.fn,
 }
 
 describe('StationsEffects', () => {
@@ -87,6 +88,39 @@ describe('StationsEffects', () => {
           a: MdViewActions.loadFullFailure({ error: 'api' }),
         })
         expect(effects.loadFull$).toBeObservable(expected)
+      })
+    })
+  })
+
+  describe('loadRelatedRecords$', () => {
+    describe('when load full success', () => {
+      beforeEach(() => {
+        searchServiceMock.search = jest.fn(() =>
+          of({ hits: { hits: [] }, aggregations: { abc: {} } })
+        )
+      })
+      it('dispatch setRelated', () => {
+        actions = hot('-a-|', {
+          a: MdViewActions.loadFullSuccess({ full }),
+        })
+        const expected = hot('-a-|', {
+          a: MdViewActions.setRelated({ related: [full] }),
+        })
+        expect(effects.loadRelatedRecords$).toBeObservable(expected)
+      })
+    })
+    describe('when api fails', () => {
+      beforeEach(() => {
+        searchServiceMock.search = jest.fn(() => throwError('api'))
+      })
+      it('dispatch loadFullFailure', () => {
+        actions = hot('-a-|', {
+          a: MdViewActions.loadFullSuccess({ full }),
+        })
+        const expected = hot('-(a|)', {
+          a: MdViewActions.setRelated({ related: null }),
+        })
+        expect(effects.loadRelatedRecords$).toBeObservable(expected)
       })
     })
   })

--- a/libs/feature/record/src/lib/state/mdview.effects.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.ts
@@ -44,7 +44,7 @@ export class MdViewEffects {
       switchMap(({ full }) =>
         this.searchService.search(
           'bucket',
-          JSON.stringify(this.esService.getRelatedRecordPaylod(full.title, 3))
+          JSON.stringify(this.esService.getRelatedRecordPayload(full.title, 3))
         )
       ),
       map((response: EsSearchResponse) => {

--- a/libs/feature/record/src/lib/state/mdview.effects.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.ts
@@ -4,6 +4,7 @@ import { ElasticsearchMapper } from '@geonetwork-ui/feature/search'
 import {
   ElasticsearchService,
   EsSearchResponse,
+  MetadataRecord,
 } from '@geonetwork-ui/util/shared'
 import { Actions, createEffect, ofType } from '@ngrx/effects'
 import { of } from 'rxjs'
@@ -34,6 +35,23 @@ export class MdViewEffects {
         return MdViewActions.loadFullSuccess({ full })
       }),
       catchError((error) => of(MdViewActions.loadFullFailure({ error })))
+    )
+  )
+
+  loadRelatedRecords$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(MdViewActions.loadFullSuccess),
+      switchMap(({ full }) =>
+        this.searchService.search(
+          'bucket',
+          JSON.stringify(this.esService.getRelatedRecordPaylod(full.title, 3))
+        )
+      ),
+      map((response: EsSearchResponse) => {
+        const related = this.esMapper.toRecords(response)
+        return MdViewActions.setRelated({ related })
+      }),
+      catchError((error) => of(MdViewActions.setRelated({ related: null })))
     )
   )
 }

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -34,6 +34,8 @@ export class MdViewFacade {
     filter((error) => error !== null)
   )
 
+  related$ = this.store.pipe(select(MdViewSelectors.getRelated))
+
   allLinks$ = this.metadata$.pipe(
     map((record) => (this.helper.hasLinks(record) ? record.links : []))
   )

--- a/libs/feature/record/src/lib/state/mdview.reducer.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.reducer.spec.ts
@@ -2,6 +2,13 @@ import { RECORDS_SUMMARY_FIXTURE } from '@geonetwork-ui/ui/search'
 import * as MdViewActions from './mdview.actions'
 import { initialMdviewState, reducer } from './mdview.reducer'
 
+const relatedRecord = {
+  title: 'title',
+  id: 'id',
+  uuid: 'uuid',
+  metadataUrl: 'url',
+}
+
 describe('MdView Reducer', () => {
   describe('undefined action', () => {
     it('should return the default state', () => {
@@ -78,6 +85,21 @@ describe('MdView Reducer', () => {
       })
     })
   })
+  describe('setRelated', () => {
+    let action
+    beforeEach(() => {
+      action = MdViewActions.setRelated({
+        related: [relatedRecord],
+      })
+    })
+    it('set related records', () => {
+      const state = reducer({ ...initialMdviewState }, action)
+      expect(state).toEqual({
+        ...initialMdviewState,
+        related: [relatedRecord],
+      })
+    })
+  })
   describe('close', () => {
     let action
     beforeEach(() => {
@@ -87,6 +109,7 @@ describe('MdView Reducer', () => {
       const state = reducer(
         {
           ...initialMdviewState,
+          related: [relatedRecord],
           loadingFull: false,
           metadata: RECORDS_SUMMARY_FIXTURE[0],
         },

--- a/libs/feature/record/src/lib/state/mdview.reducer.ts
+++ b/libs/feature/record/src/lib/state/mdview.reducer.ts
@@ -8,6 +8,7 @@ export interface MdViewState {
   loadingFull: boolean
   error: string | null
   metadata?: MetadataRecord
+  related?: MetadataRecord[]
 }
 
 export const initialMdviewState: MdViewState = {
@@ -35,9 +36,13 @@ const mdViewReducer = createReducer(
     error,
     loadingFull: false,
   })),
+  on(MdViewActions.setRelated, (state, { related }) => ({
+    ...state,
+    related,
+  })),
   on(MdViewActions.close, (state) => {
     // eslint-disable-next-line
-    const { metadata, ...stateWithoutMd } = state
+    const { metadata, related, ...stateWithoutMd } = state
     return stateWithoutMd
   })
 )

--- a/libs/feature/record/src/lib/state/mdview.selectors.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.selectors.spec.ts
@@ -1,5 +1,12 @@
 import * as MdViewSelectors from './mdview.selectors'
 
+const relatedRecord = {
+  title: 'title',
+  id: 'id',
+  uuid: 'uuid',
+  metadataUrl: 'url',
+}
+
 describe('MdView Selectors', () => {
   let state
 
@@ -82,6 +89,15 @@ describe('MdView Selectors', () => {
           error: null,
         })
         expect(results).toBe(null)
+      })
+    })
+    describe('getRelated', () => {
+      it('returns related records', () => {
+        const results = MdViewSelectors.getRelated.projector({
+          ...state,
+          related: [relatedRecord],
+        })
+        expect(results).toEqual([relatedRecord])
       })
     })
   })

--- a/libs/feature/record/src/lib/state/mdview.selectors.ts
+++ b/libs/feature/record/src/lib/state/mdview.selectors.ts
@@ -25,3 +25,7 @@ export const getMetadataError = createSelector(
   getMdViewState,
   (state: MdViewState) => state.error
 )
+export const getRelated = createSelector(
+  getMdViewState,
+  (state: MdViewState) => state.related
+)

--- a/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
+++ b/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
@@ -1,9 +1,11 @@
-<div class="w-64 overflow-hidden rounded-lg shadow-lg">
-  <img
-    class="object-cover w-full h-52"
-    [src]="record.thumbnailUrl"
-    [alt]="record.title"
-  />
+<div class="w-64 overflow-hidden rounded-lg shadow-lg bg-white">
+  <div class="object-cover w-full h-52 bg-gray-100">
+    <img
+      *ngIf="record.thumbnailUrl"
+      [src]="record.thumbnailUrl | safe: 'url'"
+      [alt]="record.title"
+    />
+  </div>
   <div class="px-5 pt-4 pb-6">
     <h4 class="max-h-20 mb-5 text-xl overflow-ellipsis overflow-hidden">
       {{ record.title }}

--- a/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
+++ b/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
@@ -1,6 +1,7 @@
 <div class="w-64 overflow-hidden rounded-lg shadow-lg bg-white">
-  <div class="object-cover w-full h-52 bg-gray-100">
+  <div class="h-52 bg-gray-100">
     <img
+      class="h-52 w-full object-cover"
       *ngIf="record.thumbnailUrl"
       [src]="record.thumbnailUrl | safe: 'url'"
       [alt]="record.title"

--- a/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
+++ b/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
@@ -1,11 +1,9 @@
 <div class="w-64 overflow-hidden rounded-lg shadow-lg bg-white">
   <div class="h-52 bg-gray-100">
-    <img
+    <gn-ui-record-thumbnail
       class="h-52 w-full object-cover"
-      *ngIf="record.thumbnailUrl"
-      [src]="record.thumbnailUrl | safe: 'url'"
-      [alt]="record.title"
-    />
+      [thumbnailUrl]="record.thumbnailUrl"
+    ></gn-ui-record-thumbnail>
   </div>
   <div class="px-5 pt-4 pb-6">
     <h4 class="max-h-20 mb-5 text-xl overflow-ellipsis overflow-hidden">

--- a/libs/ui/elements/src/lib/related-record-card/related-record-card.component.spec.ts
+++ b/libs/ui/elements/src/lib/related-record-card/related-record-card.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { MatIconModule } from '@angular/material/icon'
+import { UiSearchModule } from '@geonetwork-ui/ui/search'
 import { TranslateModule } from '@ngx-translate/core'
 import { RelatedRecordCardComponent } from './related-record-card.component'
 
@@ -10,7 +11,7 @@ describe('RelatedRecordCardComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [RelatedRecordCardComponent],
-      imports: [MatIconModule, TranslateModule.forRoot()],
+      imports: [MatIconModule, UiSearchModule, TranslateModule.forRoot()],
     }).compileComponents()
   })
 

--- a/libs/ui/elements/src/lib/ui-elements.module.ts
+++ b/libs/ui/elements/src/lib/ui-elements.module.ts
@@ -12,6 +12,7 @@ import { UiLayoutModule } from '@geonetwork-ui/ui/layout'
 import { TranslateModule } from '@ngx-translate/core'
 import { LinkCardComponent } from './link-card/link-card.component'
 import { RelatedRecordCardComponent } from './related-record-card/related-record-card.component'
+import { UiSearchModule } from '@geonetwork-ui/ui/search'
 
 @NgModule({
   imports: [
@@ -22,6 +23,7 @@ import { RelatedRecordCardComponent } from './related-record-card/related-record
     UiLayoutModule,
     TranslateModule.forChild(),
     UtilSharedModule,
+    UiSearchModule,
   ],
   declarations: [
     MetadataInfoComponent,

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -243,4 +243,56 @@ describe('ElasticsearchService', () => {
       })
     })
   })
+
+  describe('#getRelatedRecordPayload', () => {
+    let payload
+    beforeEach(() => {
+      payload = service.getRelatedRecordPayload('record title', 4)
+    })
+    it('returns ES payload', () => {
+      expect(payload).toEqual({
+        _source: [
+          'uuid',
+          'id',
+          'title',
+          'resource*',
+          'resourceTitleObject',
+          'resourceAbstractObject',
+          'overview',
+          'logo',
+          'codelist_status_text',
+          'linkProtocol',
+        ],
+        query: {
+          bool: {
+            must: [
+              {
+                more_like_this: {
+                  fields: [
+                    'resourceTitleObject.default',
+                    'resourceAbstractObject.default',
+                    'tag.raw',
+                  ],
+                  like: 'record title',
+                  max_query_terms: 12,
+                  min_term_freq: 1,
+                },
+              },
+              {
+                terms: {
+                  isTemplate: ['n'],
+                },
+              },
+              {
+                terms: {
+                  draft: ['n', 'e'],
+                },
+              },
+            ],
+          },
+        },
+        size: 4,
+      })
+    })
+  })
 })

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -9,6 +9,7 @@ import {
   StateConfigFilters,
 } from '../models'
 import { BootstrapService } from '../services'
+import { ES_SOURCE_SUMMARY } from './constant'
 
 @Injectable({
   providedIn: 'root',
@@ -45,6 +46,45 @@ export class ElasticsearchService {
           values: [uuid],
         },
       },
+    }
+  }
+
+  getRelatedRecordPayload(
+    title: string,
+    size: number = 6,
+    _source = ES_SOURCE_SUMMARY
+  ): EsSearchParams {
+    return {
+      query: {
+        bool: {
+          must: [
+            {
+              more_like_this: {
+                fields: [
+                  'resourceTitleObject.default',
+                  'resourceAbstractObject.default',
+                  'tag.raw',
+                ],
+                like: title,
+                min_term_freq: 1,
+                max_query_terms: 12,
+              },
+            },
+            {
+              terms: {
+                isTemplate: ['n'],
+              },
+            },
+            {
+              terms: {
+                draft: ['n', 'e'],
+              },
+            },
+          ],
+        },
+      },
+      size,
+      _source,
     }
   }
 

--- a/translations/de.json
+++ b/translations/de.json
@@ -116,6 +116,7 @@
   "record.section.download": "",
   "record.section.links": "",
   "record.section.preview": "",
+  "record.section.related": "",
   "record.tab.data": "",
   "record.tab.map": "",
   "records": "",

--- a/translations/en.json
+++ b/translations/en.json
@@ -116,6 +116,7 @@
   "record.section.download": "Downloads",
   "record.section.links": "Links",
   "record.section.preview": "Preview",
+  "record.section.related": "Related records",
   "record.tab.data": "Table view",
   "record.tab.map": "Map view",
   "records": "records",

--- a/translations/es.json
+++ b/translations/es.json
@@ -116,6 +116,7 @@
   "record.section.download": "",
   "record.section.links": "",
   "record.section.preview": "",
+  "record.section.related": "",
   "record.tab.data": "",
   "record.tab.map": "",
   "records": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -116,6 +116,7 @@
   "record.section.download": "Téléchargements",
   "record.section.links": "Liens",
   "record.section.preview": "Aperçu",
+  "record.section.related": "Fiches associées",
   "record.tab.data": "Vue tableau",
   "record.tab.map": "Vue carte",
   "records": "enregistrements",

--- a/translations/it.json
+++ b/translations/it.json
@@ -116,6 +116,7 @@
   "record.section.download": "",
   "record.section.links": "",
   "record.section.preview": "",
+  "record.section.related": "",
   "record.tab.data": "",
   "record.tab.map": "",
   "records": "",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -116,6 +116,7 @@
   "record.section.download": "",
   "record.section.links": "",
   "record.section.preview": "",
+  "record.section.related": "",
   "record.tab.data": "",
   "record.tab.map": "",
   "records": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -116,6 +116,7 @@
   "record.section.download": "",
   "record.section.links": "",
   "record.section.preview": "",
+  "record.section.related": "",
   "record.tab.data": "",
   "record.tab.map": "",
   "records": "",


### PR DESCRIPTION
Handle related records fetching through state effect on `LoadRecordFullSuccess` action.
Add the related record section in the record-metadata component.

This PR does not address layout issues with the `related-card` component, neither the action on the click, it takes the component as it is except:

- add gray box when no image
- fix sanitize for unsafe urls

![Screenshot from 2021-12-04 17-46-45](https://user-images.githubusercontent.com/1491924/144717543-9c5549df-a21b-40bd-b289-02a35729ba2c.png)


