### PR TITLE
Datahub: use maxExtent from mapConfig as extent fallback

### DIFF
--- a/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
@@ -28,6 +28,7 @@ import {
 
 import {
   DEFAULT_BASELAYER_CONTEXT,
+  DEFAULT_VIEW,
   MapContextService,
 } from './map-context.service'
 
@@ -309,6 +310,71 @@ describe('MapContextService', () => {
           .getSource()
           .getUrls()
         expect(baselayerUrls).toEqual(DEFAULT_BASELAYER_CONTEXT.urls)
+      })
+    })
+    describe('uses default fallback view (without config)', () => {
+      let view
+      const map = new Map({})
+      const mapContext = MAP_CTX_FIXTURE
+      mapContext.view.extent = null
+      mapContext.view.center = null
+      mapContext.view.zoom = null
+      beforeEach(() => {
+        service.resetMapFromContext(map, mapContext)
+      })
+      it('create a map', () => {
+        expect(map).toBeTruthy()
+        expect(map).toBeInstanceOf(Map)
+      })
+      it('add layers', () => {
+        const layers = map.getLayers().getArray()
+        expect(layers.length).toEqual(3)
+      })
+      it('set view', () => {
+        view = map.getView()
+        expect(view).toBeTruthy()
+        expect(view).toBeInstanceOf(View)
+      })
+      it('set center', () => {
+        const center = view.getCenter()
+        expect(center).toEqual(DEFAULT_VIEW.center)
+      })
+      it('set zoom', () => {
+        const zoom = view.getZoom()
+        expect(zoom).toEqual(DEFAULT_VIEW.zoom)
+      })
+    })
+    describe('uses fallback view from config', () => {
+      let view
+      const map = new Map({})
+      const mapConfig = MAP_CONFIG_FIXTURE
+      const mapContext = MAP_CTX_FIXTURE
+      mapContext.view.extent = null
+      mapContext.view.center = null
+      mapContext.view.zoom = null
+      beforeEach(() => {
+        service.resetMapFromContext(map, mapContext, mapConfig)
+      })
+      it('create a map', () => {
+        expect(map).toBeTruthy()
+        expect(map).toBeInstanceOf(Map)
+      })
+      it('add layers', () => {
+        const layers = map.getLayers().getArray()
+        expect(layers.length).toEqual(3)
+      })
+      it('set view', () => {
+        view = map.getView()
+        expect(view).toBeTruthy()
+        expect(view).toBeInstanceOf(View)
+      })
+      it('set center', () => {
+        const center = view.getCenter()
+        expect(center).toEqual([271504.324469, 5979210.100579999])
+      })
+      it('set zoom', () => {
+        const zoom = view.getZoom()
+        expect(zoom).toEqual(3)
       })
     })
   })

