### PR TITLE
Datahub: Display WMTS on map and zoom to its extent

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.15.0]
 
     steps:
       - name: Checkout
@@ -61,6 +61,11 @@ jobs:
 
   gh-pages:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.15.0]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/libs/feature/map/src/lib/map-context/map-context.model.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.model.ts
@@ -1,10 +1,12 @@
 import type { FeatureCollection } from 'geojson'
 import { Coordinate } from 'ol/coordinate'
 import type { Extent } from 'ol/extent'
+import { Options } from 'ol/source/WMTS'
 
 export enum MapContextLayerTypeEnum {
   XYZ = 'xyz',
   WMS = 'wms',
+  WMTS = 'wmts',
   WFS = 'wfs',
   GEOJSON = 'geojson',
 }
@@ -18,6 +20,13 @@ export interface MapContextLayerWmsModel {
   type: 'wms'
   url: string
   name: string
+}
+
+export interface MapContextLayerWmtsModel {
+  type: 'wmts'
+  url: string
+  name: string
+  options: Options
 }
 
 interface MapContextLayerWfsModel {
@@ -58,6 +67,7 @@ export type MapContextLayerGeojsonModel =
 
 export type MapContextLayerModel =
   | MapContextLayerWmsModel
+  | MapContextLayerWmtsModel
   | MapContextLayerWfsModel
   | MapContextLayerXyzModel
   | MapContextLayerGeojsonModel

--- a/libs/feature/map/src/lib/map-context/map-context.model.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.model.ts
@@ -24,8 +24,6 @@ export interface MapContextLayerWmsModel {
 
 export interface MapContextLayerWmtsModel {
   type: 'wmts'
-  url: string
-  name: string
   options: Options
 }
 

--- a/libs/feature/map/src/lib/map-context/map-context.service.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.ts
@@ -21,6 +21,7 @@ import { bbox as bboxStrategy } from 'ol/loadingstrategy'
 import { LayerConfig, MapConfig } from '@geonetwork-ui/util/app-config'
 import { FeatureCollection } from 'geojson'
 import { fromLonLat } from 'ol/proj'
+import { WMTS } from 'ol/source'
 
 export const DEFAULT_BASELAYER_CONTEXT: MapContextLayerXyzModel = {
   type: MapContextLayerTypeEnum.XYZ,
@@ -83,6 +84,10 @@ export class MapContextService {
             params: { LAYERS: layerModel.name },
             gutter: 20,
           }),
+        })
+      case MapContextLayerTypeEnum.WMTS:
+        return new TileLayer({
+          source: new WMTS(layerModel.options),
         })
       case MapContextLayerTypeEnum.WFS:
         return new VectorLayer({

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -18,6 +18,7 @@ import { from, Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { MapContextLayerModel, MapContextViewModel } from '../..'
 import { MapUtilsWMSService } from './map-utils-wms.service'
+import { MetadataLinkValid } from '@geonetwork-ui/util/shared'
 
 const FEATURE_PROJECTION = 'EPSG:3857'
 const DATA_PROJECTION = 'EPSG:4326'
@@ -162,7 +163,7 @@ export class MapUtilsService {
     return { center, zoom }
   }
 
-  getWmtsOptionsFromCapabilities(link): Observable<Options> {
+  getWmtsOptionsFromCapabilities(link: MetadataLinkValid): Observable<Options> {
     return from(
       fetch(link.url)
         .then(function (response) {

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
@@ -80,6 +80,11 @@ class MapUtilsServiceMock {
       }
     })
   })
+  getWmtsOptionsFromCapabilities = jest.fn(function () {
+    return new Observable((observer) => {
+      observer.next(null)
+    })
+  })
   _returnImmediately = true
   _observer = null
 }
@@ -394,6 +399,32 @@ describe('DataViewMapComponent', () => {
             {
               type: 'geojson',
               data: SAMPLE_GEOJSON,
+            },
+          ],
+          view: expect.any(Object),
+        })
+      })
+    })
+
+    describe('with a link using WMTS protocol', () => {
+      beforeEach(fakeAsync(() => {
+        mdViewFacade.mapApiLinks$.next([
+          {
+            url: 'http://abcd.com/wmts',
+            name: 'orthophoto',
+            protocol: 'OGC:WMTS',
+          },
+        ])
+        mdViewFacade.geoDataLinks$.next([])
+        tick(200)
+        fixture.detectChanges()
+      }))
+      it('emits a map context with the downloaded data from WFS', () => {
+        expect(mapComponent.context).toEqual({
+          layers: [
+            {
+              type: 'wmts',
+              options: expect.any(Object),
             },
           ],
           view: expect.any(Object),

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -168,9 +168,7 @@ export class DataViewMapComponent implements OnInit, OnDestroy {
     } else if (this.linkHelper.isWmtsLink(link)) {
       return this.mapUtils.getWmtsOptionsFromCapabilities(link).pipe(
         map((options) => ({
-          url: link.url,
           type: MapContextLayerTypeEnum.WMTS,
-          name: link.name,
           options: options,
         }))
       )

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -165,6 +165,15 @@ export class DataViewMapComponent implements OnInit, OnDestroy {
         type: MapContextLayerTypeEnum.WMS,
         name: link.name,
       })
+    } else if (this.linkHelper.isWmtsLink(link)) {
+      return this.mapUtils.getWmtsOptionsFromCapabilities(link).pipe(
+        map((options) => ({
+          url: link.url,
+          type: MapContextLayerTypeEnum.WMTS,
+          name: link.name,
+          options: options,
+        }))
+      )
     } else if (this.linkHelper.isWfsLink(link)) {
       return this.dataService
         .getGeoJsonDownloadUrlFromWfs(link.url, link.name)

--- a/libs/feature/search/src/lib/utils/links/link-helper.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/links/link-helper.service.spec.ts
@@ -291,6 +291,14 @@ describe('LinkHelperService', () => {
       expect(service.isWmsLink(LINK_FIXTURES.geodataWfs)).toBeFalsy()
     })
   })
+  describe('#isWmtsLink', () => {
+    it('returns true for a WMTS link', () => {
+      expect(service.isWmtsLink(LINK_FIXTURES.geodataWmts)).toBeTruthy()
+    })
+    it('returns false for a WMS link', () => {
+      expect(service.isWmtsLink(LINK_FIXTURES.geodataWms)).toBeFalsy()
+    })
+  })
   describe('#isWfsLink', () => {
     it('returns true for a WFS link', () => {
       expect(service.isWfsLink(LINK_FIXTURES.geodataWfs)).toBeTruthy()

--- a/libs/feature/search/src/lib/utils/links/link-helper.service.ts
+++ b/libs/feature/search/src/lib/utils/links/link-helper.service.ts
@@ -62,6 +62,9 @@ export class LinkHelperService {
   isWmsLink(link: MetadataLinkValid): boolean {
     return /^OGC:WMS/.test(link.protocol)
   }
+  isWmtsLink(link: MetadataLinkValid): boolean {
+    return /^OGC:WMTS/.test(link.protocol)
+  }
   isWfsLink(link: MetadataLinkValid): boolean {
     return (
       /^OGC:WFS/.test(link.protocol) ||
@@ -84,6 +87,8 @@ export class LinkHelperService {
     let format
     if (this.isWmsLink(link)) {
       format = 'WMS'
+    } else if (this.isWmtsLink(link)) {
+      format = 'WMTS'
     } else if (this.isWfsLink(link)) {
       format = 'WFS'
     } else if (this.isEsriRestFeatureServer(link)) {

--- a/libs/feature/search/src/lib/utils/links/link.fixtures.ts
+++ b/libs/feature/search/src/lib/utils/links/link.fixtures.ts
@@ -108,6 +108,12 @@ export const LINK_FIXTURES = {
     label: 'mylayer',
     url: 'https://my.ogc.server/wms',
   },
+  geodataWmts: {
+    protocol: 'OGC:WMTS',
+    name: 'mylayer',
+    label: 'mylayer',
+    url: 'https://my.ogc.server/wmts',
+  },
   geodataWfs: {
     protocol: 'OGC:WFS',
     name: 'mylayer',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "geonetwork-ui",
   "version": "0.0.0",
+  "engines": {
+    "node": "^16.15.0",
+    "npm": "^8.5.5"
+  },
   "scripts": {
     "ng": "nx",
     "postinstall": "node ./decorate-angular-cli.js && ngcc --properties es2015 browser module main",


### PR DESCRIPTION
PR adds WMTS to the layer types displayed on the preview map. When testing with dataset `329859b4-84cd-497e-af48-4bd35c8ea209` a white background is displayed with the layer (see screenshot). I'm wondering if we can prevent this on the client side or if we depend on the server here. Also wondering if we could (easily) cache the `GetCapabilities` (not using ogc-client in this case).

![wmts](https://user-images.githubusercontent.com/6329425/172633486-abc04048-9281-4ef9-b00c-4ee9aac3be5a.png)
