### PR TITLE
Layout / improve performance of sticky header animation

### DIFF
--- a/apps/datahub/src/app/record/header-record/header-record.component.html
+++ b/apps/datahub/src/app/record/header-record/header-record.component.html
@@ -5,7 +5,13 @@
     <div
       *ngIf="metadata"
       class="font-title text-center px-2 mx-48 text-[28px] mb-[41px]"
-      [style.transform]="'scale(' + (0.85 + 0.15 * expandRatio) + ')'"
+      [style.transform]="
+        'scale(' +
+        (0.85 + 0.15 * expandRatio) +
+        ') translate(0, ' +
+        (1 - expandRatio) * 70 +
+        'px)'
+      "
     >
       {{ metadata.title }}
     </div>

--- a/apps/datahub/src/app/record/header-record/header-record.component.html
+++ b/apps/datahub/src/app/record/header-record/header-record.component.html
@@ -1,17 +1,10 @@
-<header class="w-full h-full" [style.background]="backgroundCss">
+<header class="w-full h-[231px]" [style.background]="backgroundCss">
   <div
     class="h-full container-lg mx-auto flex flex-col justify-center relative"
   >
     <div
       *ngIf="metadata"
       class="font-title text-center px-2 mx-48 text-[28px] mb-[41px]"
-      [style.transform]="
-        'scale(' +
-        (0.85 + 0.15 * expandRatio) +
-        ') translate(0, ' +
-        (1 - expandRatio) * 70 +
-        'px)'
-      "
     >
       {{ metadata.title }}
     </div>
@@ -24,43 +17,43 @@
       >
       </gn-ui-navigation-button>
     </div>
-
-    <div
-      class="absolute bg-primary flex space-x-8 justify-between py-5 px-20 text-sm rounded-lg text-white"
-      style="left: 0; right: 0; bottom: -20px"
-    >
-      <button
-        gnUiAnchorLink="about"
-        gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
-        class="uppercase font-medium tracking-wider"
-        translate
-      >
-        record.metadata.about
-      </button>
-      <button
-        gnUiAnchorLink="preview"
-        gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
-        class="uppercase font-medium tracking-wider"
-        translate
-      >
-        record.metadata.preview
-      </button>
-      <button
-        gnUiAnchorLink="access"
-        gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
-        class="uppercase font-medium tracking-wider"
-        translate
-      >
-        record.metadata.access
-      </button>
-      <button
-        gnUiAnchorLink="links"
-        gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
-        class="uppercase font-medium tracking-wider"
-        translate
-      >
-        record.metadata.links
-      </button>
-    </div>
   </div>
 </header>
+
+<div
+  class="container-lg mx-auto bg-primary flex space-x-8 justify-between py-5 px-20 text-sm rounded-lg text-white sticky z-20 mt-[-40px]"
+  style="left: 0; right: 0; top: 10px"
+>
+  <button
+    gnUiAnchorLink="about"
+    gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
+    class="uppercase font-medium tracking-wider"
+    translate
+  >
+    record.metadata.about
+  </button>
+  <button
+    gnUiAnchorLink="preview"
+    gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
+    class="uppercase font-medium tracking-wider"
+    translate
+  >
+    record.metadata.preview
+  </button>
+  <button
+    gnUiAnchorLink="access"
+    gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
+    class="uppercase font-medium tracking-wider"
+    translate
+  >
+    record.metadata.access
+  </button>
+  <button
+    gnUiAnchorLink="links"
+    gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
+    class="uppercase font-medium tracking-wider"
+    translate
+  >
+    record.metadata.links
+  </button>
+</div>

