### PR TITLE
search: escape special characters

### DIFF
--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -1,6 +1,5 @@
-import { ElasticsearchService } from './elasticsearch.service'
 import { Observable } from 'rxjs'
-import { ES_QUERY_STRING_FIELDS } from './constant'
+import { ElasticsearchService } from './elasticsearch.service'
 
 let autocompleteConfig
 
@@ -125,6 +124,23 @@ describe('ElasticsearchService', () => {
             },
           ],
         },
+      })
+    })
+    describe('any has special characters', () => {
+      let query
+      beforeEach(() => {
+        const any = 'scot (){?[ / test'
+        query = service['buildPayloadQuery'](
+          {
+            any,
+          },
+          {}
+        )
+      })
+      it('escapes special char', () => {
+        expect(query.bool.must[0].query_string.query).toEqual(
+          `scot \\(\\)\\{\\?\\[ \\/ test`
+        )
       })
     })
   })

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -120,7 +120,7 @@ export class ElasticsearchService {
             ? [
                 {
                   query_string: {
-                    query: any,
+                    query: this.escapeSpecialCharacters(any),
                     fields: ES_QUERY_STRING_FIELDS,
                   },
                 },
@@ -308,7 +308,7 @@ export class ElasticsearchService {
 
   private escapeSpecialCharacters(querystring) {
     return querystring.replace(
-      /(\+|-|&&|\|\||!|\{|\}|\[|\]\^|\~|\?|:|\\{1}|\(|\))/g,
+      /(\+|-|\/|&&|\|\||!|\{|\}|\[|\]\^|~|\?|:|\\{1}|\(|\))/g,
       '\\$1'
     )
   }

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -305,4 +305,11 @@ export class ElasticsearchService {
     }
     return queryString
   }
+
+  private escapeSpecialCharacters(querystring) {
+    return querystring.replace(
+      /(\+|-|&&|\|\||!|\{|\}|\[|\]\^|\~|\?|:|\\{1}|\(|\))/g,
+      '\\$1'
+    )
+  }
 }


### PR DESCRIPTION
`? + - ( { `and more are escaped in the `query_string` parameter.
This prevent from ES errors.