### PR TITLE
Datahub (record-preview): fix icons

### DIFF
--- a/apps/datahub/src/app/search/record-preview-datahub/record-preview-datahub.component.html
+++ b/apps/datahub/src/app/search/record-preview-datahub/record-preview-datahub.component.html
@@ -25,21 +25,21 @@
       {{ abstract }}
     </div>
     <div
-      class="order-2 text-primary opacity-25 uppercase sm:truncate sm:order-3 sm:row-end-4 sm:col-span-8 md:col-span-9"
+      class="order-2 text-primary opacity-25 uppercase sm:truncate sm:order-3 sm:row-end-4 sm:col-span-8 lg:col-span-9"
     >
       {{ record.contact?.organisation }}
     </div>
     <div
-      class="order-4 basis-1/2 flex flex-row sm:row-end-4 sm:justify-end sm:col-span-2 md:col-span-1"
+      class="order-4 basis-1/2 flex flex-row sm:row-end-4 sm:justify-end sm:col-span-2 lg:col-span-1"
     >
       <mat-icon
         *ngIf="isDownloadable"
-        class="material-icons-outlined text-primary opacity-25 mr-4"
+        class="material-icons-outlined text-primary opacity-25 mx-1"
         >cloud_download</mat-icon
       >
       <mat-icon
         *ngIf="isViewable"
-        class="material-icons-outlined text-primary opacity-25 mr-4"
+        class="material-icons-outlined text-primary opacity-25 mx-1"
         >map</mat-icon
       >
     </div>


### PR DESCRIPTION
PR fixes a small glitch with the icons in the record preview component :

![broken_icons](https://user-images.githubusercontent.com/6329425/174799484-b6d36a4b-4ede-4620-a7bd-22a3d73b3603.png)
