### PR TITLE
Improve handling of parallel searches

### DIFF
--- a/libs/feature/search/src/lib/state/actions.ts
+++ b/libs/feature/search/src/lib/state/actions.ts
@@ -38,7 +38,7 @@ export const CLEAR_ERROR = '[Search] Clear Error'
 
 export const DEFAULT_SEARCH_KEY = 'default'
 
-abstract class AbstractAction {
+export abstract class AbstractAction {
   id?: string
   protected constructor(id?: string) {
     this.id = id || DEFAULT_SEARCH_KEY

--- a/libs/feature/search/src/lib/state/effects.ts
+++ b/libs/feature/search/src/lib/state/effects.ts
@@ -10,11 +10,11 @@ import { Actions, createEffect, ofType } from '@ngrx/effects'
 import { select, Store } from '@ngrx/store'
 import { of } from 'rxjs'
 import {
-  switchMap,
-  map,
-  withLatestFrom,
-  mergeMap,
   catchError,
+  map,
+  mergeMap,
+  switchMap,
+  withLatestFrom,
 } from 'rxjs/operators'
 import {
   AddResults,
@@ -45,6 +45,7 @@ import {
 import { SearchState } from './reducer'
 import { getSearchStateSearch } from './selectors'
 import { HttpErrorResponse } from '@angular/common/http'
+import { switchMapWithSearchId } from '../utils/operators/search.operator'
 
 @Injectable()
 export class SearchEffects {
@@ -87,9 +88,7 @@ export class SearchEffects {
   loadResults$ = createEffect(() =>
     this.actions$.pipe(
       ofType(REQUEST_MORE_RESULTS),
-      // mergeMap is used because of multiple search concerns
-      // TODO: should implement our own switchMap to filter by searchId
-      mergeMap((action: SearchActions) =>
+      switchMapWithSearchId((action: SearchActions) =>
         this.authService.authReady().pipe(
           withLatestFrom(
             this.store$.pipe(select(getSearchStateSearch, action.id))

--- a/libs/feature/search/src/lib/utils/operators/search.operator.spec.ts
+++ b/libs/feature/search/src/lib/utils/operators/search.operator.spec.ts
@@ -1,0 +1,27 @@
+import { of } from 'rxjs'
+import { delay, map } from 'rxjs/operators'
+import { RequestMoreResults } from '../../state/actions'
+import { switchMapWithSearchId } from './search.operator'
+import { fakeAsync, tick } from '@angular/core/testing'
+
+describe('switchMapWithSearchId', () => {
+  describe('actions with various search ids', () => {
+    let sub
+    beforeEach(fakeAsync(() => {
+      sub = jest.fn()
+      of('A', 'A', 'B', 'C', 'A', 'C')
+        .pipe(
+          map((id) => new RequestMoreResults(id)),
+          switchMapWithSearchId((action) => of(action.id).pipe(delay(10)))
+        )
+        .subscribe(sub)
+      tick(10)
+    }))
+    it('only unsubscribes previous observables with the same search id', () => {
+      expect(sub).toHaveBeenCalledTimes(3)
+      expect(sub).toHaveBeenNthCalledWith(1, 'B')
+      expect(sub).toHaveBeenNthCalledWith(2, 'A')
+      expect(sub).toHaveBeenNthCalledWith(3, 'C')
+    })
+  })
+})

--- a/libs/feature/search/src/lib/utils/operators/search.operator.ts
+++ b/libs/feature/search/src/lib/utils/operators/search.operator.ts
@@ -1,15 +1,40 @@
-import { Action } from '@ngrx/store'
-import { ActionStateStream } from '@nrwl/angular/src/runtime/nx/data-persistence'
-import { Observable } from 'rxjs'
+import { Observable, Observer, Subscription } from 'rxjs'
+import { AbstractAction } from '../../state/actions'
+import { mergeMap } from 'rxjs/operators'
 
-export interface HandleSearchOpts<T extends Array<unknown>> {
-  run(): Observable<Action>
-  onError?(): Observable<any> | any
-}
-export function searchOperator<T extends Array<unknown>, A extends Action>(
-  opts: HandleSearchOpts<T>
+/**
+ * This operator will only unsubscribe to previous observables if the new
+ * one applies to the same search id; this allows having parallel searches
+ * with different id while avoiding concurrent requests with the same
+ * search id
+ * @param project
+ */
+export function switchMapWithSearchId<A extends AbstractAction, T>(
+  project: (value: A) => Observable<T>
 ) {
-  return (source: ActionStateStream<T, A>) => {
-    return source.pipe()
-  }
+  const subscriptionsBySearchId: { [id: string]: Subscription } = {}
+  return (source: Observable<A>) =>
+    source.pipe(
+      mergeMap(
+        (action) =>
+          new Observable((observer: Observer<T>) => {
+            const { id: searchId } = action
+            const observable = project(action)
+            if (subscriptionsBySearchId[searchId]) {
+              subscriptionsBySearchId[searchId].unsubscribe()
+            }
+            subscriptionsBySearchId[searchId] = observable.subscribe({
+              next(value: T) {
+                observer.next(value)
+              },
+              complete() {
+                observer.complete()
+              },
+              error(err: unknown) {
+                observer.error(err)
+              },
+            })
+          })
+      )
+    )
 }


### PR DESCRIPTION
This adds a custom operator for making sure that search requests with the _same search id_ will behave correctly, e.g. new requests will cancel previous ones. Requests with different search ids will not interact.