--- a/apps/datahub/src/app/record/header-record/header-record.component.ts
+++ b/apps/datahub/src/app/record/header-record/header-record.component.ts
@@ -14,7 +14,9 @@ import { getThemeConfig } from '@geonetwork-ui/util/app-config'
 export class HeaderRecordComponent {
   @Input() metadata: MetadataRecord
   @Input() expandRatio: number
-  backgroundCss = getThemeConfig().HEADER_BACKGROUND
+  backgroundCss =
+    getThemeConfig().HEADER_BACKGROUND ||
+    "center url('assets/img/default_header_bg.webp')"
 
   constructor(
     private searchRouter: RouterFacade,

--- a/apps/datahub/src/app/record/header-record/header-record.component.ts
+++ b/apps/datahub/src/app/record/header-record/header-record.component.ts
@@ -13,7 +13,6 @@ import { getThemeConfig } from '@geonetwork-ui/util/app-config'
 })
 export class HeaderRecordComponent {
   @Input() metadata: MetadataRecord
-  @Input() expandRatio: number
   backgroundCss =
     getThemeConfig().HEADER_BACKGROUND ||
     "center url('assets/img/default_header_bg.webp')"

--- a/apps/datahub/src/app/record/record-page/record-page.component.html
+++ b/apps/datahub/src/app/record/record-page/record-page.component.html
@@ -1,11 +1,10 @@
-<div id="record-page" class="h-screen overflow-auto">
-  <gn-ui-sticky-header [fullHeightPx]="231" [minHeightPx]="112">
-    <ng-template let-expandRatio>
-      <datahub-header-record
-        [metadata]="mdViewFacade.metadata$ | async"
-        [expandRatio]="expandRatio"
-      ></datahub-header-record>
-    </ng-template>
-  </gn-ui-sticky-header>
+<div
+  id="record-page"
+  class="h-screen overflow-auto"
+  style="scroll-padding-top: 80px"
+>
+  <datahub-header-record
+    [metadata]="mdViewFacade.metadata$ | async"
+  ></datahub-header-record>
   <gn-ui-record-metadata></gn-ui-record-metadata>
 </div>

--- a/apps/datahub/src/app/search/search-header/search-header.component.html
+++ b/apps/datahub/src/app/search/search-header/search-header.component.html
@@ -1,9 +1,12 @@
 <header class="h-full" [style.background]="backgroundCss">
   <div class="container-md h-full mx-auto flex flex-col justify-center">
-    <div class="py-8 relative" [style.margin-top]="expandRatio * 97 + 'px'">
+    <div
+      class="py-8 relative"
+      [style.transform]="'translate(0, ' + (1 - expandRatio) * 216 + 'px)'"
+    >
       <div
         class="font-title text-[48px] leading-[58px] absolute w-full"
-        [style.bottom]="'100%'"
+        style="bottom: 100%"
         [style.opacity]="expandRatio"
         [innerHTML]="'datahub.header.title.html' | translate"
       ></div>
@@ -29,7 +32,6 @@
       class="tabs flex justify-center py-4 mt-12 font-medium absolute"
       style="bottom: 0; left: 0; right: 0"
       [style.opacity]="expandRatio"
-      [style.visibility]="expandRatio > 0 ? 'visible' : 'hidden'"
     >
       <!--      <div class="uppercase text-white">Fil d'activité</div>-->
       <div

--- a/apps/datahub/src/app/search/search-header/search-header.component.ts
+++ b/apps/datahub/src/app/search/search-header/search-header.component.ts
@@ -23,7 +23,9 @@ export class SearchHeaderComponent {
   searchInputRouteValue$ = this.routerFacade.anySearch$.pipe(
     map((any) => ({ title: any }))
   )
-  backgroundCss = getThemeConfig().HEADER_BACKGROUND
+  backgroundCss =
+    getThemeConfig().HEADER_BACKGROUND ||
+    "center url('assets/img/default_header_bg.webp')"
 
   constructor(
     private routerFacade: RouterFacade,

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -69,7 +69,7 @@ main_color = "#212029" # All-purpose text color
 background_color = "#fdfbff"
 
 # This mandatory parameter indicates which background should be used for the main header
-header_background = "center / cover url('assets/img/default_header_bg.webp')"
+header_background = "center url('assets/img/default_header_bg.webp')"
 
 # This optional parameter allows to override the fallback image that should be used for thumbnails, 
 # if the metadata record has no thumbnail image url or it is broken.

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -68,8 +68,8 @@ secondary_color = "#8bc832"
 main_color = "#212029" # All-purpose text color
 background_color = "#fdfbff"
 
-# This mandatory parameter indicates which background should be used for the main header
-header_background = "center url('assets/img/default_header_bg.webp')"
+# This optional parameter indicates which background should be used for the main header
+# header_background = "center url('assets/img/default_header_bg.webp')"
 
 # This optional parameter allows to override the fallback image that should be used for thumbnails, 
 # if the metadata record has no thumbnail image url or it is broken.

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
@@ -32,7 +32,6 @@
   </div>
 </div>
 <div
-  id="preview"
   style="height: 648px"
   *ngIf="(displayMap$ | async) || (displayData$ | async)"
 >
@@ -42,7 +41,11 @@
   >
     <div class="container-lg mx-auto">
       <div>
-        <div class="text-[28px] font-title transform translate-y-10" translate>
+        <div
+          class="text-[28px] font-title transform translate-y-10"
+          translate
+          id="preview"
+        >
           record.metadata.preview
         </div>
         <mat-tab-group

--- a/libs/ui/layout/src/lib/sticky-header/sticky-header.component.html
+++ b/libs/ui/layout/src/lib/sticky-header/sticky-header.component.html
@@ -4,7 +4,11 @@
   style="top: 0"
   [style.height]="fullHeightPx + 'px'"
 >
-  <div #innerContainer class="relative pointer-events-auto">
+  <div
+    #innerContainer
+    class="relative pointer-events-auto"
+    [style.height]="fullHeightPx + 'px'"
+  >
     <ng-container
       [ngTemplateOutlet]="template"
       [ngTemplateOutletContext]="{ $implicit: expandRatio }"

--- a/libs/ui/layout/src/lib/sticky-header/sticky-header.component.html
+++ b/libs/ui/layout/src/lib/sticky-header/sticky-header.component.html
@@ -4,11 +4,7 @@
   style="top: 0"
   [style.height]="fullHeightPx + 'px'"
 >
-  <div
-    #innerContainer
-    class="relative pointer-events-auto"
-    style="transition: height 0.03s ease"
-  >
+  <div #innerContainer class="relative pointer-events-auto">
     <ng-container
       [ngTemplateOutlet]="template"
       [ngTemplateOutletContext]="{ $implicit: expandRatio }"

--- a/libs/ui/layout/src/lib/sticky-header/sticky-header.component.spec.ts
+++ b/libs/ui/layout/src/lib/sticky-header/sticky-header.component.spec.ts
@@ -75,7 +75,7 @@ describe('StickyHeaderComponent', () => {
         tick(20)
       }))
       it('sets height between full and min height', () => {
-        expect(headerEl.style.height).toBe('250px')
+        expect(headerEl.style.transform).toBe('translate(0, -50px)')
       })
       it('sets opacity using expandRatio', () => {
         expect(contentEl.style.opacity).toBe('0.75')
@@ -88,7 +88,7 @@ describe('StickyHeaderComponent', () => {
         tick(20)
       }))
       it('sets height at min height', () => {
-        expect(headerEl.style.height).toBe('100px')
+        expect(headerEl.style.transform).toBe('translate(0, -200px)')
       })
       it('sets opacity using expandRatio', () => {
         expect(contentEl.style.opacity).toBe('0')

--- a/libs/ui/layout/src/lib/sticky-header/sticky-header.component.ts
+++ b/libs/ui/layout/src/lib/sticky-header/sticky-header.component.ts
@@ -99,7 +99,9 @@ export class StickyHeaderComponent
         this.minHeightPx,
         this.fullHeightPx - offsetTop
       )
-      this.innerContainer.nativeElement.style.height = newHeightPx + 'px'
+      this.innerContainer.nativeElement.style.transform = `translate(0, ${
+        newHeightPx - this.fullHeightPx
+      }px)`
       this.expandRatio =
         (newHeightPx - this.minHeightPx) /
         (this.fullHeightPx - this.minHeightPx)

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -154,18 +154,13 @@ export function loadAppConfig() {
       const parsedThemeSection = parseConfigSection(
         parsed,
         'theme',
-        [
-          'primary_color',
-          'secondary_color',
-          'main_color',
-          'background_color',
-          'header_background',
-        ],
+        ['primary_color', 'secondary_color', 'main_color', 'background_color'],
         [
           'main_font',
           'title_font',
           'fonts_stylesheet_url',
           'thumbnail_placeholder',
+          'header_background',
         ],
         warnings,
         errors


### PR DESCRIPTION
* Change size of default header background  
  Using `cover` means the background image gets resized according to the header size, which makes the browser spend much more time in the layout/painting phase.

* Removed the height transition which does not really change anything at all.

* Avoid changing `height` of header, change `transform` instead; this will avoid reflows of the layout

Performance is probably in the range of acceptable now.