### PR TITLE
Datahub / allow specifying a different path to the docker container when providing a custom config file

### DIFF
--- a/apps/datahub/README.md
+++ b/apps/datahub/README.md
@@ -68,3 +68,15 @@ $ docker run -p 8080:80 \
 ```
 
 If a file named `default.toml` is found in the `/conf` folder _of the app container_ at startup, it will be used by the application.
+
+You can specify a different directory to look for the `default.toml` file using the `CONFIG_DIRECTORY_OVERRIDE` env variable, like so:
+
+```bash
+# this assumes a file named `default.toml` is located in the /home/user/custom-conf directory:
+$ docker run -p 8080:80 \
+             -v /home/user/custom-conf:/some/random/path \
+             -e CONFIG_DIRECTORY_OVERRIDE=/some/random/path \
+             geonetwork-ui/datahub
+```
+
+This can be useful when dealing with existing volumes having their own directory structure.

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -21,8 +21,8 @@ primary_color = "#0f4395"
 secondary_color = "#8bc832"
 main_color = "#212029" # All-purpose text color
 background_color = "#fdfbff"
-# main_font = "My Custom Font", fallback-font
-# title_font = "My Custom Title Font", fallback-font-title
+# main_font = "'My Custom Font', fallback-font"
+# title_font = "'My Custom Title Font', fallback-font-title"
 # fonts_stylesheet_url = "https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Permanent+Marker&display=swap"
 
 ### TRANSLATIONS

--- a/tools/docker/Dockerfile.apps
+++ b/tools/docker/Dockerfile.apps
@@ -5,8 +5,9 @@ FROM nginx:1.21.4-alpine
 
 ARG APP_NAME="search"
 ENV APP_NAME=${APP_NAME}
-ENV GN4_API_URL "https://localhost/geonetwork/srv/api"
+ENV GN4_API_URL ""
 ENV PROXY_PATH ""
+ENV CONFIG_DIRECTORY_OVERRIDE ""
 
 COPY dist/apps/${APP_NAME} /usr/share/nginx/html/${APP_NAME}
 COPY tools/docker/docker-entrypoint.sh /

--- a/tools/docker/docker-entrypoint.sh
+++ b/tools/docker/docker-entrypoint.sh
@@ -2,13 +2,15 @@
 
 CONFIG_FILE_PATH=assets/configuration/
 CONFIG_FILE_NAME=default.toml
+CONFIG_OVERRIDE_FILE_PATH=${CONFIG_DIRECTORY_OVERRIDE:-/conf}/${CONFIG_FILE_NAME}
 
-# copy the conf file from /conf if present
-if [ -f "/conf/${CONFIG_FILE_NAME}" ]
+# copy the conf file from $CONFIG_DIRECTORY_OVERRIDE (defaults to /conf) if present
+if [ -f "${CONFIG_OVERRIDE_FILE_PATH}" ]
 then
-  cp /conf/${CONFIG_FILE_NAME} /usr/share/nginx/html/${APP_NAME}/${CONFIG_FILE_PATH}${CONFIG_FILE_NAME}
-  echo "[INFO] Copied custom configuration file located in /conf/${CONFIG_FILE_NAME}"
+  cp ${CONFIG_OVERRIDE_FILE_PATH} /usr/share/nginx/html/${APP_NAME}/${CONFIG_FILE_PATH}${CONFIG_FILE_NAME}
+  echo "[INFO] Copied custom configuration file located at ${CONFIG_OVERRIDE_FILE_PATH}"
 else
+  echo "[INFO] No custom configuration file found at ${CONFIG_OVERRIDE_FILE_PATH}"
   # Modify the GN4 url and proxy path based on env variables (if defined)
   if [ ! -z "${GN4_API_URL}" ]
   then


### PR DESCRIPTION
Previously the `/conf` directory was hardcoded and that would have made things more complicated in some cases (e.g. existing volumes with their own structure).