### PR TITLE
datahub: Fix router scroll

### DIFF
--- a/apps/datahub/src/app/app.component.html
+++ b/apps/datahub/src/app/app.component.html
@@ -6,7 +6,11 @@
   >
     <datahub-search-page></datahub-search-page>
   </div>
-  <div class="h-screen overflow-auto" *ngIf="isRecordOpened$ | async">
+  <div
+    id="record-page"
+    class="h-screen overflow-auto"
+    *ngIf="isRecordOpened$ | async"
+  >
     <datahub-record-page></datahub-record-page>
   </div>
 </div>

--- a/libs/feature/router/src/lib/default/constants.ts
+++ b/libs/feature/router/src/lib/default/constants.ts
@@ -2,5 +2,8 @@ import { Component } from '@angular/core'
 
 export const ROUTER_STATE_KEY = 'router'
 
+export const ROUTER_ROUTE_SEARCH = 'search'
+export const ROUTER_ROUTE_DATASET = 'dataset'
+
 export class SearchRouteComponent extends Component {}
 export class MetadataRouteComponent extends Component {}

--- a/libs/feature/router/src/lib/default/index.ts
+++ b/libs/feature/router/src/lib/default/index.ts
@@ -1,2 +1,3 @@
 export * from './router.module'
+export * from './constants'
 export * from './state'

--- a/libs/feature/router/src/lib/default/router.module.ts
+++ b/libs/feature/router/src/lib/default/router.module.ts
@@ -1,28 +1,29 @@
 import { InjectionToken, ModuleWithProviders, NgModule } from '@angular/core'
-import { ResultsLayoutConfigModel } from '@geonetwork-ui/ui/search'
-import { RouterFacade } from './state'
 import { RouterModule, Routes } from '@angular/router'
+import { EffectsModule } from '@ngrx/effects'
 import {
   DefaultRouterStateSerializer,
   routerReducer,
   StoreRouterConnectingModule,
 } from '@ngrx/router-store'
-import { RouterEffects } from './state/router.effects'
-import { EffectsModule } from '@ngrx/effects'
 import { StoreModule } from '@ngrx/store'
 import {
   MetadataRouteComponent,
+  ROUTER_ROUTE_DATASET,
+  ROUTER_ROUTE_SEARCH,
   ROUTER_STATE_KEY,
   SearchRouteComponent,
 } from './constants'
+import { RouterFacade } from './state'
+import { RouterEffects } from './state/router.effects'
 
 const ROUTES: Routes = [
   {
-    path: 'search',
+    path: ROUTER_ROUTE_SEARCH,
     component: SearchRouteComponent,
   },
   {
-    path: 'dataset/:metadataUuid',
+    path: `${ROUTER_ROUTE_DATASET}/:metadataUuid`,
     component: MetadataRouteComponent,
   },
 ]

--- a/libs/feature/router/src/lib/default/state/router.facade.ts
+++ b/libs/feature/router/src/lib/default/state/router.facade.ts
@@ -4,6 +4,7 @@ import { MetadataRecord } from '@geonetwork-ui/util/shared'
 import { RouterReducerState } from '@ngrx/router-store'
 import { select, Store } from '@ngrx/store'
 import { filter, take } from 'rxjs/operators'
+import { ROUTER_ROUTE_DATASET, ROUTER_ROUTE_SEARCH } from '../constants'
 import {
   backAction,
   forwardAction,
@@ -34,7 +35,7 @@ export class RouterFacade {
       )
       .subscribe(() => {
         this.go({
-          path: `dataset/${metadata.uuid}`,
+          path: `${ROUTER_ROUTE_DATASET}/${metadata.uuid}`,
         })
         this.store.dispatch(
           MdViewActions.setIncompleteMetadata({ incomplete: metadata })
@@ -44,7 +45,7 @@ export class RouterFacade {
 
   goToSearch() {
     this.go({
-      path: `search/`,
+      path: `${ROUTER_ROUTE_SEARCH}/`,
     })
   }
 


### PR DESCRIPTION
The `Router` was configured with the [scrollPositionRestoration](https://angular.io/api/router/ExtraOptions#scrollPositionRestoration) option:
```js
      scrollPositionRestoration: 'enabled',
```
which manages the scroll position on the global viewport, using the [ViewportScroll](https://angular.io/api/common/ViewportScroller) class.

As the scroll is not managed in the viewport anymore, to avoid infinite scroll issues, we must manually intercept the router scrolling event and scroll to top of the record page.
We do what the router option does, but for our own div instead of for the viewport.