### PR TITLE
Data preview / allow inferring a WFS feature type if none provided

### DIFF
--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
@@ -178,7 +178,7 @@ describe('DataDownloadsComponent', () => {
             url: 'https://www.ifremer.fr/services/wfs/surveillance_littorale',
           },
           {
-            protocol: 'ESRI:REST',
+            protocol: 'OGC:WFS',
             name: 'mes_hdf',
             format: 'arcgis geoservices rest api',
             description: 'ArcGIS GeoService Wfs',
@@ -222,7 +222,7 @@ describe('DataDownloadsComponent', () => {
             format: 'WFS:csv',
             mediaType: 'application/json',
             name: 'mes_hdf',
-            protocol: 'ESRI:REST',
+            protocol: 'OGC:WFS',
             url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf/WFSServer/0',
           },
           {
@@ -244,7 +244,7 @@ describe('DataDownloadsComponent', () => {
             format: 'WFS:geojson',
             mediaType: 'application/json',
             name: 'mes_hdf',
-            protocol: 'ESRI:REST',
+            protocol: 'OGC:WFS',
             url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf/WFSServer/0',
           },
           {

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
@@ -103,7 +103,7 @@ const SAMPLE_GEOJSON = {
 
 class DataServiceMock {
   getGeoJsonDownloadUrlFromWfs = jest.fn((url) => of(url + '?download'))
-  getGeoJsonDownloadUrlFromEsriRest = jest.fn((url) => of(url + '?download'))
+  getGeoJsonDownloadUrlFromEsriRest = jest.fn((url) => url + '?download')
   readGeoJsonDataset = jest.fn((url) =>
     url.indexOf('error') > -1
       ? throwError(new Error('data loading error'))
@@ -423,6 +423,32 @@ describe('DataViewMapComponent', () => {
             {
               type: 'wmts',
               options: expect.any(Object),
+            },
+          ],
+          view: expect.any(Object),
+        })
+      })
+    })
+
+    describe('with a link using ESRI:REST protocol', () => {
+      beforeEach(fakeAsync(() => {
+        mdViewFacade.mapApiLinks$.next([])
+        mdViewFacade.geoDataLinks$.next([
+          {
+            protocol: 'ESRI:REST',
+            name: 'mes_hdf',
+            url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf/FeatureServer/0',
+          },
+        ])
+        tick(200)
+        fixture.detectChanges()
+      }))
+      it('emits a map context with the the downloaded data from the ESRI REST API', () => {
+        expect(mapComponent.context).toEqual({
+          layers: [
+            {
+              type: 'geojson',
+              data: SAMPLE_GEOJSON,
             },
           ],
           view: expect.any(Object),

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
@@ -430,32 +430,6 @@ describe('DataViewMapComponent', () => {
       })
     })
 
-    describe('with a link using ESRI:REST protocol', () => {
-      beforeEach(fakeAsync(() => {
-        mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geoDataLinks$.next([
-          {
-            protocol: 'ESRI:REST',
-            name: 'mes_hdf',
-            url: 'https://services8.arcgis.com/rxZzohbySMKHTNcy/arcgis/rest/services/mes_hdf/WFSServer/0',
-          },
-        ])
-        tick(200)
-        fixture.detectChanges()
-      }))
-      it('emits a map context with the the downloaded data from WFS', () => {
-        expect(mapComponent.context).toEqual({
-          layers: [
-            {
-              type: 'geojson',
-              data: SAMPLE_GEOJSON,
-            },
-          ],
-          view: expect.any(Object),
-        })
-      })
-    })
-
     describe('with a link using WFS which returns an error', () => {
       beforeEach(() => {
         mdViewFacade.mapApiLinks$.next([])

--- a/libs/feature/record/src/lib/service/data.service.ts
+++ b/libs/feature/record/src/lib/service/data.service.ts
@@ -46,7 +46,12 @@ export class DataService {
       }),
       // eslint-disable-next-line -- ogc-client lacks typing
       map((endpoint: any) => {
-        const featureType = endpoint.getFeatureTypeSummary(featureTypeName)
+        const featureTypes = endpoint.getFeatureTypes()
+        const featureType = endpoint.getFeatureTypeSummary(
+          featureTypes.length === 1 && !featureTypeName
+            ? featureTypes[0].name
+            : featureTypeName
+        )
         if (!featureType) {
           throw new Error('wfs.featuretype.notfound')
         }

--- a/libs/feature/search/src/lib/utils/mapper/atomic-operations.ts
+++ b/libs/feature/search/src/lib/utils/mapper/atomic-operations.ts
@@ -63,13 +63,7 @@ export const mapLink = (sourceLink: SourceWithUnknownProps): MetadataLink => {
     }
   }
 
-  const sourceName = selectField<string>(sourceLink, 'name')
-  const sourceNameEmpty = sourceName === null || sourceName === ''
-  const filenameRegex = /\/?([^/]+)$/
-  const name =
-    sourceNameEmpty && filenameRegex.test(url)
-      ? url.match(filenameRegex)[1]
-      : sourceName
+  const name = selectField<string>(sourceLink, 'name')
   const description = selectField<string>(sourceLink, 'description')
   const label = description || name
   const protocol = selectField<string>(sourceLink, 'protocol')

--- a/libs/feature/search/src/lib/utils/mapper/elasticsearch.mapper.spec.ts
+++ b/libs/feature/search/src/lib/utils/mapper/elasticsearch.mapper.spec.ts
@@ -121,7 +121,6 @@ describe('ElasticsearchMapper', () => {
               description: 'Download this file!',
               label: 'Download this file!',
               url: 'https://my.website/services/static/data.csv',
-              name: 'data.csv',
             },
           ])
         })

--- a/libs/util/shared/src/lib/fixtures/link.fixtures.ts
+++ b/libs/util/shared/src/lib/fixtures/link.fixtures.ts
@@ -139,7 +139,7 @@ export const LINK_FIXTURES = {
     url: 'https://my.esri.server/FeatureServer',
   },
   geodataRestWfs: {
-    protocol: 'ESRI:REST',
+    protocol: 'OGC:WFS',
     name: 'mywfsrestlayer',
     label: 'mywfsrestlayer',
     url: 'https://my.esri.server/WFSServer',

--- a/libs/util/shared/src/lib/links/link-classifier.service.ts
+++ b/libs/util/shared/src/lib/links/link-classifier.service.ts
@@ -53,8 +53,6 @@ export class LinkClassifierService {
       }
       if (/^OGC:WFS/.test(link.protocol))
         return [LinkUsage.API, LinkUsage.DOWNLOAD, LinkUsage.GEODATA]
-      if (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
-        return [LinkUsage.API, LinkUsage.DOWNLOAD, LinkUsage.GEODATA]
       if (/^ESRI:REST/.test(link.protocol) && /FeatureServer/.test(link.url))
         return [LinkUsage.API, LinkUsage.DOWNLOAD, LinkUsage.GEODATA]
       if (/^OGC:WMS/.test(link.protocol))

--- a/libs/util/shared/src/lib/links/link-helper.service.spec.ts
+++ b/libs/util/shared/src/lib/links/link-helper.service.spec.ts
@@ -297,10 +297,7 @@ describe('LinkHelperService', () => {
     it('returns true for a WFS link', () => {
       expect(service.isWfsLink(LINK_FIXTURES.geodataWfs)).toBeTruthy()
     })
-    it('returns true for a ESRI WFS link', () => {
-      expect(service.isWfsLink(LINK_FIXTURES.geodataRestWfs)).toBeTruthy()
-    })
-    it('returns false for a WFS link', () => {
+    it('returns false for a WMS link', () => {
       expect(service.isWfsLink(LINK_FIXTURES.geodataWms)).toBeFalsy()
     })
   })
@@ -310,7 +307,7 @@ describe('LinkHelperService', () => {
         service.isEsriRestFeatureServer(LINK_FIXTURES.geodataRest)
       ).toBeTruthy()
     })
-    it('returns false for a ESRI:REST WFSServer link', () => {
+    it('returns false for a WFS link', () => {
       expect(
         service.isEsriRestFeatureServer(LINK_FIXTURES.geodataRestWfs)
       ).toBeFalsy()

--- a/libs/util/shared/src/lib/links/link-helper.service.ts
+++ b/libs/util/shared/src/lib/links/link-helper.service.ts
@@ -62,10 +62,7 @@ export class LinkHelperService {
     return /^OGC:WMTS/.test(link.protocol)
   }
   isWfsLink(link: MetadataLinkValid): boolean {
-    return (
-      /^OGC:WFS/.test(link.protocol) ||
-      (/^ESRI:REST/.test(link.protocol) && /WFSServer/.test(link.url))
-    )
+    return /^OGC:WFS/.test(link.protocol)
   }
   isLandingPage(link: MetadataLink): boolean {
     return this.linkClassifier


### PR DESCRIPTION
This PR adds a heuristics when a record contains a WFS link but with no featureType specified, and that the WFS only advertises one feature type in total. In this case and only in this one, the only feature type available will be used.

Also removed some heuristics related to ESRI records that should not be required any more.

Requires https://github.com/geonetwork/core-geonetwork/pull/6587 to have this work for records harvested from ArcGIS catalogs:

![image](https://user-images.githubusercontent.com/10629150/193859986-f9a92f33-644c-4659-a844-b78ccf826043.png)