### PR TITLE
Datahub: Add crossorigin attribute for preload links

### DIFF
--- a/apps/datahub/src/index.html
+++ b/apps/datahub/src/index.html
@@ -12,7 +12,12 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
     />
-    <link rel="preload" href="assets/configuration/default.toml" as="fetch" />
+    <link
+      rel="preload"
+      href="assets/configuration/default.toml"
+      as="fetch"
+      crossorigin
+    />
     <!--
       Add more preload links here to reduce the time to initial page render!
       Example:

--- a/tools/docker/docker-entrypoint.sh
+++ b/tools/docker/docker-entrypoint.sh
@@ -47,7 +47,7 @@ if [ -d "${CUSTOM_ASSETS_PATH}" ] && [ "$(ls -A ${CUSTOM_ASSETS_PATH})" ]; then
   for image in ${images}
   do
     echo "[INFO] Adding preload link for ${image}..."
-    sed -i "s@<!--%PRELOAD_LINKS%-->@<!--%PRELOAD_LINKS%-->\n<link rel=\"preload\" href=\"assets/${image}\" as=\"image\" importance=\"high\" />@" \
+    sed -i "s@<!--%PRELOAD_LINKS%-->@<!--%PRELOAD_LINKS%-->\n<link rel=\"preload\" href=\"assets/${image}\" as=\"image\" importance=\"high\" crossorigin />@" \
       ${APP_FILES_PATH}index.html
   done
 else


### PR DESCRIPTION
PR adds `crossorigin` attribute to preload links to make them being used by browser and prevent loading them twice (cf current chromium warning for `default.toml`).

```
polyfills.ed0cba819d7212ef.js:1 A preload for 'https://www.geo2france.fr/datahub/assets/configuration/default.toml' is found,
but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.
(anonymous) @ polyfills.ed0cba819d7212ef.js:1
search:1 The resource https://www.geo2france.fr/datahub/assets/configuration/default.toml was preloaded using link preload
but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is
preloaded intentionally.
```