### PR TITLE
Fix scolling for navigation

### DIFF
--- a/apps/datahub/src/app/record/record-page/record-page.component.html
+++ b/apps/datahub/src/app/record/record-page/record-page.component.html
@@ -1,4 +1,4 @@
-<div class="h-screen overflow-auto">
+<div id="record-page" class="h-screen overflow-auto">
   <gn-ui-sticky-header [fullHeightPx]="231" [minHeightPx]="112">
     <ng-template let-expandRatio>
       <datahub-header-record

--- a/apps/datahub/src/app/record/record-page/record-page.component.spec.ts
+++ b/apps/datahub/src/app/record/record-page/record-page.component.spec.ts
@@ -35,4 +35,7 @@ describe('RecordPageComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy()
   })
+  it('has id="record-page" at root for related records scroll', () => {
+    expect(fixture.nativeElement.children[0].id).toBe('record-page')
+  })
 })


### PR DESCRIPTION
PR recovers the div id that allows to scroll to top when navigating to related record.

TODO:

- [ ] do not scroll to top when returning to search