### PR TITLE
CI / make PR docker images build again

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || '' }} # use the PR head ref if applicable; otherwise keep default behaviour
           persist-credentials: false
           fetch-depth: 0
 


### PR DESCRIPTION
This makes sure that when the Artifacts workflow runs on a PR, the ref used to build the docker images is the actual PR head and not a merge commit with the main branch. Otherwise git has no ref for the current HEAD, and the docker image cannot be correctly tagged by the `tools/print-docker-tag.sh` script.