### PR TITLE
datahub: add an icon for the contact url in the record view

### DIFF
--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
@@ -2,14 +2,21 @@
   <p class="text-gray-700 text-xs mb-3 uppercase" translate>
     record.metadata.contact
   </p>
-  <p
-    class="text-primary font-title text-21 mb-1 cursor-pointer hover:text-primary-darker"
-    (click)="onContactClick()"
-  >
-    {{ metadata.contact.organisation }}
-  </p>
+  <div class="flex mb-1">
+    <div
+      class="text-primary font-title text-21 mr-2 cursor-pointer hover:opacity-50"
+      (click)="onContactClick()"
+    >
+      {{ metadata.contact.organisation }}
+    </div>
+    <div *ngIf="metadata.contact.website">
+      <a [href]="metadata.contact.website" target="_blank"
+        ><mat-icon
+          class="text-primary opacity-25 cursor-pointer hover:opacity-75 transition-all"
+          >open_in_new</mat-icon
+        ></a
+      >
+    </div>
+  </div>
   <p class="text-gray-700 text-sm mb-2">{{ metadata.contact.email }}</p>
-  <p *ngIf="metadata.contact.website" class="text-gray-700 mb-4">
-    <a [href]="metadata.contact.website">{{ metadata.contact.website }}</a>
-  </p>
 </div>

--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.spec.ts
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.spec.ts
@@ -1,3 +1,4 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
 
@@ -10,6 +11,7 @@ describe('MetadataContactComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [MetadataContactComponent],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents()
   })
 
@@ -36,7 +38,9 @@ describe('MetadataContactComponent', () => {
       jest.spyOn(component.contact, 'emit')
     })
     it('emit contact click with contact name', () => {
-      const el = fixture.debugElement.queryAll(By.css('p'))[1].nativeElement
+      const el = fixture.debugElement.query(
+        By.css('.text-primary.font-title')
+      ).nativeElement
       el.click()
       expect(component.contact.emit).toHaveBeenCalledWith('Worldcop')
     })
@@ -47,15 +51,18 @@ describe('MetadataContactComponent', () => {
       ps = fixture.debugElement.queryAll(By.css('p'))
     })
     it('displays the contact name', () => {
-      expect(ps[1].nativeElement.innerHTML).toBe(' Worldcop ')
+      const el = fixture.debugElement.query(
+        By.css('.text-primary.font-title')
+      ).nativeElement
+      expect(el.innerHTML).toBe(' Worldcop ')
     })
     it('displays the contact email', () => {
-      expect(ps[2].nativeElement.innerHTML).toBe('john@world.co')
+      expect(ps[1].nativeElement.innerHTML).toBe('john@world.co')
     })
     it('displays a link to the contact website', () => {
-      const a = ps[3].children[0]
-      expect(a.name).toBe('a')
-      expect(a.nativeElement.innerHTML).toBe('https://john.world.co')
+      const a = fixture.debugElement.query(By.css('a'))
+      expect(a.attributes.href).toBe('https://john.world.co')
+      expect(a.attributes.target).toBe('_blank')
     })
   })
 })


### PR DESCRIPTION
- before
![Screenshot from 2022-05-04 09-35-30](https://user-images.githubusercontent.com/1491924/166709931-4798625e-3615-4930-8696-1c092da4ae94.png)
- after
![Screenshot from 2022-05-04 17-00-03](https://user-images.githubusercontent.com/1491924/166709905-13a9dfe5-89ac-4811-acc6-b326e510d3b9.png)

