### PR TITLE
Autocomplete: Close suggestions on page scroll

### DIFF
--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
@@ -75,6 +75,7 @@ export class AutocompleteComponent
   }
 
   ngOnInit(): void {
+    window.addEventListener('scroll', () => this.scrollEvent(), true)
     this.suggestions$ = this.control.valueChanges.pipe(
       tap(() => (this.error = null)),
       filter((value) => value.length > 2),
@@ -96,6 +97,10 @@ export class AutocompleteComponent
     this.control.valueChanges
       .pipe(filter((value) => typeof value === 'string'))
       .subscribe(this.lastInputValue$)
+  }
+
+  scrollEvent(): void {
+    if (this.triggerRef.panelOpen) this.triggerRef.updatePosition()
   }
 
   ngAfterViewInit(): void {


### PR DESCRIPTION
PR now updates the position of autocomplete suggestions when the page is scrolled. Couldn't add the `window` event listener the "angular" way via `HostListener`, `Renderer2` nor `fromEvent`, wondering why...

Todo:

- [ ] remove event listener
- [ ] add a test