### PR TITLE
Datahub: fix focus on search input after scroll

### DIFF
--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -1,7 +1,7 @@
 <header class="h-full px-5" [style.background]="backgroundCss">
   <div class="container-lg h-full mx-auto flex flex-col justify-end">
     <div
-      class="py-8 relative"
+      class="py-8 relative z-50"
       [style.transform]="'translate(0, ' + (1 - expandRatio) * 234 + 'px)'"
     >
       <div


### PR DESCRIPTION
Currently, the focus on search input is broken when scrolling down (which sets the opacity of the tabs div to a negative value but does not hide it). The click events are thus intercepted by the buttons of the tabs div.

This PR sets the tabs div visibility to hidden if its opacity becomes smaller than 0 and allows focusing the search again after scrolling down.