### PR TITLE
Fix build errors related to npm 8.11, improve CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v2
+        with:
+          main-branch-name: 'master'
+
       - name: Cache node modules
         uses: actions/cache@v1
         env:
@@ -44,20 +49,12 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Install
-        run: npm ci
-
-      - name: Lint
-        run: npm run affected:lint
-
-      - name: Check formatting
-        run: npm run format:check
-
-      - name: Unit tests
-        run: npm run affected:test
-
-      - name: Attempt production build
-        run: npm run affected:build
+      - run: npm ci
+      - run: npx nx workspace-lint
+      - run: npx nx format:check --base=$NX_BASE --head=$NX_HEAD
+      - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=lint --parallel=3
+      - run: npx nx affected --base=$NX_BASE --head=$NX_HEAD --target=test --parallel=3 --ci --code-coverage
+      - run: npx nx affected --target=build --parallel=3
 
   gh-pages:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
       - name: Cache node modules
         uses: actions/cache@v1
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,8 +107,7 @@
         "typescript": "4.5.5"
       },
       "engines": {
-        "node": "^16.15.0",
-        "npm": "^8.5.5"
+        "node": ">=14.17.0 <=16.15.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "geonetwork-ui",
   "version": "0.0.0",
   "engines": {
-    "node": "^16.15.0",
-    "npm": "^8.5.5"
+    "node": ">=14.17.0 <=16.15.0"
   },
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
This PR does:
* use ranges for engine version in package.json
* force npm 8.5.5 for the gh-pages workflow as well
* rework the CI a bit to make it faster (hopefully), using NX recommended steps as described here: https://nx.dev/ci/monorepo-ci-github-actions