### PR TITLE
Datahub: Open related records in new tab

### DIFF
--- a/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
+++ b/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
@@ -1,6 +1,7 @@
-<div
-  class="w-72 h-96 overflow-hidden rounded-lg shadow-primary-light bg-white cursor-pointer"
+<a
+  class="w-72 h-96 overflow-hidden rounded-lg shadow-primary-light bg-white cursor-pointer block"
   [routerLink]="['/dataset', record.uuid]"
+  target="_blank"
 >
   <div class="h-52 bg-gray-100">
     <gn-ui-thumbnail
@@ -24,4 +25,4 @@
       </button>
     </div>
   </div>
-</div>
+</a>


### PR DESCRIPTION
PR adds `<a>` tag to `related-record-card` and opens records in new tab:

![related](https://user-images.githubusercontent.com/6329425/193529301-d422ff12-37c8-48a1-b3f8-cefac0ee0b92.png)
