### PR TITLE
Datahub: Add a button to open layers in external viewer

### DIFF
--- a/conf/default.toml
+++ b/conf/default.toml
@@ -22,6 +22,21 @@ proxy_path = ""
 # Expressed in the map view projection (EPSG:3857)
 # max_extent = [-418263.418776, 5251529.591305, 961272.067714, 6706890.609855]
 
+# Optional; URL template enabling to open map layers in an external viewer; if set, displays a button next to the map's layer drop down
+# The template must include the following placeholders, which allow the datahub to inject the correct values when adding a layer to a viewer:
+# ${service_url}: URL of the OWS
+# ${service_type}: Type of the OWS; currently supported WMS, WFS
+# ${layer_name}: Name of the layer
+# Be careful to use englobing single quotes, if your template syntax includes JSON (with double quotes)
+# Examples:
+# mapfishapp template:
+# external_viewer_url_template = 'https://dev.geo2france.fr/mapfishapp/?owsurl=${service_url}&layername=${layer_name}&owstype=${service_type}Layer'
+# mapstore template
+# external_viewer_url_template = 'https://dev.geo2france.fr/mapstore/#/?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["${layer_name}"],"sources":[{"url":"${service_url}","type":"${service_type}"}]}]'
+
+# Optional; if true, opens external viewer in new tab (default false)
+# external_viewer_open_new_tab = false
+
 # Optional; if true, the default basemap will not be added to the map.
 # Use [[map_layer]] sections to define your own custom layers (see below)
 # do_not_use_default_basemap = false

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.css
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.css
@@ -1,9 +1,3 @@
-gn-ui-dropdown-selector {
-  bottom: 0;
-  left: 0;
-  right: 0;
-}
-
 gn-ui-loading-mask {
   top: 0;
   bottom: 0;

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.html
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.html
@@ -33,11 +33,18 @@
   >
     <span translate>{{ error }}</span>
   </gn-ui-popup-alert>
-  <gn-ui-dropdown-selector
-    [title]="'map.select.layer' | translate"
-    class="absolute m-2"
-    [choices]="dropdownChoices$ | async"
-    [showTitle]="false"
-    (selectValue)="selectLinkToDisplay($event)"
-  ></gn-ui-dropdown-selector>
+  <div class="absolute flex w-full" style="bottom: 0">
+    <gn-ui-dropdown-selector
+      class="flex-grow m-2"
+      [title]="'map.select.layer' | translate"
+      [choices]="dropdownChoices$ | async"
+      [showTitle]="false"
+      (selectValue)="selectLinkToDisplay($event)"
+    ></gn-ui-dropdown-selector>
+    <gn-ui-external-viewer-button
+      [link]="selectedLink$ | async"
+      [mapConfig]="mapConfig"
+    >
+    </gn-ui-external-viewer-button>
+  </div>
 </div>

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -73,11 +73,12 @@ export class DataViewMapComponent implements OnInit, OnDestroy {
   loading = false
   error = null
 
-  currentLayers$ = combineLatest([
+  selectedLink$ = combineLatest([
     this.compatibleMapLinks$,
     this.selectedLinkIndex$.pipe(distinctUntilChanged()),
-  ]).pipe(
-    map(([links, index]) => links[index]),
+  ]).pipe(map(([links, index]) => links[index]))
+
+  currentLayers$ = this.selectedLink$.pipe(
     switchMap((link) => {
       if (!link) {
         return of([])

--- a/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.html
+++ b/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.html
@@ -1,0 +1,8 @@
+<gn-ui-button
+  *ngIf="externalViewer"
+  (click)="openInExternalViewer()"
+  type="primary"
+  extraClass="m-2 flex"
+>
+  <span class="text-white" translate> record.externalViewer.open </span>
+</gn-ui-button>

--- a/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.spec.ts
+++ b/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.spec.ts
@@ -1,0 +1,119 @@
+import { Component } from '@angular/core'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { By } from '@angular/platform-browser'
+import { LinkHelperService } from '@geonetwork-ui/feature/search'
+import { MAP_CONFIG_FIXTURE } from '@geonetwork-ui/util/app-config'
+
+import { ExternalViewerButtonComponent } from './external-viewer-button.component'
+
+class LinkHelperServiceMock {
+  isWmsLink = jest.fn((link) => link.protocol === 'OGC:WMS')
+  isWfsLink = jest.fn((link) => link.protocol === 'OGC:WFS')
+}
+
+@Component({
+  selector: 'gn-ui-button',
+  template: '<div></div>',
+})
+export class MockButtonComponent {}
+
+describe('ExternalViewerButtonComponent', () => {
+  let component: ExternalViewerButtonComponent
+  let fixture: ComponentFixture<ExternalViewerButtonComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ExternalViewerButtonComponent, MockButtonComponent],
+      providers: [
+        {
+          provide: LinkHelperService,
+          useClass: LinkHelperServiceMock,
+        },
+      ],
+    }).compileComponents()
+  })
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExternalViewerButtonComponent)
+    component = fixture.componentInstance
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+  describe('with mapConfig and no link', () => {
+    beforeEach(() => {
+      component.mapConfig = MAP_CONFIG_FIXTURE
+      component.link = null
+      fixture.detectChanges()
+    })
+    it('sets externalViewer to display button to false', () => {
+      expect(component.externalViewer).toEqual(false)
+    })
+  })
+  describe('with mapConfig and WMS link', () => {
+    beforeEach(() => {
+      component.mapConfig = MAP_CONFIG_FIXTURE
+      component.link = {
+        url: 'http://example.com/',
+        name: 'layername',
+        protocol: 'OGC:WMS',
+      }
+      fixture.detectChanges()
+    })
+    it('sets externalViewer to display button to true', () => {
+      expect(component.externalViewer).toEqual(true)
+    })
+    describe('click button', () => {
+      let buttonComponent: MockButtonComponent
+      let componentSpy
+      let windowSpy
+      const openMock = jest.fn().mockReturnThis()
+      const focusMock = jest.fn().mockReturnThis()
+      beforeEach(() => {
+        buttonComponent = fixture.debugElement.query(
+          By.directive(MockButtonComponent)
+        )
+        componentSpy = jest.spyOn(component, 'openInExternalViewer')
+        windowSpy = jest
+          .spyOn(global, 'window', 'get')
+          .mockImplementation(() => ({
+            open: openMock,
+            focus: focusMock,
+          }))
+        buttonComponent.nativeElement.click()
+      })
+
+      afterEach(() => {
+        componentSpy.mockRestore()
+        windowSpy.mockRestore()
+      })
+      it('calls openInExternalViewer', () => {
+        expect(component.openInExternalViewer).toHaveBeenCalled()
+      })
+      it('opens window in new tab with URL including WMS link params', () => {
+        expect(openMock).toHaveBeenCalledWith(
+          'https://example.com/myviewer?url=http://example.com/&name=layername&type=wms',
+          '_blank'
+        )
+      })
+      it('focuses window', () => {
+        expect(focusMock).toHaveBeenCalled()
+      })
+    })
+  })
+  describe('with mapConfig and non WMS link', () => {
+    beforeEach(() => {
+      component.mapConfig = MAP_CONFIG_FIXTURE
+      component.link = {
+        url: 'http://example.com/',
+        name: 'layername',
+        protocol: 'NOT:WMS',
+      }
+      fixture.detectChanges()
+    })
+    it('sets externalViewer to display button to false', () => {
+      expect(component.externalViewer).toEqual(false)
+    })
+  })
+})

--- a/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.ts
+++ b/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.ts
@@ -1,0 +1,50 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
+import { LinkHelperService } from '@geonetwork-ui/feature/search'
+import { MapConfig } from '@geonetwork-ui/util/app-config'
+import { MetadataLinkValid } from '@geonetwork-ui/util/shared'
+
+@Component({
+  selector: 'gn-ui-external-viewer-button',
+  templateUrl: './external-viewer-button.component.html',
+  styleUrls: ['./external-viewer-button.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ExternalViewerButtonComponent {
+  @Input() link: MetadataLinkValid
+  @Input() mapConfig: MapConfig
+
+  get externalViewer() {
+    if (this.link && this.mapConfig) {
+      return (
+        !!this.mapConfig.EXTERNAL_VIEWER_URL_TEMPLATE &&
+        !!this.supportedLinkLayerType
+      )
+    }
+    return false
+  }
+
+  get supportedLinkLayerType() {
+    if (!this.link) return null
+    return this.linkHelper.isWmsLink(this.link)
+      ? 'wms'
+      : this.linkHelper.isWfsLink(this.link)
+      ? 'wfs'
+      : null
+  }
+
+  constructor(private linkHelper: LinkHelperService) {}
+
+  openInExternalViewer() {
+    const templateUrl = this.mapConfig.EXTERNAL_VIEWER_URL_TEMPLATE
+    const url = templateUrl
+      .replace('${layer_name}', `${this.link.name}`)
+      .replace('${service_url}', `${this.link.url}`)
+      .replace('${service_type}', `${this.supportedLinkLayerType}`)
+    window
+      .open(
+        url,
+        this.mapConfig.EXTERNAL_VIEWER_OPEN_NEW_TAB ? '_blank' : '_self'
+      )
+      .focus()
+  }
+}

--- a/libs/feature/record/src/lib/feature-record.module.ts
+++ b/libs/feature/record/src/lib/feature-record.module.ts
@@ -22,6 +22,7 @@ import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
 import { TranslateModule } from '@ngx-translate/core'
 import { DataOtherlinksComponent } from './data-otherlinks/data-otherlinks.component'
 import { RelatedRecordsComponent } from './related-records/related-records.component'
+import { ExternalViewerButtonComponent } from './external-viewer-button/external-viewer-button.component'
 
 @NgModule({
   declarations: [
@@ -32,6 +33,7 @@ import { RelatedRecordsComponent } from './related-records/related-records.compo
     DataApisComponent,
     DataOtherlinksComponent,
     RelatedRecordsComponent,
+    ExternalViewerButtonComponent,
   ],
   imports: [
     CommonModule,

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -33,6 +33,8 @@ another_path = '/whatever'
 max_zoom = 10
 max_extent = [-418263.418776, 5251529.591305, 961272.067714, 6706890.609855]
 do_not_use_default_basemap = false
+external_viewer_url_template = 'https://example.com/myviewer?'
+external_viewer_open_new_tab = true
 another_zoom = 15
 [[map_layer]]
 type = "wms"
@@ -209,6 +211,8 @@ describe('app config utils', () => {
             max_zoom = 10
             max_extent = [-418263.418776, 5251529.591305, 961272.067714, 6706890.609855]
             do_not_use_default_basemap = true
+            external_viewer_url_template = 'https://example.com/myviewer?'
+            external_viewer_open_new_tab = true
             [[map_layer]]
             type = "wms"
             url = "https://www.geo2france.fr/geoserver/cr_hdf/ows"
@@ -228,6 +232,8 @@ describe('app config utils', () => {
             -418263.418776, 5251529.591305, 961272.067714, 6706890.609855,
           ],
           DO_NOT_USE_DEFAULT_BASEMAP: true,
+          EXTERNAL_VIEWER_URL_TEMPLATE: 'https://example.com/myviewer?',
+          EXTERNAL_VIEWER_OPEN_NEW_TAB: true,
           MAP_LAYERS: [
             {
               TYPE: 'wms',
@@ -259,6 +265,8 @@ describe('app config utils', () => {
         expect(getMapConfig()).toEqual({
           MAX_ZOOM: undefined,
           MAX_EXTENT: undefined,
+          EXTERNAL_VIEWER_URL_TEMPLATE: undefined,
+          EXTERNAL_VIEWER_OPEN_NEW_TAB: undefined,
           DO_NOT_USE_DEFAULT_BASEMAP: false,
           MAP_LAYERS: [],
         })

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -134,6 +134,10 @@ export function loadAppConfig() {
           : ({
               MAX_ZOOM: parsedMapSection.max_zoom,
               MAX_EXTENT: parsedMapSection.max_extent,
+              EXTERNAL_VIEWER_URL_TEMPLATE:
+                parsedMapSection.external_viewer_url_template,
+              EXTERNAL_VIEWER_OPEN_NEW_TAB:
+                parsedMapSection.external_viewer_open_new_tab,
               DO_NOT_USE_DEFAULT_BASEMAP:
                 !!parsedMapSection.do_not_use_default_basemap,
               MAP_LAYERS: parsedLayersSections.map(

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -29,6 +29,8 @@ export interface LayerConfig {
 export interface MapConfig {
   MAX_ZOOM?: number
   MAX_EXTENT?: [number, number, number, number] // Expressed as [minx, miny, maxx, maxy]
+  EXTERNAL_VIEWER_URL_TEMPLATE?: string
+  EXTERNAL_VIEWER_OPEN_NEW_TAB?: string
   DO_NOT_USE_DEFAULT_BASEMAP: boolean
   MAP_LAYERS: LayerConfig[]
 }
@@ -115,7 +117,14 @@ export function loadAppConfig() {
         parsed,
         'map',
         [],
-        ['max_zoom', 'max_extent', 'baselayer', 'do_not_use_default_basemap'],
+        [
+          'max_zoom',
+          'max_extent',
+          'baselayer',
+          'do_not_use_default_basemap',
+          'external_viewer_url_template',
+          'external_viewer_open_new_tab',
+        ],
         warnings,
         errors
       )

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -7,6 +7,8 @@ proxy_path = "/proxy/?url="
 max_zoom = 10
 max_extent = [-418263.418776, 5251529.591305, 961272.067714, 6706890.609855]
 do_not_use_default_basemap = false
+external_viewer_url_template = 'https://example.com/myviewer?'
+external_viewer_open_new_tab = true
 [[map_layer]]
 type = "wms"
 url = "https://www.geo2france.fr/geoserver/cr_hdf/ows"
@@ -44,6 +46,9 @@ export const MAP_CONFIG_FIXTURE = {
   MAX_ZOOM: 10,
   MAX_EXTENT: [-418263.418776, 5251529.591305, 961272.067714, 6706890.609855],
   DO_NOT_USE_DEFAULT_BASEMAP: false,
+  EXTERNAL_VIEWER_URL_TEMPLATE:
+    'https://example.com/myviewer?url=${service_url}&name=${layer_name}&type=${service_type}',
+  EXTERNAL_VIEWER_OPEN_NEW_TAB: true,
   MAP_LAYERS: [
     {
       TYPE: 'xyz',

--- a/translations/de.json
+++ b/translations/de.json
@@ -103,6 +103,7 @@
   "previous": "",
   "record.action.download": "",
   "record.action.view": "",
+  "record.externalViewer.open": "",
   "record.metadata.about": "",
   "record.metadata.access": "",
   "record.metadata.api": "",

--- a/translations/en.json
+++ b/translations/en.json
@@ -103,6 +103,7 @@
   "previous": "previous",
   "record.action.download": "Download",
   "record.action.view": "View",
+  "record.externalViewer.open": "Open in map viewer",
   "record.metadata.about": "About",
   "record.metadata.access": "Access",
   "record.metadata.api": "API",

--- a/translations/es.json
+++ b/translations/es.json
@@ -103,6 +103,7 @@
   "previous": "",
   "record.action.download": "",
   "record.action.view": "",
+  "record.externalViewer.open": "",
   "record.metadata.about": "",
   "record.metadata.access": "",
   "record.metadata.api": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -103,6 +103,7 @@
   "previous": "précédent",
   "record.action.download": "Télécharger",
   "record.action.view": "Voir",
+  "record.externalViewer.open": "Ouvrir dans visualiseur",
   "record.metadata.about": "À propos",
   "record.metadata.access": "Accès",
   "record.metadata.api": "API",

--- a/translations/it.json
+++ b/translations/it.json
@@ -103,6 +103,7 @@
   "previous": "",
   "record.action.download": "",
   "record.action.view": "",
+  "record.externalViewer.open": "",
   "record.metadata.about": "",
   "record.metadata.access": "",
   "record.metadata.api": "",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -103,6 +103,7 @@
   "previous": "",
   "record.action.download": "",
   "record.action.view": "",
+  "record.externalViewer.open": "",
   "record.metadata.about": "",
   "record.metadata.access": "",
   "record.metadata.api": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -103,6 +103,7 @@
   "previous": "",
   "record.action.download": "",
   "record.action.view": "",
+  "record.externalViewer.open": "",
   "record.metadata.about": "",
   "record.metadata.access": "",
   "record.metadata.api": "",


### PR DESCRIPTION
PR adds a button to the map that allows to open the currently selected layer in an external viewer. Currently, supports `WMS` and `WFS`. Tested with mapstore where both work fine and mapfishapp, which did not open the `WFS`s I've tried. Not sure if this is supported by mapfishapp.

TODO
- [x] fix extract i18n

![externalviewer](https://user-images.githubusercontent.com/6329425/155510746-d34b76c4-1086-444f-8471-7abd5d280ca7.png)