### PR TITLE
Exclude templates and subtemplates from search

### DIFF
--- a/libs/util/shared/src/lib/models/elasticsearch.model.ts
+++ b/libs/util/shared/src/lib/models/elasticsearch.model.ts
@@ -32,3 +32,6 @@ export interface EsSearchParams {
 }
 
 export type EsSearchResponse = any
+
+export type EsTemplateValues = 'y' | 'n' | 's'
+export type EsTemplateType = EsTemplateValues | EsTemplateValues[]

--- a/libs/util/shared/src/lib/models/elasticsearch.model.ts
+++ b/libs/util/shared/src/lib/models/elasticsearch.model.ts
@@ -33,5 +33,5 @@ export interface EsSearchParams {
 
 export type EsSearchResponse = any
 
-export type EsTemplateValues = 'y' | 'n' | 's'
+export type EsTemplateValues = 'y' | 'n' | 's' | 't'
 export type EsTemplateType = EsTemplateValues | EsTemplateValues[]


### PR DESCRIPTION
YAGNI implementation to remove the templates and subtemplates from the search.
It will always be the case for the searches we have at the moment, so i don't put it in the state yet.
I think the `esService` will need some refactoring but it's a bit too soon, I think what could be good is too have functions which merge all of the pieces of the payload together to build the query.

I think that having something like `isTemplate` as JSON `bool` ES param is better than to mix them in the `query_string`.
Open to discussion.

Thanks