### PR TITLE
Continue organizations refactoring

### DIFF
--- a/apps/datahub/src/app/home/search/record-preview-datahub/record-preview-datahub.component.html
+++ b/apps/datahub/src/app/home/search/record-preview-datahub/record-preview-datahub.component.html
@@ -29,7 +29,7 @@
     <div
       class="text-primary opacity-25 uppercase col-start-1 col-span-2 row-start-2 sm:truncate sm:row-start-3 sm:col-span-1"
     >
-      {{ record.resourceContacts?.[0]?.organisation }}
+      {{ contact?.organisation }}
     </div>
     <div
       class="icons flex flex-row col-start-1 row-start-4 sm:col-start-2 sm:row-start-3 sm:absolute sm:right-[0.4em]"

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.ts
@@ -70,6 +70,8 @@ export class OrganisationsComponent {
   }
 
   searchByOrganisation(organisation: Organisation) {
-    this.searchService.updateSearch({ Org: { [organisation.name]: true } })
+    this.searchService.updateSearch({
+      OrgForResource: { [organisation.name]: true },
+    })
   }
 }

--- a/libs/feature/router/README.md
+++ b/libs/feature/router/README.md
@@ -7,7 +7,7 @@ A defaut router is implemented to manage the search state and the record view st
 
 - `/search` to be on search result page
 - `/search?q=island` search for `any=island`
-- `/search?publisher=island` search for `Org=island`
+- `/search?publisher=island` search for `OrgForResource=island`
 - `/dataset/cf5048f6-5bbf-4e44-ba74-e6f429af51ea` to be on the details of the record page.
 
 ## Principle
@@ -83,6 +83,6 @@ export enum ROUTE_PARAMS {
 export type SearchRouteParams = Partial<Record<ROUTE_PARAMS, string>>
 export const ROUTE_PARAMS_MAPPING: SearchRouteParams = {
   [ROUTE_PARAMS.ANY]: 'any',
-  [ROUTE_PARAMS.PUBLISHER]: 'Org',
+  [ROUTE_PARAMS.PUBLISHER]: 'OrgForResource',
 }
 ```

--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.ts
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.ts
@@ -18,7 +18,7 @@ export class MetadataContactComponent {
   @Output() contact = new EventEmitter<string>()
 
   get shownContact() {
-    return this.metadata.resourceContacts?.[0]
+    return this.metadata.resourceContacts?.[0] || this.metadata.contact
   }
 
   onContactClick() {

--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
@@ -25,7 +25,7 @@
         >
         <img
           *ngIf="hasLogo"
-          [src]="record.contact.logoUrl"
+          [src]="contact.logoUrl"
           alt="Organization logo"
           class="object-contain w-full h-full"
         />
@@ -36,14 +36,14 @@
           href="#"
           class="font-bold transition duration-200 text-primary hover:text-primary-darker truncate max-w-full"
         >
-          {{ record.contact.organisation }}
+          {{ contact.organisation }}
         </a>
         <a
           *ngIf="hasOnlyPerson"
           href="#"
           class="font-bold transition duration-200 text-primary hover:text-primary-darker truncate max-w-full"
         >
-          {{ record.contact.name }}
+          {{ contact.name }}
         </a>
         <p class="text-gray-900">
           <span translate [translateParams]="{ time }"

--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.ts
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.ts
@@ -20,17 +20,13 @@ export class RecordPreviewFeedComponent extends RecordPreviewComponent {
   }
 
   get hasOrganization() {
-    return this.record.contact && this.record.contact.organisation
+    return this.contact && this.contact.organisation
   }
   get hasLogo() {
-    return this.record.contact && this.record.contact.logoUrl
+    return this.contact && this.contact.logoUrl
   }
   get hasOnlyPerson() {
-    return (
-      this.record.contact &&
-      !this.record.contact.organisation &&
-      this.record.contact.name
-    )
+    return this.contact && !this.contact.organisation && this.contact.name
   }
   get time() {
     return this.timeFormat.format(this.record.createdOn, Date.now())

--- a/libs/ui/search/src/lib/record-preview/record-preview.component.ts
+++ b/libs/ui/search/src/lib/record-preview/record-preview.component.ts
@@ -8,7 +8,7 @@ import {
   ElementRef,
   TemplateRef,
 } from '@angular/core'
-import { MetadataRecord } from '@geonetwork-ui/util/shared'
+import { MetadataContact, MetadataRecord } from '@geonetwork-ui/util/shared'
 import { fromEvent, Subscription } from 'rxjs'
 
 @Component({
@@ -27,6 +27,9 @@ export class RecordPreviewComponent implements OnInit, OnDestroy {
   }
   get isDownloadable() {
     return this.record.hasDownloads
+  }
+  get contact(): MetadataContact {
+    return this.record.resourceContacts?.[0] || this.record.contact
   }
 
   constructor(protected elementRef: ElementRef) {}

--- a/libs/util/shared/src/lib/elasticsearch/constant.ts
+++ b/libs/util/shared/src/lib/elasticsearch/constant.ts
@@ -16,6 +16,7 @@ export const ES_SOURCE_SUMMARY = [
   'codelist_status_text',
   'linkProtocol',
   'contactForResource.organisation',
+  'contact.organisation',
   'userSavedCount',
 ]
 
@@ -23,6 +24,7 @@ export const ES_SOURCE_BRIEF = [
   ...ES_SOURCE_SUMMARY,
   'resourceTypeObject',
   'Org',
+  'OrgForResource',
 ]
 
 export const ElasticSearchSources = {

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -300,6 +300,7 @@ describe('ElasticsearchService', () => {
           'codelist_status_text',
           'linkProtocol',
           'contactForResource.organisation',
+          'contact.organisation',
           'userSavedCount',
         ],
         query: {


### PR DESCRIPTION
This is a follow-up of #312 to make sure that contacts for the resource and the metadata are used everywhere consistently:
* fix the filter by organization on the orgs page; also reworked the test a little bit to improve readability
* show organizations correctly in the news feed and datahub search