### PR TITLE
Adds WMS gutter to improve rendering

### DIFF
--- a/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
@@ -106,6 +106,11 @@ describe('MapContextService', () => {
         expect(urls.length).toBe(1)
         expect(urls[0]).toEqual(layerModel.url)
       })
+      it('set WMS gutter of 20px', () => {
+        const source = layer.getSource()
+        const gutter = source.gutter_
+        expect(gutter).toBe(20)
+      })
     })
 
     describe('GEOJSON', () => {

--- a/libs/feature/map/src/lib/map-context/map-context.service.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.ts
@@ -71,6 +71,7 @@ export class MapContextService {
           source: new TileWMS({
             url: layerModel.url,
             params: { LAYERS: layerModel.name },
+            gutter: 20,
           }),
         })
       case MapContextLayerTypeEnum.WFS:


### PR DESCRIPTION
PR sets `20px` gutter for `TileWMS` sources to improve rendering.
![gutter](https://user-images.githubusercontent.com/6329425/167628654-d2215709-d3cb-4a81-942a-547656a37cae.png)

