### PR TITLE
Datahub: Rework text colors

### DIFF
--- a/apps/datahub/src/app/record/header-record/header-record.component.html
+++ b/apps/datahub/src/app/record/header-record/header-record.component.html
@@ -5,6 +5,7 @@
     <div
       *ngIf="metadata"
       class="font-title text-center px-2 text-[28px] mb-[41px] line-clamp-4 sm:mx-48"
+      [style.color]="foregroundColor"
     >
       {{ metadata.title }}
     </div>

--- a/apps/datahub/src/app/record/header-record/header-record.component.spec.ts
+++ b/apps/datahub/src/app/record/header-record/header-record.component.spec.ts
@@ -8,6 +8,7 @@ import { HeaderRecordComponent } from './header-record.component'
 jest.mock('@geonetwork-ui/util/app-config', () => ({
   getThemeConfig: () => ({
     HEADER_BACKGROUND: 'red',
+    HEADER_FOREGROUND_COLOR: 'white',
   }),
 }))
 

--- a/apps/datahub/src/app/record/header-record/header-record.component.ts
+++ b/apps/datahub/src/app/record/header-record/header-record.component.ts
@@ -12,6 +12,7 @@ import { MetadataRecord } from '@geonetwork-ui/util/shared'
 export class HeaderRecordComponent {
   @Input() metadata: MetadataRecord
   backgroundCss = getThemeConfig().HEADER_BACKGROUND
+  foregroundColor = getThemeConfig().HEADER_FOREGROUND_COLOR
 
   constructor(private searchService: SearchService) {}
 

--- a/apps/datahub/src/app/search/record-preview-datahub/record-preview-datahub.component.html
+++ b/apps/datahub/src/app/search/record-preview-datahub/record-preview-datahub.component.html
@@ -25,7 +25,7 @@
       {{ abstract }}
     </div>
     <div
-      class="order-2 text-gray-400 uppercase sm:truncate sm:order-3 sm:row-end-4 sm:col-span-8 md:col-span-9"
+      class="order-2 text-primary opacity-25 uppercase sm:truncate sm:order-3 sm:row-end-4 sm:col-span-8 md:col-span-9"
     >
       {{ record.contact?.organisation }}
     </div>
@@ -34,12 +34,12 @@
     >
       <mat-icon
         *ngIf="isDownloadable"
-        class="material-icons-outlined text-gray-200 mr-4"
+        class="material-icons-outlined text-primary opacity-25 mr-4"
         >cloud_download</mat-icon
       >
       <mat-icon
         *ngIf="isViewable"
-        class="material-icons-outlined text-gray-200 mr-4"
+        class="material-icons-outlined text-primary opacity-25 mr-4"
         >map</mat-icon
       >
     </div>

--- a/apps/datahub/src/app/search/record-preview-datahub/record-preview-datahub.component.html
+++ b/apps/datahub/src/app/search/record-preview-datahub/record-preview-datahub.component.html
@@ -13,7 +13,7 @@
     class="content flex-grow grid grid-cols-1 auto-rows-min justify-between min-w-0 pr-6 sm:pl-6 sm:pr-12 sm:grid-cols-10"
   >
     <div
-      class="order-1 mb-3 mt-5 font-title text-21 line-clamp-2 sm:line-clamp-1 sm:col-span-10 sm:mt-2"
+      class="order-1 mb-3 mt-5 font-title text-21 text-title line-clamp-2 sm:line-clamp-1 sm:col-span-10 sm:mt-2"
       style="font-size: 21px"
       [title]="record.title"
     >

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -77,8 +77,11 @@ secondary_color = "#001638"
 main_color = "#212029" # All-purpose text color
 background_color = "#fdfbff"
 
-# This optional parameter indicates which background should be used for the main header
+# These optional parameters indicate which background should be used for the main header and the text color used 
+# on top of the background. The color should be chosen to contrast well with the background (defaults to white).
+# Note: The search header does not use the header_foreground_color as it allows futher customisation via HTML.
 # header_background = "center /cover url('assets/img/header_bg.webp')" or "var(--color-gray-500)"
+# header_foreground_color = 'white'
 
 # This optional parameter allows to override the fallback image that should be used for thumbnails, 
 # if the metadata record has no thumbnail image url or it is broken.

--- a/libs/feature/record/src/lib/data-apis/data-apis.component.html
+++ b/libs/feature/record/src/lib/data-apis/data-apis.component.html
@@ -1,5 +1,5 @@
 <p
-  class="font-title text-[28px] font-medium mt-8 mb-2 text-secondary text-center sm:mt-12 sm:mb-4 sm:text-left"
+  class="font-title text-[28px] font-medium mt-8 mb-2 text-title text-center sm:mt-12 sm:mb-4 sm:text-left"
   translate
 >
   record.metadata.api

--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.html
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.html
@@ -1,6 +1,6 @@
 <p
   *ngIf="(links$ | async) && (links$ | async).length > 0"
-  class="font-title text-[28px] font-medium mt-8 mb-6 text-center sm:mt-12 sm:mb-4 sm:text-left"
+  class="font-title text-[28px] text-title font-medium mt-8 mb-6 text-center sm:mt-12 sm:mb-4 sm:text-left"
   translate
 >
   record.metadata.download

--- a/libs/feature/record/src/lib/data-otherlinks/data-otherlinks.component.html
+++ b/libs/feature/record/src/lib/data-otherlinks/data-otherlinks.component.html
@@ -1,5 +1,5 @@
 <p
-  class="font-title text-[28px] font-medium mt-8 mb-6 text-primary text-center sm:mt-12 sm:mb-4 sm:text-left"
+  class="font-title text-[28px] font-medium mt-8 mb-6 text-title text-center sm:mt-12 sm:mb-4 sm:text-left"
   translate
 >
   record.metadata.links

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
@@ -44,7 +44,7 @@
     <div class="container-lg px-4 lg:mx-auto">
       <div>
         <div
-          class="text-[28px] font-title transform sm:translate-y-10"
+          class="text-[28px] text-title font-title transform sm:translate-y-10"
           translate
           id="preview"
         >

--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.html
@@ -57,7 +57,9 @@
         >
           <mat-tab [disabled]="(displayMap$ | async) === false">
             <ng-template mat-tab-label>
-              <span class="uppercase text-sm" translate>record.tab.map</span>
+              <span class="uppercase text-sm text-primary opacity-75" translate
+                >record.tab.map</span
+              >
             </ng-template>
             <div
               class="block mt-6 sm:mt-10"
@@ -69,7 +71,9 @@
           </mat-tab>
           <mat-tab [disabled]="(displayData$ | async) === false">
             <ng-template mat-tab-label>
-              <span class="uppercase text-sm" translate>record.tab.data</span>
+              <span class="uppercase text-sm text-primary opacity-75" translate
+                >record.tab.data</span
+              >
             </ng-template>
             <div
               class="block mt-10"

--- a/libs/feature/record/src/lib/related-records/related-records.component.html
+++ b/libs/feature/record/src/lib/related-records/related-records.component.html
@@ -1,5 +1,5 @@
 <p
-  class="font-title text-[28px] font-medium mt-6 sm:mt-10 mb-4 text-center sm:text-left"
+  class="font-title text-[28px] text-title font-medium mt-6 sm:mt-10 mb-4 text-center sm:text-left"
   translate
 >
   record.metadata.related

--- a/libs/ui/elements/src/lib/api-card/api-card.component.html
+++ b/libs/ui/elements/src/lib/api-card/api-card.component.html
@@ -2,7 +2,7 @@
   class="flex flex-col justify-between h-40 pt-5 pb-6 px-7 rounded bg-gray-100 border-4 border-transparent hover:border-gray-100 hover:bg-white filter overflow-hidden"
 >
   <div
-    class="font-title font-medium text-21 overflow-ellipsis overflow-hidden break-words pb-5"
+    class="font-title font-medium text-21 text-black overflow-ellipsis overflow-hidden break-words pb-5"
     style="height: 4.5rem"
   >
     {{ link.name || link.description }}

--- a/libs/ui/elements/src/lib/download-item/download-item.component.html
+++ b/libs/ui/elements/src/lib/download-item/download-item.component.html
@@ -3,7 +3,7 @@
 >
   <div class="flex-grow-1 overflow-hidden">
     <div
-      class="text-21 capitalize truncate font-title max-w-4xl"
+      class="text-21 text-black capitalize truncate font-title max-w-4xl"
       [title]="link.name"
     >
       {{ link.name }}

--- a/libs/ui/elements/src/lib/link-card/link-card.component.html
+++ b/libs/ui/elements/src/lib/link-card/link-card.component.html
@@ -2,7 +2,7 @@
   class="flex flex-col justify-between root h-40 flex-grow py-5 px-5 bg-white rounded border-gray-300 filter shadow-primary-light hover:shadow-primary overflow-hidden lg:w-80"
 >
   <div class="max-h-24 overflow-hidden overflow-ellipsis">
-    <p class="font-title font-medium text-21 break-words pb-1">
+    <p class="font-title font-medium text-21 text-black break-words pb-1">
       {{ link.name }}
     </p>
     <p class="font-medium text-sm break-words">

--- a/libs/ui/elements/src/lib/metadata-catalog/metadata-catalog.component.html
+++ b/libs/ui/elements/src/lib/metadata-catalog/metadata-catalog.component.html
@@ -1,5 +1,5 @@
 <div>
-  <p class="text-gray-600 text-xs mb-3 uppercase" translate>
+  <p class="text-gray-700 text-xs mb-3 uppercase" translate>
     record.metadata.catalog
   </p>
   <p class="text-primary font-title text-21 mb-1">

--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
@@ -1,5 +1,5 @@
 <div *ngIf="metadata.contact" class="mb-6 sm:mb-12">
-  <p class="text-gray-600 text-xs mb-3 uppercase" translate>
+  <p class="text-gray-700 text-xs mb-3 uppercase" translate>
     record.metadata.contact
   </p>
   <p
@@ -8,8 +8,8 @@
   >
     {{ metadata.contact.organisation }}
   </p>
-  <p class="text-gray-600 text-sm mb-2">{{ metadata.contact.email }}</p>
-  <p *ngIf="metadata.contact.website" class="text-gray-600 mb-4">
+  <p class="text-gray-700 text-sm mb-2">{{ metadata.contact.email }}</p>
+  <p *ngIf="metadata.contact.website" class="text-gray-700 mb-4">
     <a [href]="metadata.contact.website">{{ metadata.contact.website }}</a>
   </p>
 </div>

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -1,4 +1,7 @@
-<p class="text-[28px] text-center mb-6 font-title sm:text-left" translate>
+<p
+  class="text-[28px] text-title text-center mb-6 font-title sm:text-left"
+  translate
+>
   record.metadata.about
 </p>
 <div class="mb-6 md-description sm:mb-4 sm:pr-16">

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -36,7 +36,7 @@
     {{ metadata.lineage }}
   </p>
   <div
-    class="py-4 px-6 rounded bg-gray-100 grid grid-cols-2 grid-rows-2 gap-6 text-gray-800"
+    class="py-4 px-6 rounded bg-gray-100 grid grid-cols-2 grid-rows-2 gap-6 text-gray-700"
   >
     <div class="border-b border-gray-300" *ngIf="metadata.updatedOn">
       <p class="text-sm" translate>record.metadata.updatedOn</p>
@@ -62,7 +62,7 @@
   *ngIf="metadata.usageConstraints"
   [title]="'record.metadata.usage' | translate"
 >
-  <div class="py-4 px-6 rounded bg-gray-100 text-gray-800">
+  <div class="py-4 px-6 rounded bg-gray-100 text-gray-700">
     <gn-ui-badge class="inline-block mr-2">{{
       metadata.usageConstraints
     }}</gn-ui-badge>
@@ -72,7 +72,7 @@
   *ngIf="landingPages && landingPages.length > 0"
   [title]="'record.metadata.details' | translate"
 >
-  <div class="py-5 px-5 rounded bg-gray-100 text-gray-800">
+  <div class="py-5 px-5 rounded bg-gray-100 text-gray-700">
     <p class="text-sm" translate>record.metadata.sheet</p>
     <a [href]="landingPages[0].url" target="_blank">
       <mat-icon class="inline-block align-bottom pt-1.5 text-xs text-black"

--- a/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
+++ b/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
@@ -9,7 +9,9 @@
     ></gn-ui-record-thumbnail>
   </div>
   <div class="flex flex-col justify-between h-44 px-5 pt-4 pb-6">
-    <h4 class="max-h-24 font-title text-21 overflow-ellipsis overflow-hidden">
+    <h4
+      class="max-h-24 font-title text-21 text-black overflow-ellipsis overflow-hidden"
+    >
       {{ record.title }}
     </h4>
     <div>

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
@@ -2,7 +2,7 @@
   <input
     #searchInput
     type="text"
-    class="appearance-none focus:outline-white leading-tight rounded w-full text-main shadow-primary-light focus:shadow-primary"
+    class="appearance-none focus:outline-white leading-tight rounded w-full text-black shadow-primary-light focus:shadow-primary"
     [placeholder]="placeholder"
     [formControl]="control"
     [matAutocomplete]="auto"

--- a/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.html
+++ b/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.html
@@ -2,7 +2,7 @@
   class="flex align-middle title border-b border-gray-100 cursor-pointer pt-2.5"
   (click)="toggle()"
 >
-  <div class="flex-grow font-medium text-sm">
+  <div class="flex-grow font-medium text-black text-sm">
     {{ title }}
   </div>
   <div class="w-8 opacity-25 text-primary icon">

--- a/libs/ui/search/src/lib/results-hits-number/results-hits-number.component.html
+++ b/libs/ui/search/src/lib/results-hits-number/results-hits-number.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!loading" class="w-full text-gray-700">
+<div *ngIf="!loading" class="w-full">
   <ng-container *ngIf="hits">
     <span translate [translateParams]="{ hits: hits.value }"
       >results.records.hits.found</span

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -53,6 +53,7 @@ main_color = "#212029" # All-purpose text color
 background_color = "#fdfbff"
 thumbnail_placeholder = 'assets/img/placeholder.svg'
 header_background = 'teal'
+header_foreground_color = "#872e2e"
 main_font = 'sans-serif'
 title_font = 'serif'
 another_color = 'red'
@@ -166,6 +167,7 @@ describe('app config utils', () => {
           FONTS_STYLESHEET_URL:
             'https://fonts.googleapis.com/css2?family=Open+Sans',
           HEADER_BACKGROUND: 'teal',
+          HEADER_FOREGROUND_COLOR: '#872e2e',
           THUMBNAIL_PLACEHOLDER: 'assets/img/placeholder.svg',
         })
       })

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -47,6 +47,7 @@ interface ThemeConfig {
   SECONDARY_COLOR: string
   MAIN_COLOR: string
   BACKGROUND_COLOR: string
+  HEADER_FOREGROUND_COLOR: string
   HEADER_BACKGROUND: string
   THUMBNAIL_PLACEHOLDER: string
   MAIN_FONT?: string
@@ -158,6 +159,7 @@ export function loadAppConfig() {
         'theme',
         ['primary_color', 'secondary_color', 'main_color', 'background_color'],
         [
+          'header_foreground_color',
           'main_font',
           'title_font',
           'fonts_stylesheet_url',
@@ -175,6 +177,8 @@ export function loadAppConfig() {
               SECONDARY_COLOR: parsedThemeSection.secondary_color,
               MAIN_COLOR: parsedThemeSection.main_color,
               BACKGROUND_COLOR: parsedThemeSection.background_color,
+              HEADER_FOREGROUND_COLOR:
+                parsedThemeSection.header_foreground_color || '#ffffff',
               THUMBNAIL_PLACEHOLDER:
                 parsedThemeSection.thumbnail_placeholder ||
                 'assets/img/thumb_placeholder.webp',

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -27,6 +27,7 @@ main_color = "#212029" # All-purpose text color
 background_color = "#fdfbff"
 thumbnail_placeholder = 'assets/img/placeholder.svg'
 header_background = 'teal'
+header_foreground_color = "#872e2e"
 main_font = 'sans-serif'
 title_font = 'serif'
 fonts_stylesheet_url = "https://fonts.googleapis.com/css2?family=Open+Sans"

--- a/tailwind.base.config.js
+++ b/tailwind.base.config.js
@@ -19,6 +19,7 @@ module.exports = {
         'secondary-darker': 'var(--color-secondary-darker)',
         'secondary-darkest': 'var(--color-secondary-darkest)',
         main: 'var(--color-main)',
+        title: 'black',
         background: 'var(--color-background)',
         gray: {
           100: 'var(--color-gray-100)',


### PR DESCRIPTION
PR makes various adaptions on text colors to better fit the mockups, in particular to make titles black when using a different `main-color`:

- introduces color `title` and `title-header` classes, makes them configurable and uses them in the components
- renames color `gray-...` to `main-...`
- makes some adaptions on used grays to better fit the mockups

Note: There are a lot of different grays or even derivations of the primary color in the mockups, that might not all be on purpose. The implementation tries to get as close and coherent as possible here. Also, but it's a small detail, personally I preferred the colored API and Links titles, that seemed lighter to me.

![dh-search](https://user-images.githubusercontent.com/6329425/166464963-48797a1d-9ae5-4383-b21f-9cc85ab8d304.png)
![dh-record](https://user-images.githubusercontent.com/6329425/166464985-e1a614ea-1651-490d-84f2-e2729608ac98.png)

