### PR TITLE
Fix External Viewer: Uri encode service url

### DIFF
--- a/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.spec.ts
+++ b/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.spec.ts
@@ -55,7 +55,7 @@ describe('ExternalViewerButtonComponent', () => {
     beforeEach(() => {
       component.mapConfig = MAP_CONFIG_FIXTURE
       component.link = {
-        url: 'http://example.com/',
+        url: 'http://example.com/ows?service=wms&request=getcapabilities',
         name: 'layername',
         protocol: 'OGC:WMS',
       }
@@ -93,7 +93,7 @@ describe('ExternalViewerButtonComponent', () => {
       })
       it('opens window in new tab with URL including WMS link params', () => {
         expect(openMock).toHaveBeenCalledWith(
-          'https://example.com/myviewer?url=http://example.com/&name=layername&type=wms',
+          'https://example.com/myviewer?url=http%3A%2F%2Fexample.com%2Fows%3Fservice%3Dwms%26request%3Dgetcapabilities&name=layername&type=wms',
           '_blank'
         )
       })

--- a/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.ts
+++ b/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.ts
@@ -38,7 +38,7 @@ export class ExternalViewerButtonComponent {
     const templateUrl = this.mapConfig.EXTERNAL_VIEWER_URL_TEMPLATE
     const url = templateUrl
       .replace('${layer_name}', `${this.link.name}`)
-      .replace('${service_url}', `${this.link.url}`)
+      .replace('${service_url}', `${encodeURIComponent(this.link.url)}`)
       .replace('${service_type}', `${this.supportedLinkLayerType}`)
     window
       .open(


### PR DESCRIPTION
PR fixes opening layers in external viewer, that contain query params. The layer's service is uri encoded, before it is passed it to the external viewer. Currently, service urls containing `request=getCapabilities` do not allow mapstore to add the layer for example. Can be tested with: https://dev.geo2france.fr/datahub/dataset/35d867a1-9420-449c-b0c4-442e7662eca6