--- a/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
@@ -315,10 +315,16 @@ describe('MapContextService', () => {
     describe('uses default fallback view (without config)', () => {
       let view
       const map = new Map({})
-      const mapContext = MAP_CTX_FIXTURE
-      mapContext.view.extent = null
-      mapContext.view.center = null
-      mapContext.view.zoom = null
+      const mapContext = {
+        extent: null,
+        center: null,
+        zoom: null,
+        layers: [
+          MAP_CTX_LAYER_XYZ_FIXTURE,
+          MAP_CTX_LAYER_WMS_FIXTURE,
+          MAP_CTX_LAYER_GEOJSON_FIXTURE,
+        ],
+      }
       beforeEach(() => {
         service.resetMapFromContext(map, mapContext)
       })
@@ -348,10 +354,12 @@ describe('MapContextService', () => {
       let view
       const map = new Map({})
       const mapConfig = MAP_CONFIG_FIXTURE
-      const mapContext = MAP_CTX_FIXTURE
-      mapContext.view.extent = null
-      mapContext.view.center = null
-      mapContext.view.zoom = null
+      const mapContext = {
+        extent: null,
+        center: null,
+        zoom: null,
+        layers: [],
+      }
       beforeEach(() => {
         service.resetMapFromContext(map, mapContext, mapConfig)
       })
@@ -361,7 +369,8 @@ describe('MapContextService', () => {
       })
       it('add layers', () => {
         const layers = map.getLayers().getArray()
-        expect(layers.length).toEqual(3)
+        console.log(layers)
+        expect(layers.length).toEqual(4)
       })
       it('set view', () => {
         view = map.getView()

--- a/libs/feature/map/src/lib/map-context/map-context.service.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.ts
@@ -32,8 +32,8 @@ export const DEFAULT_BASELAYER_CONTEXT: MapContextLayerXyzModel = {
 }
 
 export const DEFAULT_VIEW: MapContextViewModel = {
-  center: fromLonLat([2.1, 46.8], 'EPSG:3857'),
-  zoom: 5,
+  center: fromLonLat([0, 15], 'EPSG:3857'),
+  zoom: 2,
 }
 
 @Injectable({

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
@@ -607,9 +607,36 @@ describe('DataViewMapComponent', () => {
           })
         })
       })
-      describe('when extent computation fails', () => {
+      describe('when extent could not be determined', () => {
         beforeEach(inject([MapUtilsService], (mapUtils) => {
           mapUtils._observer.next(null)
+          fixture.detectChanges()
+        }))
+        it('emits a new map context with the selected layer and extent null', () => {
+          expect(mapComponent.context).toEqual({
+            layers: [
+              {
+                url: 'http://abcd.com/',
+                name: 'layer2',
+                type: 'wms',
+              },
+            ],
+            view: {
+              extent: null,
+            },
+          })
+        })
+        it('provides selected link to the external viewer component', () => {
+          expect(externalViewerButtonComponent.link).toEqual({
+            url: 'http://abcd.com/',
+            name: 'layer2',
+            protocol: 'OGC:WMS',
+          })
+        })
+      })
+      describe('when extent computation fails', () => {
+        beforeEach(inject([MapUtilsService], (mapUtils) => {
+          mapUtils._observer.error('extent computation failed')
           fixture.detectChanges()
         }))
         it('emits a new map context with the selected layer and a default view', () => {
@@ -621,7 +648,7 @@ describe('DataViewMapComponent', () => {
                 type: 'wms',
               },
             ],
-            view: { extent: null },
+            view: { extent: undefined },
           })
         })
         it('provides selected link to the external viewer component', () => {

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
@@ -609,7 +609,7 @@ describe('DataViewMapComponent', () => {
       })
       describe('when extent computation fails', () => {
         beforeEach(inject([MapUtilsService], (mapUtils) => {
-          mapUtils._observer.error('extent computation failed')
+          mapUtils._observer.next(null)
           fixture.detectChanges()
         }))
         it('emits a new map context with the selected layer and a default view', () => {
@@ -621,7 +621,7 @@ describe('DataViewMapComponent', () => {
                 type: 'wms',
               },
             ],
-            view: expect.any(Object),
+            view: { extent: null },
           })
         })
         it('provides selected link to the external viewer component', () => {

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -103,21 +103,14 @@ export class DataViewMapComponent implements OnInit, OnDestroy {
           console.warn(error) // FIXME: report this to the user somehow
           return of(undefined)
         }),
-        map((extent) =>
-          extent
-            ? ({
-                layers,
-                view: {
-                  extent,
-                },
-              } as MapContextModel)
-            : ({
-                layers,
-                view: {
-                  center: fromLonLat([2.1, 46.8], 'EPSG:3857'),
-                  zoom: 5,
-                },
-              } as MapContextModel)
+        map(
+          (extent) =>
+            ({
+              layers,
+              view: {
+                extent,
+              },
+            } as MapContextModel)
         ),
         tap(() => this.resetSelection())
       )


### PR DESCRIPTION
If the extent of a layer displayed on the map, cannot be determined, the PR:

- uses the `maxExtent` param (if present) from the config's `map` section as a fallback extent
- otherwise applies a default value in `mapcontext service`