### PR TITLE
Handle GeoJSON layers as remote files in map-context

### DIFF
--- a/conf/default.toml
+++ b/conf/default.toml
@@ -42,9 +42,10 @@ proxy_path = ""
 # do_not_use_default_basemap = false
 
 # One or several layers (as background or overlay) can be added to the map with the following properties:
-# - type (mandatory): Indicates the layer type. Possible values are 'xyz', 'wms', 'wfs'.
-# - url (mandatory): Layer endpoint URL.
-# - name: Mandatory for 'wms', 'wfs' types where it indicates the layer name or feature type.
+# - type (mandatory): Indicates the layer type. Possible values are 'xyz', 'wms', 'wfs', 'geojson'.
+# - url (mandatory for 'xyz', 'wms' and 'wfs' types): Layer endpoint URL.
+# - name (mandatory for 'wms' and 'wfs' types): indicates the layer name or feature type.
+# - data (for 'geojson' type only): inline GeoJSON data as string
 # Layer order in the config is the same as in the map, the first one being the bottom one.
 # Each layer is defined in its own [[map_layer]] section.
 # Example:
@@ -55,6 +56,14 @@ proxy_path = ""
 # type = "wfs"
 # url = "https://www.geo2france.fr/geoserver/cr_hdf/ows"
 # name = "masque_hdf_ign_carto_latin1"
+# [[map_layer]]
+# type = "geojson"
+# data = """
+# {
+#   "type": "FeatureCollection",
+#   "features": [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [125.6, 10.1]}}]
+# }
+# """
 
 ### VISUAL THEME
 

--- a/libs/feature/map/src/lib/map-context/map-context.fixtures.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.fixtures.ts
@@ -20,6 +20,10 @@ export const MAP_CTX_LAYER_GEOJSON_FIXTURE: MapContextLayerModel = {
   type: MapContextLayerTypeEnum.GEOJSON,
   data: FEATURE_COLLECTION_POLYGON_FIXTURE_4326,
 }
