### PR TITLE
Datahub: Link key figure components to search and org tabs

### DIFF
--- a/apps/datahub/src/app/home/news-page/key-figures/key-figures.component.html
+++ b/apps/datahub/src/app/home/news-page/key-figures/key-figures.component.html
@@ -1,18 +1,22 @@
 <div class="flex flex-col">
-  <gn-ui-figure
-    class="py-[37px] pl-[47px] rounded-lg bg-white mb-5"
-    style="box-shadow: 0 0 44px 0 rgba(5, 31, 156, 0.09)"
-    [figure]="recordsCount$ | async"
-    [icon]="'folder_open'"
-    [title]="'catalog.figures.datasets' | translate"
-    [color]="'secondary'"
-  ></gn-ui-figure>
-  <gn-ui-figure
-    class="py-[37px] pl-[47px] rounded-lg bg-white"
-    style="box-shadow: 0 0 44px 0 rgba(5, 31, 156, 0.09)"
-    [figure]="orgsCount$ | async"
-    [icon]="'corporate_fare'"
-    [title]="'catalog.figures.organisations' | translate"
-    [color]="'secondary'"
-  ></gn-ui-figure>
+  <a [routerLink]="ROUTE_SEARCH">
+    <gn-ui-figure
+      class="py-[37px] pl-[47px] rounded-lg border bg-white mb-5 hover:bg-gray-50 hover:text-primary hover:border-primary hover:cursor-pointer"
+      style="box-shadow: 0 0 44px 0 rgba(5, 31, 156, 0.09)"
+      [figure]="recordsCount$ | async"
+      [icon]="'folder_open'"
+      [title]="'catalog.figures.datasets' | translate"
+      [color]="'secondary'"
+    ></gn-ui-figure>
+  </a>
+  <a [routerLink]="ROUTE_ORGANISATIONS">
+    <gn-ui-figure
+      class="py-[37px] pl-[47px] rounded-lg bg-white border hover:bg-gray-50 hover:text-primary hover:border-primary hover:cursor-pointer"
+      style="box-shadow: 0 0 44px 0 rgba(5, 31, 156, 0.09)"
+      [figure]="orgsCount$ | async"
+      [icon]="'corporate_fare'"
+      [title]="'catalog.figures.organisations' | translate"
+      [color]="'secondary'"
+    ></gn-ui-figure>
+  </a>
 </div>

--- a/apps/datahub/src/app/home/news-page/key-figures/key-figures.component.spec.ts
+++ b/apps/datahub/src/app/home/news-page/key-figures/key-figures.component.spec.ts
@@ -7,6 +7,8 @@ import {
 } from '@geonetwork-ui/feature/catalog'
 import { TranslateModule } from '@ngx-translate/core'
 import { NO_ERRORS_SCHEMA } from '@angular/core'
+import { RouterTestingModule } from '@angular/router/testing'
+import { By } from '@angular/platform-browser'
 
 class RecordsServiceMock {
   recordsCount$ = of(1234)
@@ -23,7 +25,7 @@ describe('KeyFiguresComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [KeyFiguresComponent],
-      imports: [TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot(), RouterTestingModule],
       providers: [
         {
           provide: RecordsService,
@@ -71,6 +73,22 @@ describe('KeyFiguresComponent', () => {
     })
     it('emits the orgs count', () => {
       expect(values[1]).toBe(456)
+    })
+  })
+  describe('routerLinks', () => {
+    let linkTags
+    beforeEach(() => {
+      linkTags = fixture.debugElement.queryAll(By.css('a'))
+    })
+    it('first href links to search route', () => {
+      expect(linkTags[0].nativeElement.getAttribute('href')).toEqual(
+        component.ROUTE_SEARCH
+      )
+    })
+    it('second href links to organisations route', () => {
+      expect(linkTags[1].nativeElement.getAttribute('href')).toEqual(
+        component.ROUTE_ORGANISATIONS
+      )
     })
   })
 })

--- a/apps/datahub/src/app/home/news-page/key-figures/key-figures.component.ts
+++ b/apps/datahub/src/app/home/news-page/key-figures/key-figures.component.ts
@@ -4,6 +4,11 @@ import {
   OrganisationsService,
   RecordsService,
 } from '@geonetwork-ui/feature/catalog'
+import { ROUTER_ROUTE_SEARCH } from '@geonetwork-ui/feature/router'
+import {
+  ROUTER_ROUTE_HOME,
+  ROUTER_ROUTE_ORGANISATIONS,
+} from '../../../router/constants'
 
 @Component({
   selector: 'datahub-key-figures',
@@ -14,6 +19,8 @@ import {
 export class KeyFiguresComponent {
   recordsCount$ = this.catalogRecords.recordsCount$.pipe(startWith('-'))
   orgsCount$ = this.catalogOrgs.countOrganisations().pipe(startWith('-'))
+  ROUTE_SEARCH = `/${ROUTER_ROUTE_HOME}/${ROUTER_ROUTE_SEARCH}`
+  ROUTE_ORGANISATIONS = `/${ROUTER_ROUTE_HOME}/${ROUTER_ROUTE_ORGANISATIONS}`
 
   constructor(
     private catalogRecords: RecordsService,

--- a/libs/ui/layout/src/lib/figure/figure.component.html
+++ b/libs/ui/layout/src/lib/figure/figure.component.html
@@ -1,5 +1,5 @@
 <div
-  class="flex flex-row justify-center items-center overflow-hidden"
+  class="flex flex-row justify-start items-center overflow-hidden"
   [title]="hoverTitle"
 >
   <mat-icon


### PR DESCRIPTION
PR adds links and styling in the datahub components to navigate via the key figures to the search and organisation tabs.