### PR TITLE
Datahub: Make navigation bar responsive

### DIFF
--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { SearchPageComponent } from './search/search-page/search-page.component'
 import { UiLayoutModule } from '@geonetwork-ui/ui/layout'
 import { FeatureCatalogModule } from '@geonetwork-ui/feature/catalog'
 import { SearchSummaryComponent } from './search/search-summary/search-summary.component'
+import { NavigationBarComponent } from './record/navigation-bar/navigation-bar.component'
 
 export const metaReducers: MetaReducer[] = !environment.production ? [] : []
 // https://github.com/nrwl/nx/issues/191
@@ -56,6 +57,7 @@ export const metaReducers: MetaReducer[] = !environment.production ? [] : []
     HeaderRecordComponent,
     RecordPageComponent,
     SearchSummaryComponent,
+    NavigationBarComponent,
   ],
   imports: [
     BrowserModule,

--- a/apps/datahub/src/app/record/header-record/header-record.component.html
+++ b/apps/datahub/src/app/record/header-record/header-record.component.html
@@ -21,39 +21,8 @@
 </header>
 
 <div
-  class="container-lg mx-4 bg-primary flex space-x-8 justify-between py-5 px-20 text-sm rounded-lg text-white sticky z-20 mt-[-40px] lg:mx-auto"
+  class="container-lg mt-[-40px] z-20 sticky lg:mx-auto"
   style="left: 0; right: 0; top: 10px"
 >
-  <button
-    gnUiAnchorLink="about"
-    gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
-    class="uppercase font-medium tracking-wider"
-    translate
-  >
-    record.metadata.about
-  </button>
-  <button
-    gnUiAnchorLink="preview"
-    gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
-    class="uppercase font-medium tracking-wider"
-    translate
-  >
-    record.metadata.preview
-  </button>
-  <button
-    gnUiAnchorLink="access"
-    gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
-    class="uppercase font-medium tracking-wider"
-    translate
-  >
-    record.metadata.download
-  </button>
-  <button
-    gnUiAnchorLink="links"
-    gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
-    class="uppercase font-medium tracking-wider"
-    translate
-  >
-    record.metadata.links
-  </button>
+  <datahub-navigation-bar></datahub-navigation-bar>
 </div>

--- a/apps/datahub/src/app/record/navigation-bar/navigation-bar.component.html
+++ b/apps/datahub/src/app/record/navigation-bar/navigation-bar.component.html
@@ -1,0 +1,47 @@
+<nav
+  class="mx-4 bg-primary flex justify-between py-2 px-4 text-sm rounded-lg text-white sm:space-x-8 sm:px-20 sm:py-5"
+>
+  <button
+    *ngFor="let l of anchorLinks"
+    gnUiAnchorLink="{{ l.anchor }}"
+    gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
+    class="uppercase font-medium tracking-wider hidden sm:block"
+    translate
+  >
+    {{ l.label }}
+  </button>
+  <div
+    (click)="toggleMobileMenu()"
+    class="w-full flex justify-between cursor-pointer sm:hidden"
+  >
+    <div
+      class="flex-shrink truncate"
+      [class]="displayMobileMenu ? 'block' : 'hidden'"
+    >
+      <div *ngFor="let l of anchorLinks">
+        <button
+          (click)="setActiveLabel($event.target)"
+          gnUiAnchorLink="{{ l.anchor }}"
+          gnUiAnchorLinkDisabledClass="cursor-default opacity-60"
+          class="block px-3 py-3 rounded-md font-medium uppercase tracking-wider w-full text-left truncate"
+          translate
+        >
+          {{ l.label }}
+        </button>
+      </div>
+    </div>
+    <button
+      class="block px-3 py-3 rounded-md font-medium uppercase tracking-wider flex-shrink truncate sm:hidden"
+      [class]="displayMobileMenu ? 'hidden' : 'block'"
+      translate
+    >
+      {{ activeLabel }}
+    </button>
+    <button
+      type="button"
+      class="h-10 inline-flex items-center justify-center p-2 rounded-md flex-shrink-0 sm:hidden"
+    >
+      <mat-icon class="align-middle">expand_more</mat-icon>
+    </button>
+  </div>
+</nav>

--- a/apps/datahub/src/app/record/navigation-bar/navigation-bar.component.spec.ts
+++ b/apps/datahub/src/app/record/navigation-bar/navigation-bar.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { NavigationBarComponent } from './navigation-bar.component'
+
+describe('NavigationBarComponent', () => {
+  let component: NavigationBarComponent
+  let fixture: ComponentFixture<NavigationBarComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NavigationBarComponent],
+    }).compileComponents()
+  })
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NavigationBarComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/apps/datahub/src/app/record/navigation-bar/navigation-bar.component.ts
+++ b/apps/datahub/src/app/record/navigation-bar/navigation-bar.component.ts
@@ -1,0 +1,44 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core'
+import { marker } from '@biesbjerg/ngx-translate-extract-marker'
+
+marker('record.metadata.about')
+marker('record.metadata.preview')
+marker('record.metadata.download')
+marker('record.metadata.links')
+
+@Component({
+  selector: 'datahub-navigation-bar',
+  templateUrl: './navigation-bar.component.html',
+  styleUrls: ['./navigation-bar.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NavigationBarComponent {
+  displayMobileMenu = false
+  anchorLinks = [
+    {
+      anchor: 'about',
+      label: 'record.metadata.about',
+    },
+    {
+      anchor: 'preview',
+      label: 'record.metadata.preview',
+    },
+    {
+      anchor: 'access',
+      label: 'record.metadata.download',
+    },
+    {
+      anchor: 'links',
+      label: 'record.metadata.links',
+    },
+  ]
+  activeLabel = this.anchorLinks[0].label
+  setActiveLabel(el: HTMLElement) {
+    const disabledClass = el.getAttribute('gnUiAnchorLinkDisabledClass')
+    const disabled = new RegExp(disabledClass).test(el.className)
+    if (!disabled) this.activeLabel = el.textContent
+  }
+  toggleMobileMenu() {
+    this.displayMobileMenu = !this.displayMobileMenu
+  }
+}

--- a/apps/datahub/src/app/record/record-page/record-page.component.css
+++ b/apps/datahub/src/app/record/record-page/record-page.component.css
@@ -1,0 +1,8 @@
+.scroll-padding {
+  scroll-padding-top: 220px;
+}
+@media only screen and (min-width: 640px) {
+  .scroll-padding {
+    scroll-padding-top: 80px;
+  }
+}

--- a/apps/datahub/src/app/record/record-page/record-page.component.html
+++ b/apps/datahub/src/app/record/record-page/record-page.component.html
@@ -1,8 +1,4 @@
-<div
-  id="record-page"
-  class="h-screen overflow-auto"
-  style="scroll-padding-top: 80px"
->
+<div id="record-page" class="h-screen overflow-auto scroll-padding">
   <datahub-header-record
     [metadata]="mdViewFacade.metadata$ | async"
   ></datahub-header-record>


### PR DESCRIPTION
Based on #249 the PR implements a responsive navigation bar, specific to the datahub app. There might still be room for improvement in the approach.

https://user-images.githubusercontent.com/6329425/163205398-d1f43d40-fd9d-4b27-b913-5fc59a3fbc14.mp4



