### PR TITLE
Datahub: Document building without docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ GeoNetwork UI provides a standard way of configuring applications using the [con
 This file can be used to:
 
 - customize the URL used to reach the GeoNetwork 4 API
+- indicate an optional proxy path to the application
 - customize the theme used in the application (colors, fonts...)
 - define custom translations for the different languages
 

--- a/apps/datahub/README.md
+++ b/apps/datahub/README.md
@@ -31,7 +31,21 @@ no path is defined.
 Please note that during development a proxy is provided by webpack on the `/dev-proxy?` url path. **It is
 not used by default in the Datahub app, you will have to set it up yourself.**
 
-## Using with Docker
+## Building without Docker
+
+Before building, remember to edit the configuration file in `conf/default.toml` to fit your deployment. It indicates the `geonetwork4_api_url` and an optional `proxy_path` to use.
+
+You can build the datahub app using the geonetwork-ui build command:
+
+```shell script
+npm run build -- datahub --prod
+```
+
+The build artifact will be stored in the `dist/apps/datahub` directory, that can be deployed on a common webserver. Use the `--prod` flag for a production build.
+
+The build also includes the app configuration file (`dist/apps/datahub/assets/configuration`). Do not modify the configuration file here, as it is overwritten on each build.
+
+## Building with Docker
 
 You can build a docker image of the Datahub application like so:
 


### PR DESCRIPTION
PR adds some doc for building datahub app without docker.

I'm not sure what the possibilities are to overload `GN4_API_URL`, `PROXY_PATH` and the entire config file without docker and in how far we should document this as well.