### PR TITLE
Document project versioning & push artifacts for applications

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -105,6 +105,7 @@ jobs:
         id: docker-auth
         run: |
           BASE_64_TOKEN=$(echo '{"username":"${{ secrets.DOCKER_HUB_USERNAME }}","password":"${{ secrets.DOCKER_HUB_PASSWORD }}","auth":"","email":"geonetworkbot@geonetwork-opensource.org"}' | base64)
+          echo ::add-mask::${BASE_64_TOKEN}
           echo ::set-output name=DOCKER_AUTH::${BASE_64_TOKEN}
 
       - name: Delete docker images for the given applications and branch

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,0 +1,115 @@
+name: Generate release and development artifacts
+
+on:
+  push:
+    # only trigger on branch push, not tags
+    branches:
+      - '*'
+  delete:
+  release:
+    types: [published]
+
+env:
+  # a list of apps to build and publish on releases
+  APP_NAMES: datafeeder,datahub
+
+jobs:
+  build-archive-docker:
+    if: github.event_name != 'delete'
+    name: Build docker images and archives
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.15.0]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Derive appropriate SHAs for base and head for `nx affected` commands
+        uses: nrwl/nx-set-shas@v2
+        with:
+          main-branch-name: 'master'
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build all applications and produce archives
+        if: github.event_name == 'release'
+        run: |
+          npx nx run-many --projects=${{ env.APP_NAMES }} --target=build
+          tools/make-archive.sh ${{env.APP_NAMES}}
+
+      - name: Upload archives to release
+        if: github.event_name == 'release'
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/archives/*
+          file_glob: true
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: Build all docker images
+        if: github.event_name == 'release'
+        run: npx nx run-many --projects=${{ env.APP_NAMES }} --target=docker-build
+
+      - name: Build affected docker images
+        if: github.event_name != 'release'
+        run: npx nx affected --target=docker-build
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+      - name: Push all docker images
+        # list all docker images, keep only the ones in the geonetwork org, and call docker push for each of them
+        run: |
+          docker image ls --format '{{.Repository}}:{{.Tag}}' --filter=reference='geonetwork/*' | \
+          xargs -r -L1 docker push $1
+
+  delete-docker:
+    if: github.event_name == 'delete' && github.ref_type == 'branch'
+    name: Delete docker images for a deleted branch
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.15.0]
+
+    steps:
+      - name: Generate Dockerhub auth
+        id: docker-auth
+        run: |
+          BASE_64_TOKEN=$(echo '{"username":"${{ secrets.DOCKER_HUB_USERNAME }}","password":"${{ secrets.DOCKER_HUB_PASSWORD }}","auth":"","email":"geonetworkbot@geonetwork-opensource.org"}' | base64)
+          echo ::set-output name=DOCKER_AUTH::${BASE_64_TOKEN}
+
+      - name: Delete docker images for the given applications and branch
+        # first list apps separated by line breaks
+        # then for each do a curl call on Dockerhub API to delete the image
+        run: |
+          echo "${{ env.APP_NAMES }}" | awk -vRS=',' '{print $1}' | \
+          xargs -I{} curl -X DELETE "https://hub.docker.com/v2/repositories/geonetwork/geonetwork-ui-{}/${{ github.ref_name }}/" -H "X-Registry-Auth: ${{steps.docker-auth.outputs.DOCKER_AUTH}}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Quality checks and deployment
 env:
   ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
@@ -11,6 +11,7 @@ on:
 
 jobs:
   lint-test-build:
+    name: Format, lint, test and build code
     runs-on: ubuntu-latest
 
     strategy:
@@ -23,9 +24,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-
-      - name: Fetch master for affected code
-        run: git fetch --no-tags --prune --depth=5 origin master
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -63,6 +61,7 @@ jobs:
         run: npx nx affected --target=build --parallel=3
 
   gh-pages:
+    name: Deploy Storybook to GitHub Pages
     runs-on: ubuntu-latest
 
     strategy:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # GeoNetwork UI
 
-GeoNetwork UI is a library of UI and Web Components to embed your catalogue in third party website or to build custom application on top of it. It relies on the GeoNetwork 4 OpenAPI.
+GeoNetwork UI is a suite of Applications made to provide a modern facade to your GeoNetwork 4 catalog.
+
+It also provides Web Components to embed your catalogue in third party websites. It relies on the GeoNetwork 4 OpenAPI.
 
 The target audience is:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,57 @@
+# Release management and procedure
+
+Since GeoNetwork UI is based on a _monorepo_ architecture, **all its components (applications, libraries) share the same
+version number.**
+
+## Version
+
+Project version is structured like so: `<major>.<minor>.<patch>`
+
+Whenever a release is made, the version number is increased according to the following rules:
+
+- **Major version** is incremented when:
+  - a breaking change is introduced in one of the following systems
+    - Configuration files
+    - Docker images usage
+  - a backend requirement change that _is not_ backwards compatible (e.g. GeoNetwork version)
+  - a significant architecture change happened
+- **Minor version** is incremented when:
+  - one or several features were added to the applications
+  - a framework upgrade was done (i.e. Angular or Nx)
+  - a backend requirement change that _is_ backwards compatible (e.g. GeoNetwork version)
+- **Patch version** is incremented for any other kind of change: bug fixes, compatibility fixes, typos, minor tweaks...
+
+### How to upgrade the version
+
+Simply use the following command:
+
+```shell
+$ npm version 1.3.6
+```
+
+This will create a commit changing the version and an associated tag.
+
+> Note that `npm version` can also automatically upgrade the version, e.g. calling `npm version minor`.
+
+## Releases
+
+### When and what to release
+
+Releases are made periodically when needed. Each release includes:
+
+- An archive of each application, named like so: `geonetwork-ui-{application-name}-{version}.zip`  
+  Example: `geonetwork-ui-datahub-1.2.5.zip`
+- A docker image of each application, tagged like so: `geonetwork/geonetwork-ui-{application-name}:{version}`  
+  Example: `geonetwork/geonetwork-ui-datahub:1.2.5`
+
+> Note that the latest development version of each application is also available by replacing the version with
+> the branch name, for example:
+> `geonetwork-ui-datahub-master.zip` or `geonetwork/geonetwork-ui-datahub:master`
+
+### How to make a release
+
+When a release is created in GitHub, the CI automatically generates the associated artifacts which
+are then either attached to the release (archives) or pushed to Dockerhub (docker images).
+
+To trigger this, simply push a git tag and then create a release from it as described here:
+https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release

--- a/apps/datafeeder/README.md
+++ b/apps/datafeeder/README.md
@@ -46,4 +46,4 @@ You can build a docker image of the Datahub application like so:
 $ nx run datafeeder:docker-build
 ```
 
-This will build a docker image with the tag `geonetwork-ui/datafeeder`.
+This will build a docker image with the tag `geonetwork/geonetwork-ui-datafeeder`.

--- a/apps/datafeeder/README.md
+++ b/apps/datafeeder/README.md
@@ -37,3 +37,13 @@ envsubst < assets/env.template.js > assets/env.js
 ### Other settings
 
 Other settings are fetched as a second step from the API `/datafeeder/config/frontend`
+
+## Building with Docker
+
+You can build a docker image of the Datahub application like so:
+
+```bash
+$ nx run datafeeder:docker-build
+```
+
+This will build a docker image with the tag `geonetwork-ui/datafeeder`.

--- a/apps/datafeeder/README.md
+++ b/apps/datafeeder/README.md
@@ -40,7 +40,7 @@ Other settings are fetched as a second step from the API `/datafeeder/config/fro
 
 ## Building with Docker
 
-You can build a docker image of the Datahub application like so:
+You can build a docker image of the Datafeeder application like so:
 
 ```bash
 $ nx run datafeeder:docker-build

--- a/apps/datafeeder/project.json
+++ b/apps/datafeeder/project.json
@@ -98,7 +98,17 @@
         "jestConfig": "apps/datafeeder/jest.config.ts",
         "passWithNoTests": true
       }
+    },
+    "docker-build": {
+      "executor": "@nrwl/workspace:run-commands",
+      "options": {
+        "commands": [
+          "nx build datafeeder --base-href='/datafeeder/'",
+          "docker build --build-arg APP_NAME=datafeeder -f ./tools/docker/Dockerfile.apps . -t $(tools/print-docker-tag.sh datafeeder)"
+        ],
+        "parallel": false
+      }
     }
   },
-  "tags": ["type:app"]
+  "tags": ["type:app", "published"]
 }

--- a/apps/datahub/README.md
+++ b/apps/datahub/README.md
@@ -6,17 +6,91 @@ UI of the web application `datahub`.
 
 Inspire by Opendata catalogs (CKAN, Opendatasoft), the Hub will host geo and non-geo dataset. It will provide dataviz tool and focuses the experience on the dataset instead of on the metadata.
 
-## Dev
+## How to run it
+
+The Datahub application is available as a docker image or as a ZIP archive.
+
+### With docker
+
+The docker image is `geonetwork/geonetwork-ui-datahub`.
+
+To run it on the 8080 port with a custom GN4 API url and proxy path, use:
+
+```bash
+$ docker run -p 8080:80 \
+             -e GN4_API_URL=https://gn4.custom/geonetwork/srv/api \
+             -e PROXY_PATH=/proxy?url= \
+             geonetwork/geonetwork-ui-datahub
+```
+
+Notice how the `GN4_API_URL` and `PROXY_PATH` variables are used to override any values present in the app configuration file.
+**This override will happen everytime the docker container is started.**
+
+The application will be available on http://localhost:8080/datahub/.
+
+#### Specifying a custom configuration file
+
+If the `GN4_API_URL` and `PROXY_PATH` environment variables are not enough and you want to specify a full configuration file,
+you can do so like this:
+
+```bash
+# this assumes a file named `default.toml` is located in the /home/user/custom-conf directory:
+$ docker run -p 8080:80 \
+             -v /home/user/custom-conf:/conf \
+             geonetwork/geonetwork-ui-datahub
+```
+
+If a file named `default.toml` is found in the `/conf` folder _of the app container_ at startup, it will be used by the application.
+
+You can specify a different directory to look for the `default.toml` file using the `CONFIG_DIRECTORY_OVERRIDE` env variable, like so:
+
+```bash
+# this assumes a file named `default.toml` is located in the /home/user/custom-conf directory:
+$ docker run -p 8080:80 \
+             -v /home/user/custom-conf:/some/random/path \
+             -e CONFIG_DIRECTORY_OVERRIDE=/some/random/path \
+             geonetwork/geonetwork-ui-datahub
+```
+
+This can be useful when dealing with existing volumes having their own directory structure.
+
+#### Adding custom assets to the docker container
+
+Any file found in the `/assets` folder _of the app container_ at startup will be copied along with the other assets already present. Existing assets with conflicting names will be
+replaced. Directory structure in the `/assets` folder will be preserved.
+
+For each image file present in the copied assets, a [preload link](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload) will be created in the `index.html` file of the application. This will help reducing the
+time to first significant draw for new visitors, especially for header backgrounds and the like.
+
+You can specify a different directory to look for the custom assets using the `ASSETS_DIRECTORY_OVERRIDE` env variable, like so:
+
+```bash
+# custom assets are located in the /home/user/my-assets directory:
+$ docker run -p 8080:80 \
+             -v /home/user/my-assets:/some/random/path \
+             -e ASSETS_DIRECTORY_OVERRIDE=/some/random/path \
+             geonetwork/geonetwork-ui-datahub
+```
+
+### From the ZIP archive
+
+Each release of GeoNetwork-UI comes with ZIP archives of all applications: https://github.com/geonetwork/geonetwork-ui/releases
+
+Download the Datahub archive and simply serve its contents using an HTTP server like Apache or NGINX.
+
+## Configuration
+
+See the [main README section for more info](../../README.md#application-configuration).
+
+## Development
+
+Executing:
 
 ```
 ng serve datahub
 ```
 
 will run `datahub` as an Angular application available on localhost:4200.
-
-## Configuration
-
-See the [main README section for more info](../../README.md#application-configuration).
 
 ### Proxy
 
@@ -53,62 +127,4 @@ You can build a docker image of the Datahub application like so:
 $ nx run datahub:docker-build
 ```
 
-This will build a docker image with the tag `geonetwork-ui/datahub`.
-
-To run it on the 8080 port with a custom GN4 API url and proxy path, use:
-
-```bash
-$ docker run -p 8080:80 \
-             -e GN4_API_URL=https://gn4.custom/geonetwork/srv/api \
-             -e PROXY_PATH=/proxy?url= \
-             geonetwork-ui/datahub
-```
-
-Notice how the `GN4_API_URL` and `PROXY_PATH` variables are used to override any values present in the app configuration file.
-**This override will happen everytime the docker container is started.**
-
-The application will be available on http://localhost:8080/datahub/.
-
-### Specifying a custom configuration file
-
-If the `GN4_API_URL` and `PROXY_PATH` environment variables are not enough and you want to specify a full configuration file,
-you can do so like this:
-
-```bash
-# this assumes a file named `default.toml` is located in the /home/user/custom-conf directory:
-$ docker run -p 8080:80 \
-             -v /home/user/custom-conf:/conf \
-             geonetwork-ui/datahub
-```
-
-If a file named `default.toml` is found in the `/conf` folder _of the app container_ at startup, it will be used by the application.
-
-You can specify a different directory to look for the `default.toml` file using the `CONFIG_DIRECTORY_OVERRIDE` env variable, like so:
-
-```bash
-# this assumes a file named `default.toml` is located in the /home/user/custom-conf directory:
-$ docker run -p 8080:80 \
-             -v /home/user/custom-conf:/some/random/path \
-             -e CONFIG_DIRECTORY_OVERRIDE=/some/random/path \
-             geonetwork-ui/datahub
-```
-
-This can be useful when dealing with existing volumes having their own directory structure.
-
-### Adding custom assets to the docker container
-
-Any file found in the `/assets` folder _of the app container_ at startup will be copied along with the other assets already present. Existing assets with conflicting names will be
-replaced. Directory structure in the `/assets` folder will be preserved.
-
-For each image file present in the copied assets, a [preload link](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload) will be created in the `index.html` file of the application. This will help reducing the
-time to first significant draw for new visitors, especially for header backgrounds and the like.
-
-You can specify a different directory to look for the custom assets using the `ASSETS_DIRECTORY_OVERRIDE` env variable, like so:
-
-```bash
-# custom assets are located in the /home/user/my-assets directory:
-$ docker run -p 8080:80 \
-             -v /home/user/my-assets:/some/random/path \
-             -e ASSETS_DIRECTORY_OVERRIDE=/some/random/path \
-             geonetwork-ui/datahub
-```
+This will build a docker image with the tag `geonetwork/geonetwork-ui-datahub`.

--- a/apps/datahub/README.md
+++ b/apps/datahub/README.md
@@ -50,10 +50,10 @@ The build also includes the app configuration file (`dist/apps/datahub/assets/co
 You can build a docker image of the Datahub application like so:
 
 ```bash
-$ nx run datahub:docker-build --tag=geonetwork-ui/datahub
+$ nx run datahub:docker-build
 ```
 
-This will build a docker image with the tag `geonetwork-ui/datahub:latest`.
+This will build a docker image with the tag `geonetwork-ui/datahub`.
 
 To run it on the 8080 port with a custom GN4 API url and proxy path, use:
 

--- a/apps/datahub/project.json
+++ b/apps/datahub/project.json
@@ -108,15 +108,12 @@
       "executor": "@nrwl/workspace:run-commands",
       "options": {
         "commands": [
-          {
-            "command": "nx build datahub --base-href='/datahub/'",
-            "forwardAllArgs": false
-          },
-          "docker build --build-arg APP_NAME=datahub -f ./tools/docker/Dockerfile.apps . -t {args.tag}"
+          "nx build datahub --base-href='/datahub/'",
+          "docker build --build-arg APP_NAME=datahub -f ./tools/docker/Dockerfile.apps . -t $(tools/print-docker-tag.sh datahub)"
         ],
         "parallel": false
       }
     }
   },
-  "tags": ["type:app"]
+  "tags": ["type:app", "published"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geonetwork-ui",
-  "version": "0.0.0",
+  "version": "1.0.0-RC1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "geonetwork-ui",
-      "version": "0.0.0",
+      "version": "1.0.0-RC1",
       "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "14.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geonetwork-ui",
-  "version": "0.0.0",
+  "version": "1.0.0-RC1",
   "engines": {
     "node": ">=14.17.0 <=16.15.0"
   },

--- a/tools/make-archive.sh
+++ b/tools/make-archive.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# This script creates an archive out of a directory in the `dist` folder,
+# and appends it with a tag or branch name
+
+# input should be a unique app name or a list of names separated by a comma
+# e.g. tools/make-archive.sh datahub,datafeeder
+appNames=$1
+gitTag=$(git describe --exact-match --tags 2>/dev/null | sed "s/^v//") # remove "v" in front of version if any
+gitBranch=$(git symbolic-ref --short HEAD)
+
+# make sure the archives dist is there and empty
+mkdir -p dist/archives
+rm -f dist/archives/*
+
+# set field separator to allow looping
+IFS=","
+for appName in $appNames
+do
+  distPath=dist/apps/${appName}
+  zipPath=dist/archives/${appName}-${gitTag:-${gitBranch}}.zip
+
+  # make sure the built files are there
+  if [[ -d "${distPath}" ]]
+  then
+    zip $zipPath -r ${distPath}
+  else
+    echo "Error: the files for the app named '${appName}' were not found in dist directory, exiting."
+    exit 1
+  fi
+done
+
+

--- a/tools/print-docker-tag.sh
+++ b/tools/print-docker-tag.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Will print a docker tag with a version based on the current git branch and tag
+# e.g.: geonetwork/geonetwork-ui-my-app:1.0.0-RC2
+# or: geonetwork/geonetwork-ui-my-app:feature-branch
+
+appName=$1
+gitTag=$(git describe --exact-match --tags 2>/dev/null | sed "s/^v//") # remove "v" in front of version if any
+gitBranch=$(git symbolic-ref --short HEAD)
+
+echo "geonetwork/geonetwork-ui-${appName}:${gitTag:-${gitBranch}}"


### PR DESCRIPTION
This PR documents how versions and releases are handled for the project. It also adds a CI workflow for generating docker images both on development branches and releases; currently only the Datafeeder and Datahub apps are part of this.

Docker images for a branch are cleaned up when a branch is removed.

The project is set for version 1.0.0-RC1.