### PR TITLE
Add language setting for elasticsearch queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,15 @@ This file can be used to:
 
 - customize the URL used to reach the GeoNetwork 4 API
 - indicate an optional proxy path to the application
+- indicate a metadata language to be used when searching
 - customize the theme used in the application (colors, fonts...)
 - define custom translations for the different languages
 
 Please refer to the embedded comments in the file for more information.
 
 > Note: as of now, only the Datahub application relies on this file
+
+**Important**: In order for the search to be efficient, please indicate the `metadata_language` of the queried catalog.
 
 ### Internationalization
 

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -10,6 +10,10 @@ geonetwork4_api_url = "/geonetwork/srv/api"
 # The actual URL will be appended after this path, e.g. : https://my.proxy/?url=http%3A%2F%2Fencoded.url%2Fows`
 # This is an optional parameter: leave empty to disable proxy usage
 proxy_path = ""
+# This optional parameter defines, in which language metadata should be queried in elasticsearch.
+# Use ISO 639-2/B (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format to indicate the language of the metadata.
+# If not indicated, a wildcard is used and no language preference is applied for the search.
+# metadata_language = "fre"
 
 ### MAP SETTINGS
 

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
@@ -131,7 +131,6 @@ describe('FuzzySearchComponent', () => {
     })
     describe('when output is defined', () => {
       beforeEach(() => {
-        component.inputSubmited.subscribe((event) => (outputValue = event))
         component.handleInputSubmission('blarg')
       })
       it('updates the search filters as well', () => {

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
@@ -51,7 +51,7 @@ const searchServiceMock = {
   updateSearch: jest.fn(),
 }
 const esServiceMock = {
-  buildAutocompletePayload: jest.fn(() => of({ fakeQuery: '' })),
+  buildAutocompletePayload: jest.fn(() => ({ fakeQuery: '' })),
 }
 const elasticsearchMapperMock = {
   toRecords: jest.fn(() => [

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
@@ -35,18 +35,13 @@ export class FuzzySearchComponent {
   displayWithFn: (MetadataRecord) => string = (record) => record?.title
 
   autoCompleteAction = (query) =>
-    this.esService
-      .buildAutocompletePayload(query)
+    this.searchApiService
+      .search(
+        'bucket',
+        JSON.stringify(this.esService.buildAutocompletePayload(query))
+      )
       .pipe(
-        switchMap((payload) =>
-          this.searchApiService
-            .search('bucket', JSON.stringify(payload))
-            .pipe(
-              map((response: EsSearchResponse) =>
-                this.esMapper.toRecords(response)
-              )
-            )
-        )
+        map((response: EsSearchResponse) => this.esMapper.toRecords(response))
       )
 
   constructor(

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
@@ -16,7 +16,7 @@ import {
   EsSearchResponse,
   MetadataRecord,
 } from '@geonetwork-ui/util/shared'
-import { map, switchMap } from 'rxjs/operators'
+import { map } from 'rxjs/operators'
 import { SearchFacade } from '../state/search.facade'
 import { ElasticsearchMapper } from '../utils/mapper'
 import { SearchService } from '../utils/service/search.service'

--- a/libs/feature/search/src/lib/state/effects.spec.ts
+++ b/libs/feature/search/src/lib/state/effects.spec.ts
@@ -32,6 +32,16 @@ import { initialState, reducer, SEARCH_FEATURE_KEY } from './reducer'
 import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { ES_FIXTURE_AGGS_REQUEST } from '@geonetwork-ui/util/shared'
 
+const globalConfigMock = {
+  GN4_API_URL: 'http://my.geonetwork.api',
+  PROXY_PATH: '/proxy?',
+  METADATA_LANGUAGE: 'fre',
+}
+jest.mock('@geonetwork-ui/util/app-config', () => ({
+  getGlobalConfig: () => globalConfigMock,
+  isConfigLoaded: jest.fn(() => true),
+}))
+
 const initialStateSearchMock = initialState[DEFAULT_SEARCH_KEY]
 const initialStateMock = {
   ...initialState,

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -27,6 +27,7 @@ const CONFIG_UNRECOGNIZED_KEYS = `
 [global]
 geonetwork4_api_url = "/geonetwork/srv/api"
 proxy_path = "/proxy/?url="
+metadata_language = "fre"
 another_path = '/whatever'
 
 [map]
@@ -138,6 +139,7 @@ describe('app config utils', () => {
         expect(getGlobalConfig()).toEqual({
           GN4_API_URL: '/geonetwork/srv/api',
           PROXY_PATH: '/proxy/?url=',
+          METADATA_LANGUAGE: 'fre',
         })
       })
     })
@@ -152,6 +154,7 @@ describe('app config utils', () => {
         expect(getGlobalConfig()).toEqual({
           GN4_API_URL: '/geonetwork/srv/api',
           PROXY_PATH: '/proxy/?url=',
+          METADATA_LANGUAGE: 'fre',
         })
       })
     })

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -107,7 +107,11 @@ export function loadAppConfig() {
           : ({
               GN4_API_URL: parsedGlobalSection.geonetwork4_api_url,
               PROXY_PATH: parsedGlobalSection.proxy_path,
-              METADATA_LANGUAGE: parsedGlobalSection.metadata_language,
+              METADATA_LANGUAGE: parsedGlobalSection.metadata_language
+                ? (
+                    parsedGlobalSection.metadata_language as string
+                  ).toLowerCase()
+                : undefined,
             } as GlobalConfig)
 
       const parsedLayersSections = parseMultiConfigSection(

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -13,6 +13,7 @@ Note: make sure that you have called \`loadAppConfig\` from '@geonetwork-ui/util
 interface GlobalConfig {
   GN4_API_URL: string
   PROXY_PATH?: string
+  METADATA_LANGUAGE?: string
 }
 let globalConfig: GlobalConfig = null
 
@@ -96,7 +97,7 @@ export function loadAppConfig() {
         parsed,
         'global',
         ['geonetwork4_api_url'],
-        ['proxy_path'],
+        ['proxy_path', 'metadata_language'],
         warnings,
         errors
       )
@@ -106,6 +107,7 @@ export function loadAppConfig() {
           : ({
               GN4_API_URL: parsedGlobalSection.geonetwork4_api_url,
               PROXY_PATH: parsedGlobalSection.proxy_path,
+              METADATA_LANGUAGE: parsedGlobalSection.metadata_language,
             } as GlobalConfig)
 
       const parsedLayersSections = parseMultiConfigSection(

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -4,6 +4,7 @@ export const CONFIG_WITH_TRANSLATIONS = `
 [global]
 geonetwork4_api_url = "/geonetwork/srv/api"
 proxy_path = "/proxy/?url="
+metadata_language = "fre"
 
 [map]
 max_zoom = 10

--- a/libs/util/shared/src/lib/elasticsearch/constant.ts
+++ b/libs/util/shared/src/lib/elasticsearch/constant.ts
@@ -30,10 +30,10 @@ export const ElasticSearchSources = {
 }
 
 export const ES_QUERY_STRING_FIELDS = [
-  'resourceTitleObject.*^5',
-  'tag.*^4',
-  'resourceAbstractObject.*^3',
-  'lineageObject.*^2',
-  'any.*',
+  'resourceTitleObject.${searchLang}^5',
+  'tag.${searchLang}^4',
+  'resourceAbstractObject.${searchLang}^3',
+  'lineageObject.${searchLang}^2',
+  'any.${searchLang}',
   'uuid',
 ]

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -15,7 +15,7 @@ describe('ElasticsearchService', () => {
   let searchFilters
 
   beforeEach(() => {
-    service = new ElasticsearchService(new MockBootstrapService() as any)
+    service = new ElasticsearchService()
   })
 
   it('should be created', () => {
@@ -192,40 +192,10 @@ describe('ElasticsearchService', () => {
 
   describe('#buildAutocompletePayload', () => {
     describe('given an autocomplete config', () => {
-      beforeEach(() => {
-        autocompleteConfig = {
-          query: {
-            bool: {
-              must: [
-                {
-                  multi_match: {
-                    query: '',
-                    type: 'bool_prefix',
-                    fields: [
-                      'resourceTitleObject.*',
-                      'resourceAbstractObject.*',
-                      'tag',
-                      'resourceIdentifier',
-                    ],
-                  },
-                },
-                {
-                  terms: {
-                    isTemplate: ['n'],
-                  },
-                },
-              ],
-            },
-          },
-          _source: ['uuid', 'id', 'title', 'resourceTitleObject'],
-        }
-      })
-      it('returns the search payload', async () => {
-        const payload = await service
-          .buildAutocompletePayload('blarg')
-          .toPromise()
+      it('returns the search payload', () => {
+        const payload = service.buildAutocompletePayload('blarg')
         expect(payload).toEqual({
-          _source: ['id', 'title', 'resourceTitleObject', 'uuid'],
+          _source: ['resourceTitleObject', 'uuid'],
           query: {
             bool: {
               must: [
@@ -237,8 +207,8 @@ describe('ElasticsearchService', () => {
                 {
                   multi_match: {
                     fields: [
-                      'resourceTitleObject.*',
-                      'resourceAbstractObject.*',
+                      'resourceTitleObject.langfre',
+                      'resourceAbstractObject.langfre',
                       'tag',
                       'resourceIdentifier',
                     ],
@@ -246,14 +216,11 @@ describe('ElasticsearchService', () => {
                     type: 'bool_prefix',
                   },
                 },
-                {
-                  terms: {
-                    isTemplate: ['n'],
-                  },
-                },
               ],
             },
           },
+          from: 0,
+          size: 20,
         })
       })
     })

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -1,22 +1,14 @@
-import { Observable } from 'rxjs'
 import { ElasticsearchService } from './elasticsearch.service'
 
-let autocompleteConfig
-
-class MockBootstrapService {
-  uiConfReady(): Observable<any> {
-    return new Observable((observer) => {
-      observer.next({
-        mods: {
-          search: {
-            autocompleteConfig,
-          },
-        },
-      })
-      observer.complete()
-    })
-  }
+const globalConfigMock = {
+  GN4_API_URL: 'http://my.geonetwork.api',
+  PROXY_PATH: '/proxy?',
+  METADATA_LANGUAGE: 'fre',
 }
+jest.mock('@geonetwork-ui/util/app-config', () => ({
+  getGlobalConfig: () => globalConfigMock,
+  isConfigLoaded: jest.fn(() => true),
+}))
 
 describe('ElasticsearchService', () => {
   let service: ElasticsearchService
@@ -103,11 +95,11 @@ describe('ElasticsearchService', () => {
               query_string: {
                 default_operator: 'AND',
                 fields: [
-                  'resourceTitleObject.*^5',
-                  'tag.*^4',
-                  'resourceAbstractObject.*^3',
-                  'lineageObject.*^2',
-                  'any.*',
+                  'resourceTitleObject.langfre^5',
+                  'tag.langfre^4',
+                  'resourceAbstractObject.langfre^3',
+                  'lineageObject.langfre^2',
+                  'any.langfre',
                   'uuid',
                 ],
                 query: 'hello',

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -191,57 +191,32 @@ export class ElasticsearchService {
   }
 
   buildAutocompletePayload(query: string): EsSearchParams {
-    const autocompleteConfig = {
-      query: {
-        bool: {
-          must: [
-            {
-              multi_match: {
-                query: '',
-                type: 'bool_prefix',
-                fields: [
-                  'resourceTitleObject.${searchLang}',
-                  'resourceAbstractObject.${searchLang}',
-                  'tag',
-                  'resourceIdentifier',
-                ],
-              },
-            },
-          ],
-        },
-      },
-      _source: ['resourceTitleObject'],
-      from: 0,
-      size: 20,
-    }
     return {
-      ...autocompleteConfig,
-      _source: [
-        ...autocompleteConfig._source.filter((source) => source !== 'uuid'),
-        'uuid',
-      ],
       query: {
-        ...autocompleteConfig.query,
         bool: {
-          ...autocompleteConfig.query.bool,
           must: [
             this.addTemplateClause('n'),
             {
               multi_match: {
-                ...autocompleteConfig.query.bool.must[0].multi_match,
+                query,
+                type: 'bool_prefix',
                 fields: this.injectLangInQueryStringFields(
-                  autocompleteConfig.query.bool.must[0].multi_match.fields,
+                  [
+                    'resourceTitleObject.${searchLang}',
+                    'resourceAbstractObject.${searchLang}',
+                    'tag',
+                    'resourceIdentifier',
+                  ],
                   this.metadataLang
                 ),
-                query,
               },
             },
-            ...autocompleteConfig.query.bool.must.filter(
-              (clause) => !('multi_match' in clause)
-            ),
           ],
         },
       },
+      _source: ['resourceTitleObject', 'uuid'],
+      from: 0,
+      size: 20,
     }
   }
 

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -12,6 +12,7 @@ import {
 } from '../models'
 import { BootstrapService } from '../services'
 import { ES_SOURCE_SUMMARY } from './constant'
+import { getGlobalConfig } from '@geonetwork-ui/util/app-config'
 
 @Injectable({
   providedIn: 'root',
@@ -20,6 +21,7 @@ export class ElasticsearchService {
   constructor(private bootstrap: BootstrapService) {}
 
   uiConf = this.bootstrap.uiConfReady('srv').pipe(take(1))
+  metadataLang = getGlobalConfig().METADATA_LANGUAGE
 
   getSearchRequestBody(
     aggregations: any,
@@ -104,14 +106,21 @@ export class ElasticsearchService {
       : undefined
   }
 
+  private injectLangInQueryStringFields(
+    queryStringFields: string[],
+    lang: string
+  ) {
+    const queryLang = lang ? `lang${lang}` : `*`
+    return queryStringFields.map((field) => {
+      return field.replace(/\$\{searchLang\}/g, queryLang)
+    })
+  }
+
   private buildPayloadQuery(
     { any, ...fieldSearchFilters }: SearchFilters,
     configFilters: StateConfigFilters
   ) {
     const queryFilters = this.stateFiltersToQueryString(fieldSearchFilters)
-    const queryAny = `(${any || '*'})`
-    const query =
-      queryAny + (queryFilters.length > 0 ? ` AND ${queryFilters}` : '')
 
     return {
       bool: {
@@ -122,7 +131,10 @@ export class ElasticsearchService {
                   query_string: {
                     query: this.escapeSpecialCharacters(any),
                     default_operator: 'AND',
-                    fields: ES_QUERY_STRING_FIELDS,
+                    fields: this.injectLangInQueryStringFields(
+                      ES_QUERY_STRING_FIELDS,
+                      this.metadataLang
+                    ),
                   },
                 },
               ]


### PR DESCRIPTION
PR adds a `metadata_language` setting that allows to indicate in which language queries should be sent to elasticsearch.