+export const MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE: MapContextLayerModel = {
+  type: MapContextLayerTypeEnum.GEOJSON,
+  url: 'https://my.host.com/data/regions.json',
+}
 
 export const MAP_CTX_VIEW_FIXTURE: MapContextViewModel = {
   center: [7.75, 48.6],

--- a/libs/feature/map/src/lib/map-context/map-context.model.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.model.ts
@@ -14,13 +14,31 @@ export interface MapContextModel {
   view?: MapContextViewModel
 }
 
-export interface MapContextLayerModel {
-  type: MapContextLayerTypeEnum
-  url?: string
-  urls?: string[]
-  name?: string
-  data?: FeatureCollection
+interface MapContextLayerWmsModel {
+  type: 'wms'
+  url: string
+  name: string
 }
+
+interface MapContextLayerWfsModel {
+  type: 'wfs'
+  url: string
+  name: string
+}
+
+type MapContextLayerXyzModel = {
+  type: 'xyz'
+} & ({ url: string } | { urls: string[] })
+
+type MapContextLayerGeojsonModel = {
+  type: 'geojson'
+} & ({ url: string } | { data: FeatureCollection | string })
+
+export type MapContextLayerModel =
+  | MapContextLayerWmsModel
+  | MapContextLayerWfsModel
+  | MapContextLayerXyzModel
+  | MapContextLayerGeojsonModel
 
 export interface MapContextViewModel {
   center?: Coordinate //expressed in map projection (EPSG:3857)

--- a/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
@@ -9,6 +9,7 @@ import VectorSource from 'ol/source/Vector'
 import XYZ from 'ol/source/XYZ'
 import { Style } from 'ol/style'
 import View from 'ol/View'
+import GeoJSON from 'ol/format/GeoJSON'
 import {
   DEFAULT_STYLE_FIXTURE,
   DEFAULT_STYLE_HL_FIXTURE,
@@ -18,6 +19,7 @@ import {
   MAP_CTX_EXTENT_FIXTURE,
   MAP_CTX_FIXTURE,
   MAP_CTX_LAYER_GEOJSON_FIXTURE,
+  MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE,
   MAP_CTX_LAYER_WMS_FIXTURE,
   MAP_CTX_LAYER_XYZ_FIXTURE,
 } from './map-context.fixtures'
@@ -105,22 +107,88 @@ describe('MapContextService', () => {
     })
 
     describe('GEOJSON', () => {
-      beforeEach(() => {
-        layerModel = MAP_CTX_LAYER_GEOJSON_FIXTURE
-        layer = service.createLayer(layerModel)
+      describe('with inline data', () => {
+        beforeEach(() => {
+          layerModel = MAP_CTX_LAYER_GEOJSON_FIXTURE
+          layer = service.createLayer(layerModel)
+        })
+        it('create a VectorLayer', () => {
+          expect(layer).toBeTruthy()
+          expect(layer).toBeInstanceOf(VectorLayer)
+        })
+        it('create a VectorSource source', () => {
+          const source = layer.getSource()
+          expect(source).toBeInstanceOf(VectorSource)
+        })
+        it('add features', () => {
+          const source = layer.getSource()
+          const features = source.getFeatures()
+          expect(features.length).toBe(layerModel.data.features.length)
+        })
       })
-      it('create a VectorLayer', () => {
-        expect(layer).toBeTruthy()
-        expect(layer).toBeInstanceOf(VectorLayer)
+      describe('with inline data as string', () => {
+        beforeEach(() => {
+          layerModel = { ...MAP_CTX_LAYER_GEOJSON_FIXTURE }
+          layerModel.data = JSON.stringify(layerModel.data)
+          layer = service.createLayer(layerModel)
+        })
+        it('create a VectorLayer', () => {
+          expect(layer).toBeTruthy()
+          expect(layer).toBeInstanceOf(VectorLayer)
+        })
+        it('create a VectorSource source', () => {
+          const source = layer.getSource()
+          expect(source).toBeInstanceOf(VectorSource)
+        })
+        it('add features', () => {
+          const source = layer.getSource()
+          const features = source.getFeatures()
+          expect(features.length).toBe(
+            MAP_CTX_LAYER_GEOJSON_FIXTURE.data.features.length
+          )
+        })
       })
-      it('create a VectorSource source', () => {
-        const source = layer.getSource()
-        expect(source).toBeInstanceOf(VectorSource)
+      describe('with invalid inline data as string', () => {
+        beforeEach(() => {
+          const spy = jest.spyOn(global.console, 'warn')
+          spy.mockClear()
+          layerModel = { ...MAP_CTX_LAYER_GEOJSON_FIXTURE, data: 'blargz' }
+          layer = service.createLayer(layerModel)
+        })
+        it('create a VectorLayer', () => {
+          expect(layer).toBeTruthy()
+          expect(layer).toBeInstanceOf(VectorLayer)
+        })
+        it('outputs error in the console', () => {
+          expect(global.console.warn).toHaveBeenCalled()
+        })
+        it('create an empty VectorSource source', () => {
+          const source = layer.getSource()
+          expect(source).toBeInstanceOf(VectorSource)
+          expect(source.getFeatures().length).toBe(0)
+        })
       })
-      it('add features', () => {
-        const source = layer.getSource()
-        const features = source.getFeatures()
-        expect(features.length).toBe(layerModel.data.features.length)
+      describe('with remote file url', () => {
+        beforeEach(() => {
+          layerModel = MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE
+          layer = service.createLayer(layerModel)
+        })
+        it('create a VectorLayer', () => {
+          expect(layer).toBeTruthy()
+          expect(layer).toBeInstanceOf(VectorLayer)
+        })
+        it('create a VectorSource source', () => {
+          const source = layer.getSource()
+          expect(source).toBeInstanceOf(VectorSource)
+        })
+        it('sets the format as GeoJSON', () => {
+          const source = layer.getSource()
+          expect(source.getFormat()).toBeInstanceOf(GeoJSON)
+        })
+        it('set the url to point to the file', () => {
+          const source = layer.getSource()
+          expect(source.getUrl()).toBe(layerModel.url)
+        })
       })
     })
   })

--- a/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
@@ -307,8 +307,8 @@ describe('MapContextService', () => {
         mapContext,
         mapConfig
       )
-      const layersContext = service.getLayersContextFromConfig(
-        MAP_CONFIG_FIXTURE.MAP_LAYERS
+      const layersContext = MAP_CONFIG_FIXTURE.MAP_LAYERS.map(
+        service.getContextLayerFromConfig
       )
 
       expect(mergedMapContext).toEqual({

--- a/libs/feature/map/src/lib/map-context/map-context.service.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.ts
@@ -160,25 +160,38 @@ export class MapContextService {
         ...(mapConfig.DO_NOT_USE_DEFAULT_BASEMAP
           ? []
           : [DEFAULT_BASELAYER_CONTEXT]),
-        ...(mapConfig.MAP_LAYERS
-          ? this.getLayersContextFromConfig(mapConfig.MAP_LAYERS)
-          : []),
+        ...mapConfig.MAP_LAYERS.map(this.getContextLayerFromConfig),
         ...mapContext.layers,
       ],
     }
   }
 
-  getLayersContextFromConfig(
-    layersConfig: LayerConfig[]
-  ): MapContextLayerModel[] {
-    const layersModel: MapContextLayerModel[] = []
-    layersConfig.forEach((layerConfig) => {
-      layersModel.push({
-        type: MapContextLayerTypeEnum[layerConfig.TYPE.toUpperCase()],
-        url: layerConfig.URL,
-        name: layerConfig.NAME,
-      })
-    })
-    return layersModel
+  getContextLayerFromConfig(config: LayerConfig): MapContextLayerModel {
+    switch (config.TYPE) {
+      case 'wms':
+        return {
+          type: 'wms',
+          url: config.URL,
+          name: config.NAME,
+        }
+      case 'wfs':
+        return {
+          type: 'wfs',
+          url: config.URL,
+          name: config.NAME,
+        }
+      case 'xyz':
+        return {
+          type: config.TYPE,
+          url: config.URL,
+          name: config.NAME,
+        }
+      case 'geojson':
+        return {
+          type: config.TYPE,
+          ...(config.DATA && { data: config.DATA }),
+          ...(config.URL && { url: config.URL }),
+        }
+    }
   }
 }

--- a/libs/feature/map/src/lib/map-context/map-context.service.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.ts
@@ -18,6 +18,7 @@ import GeoJSON from 'ol/format/GeoJSON'
 import { MapUtilsService } from '../utils/map-utils.service'
 import { bbox as bboxStrategy } from 'ol/loadingstrategy'
 import { LayerConfig, MapConfig } from '@geonetwork-ui/util/app-config'
+import { FeatureCollection } from 'geojson'
 
 export const DEFAULT_BASELAYER_CONTEXT: MapContextLayerModel = {
   type: MapContextLayerTypeEnum.XYZ,
@@ -54,21 +55,21 @@ export class MapContextService {
   }
 
   createLayer(layerModel: MapContextLayerModel): Layer {
-    const { type, url, urls, name } = layerModel
+    const { type } = layerModel
     const style = this.styleService.styles.default
     switch (type) {
       case MapContextLayerTypeEnum.XYZ:
         return new TileLayer({
           source: new XYZ({
-            url,
-            urls,
+            url: 'url' in layerModel ? layerModel.url : undefined,
+            urls: 'urls' in layerModel ? layerModel.urls : undefined,
           }),
         })
       case MapContextLayerTypeEnum.WMS:
         return new TileLayer({
           source: new TileWMS({
-            url,
-            params: { LAYERS: name },
+            url: layerModel.url,
+            params: { LAYERS: layerModel.name },
           }),
         })
       case MapContextLayerTypeEnum.WFS:
@@ -76,35 +77,38 @@ export class MapContextService {
           source: new VectorSource({
             format: new GeoJSON(),
             url: function (extent) {
-              return `${url}?service=WFS&version=1.1.0&request=GetFeature&outputFormat=application/json&typename=${name}&srsname=EPSG:3857&bbox=${extent.join(
-                ','
-              )},EPSG:3857`
+              return `${
+                layerModel.url
+              }?service=WFS&version=1.1.0&request=GetFeature&outputFormat=application/json&typename=${
+                layerModel.name
+              }&srsname=EPSG:3857&bbox=${extent.join(',')},EPSG:3857`
             },
             strategy: bboxStrategy,
           }),
           style,
         })
       case MapContextLayerTypeEnum.GEOJSON: {
-        const { url, data } = layerModel
-        if (url) {
+        if ('url' in layerModel) {
           return new VectorLayer({
             source: new VectorSource({
               format: new GeoJSON(),
-              url,
+              url: layerModel.url,
             }),
             style,
           })
         } else {
-          let geojson = data
-          if (typeof data === 'string') {
+          let geojson = layerModel.data
+          if (typeof geojson === 'string') {
             try {
-              geojson = JSON.parse(data)
+              geojson = JSON.parse(geojson)
             } catch (e) {
               console.warn('A layer could not be created', layerModel, e)
               geojson = { type: 'FeatureCollection', features: [] }
             }
           }
-          const features = this.mapUtils.readFeatureCollection(geojson)
+          const features = this.mapUtils.readFeatureCollection(
+            geojson as FeatureCollection
+          )
           return new VectorLayer({
             source: new VectorSource({
               features,
@@ -113,6 +117,8 @@ export class MapContextService {
           })
         }
       }
+      default:
+        throw new Error(`Unrecognized layer type: ${layerModel.type}`)
     }
   }
 

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -118,6 +118,8 @@ export class MapUtilsService {
     if (
       layer &&
       layer.type === 'geojson' &&
+      'data' in layer &&
+      typeof layer.data === 'object' &&
       layer.data.features[0] &&
       layer.data.features[0].geometry
     ) {

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -22,9 +22,10 @@ export function getGlobalConfig(): GlobalConfig {
 }
 
 export interface LayerConfig {
-  TYPE: 'xyz' | 'wms' | 'wfs'
-  URL: string
+  TYPE: 'xyz' | 'wms' | 'wfs' | 'geojson'
+  URL?: string
   NAME?: string
+  DATA?: string
 }
 export interface MapConfig {
   MAX_ZOOM?: number
@@ -109,8 +110,8 @@ export function loadAppConfig() {
       const parsedLayersSections = parseMultiConfigSection(
         parsed,
         'map_layer',
-        ['type', 'url'],
-        ['name'],
+        ['type'],
+        ['name', 'url', 'data'],
         warnings,
         errors
       )
@@ -147,6 +148,7 @@ export function loadAppConfig() {
                     TYPE: map_layer.type,
                     URL: map_layer.url,
                     NAME: map_layer.name,
+                    DATA: map_layer.data,
                   } as LayerConfig)
               ),
             } as MapConfig)

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -31,7 +31,7 @@ export interface MapConfig {
   MAX_ZOOM?: number
   MAX_EXTENT?: [number, number, number, number] // Expressed as [minx, miny, maxx, maxy]
   EXTERNAL_VIEWER_URL_TEMPLATE?: string
-  EXTERNAL_VIEWER_OPEN_NEW_TAB?: string
+  EXTERNAL_VIEWER_OPEN_NEW_TAB?: boolean
   DO_NOT_USE_DEFAULT_BASEMAP: boolean
   MAP_LAYERS: LayerConfig[]
 }

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -1,3 +1,5 @@
+import { MapConfig } from './app-config'
+
 export const CONFIG_WITH_TRANSLATIONS = `
 [global]
 geonetwork4_api_url = "/geonetwork/srv/api"
@@ -43,7 +45,7 @@ my.sample.text = "Un bon exemple de texte."
 "my.quoted.text" = 'du texte entre guillements.'
 `
 
-export const MAP_CONFIG_FIXTURE = {
+export const MAP_CONFIG_FIXTURE: MapConfig = {
   MAX_ZOOM: 10,
   MAX_EXTENT: [-418263.418776, 5251529.591305, 961272.067714, 6706890.609855],
   DO_NOT_USE_DEFAULT_BASEMAP: false,


### PR DESCRIPTION
This PR includes:
* handling of GeoJSON files given as URL instead of inline data for the map-context component
* support for GeoJSON layers in app-config, either inline of with a URL
* stricter types for the map context layers

A valid map layer in the config can now be:
```toml
[[map_layer]]
type = "geojson"
url = "https://france-geojson.gregoiredavid.fr/repo/regions.geojson"
```

or

```toml
[[map_layer]]
type = "geojson"
data = """
{
"type": "FeatureCollection",
"features": [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [125.6, 10.1]}}]
}
"""
```