### PR TITLE
Various fixes

### DIFF
--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
@@ -28,8 +28,8 @@ export class DataDownloadsComponent {
     switchMap((links) => {
       const wfsLinks = links.filter((link) => this.linkHelper.isWfsLink(link))
       const esriRestLinks = links
-        .filter(this.linkHelper.isEsriRestFeatureServer)
-        .flatMap(this.dataService.getDownloadLinksFromEsriRest)
+        .filter((link) => this.linkHelper.isEsriRestFeatureServer(link))
+        .flatMap((link) => this.dataService.getDownloadLinksFromEsriRest(link))
       const otherLinks = links
         .filter((link) => !/^OGC:WFS|ESRI:REST/.test(link.protocol))
         .map((link) =>

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.html
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.html
@@ -6,7 +6,7 @@
     [showTitle]="false"
     (selectValue)="selectLinkToDisplay($event)"
   ></gn-ui-dropdown-selector>
-  <div class="relative">
+  <div class="relative h-full">
     <gn-ui-table
       *ngIf="tableData$ | async"
       class="overflow-auto flex-grow"


### PR DESCRIPTION
PR fixes

- calling `getDownloadLinksFromEsriRest`
- default height for table when loading

TODOs:

- [ ] fix scroll to top
- [ ] handle 404 error on WFS to prevent displaying empty "Donwloads" on http://localhost:4200/dataset/urn:isogeo:metadata:uuid:1355be63-7f12-41f7-bcc8-724146679eb3
- [ ] close feature-info when clicking related record
- [ ] navigating from record with WMS to search and then other record displays WMS from other record until new context in loaded