### PR TITLE
Proxy: don't use the proxy if the url is on the same host

### DIFF
--- a/libs/util/shared/src/lib/services/proxy.service.spec.ts
+++ b/libs/util/shared/src/lib/services/proxy.service.spec.ts
@@ -33,7 +33,7 @@ describe('ProxyService', () => {
         proxyPath = 'https://proxy.org/abc?url='
         service = TestBed.inject(ProxyService)
       })
-      it('applies the proxy', () => {
+      it('different host: applies the proxy', () => {
         expect(service.getProxiedUrl('http://anotherhost/abcd')).toEqual(
           `https://proxy.org/abc?url=http%3A%2F%2Fanotherhost%2Fabcd`
         )
@@ -42,9 +42,21 @@ describe('ProxyService', () => {
         const proxied = service.getProxiedUrl('http://anotherhost/abcd')
         expect(service.getProxiedUrl(proxied)).toEqual(proxied)
       })
-      it('does not apply the proxy if on the same host', () => {
+      it('same host/port/protocol: does not apply the proxy', () => {
         const proxied = service.getProxiedUrl('http://myhost:1234/wms')
         expect(proxied).toEqual('http://myhost:1234/wms')
+      })
+      it('different protocol: applies the proxy', () => {
+        const proxied = service.getProxiedUrl('https://myhost:1234/wms')
+        expect(proxied).toEqual(
+          'https://proxy.org/abc?url=https%3A%2F%2Fmyhost%3A1234%2Fwms'
+        )
+      })
+      it('different port: applies the proxy', () => {
+        const proxied = service.getProxiedUrl('http://myhost:123/wms')
+        expect(proxied).toEqual(
+          'https://proxy.org/abc?url=http%3A%2F%2Fmyhost%3A123%2Fwms'
+        )
       })
     })
     describe('with a relative value for PROXY_PATH', () => {

--- a/libs/util/shared/src/lib/services/proxy.service.spec.ts
+++ b/libs/util/shared/src/lib/services/proxy.service.spec.ts
@@ -42,6 +42,10 @@ describe('ProxyService', () => {
         const proxied = service.getProxiedUrl('http://anotherhost/abcd')
         expect(service.getProxiedUrl(proxied)).toEqual(proxied)
       })
+      it('does not apply the proxy if on the same host', () => {
+        const proxied = service.getProxiedUrl('http://myhost:1234/wms')
+        expect(proxied).toEqual('http://myhost:1234/wms')
+      })
     })
     describe('with a relative value for PROXY_PATH', () => {
       beforeEach(() => {
@@ -56,6 +60,10 @@ describe('ProxyService', () => {
       it('does not apply the proxy twice', () => {
         const proxied = service.getProxiedUrl('http://anotherhost/abcd')
         expect(service.getProxiedUrl(proxied)).toEqual(proxied)
+      })
+      it('does not apply the proxy if on the same host', () => {
+        const proxied = service.getProxiedUrl('http://myhost:1234/wms')
+        expect(proxied).toEqual('http://myhost:1234/wms')
       })
     })
     describe('without a value for PROXY_PATH', () => {

--- a/libs/util/shared/src/lib/services/proxy.service.ts
+++ b/libs/util/shared/src/lib/services/proxy.service.ts
@@ -20,7 +20,8 @@ export class ProxyService {
     const proxyUrl = new URL(this.proxyPath, current.toString()).toString()
     if (
       current.hostname === urlObj.hostname &&
-      current.protocol === urlObj.protocol
+      current.protocol === urlObj.protocol &&
+      current.port === urlObj.port
     ) {
       return url
     }

--- a/libs/util/shared/src/lib/services/proxy.service.ts
+++ b/libs/util/shared/src/lib/services/proxy.service.ts
@@ -15,10 +15,15 @@ export class ProxyService {
    */
   getProxiedUrl(url: string): string {
     if (!this.proxyPath) return url
-    const proxyUrl = new URL(
-      this.proxyPath,
-      window.location.toString()
-    ).toString()
+    const urlObj = new URL(url)
+    const current = window.location
+    const proxyUrl = new URL(this.proxyPath, current.toString()).toString()
+    if (
+      current.hostname === urlObj.hostname &&
+      current.protocol === urlObj.protocol
+    ) {
+      return url
+    }
     if (url.indexOf(proxyUrl) === 0) return url
     return new URL(
       `${this.proxyPath}${encodeURIComponent(url)}`,


### PR DESCRIPTION
https://www.geo2france.fr/proxy/?url=https%3A%2F%2Fwww.geo2france.fr%2Fgeoserver%2Fcr_hdf%2Fows%3FSERVICE%3DWMS%26REQUEST%3DGetCapabilities should not happen.