### PR TITLE
Remove crossorigin from preloaded images assets

### DIFF
--- a/tools/docker/docker-entrypoint.sh
+++ b/tools/docker/docker-entrypoint.sh
@@ -47,7 +47,7 @@ if [ -d "${CUSTOM_ASSETS_PATH}" ] && [ "$(ls -A ${CUSTOM_ASSETS_PATH})" ]; then
   for image in ${images}
   do
     echo "[INFO] Adding preload link for ${image}..."
-    sed -i "s@<!--%PRELOAD_LINKS%-->@<!--%PRELOAD_LINKS%-->\n<link rel=\"preload\" href=\"assets/${image}\" as=\"image\" importance=\"high\" crossorigin />@" \
+    sed -i "s@<!--%PRELOAD_LINKS%-->@<!--%PRELOAD_LINKS%-->\n<link rel=\"preload\" href=\"assets/${image}\" as=\"image\" importance=\"high\" />@" \
       ${APP_FILES_PATH}index.html
   done
 else


### PR DESCRIPTION
Adding the crossorigin attribute to preloaded images was wrongly applied in the context of the request credentials mode since it does not match as expected (no Access-Control-Allow-Origin rule and those resources are not external either).

Probably was added when fixing this issue https://github.com/geonetwork/geonetwork-ui/pull/265 (but when it's a toml file requested as fetch, it changes the behavior). 
Found some good intro on this link: https://beamtic.com/crossorigin-attribute-and-preload-not-used 