### PR TITLE
Datahub / disable worker in ogc-client if a proxy path is set

### DIFF
--- a/apps/datahub/src/main.ts
+++ b/apps/datahub/src/main.ts
@@ -3,13 +3,19 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic'
 
 import { AppModule } from './app/app.module'
 import { environment } from './environments/environment'
-import { loadAppConfig } from '@geonetwork-ui/util/app-config'
+import { loadAppConfig, getGlobalConfig } from '@geonetwork-ui/util/app-config'
+import { enableFallbackWithoutWorker } from '@camptocamp/ogc-client'
 
 if (environment.production) {
   enableProdMode()
 }
 
 loadAppConfig().then(() => {
+  if (getGlobalConfig().PROXY_PATH) {
+    // disable worker in ogc-client to allow using a proxy with a Referer check
+    enableFallbackWithoutWorker()
+  }
+
   platformBrowserDynamic()
     .bootstrapModule(AppModule)
     .catch((err) => console.error(err))

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
@@ -517,23 +517,45 @@ describe('DataViewMapComponent', () => {
   })
 
   describe('when setting a proxy path', () => {
-    beforeEach(() => {
-      proxyPath = 'http://my.proxy/?url='
-      mdViewFacade.mapApiLinks$.next([])
-      mdViewFacade.geoDataLinks$.next([
-        {
-          url: 'http://abcd.com/data.geojson',
-          name: 'data.geojson',
-          protocol: 'WWW:DOWNLOAD',
-          format: 'geojson',
-        },
-      ])
+    describe('file', () => {
+      beforeEach(() => {
+        proxyPath = 'http://my.proxy/?url='
+        mdViewFacade.mapApiLinks$.next([])
+        mdViewFacade.geoDataLinks$.next([
+          {
+            url: 'http://abcd.com/data.geojson',
+            name: 'data.geojson',
+            protocol: 'WWW:DOWNLOAD',
+            format: 'geojson',
+          },
+        ])
+      })
+      it('loads the data using the proxy', () => {
+        expect(readDataset).toHaveBeenCalledWith(
+          'http://my.proxy/?url=http://abcd.com/data.geojson',
+          'geojson'
+        )
+      })
     })
-    it('loads the data using the proxy', () => {
-      expect(readDataset).toHaveBeenCalledWith(
-        'http://my.proxy/?url=http://abcd.com/data.geojson',
-        'geojson'
-      )
+
+    describe('WFS', () => {
+      beforeEach(() => {
+        proxyPath = 'http://my.proxy/?url='
+        mdViewFacade.mapApiLinks$.next([])
+        mdViewFacade.geoDataLinks$.next([
+          {
+            url: 'http://abcd.com/wfs',
+            name: 'feature-type',
+            protocol: 'OGC:WFS',
+          },
+        ])
+      })
+      it('loads the data using the proxy', () => {
+        expect(readDataset).toHaveBeenCalledWith(
+          'http://my.proxy/?url=http://abcd.com/wfs?GetFeature',
+          'geojson'
+        )
+      })
     })
   })
 })

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -134,12 +134,10 @@ export class DataViewMapComponent {
               throw new Error('map.wfs.geojson.not.supported')
             }
             return readDataset(
-              this.proxy.getProxiedUrl(
-                endpoint.getFeatureUrl(link.name, {
-                  asJson: true,
-                  outputCrs: 'EPSG:4326',
-                })
-              ),
+              endpoint.getFeatureUrl(link.name, {
+                asJson: true,
+                outputCrs: 'EPSG:4326',
+              }),
               'geojson'
             ).then((features) => ({
               type: MapContextLayerTypeEnum.GEOJSON,

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.spec.ts
@@ -303,16 +303,10 @@ describe('DataViewTableComponent', () => {
       })
     })
     describe('WFS', () => {
-      let dropDownComponent: MockDropdownSelectorComponent
-
       beforeEach(() => {
-        dropDownComponent = fixture.debugElement.query(
-          By.directive(MockDropdownSelectorComponent)
-        ).componentInstance
         proxyPath = 'http://my.proxy/?url='
-        facade.dataLinks$.next(GEODATALINKS_FIXTURE)
+        facade.dataLinks$.next(GEODATALINKS_FIXTURE.slice(1))
         facade.geoDataLinks$.next([])
-        dropDownComponent.selectValue.emit(1)
         fixture.detectChanges()
       })
       it('loads the data using the proxy', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@angular/router": "12.2.0",
         "@biesbjerg/ngx-translate-extract": "^7.0.4",
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-        "@camptocamp/ogc-client": "^0.3.3",
+        "@camptocamp/ogc-client": "^0.3.4",
         "@ltd/j-toml": "^1.24.0",
         "@ngrx/router-store": "^12.2.0",
         "@nguniversal/express-engine": "^12.0.1",
@@ -2738,9 +2738,9 @@
       }
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.3.tgz",
-      "integrity": "sha512-Up+elu5lxEOKWOT+odWn9pmGt0iAi3T48xWHbY/6c9/jRnsjdrhzXaqxExq5OLjS36PovKWVGYB4rDkt3feeFQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.4.tgz",
+      "integrity": "sha512-b/9Cl2fYaV08Gb0fCwivsm+qIAZFGarj7M6Mh2Isz99AyqrUv3EVIOMlAksHHVigRUFkNIKOkQg+YqPzTkA3UQ==",
       "dependencies": {
         "@rgrove/parse-xml": "^3.0.0"
       }
@@ -44028,9 +44028,9 @@
       }
     },
     "@camptocamp/ogc-client": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.3.tgz",
-      "integrity": "sha512-Up+elu5lxEOKWOT+odWn9pmGt0iAi3T48xWHbY/6c9/jRnsjdrhzXaqxExq5OLjS36PovKWVGYB4rDkt3feeFQ==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-0.3.4.tgz",
+      "integrity": "sha512-b/9Cl2fYaV08Gb0fCwivsm+qIAZFGarj7M6Mh2Isz99AyqrUv3EVIOMlAksHHVigRUFkNIKOkQg+YqPzTkA3UQ==",
       "requires": {
         "@rgrove/parse-xml": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@angular/router": "12.2.0",
     "@biesbjerg/ngx-translate-extract": "^7.0.4",
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-    "@camptocamp/ogc-client": "^0.3.3",
+    "@camptocamp/ogc-client": "^0.3.4",
     "@ltd/j-toml": "^1.24.0",
     "@ngrx/router-store": "^12.2.0",
     "@nguniversal/express-engine": "^12.0.1",


### PR DESCRIPTION
ogc-client now offers the possibility to disable using a worker altogether.

Also fixes an issue where the data url would be going through the proxy twice for the map data view.