### PR TITLE
Improve search by setting priorities on search fields

### DIFF
--- a/libs/util/shared/src/lib/elasticsearch/constant.ts
+++ b/libs/util/shared/src/lib/elasticsearch/constant.ts
@@ -27,3 +27,11 @@ export const ElasticSearchSources = {
   [ElasticsearchMetadataModels.SUMMARY]: ES_SOURCE_SUMMARY,
   [ElasticsearchMetadataModels.BRIEF]: ES_SOURCE_BRIEF,
 }
+
+export const ES_QUERY_STRING_FIELDS = [
+  'resourceTitleObject.*^5',
+  'tag.*^4',
+  'resourceAbstractObject.*^3',
+  'lineageObject.*^2',
+  'any',
+]

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -1,5 +1,6 @@
 import { ElasticsearchService } from './elasticsearch.service'
 import { Observable } from 'rxjs'
+import { ES_QUERY_STRING_FIELDS } from './constant'
 
 let autocompleteConfig
 
@@ -102,6 +103,7 @@ describe('ElasticsearchService', () => {
           must: [
             {
               query_string: {
+                fields: ES_QUERY_STRING_FIELDS,
                 query: '(*) AND (tag.default:"world" tag.default:"vector")',
               },
             },

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core'
 import { Observable } from 'rxjs'
 import { map, take } from 'rxjs/operators'
+import { ES_QUERY_STRING_FIELDS } from './constant'
 import {
   EsSearchParams,
   EsTemplateType,
@@ -114,7 +115,15 @@ export class ElasticsearchService {
 
     return {
       bool: {
-        must: [{ query_string: { query } }, this.addTemplateClause('n')],
+        must: [
+          {
+            query_string: {
+              query,
+              fields: ES_QUERY_STRING_FIELDS,
+            },
+          },
+          this.addTemplateClause('n'),
+        ],
         filter: this.buildPayloadFilter(configFilters),
       },
     }


### PR DESCRIPTION
PR weighs the searched fields in the following order:

- title
- keywords
- abstract
- lineage
- (any)