### PR TITLE
Datahub / Add favorites toggle icon on record view and news feed

### DIFF
--- a/apps/datahub/src/app/record/header-record/header-record.component.css
+++ b/apps/datahub/src/app/record/header-record/header-record.component.css
@@ -1,0 +1,4 @@
+gn-ui-favorite-star {
+  --star-toggle-enabled-color: var(--color-background);
+  --star-toggle-disabled-color: var(--color-background) white;
+}

--- a/apps/datahub/src/app/record/header-record/header-record.component.html
+++ b/apps/datahub/src/app/record/header-record/header-record.component.html
@@ -2,6 +2,10 @@
   <div
     class="h-full container-lg mx-auto flex flex-col justify-center relative"
   >
+    <gn-ui-favorite-star
+      [record]="metadata"
+      class="absolute text-background top-[0.85em] right-[0.85em]"
+    ></gn-ui-favorite-star>
     <div
       *ngIf="metadata"
       class="font-title text-center px-2 text-[28px] mb-[41px] line-clamp-4 sm:mx-48"

--- a/libs/feature/search/src/lib/results-list/results-list.container.component.html
+++ b/libs/feature/search/src/lib/results-list/results-list.container.component.html
@@ -14,6 +14,7 @@
     [loading]="facade.isLoading$ | async"
     [records]="facade.results$ | async"
     [layoutConfig]="layoutConfig$ | async"
+    [favoriteTemplate]="favoriteToggle"
     (mdSelect)="onMetadataSelection($event)"
   ></gn-ui-results-list>
 </div>
@@ -29,3 +30,7 @@
     [error]="errorMessage$ | async"
   ></gn-ui-search-results-error>
 </div>
+
+<ng-template #favoriteToggle let-record>
+  <gn-ui-favorite-star [record]="record"></gn-ui-favorite-star>
+</ng-template>

--- a/libs/ui/inputs/src/lib/star-toggle/star-toggle.component.css
+++ b/libs/ui/inputs/src/lib/star-toggle/star-toggle.component.css
@@ -1,3 +1,10 @@
+button.enabled {
+  color: var(--star-toggle-enabled-color, var(--color-secondary));
+}
+button.disabled {
+  color: var(--star-toggle-disabled-color, var(--color-primary));
+}
+
 mat-icon {
   width: 1em;
   height: 1em;

--- a/libs/ui/inputs/src/lib/star-toggle/star-toggle.component.html
+++ b/libs/ui/inputs/src/lib/star-toggle/star-toggle.component.html
@@ -3,8 +3,8 @@
     type="button"
     (click)="toggle($event)"
     [ngClass]="{
-      'text-secondary': toggled,
-      'text-primary opacity-25': !toggled,
+      enabled: toggled,
+      'disabled opacity-[0.45]': !toggled,
       'transition hover:scale-125 will-change-transform': !disabled,
       'cursor-default': disabled
     }"

--- a/libs/ui/inputs/src/lib/star-toggle/star-toggle.component.ts
+++ b/libs/ui/inputs/src/lib/star-toggle/star-toggle.component.ts
@@ -31,5 +31,6 @@ export class StarToggleComponent {
       this.newValue.emit(this.toggled)
     }
     event.stopPropagation()
+    event.preventDefault()
   }
 }

--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
@@ -52,8 +52,14 @@
         </p>
       </div>
     </div>
-    <div class="pt-5 pb-5 px-10">
-      <h1 class="title-font text-[21px] font-medium mb-3">
+    <div class="pt-5 pb-5 px-10 relative">
+      <div class="absolute top-[0.85em] right-[0.85em]">
+        <ng-container
+          [ngTemplateOutlet]="favoriteTemplate"
+          [ngTemplateOutletContext]="{ $implicit: record }"
+        ></ng-container>
+      </div>
+      <h1 class="title-font text-[21px] font-medium mb-3 pr-8">
         {{ record.title }}
       </h1>
       <p class="text-gray-900 line-clamp-3">{{ record.abstract }}</p>

