### PR TITLE
Datahub: Fix click on organisation

### DIFF
--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -13,7 +13,6 @@
       <gn-ui-fuzzy-search
         class="text-[18px]"
         (itemSelected)="onFuzzySearchSelection($event)"
-        [value]="searchInputRouteValue$ | async"
       ></gn-ui-fuzzy-search>
       <div class="flex h-0 py-5" [style.opacity]="-0.6 + expandRatio * 2">
         <datahub-header-badge-button

--- a/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
@@ -1,13 +1,11 @@
-import { Component, Input, NO_ERRORS_SCHEMA } from '@angular/core'
+import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { By } from '@angular/platform-browser'
 import { AuthService } from '@geonetwork-ui/feature/auth'
 import {
   RouterFacade,
   ROUTER_ROUTE_SEARCH,
 } from '@geonetwork-ui/feature/router'
 import { SearchFacade, SearchService } from '@geonetwork-ui/feature/search'
-import { MetadataRecord } from '@geonetwork-ui/util/shared'
 import { TranslateModule } from '@ngx-translate/core'
 import { BehaviorSubject } from 'rxjs'
 import { HomeHeaderComponent } from './home-header.component'
@@ -43,15 +41,6 @@ const authServiceMock = {
       })
   ),
 }
-/* eslint-disable */
-@Component({
-  selector: 'gn-ui-fuzzy-search',
-  template: '',
-})
-class FuzzySearchComponentMock {
-  @Input() value?: MetadataRecord
-}
-/* eslint-enable */
 
 describe('HeaderComponent', () => {
   let component: HomeHeaderComponent
@@ -60,7 +49,7 @@ describe('HeaderComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
-      declarations: [HomeHeaderComponent, FuzzySearchComponentMock],
+      declarations: [HomeHeaderComponent],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
         {
@@ -93,23 +82,6 @@ describe('HeaderComponent', () => {
     expect(component).toBeTruthy()
   })
 
-  describe('search route parameter', () => {
-    it('passed to fuzzy search as AutoComplete item object', () => {
-      const fuzzyCpt = fixture.debugElement.query(
-        By.directive(FuzzySearchComponentMock)
-      ).componentInstance
-      expect(fuzzyCpt.value).toEqual({ title: 'scot' })
-    })
-    it('value is changed on route update', () => {
-      routerFacadeMock.anySearch$.next('river')
-      const fuzzyCpt = fixture.debugElement.query(
-        By.directive(FuzzySearchComponentMock)
-      ).componentInstance
-      fixture.detectChanges()
-
-      expect(fuzzyCpt.value).toEqual({ title: 'river' })
-    })
-  })
   describe('tabs navigation', () => {
     describe('click datasets tab', () => {
       beforeEach(() => {

--- a/apps/datahub/src/app/home/home-header/home-header.component.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.ts
@@ -29,9 +29,6 @@ marker('datahub.header.popularRecords')
 export class HomeHeaderComponent {
   @Input() expandRatio: number
 
-  searchInputRouteValue$ = this.routerFacade.anySearch$.pipe(
-    map((any) => ({ title: any }))
-  )
   backgroundCss =
     getThemeConfig().HEADER_BACKGROUND ||
     `center /cover url('assets/img/header_bg.webp')`

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.spec.ts
@@ -51,7 +51,7 @@ class OrganisationsServiceMock {
 }
 
 class SearchServiceMock {
-  updateSearch = jest.fn()
+  setSearch = jest.fn()
 }
 
 const organisationMock = {
@@ -208,7 +208,7 @@ describe('OrganisationsComponent', () => {
         jest.restoreAllMocks()
       })
       it('should call searchByOrganisation() with correct organisation', () => {
-        expect(searchService.updateSearch).toHaveBeenCalledWith({
+        expect(searchService.setSearch).toHaveBeenCalledWith({
           OrgForResource: { [organisationMock.name]: true },
         })
       })

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.ts
@@ -70,7 +70,7 @@ export class OrganisationsComponent {
   }
 
   searchByOrganisation(organisation: Organisation) {
-    this.searchService.updateSearch({
+    this.searchService.setSearch({
       OrgForResource: { [organisation.name]: true },
     })
   }

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.html
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.html
@@ -4,6 +4,6 @@
   [action]="autoCompleteAction"
   (itemSelected)="handleItemSelection($event)"
   (inputSubmitted)="handleInputSubmission($event)"
-  [value]="value"
+  [value]="searchInputValue$ | async"
   [clearOnSelection]="true"
 ></gn-ui-autocomplete>

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
@@ -2,7 +2,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   EventEmitter,
-  Input,
   Output,
   ViewChild,
 } from '@angular/core'
@@ -28,10 +27,14 @@ import { SearchService } from '../utils/service/search.service'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FuzzySearchComponent {
-  @Input() value?: MetadataRecord
   @ViewChild(AutocompleteComponent) autocomplete: AutocompleteComponent
   @Output() itemSelected = new EventEmitter<MetadataRecord>()
   @Output() inputSubmited = new EventEmitter<string>()
+
+  searchInputValue$ = this.searchFacade.searchFilters$.pipe(
+    map((searchFilter) => ({ title: searchFilter.any }))
+  )
+
   displayWithFn: (MetadataRecord) => string = (record) => record?.title
 
   autoCompleteAction = (query) =>


### PR DESCRIPTION
PR calls `setSearch` instead of `updateSearch` to prevent keeping current search params.

Todo:

- [x] make `autocomplete` input listen to `setSearch` => subscribes `fuzzy-search.component` to `search-facade` to pass value to `autocomplete.component`