### PR TITLE
datahub: Add default map style based on PRIMARY_COLOR

### DIFF
--- a/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
@@ -6,7 +6,9 @@ import Map from 'ol/Map'
 import TileWMS from 'ol/source/TileWMS'
 import VectorSource from 'ol/source/Vector'
 import XYZ from 'ol/source/XYZ'
+import { Style } from 'ol/style'
 import View from 'ol/View'
+import { MapStyleService } from '../style/map-style.service'
 import {
   MAP_CTX_FIXTURE,
   MAP_CTX_LAYER_GEOJSON_FIXTURE,
@@ -17,12 +19,21 @@ import {
 
 import { MapContextService } from './map-context.service'
 
+const mapStyleServiceMock = {
+  createDefaultStyle: jest.fn(() => new Style()),
+}
 describe('MapContextService', () => {
   let service: MapContextService
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
+      providers: [
+        {
+          provide: MapStyleService,
+          useValue: mapStyleServiceMock,
+        },
+      ],
     })
     service = TestBed.inject(MapContextService)
   })

--- a/libs/feature/map/src/lib/map-context/map-context.service.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core'
+import { MapStyleService } from '../style/map-style.service'
 import {
   MapContextLayerModel,
   MapContextLayerTypeEnum,
@@ -21,7 +22,11 @@ import GeoJSON from 'ol/format/GeoJSON'
   providedIn: 'root',
 })
 export class MapContextService {
-  constructor(private mapUtils: MapUtilsService) {}
+  private style = this.styleService.createDefaultStyle()
+  constructor(
+    private mapUtils: MapUtilsService,
+    private styleService: MapStyleService
+  ) {}
 
   resetMapFromContext(map: Map, mapContext: MapContextModel): Map {
     if (mapContext.view) {
@@ -34,6 +39,7 @@ export class MapContextService {
 
   createLayer(layerModel: MapContextLayerModel): Layer {
     const { type, url, name } = layerModel
+    const style = this.style
     switch (type) {
       case MapContextLayerTypeEnum.XYZ:
         return new TileLayer({
@@ -59,6 +65,7 @@ export class MapContextService {
             },
             strategy: bboxStrategy,
           }),
+          style,
         })
       case MapContextLayerTypeEnum.GEOJSON: {
         const { data } = layerModel
@@ -67,6 +74,7 @@ export class MapContextService {
           source: new VectorSource({
             features,
           }),
+          style,
         })
       }
     }

--- a/libs/feature/map/src/lib/style/map-style.service.spec.ts
+++ b/libs/feature/map/src/lib/style/map-style.service.spec.ts
@@ -1,0 +1,100 @@
+import { TestBed } from '@angular/core/testing'
+import { getThemeConfig } from '@geonetwork-ui/util/app-config'
+import chroma from 'chroma-js'
+import Style from 'ol/style/Style'
+
+import { MapStyleService } from './map-style.service'
+
+jest.mock('@geonetwork-ui/util/app-config', () => ({
+  getThemeConfig: () => ({
+    PRIMARY_COLOR: 'blue',
+  }),
+}))
+
+describe('MapStyleService', () => {
+  let service: MapStyleService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+    service = TestBed.inject(MapStyleService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+
+  describe('#createDefaultStyle', () => {
+    describe('when options are given', () => {
+      let styles, style, circle, stroke, fill
+      beforeEach(() => {
+        const options = {
+          color: 'red',
+          width: 5,
+          radius: 2,
+        }
+        styles = service.createDefaultStyle(options)
+        style = styles[0]
+      })
+      it('creates an array of 1 style', () => {
+        expect(styles).toBeInstanceOf(Array)
+        expect(styles.length).toBe(1)
+        expect(style).toBeInstanceOf(Style)
+      })
+      describe('creates a circle', () => {
+        beforeEach(() => {
+          circle = style.getImage()
+        })
+        it('has correct radius', () => {
+          expect(circle.getRadius()).toBe(2)
+        })
+        it('has correct fill color', () => {
+          expect(circle.getFill().getColor()).toBe('red')
+        })
+        it('has correct stroke color and width', () => {
+          expect(circle.getStroke().getColor()).toBe('white')
+          expect(circle.getStroke().getWidth()).toBe(5)
+        })
+      })
+      describe('creates a fill', () => {
+        beforeEach(() => {
+          fill = style.getFill()
+        })
+        it('has correct color', () => {
+          expect(fill.getColor()).toBe(chroma('red').alpha(0.25).css())
+        })
+      })
+      describe('creates a stroke', () => {
+        beforeEach(() => {
+          stroke = style.getStroke()
+        })
+        it('has correct color', () => {
+          expect(stroke.getColor()).toBe('white')
+        })
+        it('has correct width', () => {
+          expect(stroke.getWidth()).toBe(5)
+        })
+      })
+    })
+    describe('when no option is given', () => {
+      let styles, style
+      beforeEach(() => {
+        styles = service.createDefaultStyle()
+        style = styles[0]
+      })
+      it('uses default width (2)', () => {
+        expect(style.getImage().getStroke().getWidth()).toBe(2)
+        expect(style.getStroke().getWidth()).toBe(2)
+      })
+      it('uses default radius (7)', () => {
+        expect(style.getImage().getRadius()).toBe(7)
+      })
+      it('uses default PRIMARY_COLOR from ThemeConfig', () => {
+        expect(style.getImage().getFill().getColor()).toBe(
+          getThemeConfig().PRIMARY_COLOR
+        )
+        expect(style.getImage().getFill().getColor()).toBe('blue')
+        expect(style.getFill().getColor()).toBe('rgba(0,0,255,0.25)')
+      })
+    })
+  })
+})

--- a/libs/feature/map/src/lib/style/map-style.service.ts
+++ b/libs/feature/map/src/lib/style/map-style.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@angular/core'
+import { getThemeConfig } from '@geonetwork-ui/util/app-config'
+import chroma from 'chroma-js'
+import { Fill, Stroke, Style } from 'ol/style'
+import CircleStyle from 'ol/style/Circle'
+
+export interface CreateStyleOptions {
+  color?: string
+  radius?: number
+  width?: number
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MapStyleService {
+  createDefaultStyle(options: CreateStyleOptions = {}) {
+    const {
+      color = getThemeConfig().PRIMARY_COLOR,
+      width = 2,
+      radius = 7,
+    } = options
+    const fill = new Fill({
+      color,
+    })
+    const stroke = new Stroke({
+      color: 'white',
+      width,
+    })
+    return [
+      new Style({
+        image: new CircleStyle({
+          fill,
+          stroke,
+          radius,
+        }),
+        fill: new Fill({
+          color: chroma(color).alpha(0.25).css(),
+        }),
+        stroke,
+      }),
+    ]
+  }
+}

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -3,7 +3,7 @@ import * as TOML from '@ltd/j-toml'
 const MISSING_CONFIG_ERROR = `Application configuration was not initialized correctly.
 This error might show up in case of an invalid/malformed configuration file. 
 
-Note: make sure that you have called \`loadAppConfig\` from '@geonetwork-ui/util-app-config' before starting the Angular application.`
+Note: make sure that you have called \`loadAppConfig\` from '@geonetwork-ui/util/app-config' before starting the Angular application.`
 
 interface GlobalConfig {
   GN4_API_URL: string


### PR DESCRIPTION
In the datahub record/preview section, the PR aims to improve the look of the features rendered on the map.
It adds a new service `MapStyleService` which is responsible to manage the styling in Openlayers.
It comes with first method `createDefaultStyle` which replaces the one by default in OL code, and is applied on each vector layer from the map context.
It takes options, as argument, by default it uses the `PRIMARY_COLOR` for the feature color.
It's a bit more beautiful in real than on the screenshot :) (click on the images to see the correct zoom)


![Screenshot from 2021-12-14 11-46-51](https://user-images.githubusercontent.com/1491924/145983939-212bc8bc-3b0d-475c-9251-e0df03bb2061.png)
![Screenshot from 2021-12-14 11-46-35](https://user-images.githubusercontent.com/1491924/145983941-be977d77-059e-4c5a-b7dc-42cf54eadab3.png)