--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.stories.ts
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.stories.ts
@@ -7,26 +7,45 @@ import {
 import { RecordPreviewFeedComponent } from './record-preview-feed.component'
 import { TranslateModule } from '@ngx-translate/core'
 import { action } from '@storybook/addon-actions'
+import { MatIconModule } from '@angular/material/icon'
 
 export default {
   title: 'Search/RecordPreviewFeedComponent',
   component: RecordPreviewFeedComponent,
   decorators: [
     moduleMetadata({
-      imports: [UtilSharedModule, UiElementsModule, TranslateModule.forRoot()],
+      imports: [
+        UtilSharedModule,
+        UiElementsModule,
+        TranslateModule.forRoot(),
+        MatIconModule,
+      ],
     }),
   ],
 } as Meta<RecordPreviewFeedComponent>
 
-const Template: Story<RecordPreviewFeedComponent> = (
-  args: RecordPreviewFeedComponent
+type RecordPreviewFeedTemplate = RecordPreviewFeedComponent & {
+  favoriteTemplateString: string
+}
+
+const Template: Story<RecordPreviewFeedTemplate> = (
+  args: RecordPreviewFeedTemplate
 ) => ({
-  component: RecordPreviewFeedComponent,
   props: { ...args, mdSelect: action('mdSelect') },
+  template: `<gn-ui-record-preview-feed
+      [record]='record'
+      [linkTarget]='linkTarget'
+      (mdSelect)='mdSelect'
+      [favoriteTemplate]='favorite'>
+    </gn-ui-record-preview-feed>
+    <ng-template #favorite let-record>${args.favoriteTemplateString}</ng-template>`,
 })
 
 export const Primary = Template.bind({})
 Primary.args = {
   record: RECORDS_FULL_FIXTURE[0],
   linkTarget: '_blank',
+  favoriteTemplateString: `<a href title="Mark '{{record.title}}' as favorite">
+    1234 <mat-icon class='align-middle'>star</mat-icon>
+  </a>`,
 }

--- a/libs/ui/search/src/lib/record-preview/record-preview.component.ts
+++ b/libs/ui/search/src/lib/record-preview/record-preview.component.ts
@@ -6,6 +6,7 @@ import {
   OnInit,
   OnDestroy,
   ElementRef,
+  TemplateRef,
 } from '@angular/core'
 import { MetadataRecord } from '@geonetwork-ui/util/shared'
 import { fromEvent, Subscription } from 'rxjs'
@@ -17,6 +18,7 @@ import { fromEvent, Subscription } from 'rxjs'
 export class RecordPreviewComponent implements OnInit, OnDestroy {
   @Input() record: MetadataRecord
   @Input() linkTarget = '_blank'
+  @Input() favoriteTemplate: TemplateRef<{ $implicit: MetadataRecord }>
   @Output() mdSelect = new EventEmitter<MetadataRecord>()
   subscription = new Subscription()
 

--- a/libs/ui/search/src/lib/results-list-item/results-list-item.component.ts
+++ b/libs/ui/search/src/lib/results-list-item/results-list-item.component.ts
@@ -7,6 +7,7 @@ import {
   Input,
   OnChanges,
   Output,
+  TemplateRef,
   ViewChild,
   ViewContainerRef,
 } from '@angular/core'
@@ -23,6 +24,7 @@ import { ResultsLayoutConfigItem } from '../results-list/results-layout.config'
 export class ResultsListItemComponent implements OnChanges, AfterViewInit {
   @Input() layoutConfig: ResultsLayoutConfigItem
   @Input() record: MetadataRecord
+  @Input() favoriteTemplate: TemplateRef<{ $implicit: MetadataRecord }>
   @Output() mdSelect = new EventEmitter<MetadataRecord>()
   initialized = false
 
@@ -48,6 +50,7 @@ export class ResultsListItemComponent implements OnChanges, AfterViewInit {
     const componentFactory =
       this.cardRef.createComponent<RecordPreviewComponent>(resolver)
     componentFactory.instance.record = this.record
+    componentFactory.instance.favoriteTemplate = this.favoriteTemplate
     componentFactory.instance.mdSelect.subscribe((record) =>
       this.mdSelect.emit(record)
     )

--- a/libs/ui/search/src/lib/results-list/results-list.component.html
+++ b/libs/ui/search/src/lib/results-list/results-list.component.html
@@ -9,6 +9,7 @@
         [record]="record"
         [layoutConfig]="layoutConfig"
         (mdSelect)="mdSelect.emit($event)"
+        [favoriteTemplate]="favoriteTemplate"
       ></gn-ui-results-list-item>
     </div>
   </div>

--- a/libs/ui/search/src/lib/results-list/results-list.component.ts
+++ b/libs/ui/search/src/lib/results-list/results-list.component.ts
@@ -4,6 +4,7 @@ import {
   EventEmitter,
   Input,
   Output,
+  TemplateRef,
 } from '@angular/core'
 import { MetadataRecord } from '@geonetwork-ui/util/shared'
 import {
@@ -22,5 +23,6 @@ export class ResultsListComponent {
   @Input() loading: boolean
   @Input() layoutConfig: ResultsLayoutConfigItem =
     DEFAULT_RESULTS_LAYOUT_CONFIG['CARD']
+  @Input() favoriteTemplate: TemplateRef<{ $implicit: MetadataRecord }>
   @Output() mdSelect = new EventEmitter<MetadataRecord>()
 }


### PR DESCRIPTION
Please note:
* CSS variables were introduced to customize the appearance of the star toggle without passing arguments through the smart component; let me know if you think this is a bad pattern, personnally I think this works well
* adding the star in the newsfeed records required defining a template outlet in the presentation component, this was quite cumbersome so again, I'm open to suggestions!

![image](https://user-images.githubusercontent.com/10629150/190635096-40def635-2cc6-4393-bff5-453110e65e3a.png)

![image](https://user-images.githubusercontent.com/10629150/190635166-fc14a7d4-e5ef-46a1-8260-e828b5f3a1cf.png)
