### PR TITLE
Datahub: Make news timeline default route

### DIFF
--- a/apps/datahub/src/app/router/datahub-router.service.spec.ts
+++ b/apps/datahub/src/app/router/datahub-router.service.spec.ts
@@ -15,7 +15,7 @@ const RouterMock = {
 const expectedRoutes = [
   {
     path: '',
-    redirectTo: 'home/search',
+    redirectTo: 'home/news',
     pathMatch: 'full',
   },
   {

--- a/apps/datahub/src/app/router/datahub-router.service.ts
+++ b/apps/datahub/src/app/router/datahub-router.service.ts
@@ -29,7 +29,7 @@ export class DatahubRouterService {
     return [
       {
         path: '',
-        redirectTo: `${ROUTER_ROUTE_HOME}/${ROUTER_ROUTE_SEARCH}`,
+        redirectTo: `${ROUTER_ROUTE_HOME}/${ROUTER_ROUTE_NEWS}`,
         pathMatch: 'full',
       },
       {


### PR DESCRIPTION
PR changes root redirect from `home/search` to `home/news`