### PR TITLE
Autocomplete: Clear search results

### DIFF
--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -100,11 +100,13 @@ describe('AutocompleteComponent', () => {
       })
     })
     describe('when input is not empty', () => {
+      let anyEmitted
       let button
       beforeEach(() => {
         component.inputRef.nativeElement.value = 'blar'
         component.inputRef.nativeElement.dispatchEvent(new InputEvent('input'))
         component.triggerRef.closePanel = jest.fn()
+        component.inputSubmitted.subscribe((event) => (anyEmitted = event))
         fixture.detectChanges()
         button = fixture.debugElement.query(By.css('.clear-btn'))
       })
@@ -122,6 +124,10 @@ describe('AutocompleteComponent', () => {
       it('closes the autocomplete panel', () => {
         button.nativeElement.click()
         expect(component.triggerRef.closePanel).toHaveBeenCalled()
+      })
+      it('clears search result by emitting empty string', () => {
+        button.nativeElement.click()
+        expect(anyEmitted).toEqual('')
       })
     })
   })

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
@@ -114,6 +114,7 @@ export class AutocompleteComponent
 
   clear(): void {
     this.inputRef.nativeElement.value = ''
+    this.inputSubmitted.emit('')
     this.selectionSubject
       .pipe(take(1))
       .subscribe((selection) => selection && selection.option.deselect())


### PR DESCRIPTION
PR emits an empty string as submitted value when clicking the autocomplete clear button in order to clear the search results.
