### PR TITLE
search: any is multilingual

### DIFF
--- a/libs/util/shared/src/lib/elasticsearch/constant.ts
+++ b/libs/util/shared/src/lib/elasticsearch/constant.ts
@@ -34,6 +34,6 @@ export const ES_QUERY_STRING_FIELDS = [
   'tag.*^4',
   'resourceAbstractObject.*^3',
   'lineageObject.*^2',
-  'any',
+  'any.*',
   'uuid',
 ]

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -107,7 +107,7 @@ describe('ElasticsearchService', () => {
                   'tag.*^4',
                   'resourceAbstractObject.*^3',
                   'lineageObject.*^2',
-                  'any',
+                  'any.*',
                   'uuid',
                 ],
                 query: 'hello',


### PR DESCRIPTION
On the last GN4 version, `any` is an object, the index is multilingual.
So using `any` in a field should be like `any.*`