### PR TITLE
nginx: Improve resources caching

### DIFF
--- a/tools/docker/nginx.apps.conf
+++ b/tools/docker/nginx.apps.conf
@@ -19,7 +19,7 @@ server {
         location / {
           try_files $uri $uri/ /APP_NAME/index.html;
 
-          add_header Cache-Control 'max-age=2592000'; # 30 days
+          add_header Cache-Control 'max-age=86400'; # 24h
         }
 
         error_page   500 502 503 504  /50x.html;

--- a/tools/docker/nginx.apps.conf
+++ b/tools/docker/nginx.apps.conf
@@ -7,7 +7,7 @@ server {
 
         server_tokens off;
 
-        location ~ /index.html|.*\.json$ {
+        location ~ /index.html|.*\.toml|.*\.json$ {
           expires -1;
           add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
         }


### PR DESCRIPTION
In the nginx configuration:
- no cache for toml files eg. `default.toml` for the configuration
- reduce caching time from 30 days to 24h. This avoids to have deprecated resources in cache for too long.