### PR TITLE
Do not display current md-record in related records

### DIFF
--- a/libs/feature/record/src/lib/state/mdview.effects.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.ts
@@ -44,7 +44,9 @@ export class MdViewEffects {
       switchMap(({ full }) =>
         this.searchService.search(
           'bucket',
-          JSON.stringify(this.esService.getRelatedRecordPayload(full.title, 3))
+          JSON.stringify(
+            this.esService.getRelatedRecordPayload(full.title, full.uuid, 3)
+          )
         )
       ),
       map((response: EsSearchResponse) => {

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -247,7 +247,7 @@ describe('ElasticsearchService', () => {
   describe('#getRelatedRecordPayload', () => {
     let payload
     beforeEach(() => {
-      payload = service.getRelatedRecordPayload('record title', 4)
+      payload = service.getRelatedRecordPayload('record title', 'some-uuid', 4)
     })
     it('returns ES payload', () => {
       expect(payload).toEqual({
@@ -289,6 +289,7 @@ describe('ElasticsearchService', () => {
                 },
               },
             ],
+            must_not: [{ wildcard: { uuid: 'some-uuid' } }],
           },
         },
         size: 4,

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -51,6 +51,7 @@ export class ElasticsearchService {
 
   getRelatedRecordPayload(
     title: string,
+    uuid: string,
     size: number = 6,
     _source = ES_SOURCE_SUMMARY
   ): EsSearchParams {
@@ -81,6 +82,7 @@ export class ElasticsearchService {
               },
             },
           ],
+          must_not: [{ wildcard: { uuid: uuid } }],
         },
       },
       size,


### PR DESCRIPTION
PR requests four related records from API, filters the currently displayed record from the related records not to be displayed, and displays a maximum of three related records.