### PR TITLE
Datahub / Make the document the scroll parent for home & record views

### DIFF
--- a/apps/datahub/src/app/home/home-page/home-page.component.html
+++ b/apps/datahub/src/app/home/home-page/home-page.component.html
@@ -1,4 +1,4 @@
-<div id="home-page" class="h-screen overflow-y-scroll">
+<div id="home-page">
   <gn-ui-sticky-header [fullHeightPx]="560" [minHeightPx]="90">
     <ng-template let-expandRatio>
       <datahub-home-header [expandRatio]="expandRatio"></datahub-home-header>

--- a/apps/datahub/src/app/home/search/search-page/search-page.component.ts
+++ b/apps/datahub/src/app/home/search/search-page/search-page.component.ts
@@ -16,8 +16,7 @@ export class SearchPageComponent implements OnInit {
   ) {}
 
   scrollableOptions: InfiniteScrollModel = {
-    container: '#home-page',
-    fromRoot: true,
+    scrollWindow: true,
   }
 
   ngOnInit() {

--- a/apps/datahub/src/app/record/record-page/record-page.component.css
+++ b/apps/datahub/src/app/record/record-page/record-page.component.css
@@ -1,8 +1,0 @@
-.scroll-padding {
-  scroll-padding-top: 220px;
-}
-@media only screen and (min-width: 640px) {
-  .scroll-padding {
-    scroll-padding-top: 80px;
-  }
-}

--- a/apps/datahub/src/app/record/record-page/record-page.component.html
+++ b/apps/datahub/src/app/record/record-page/record-page.component.html
@@ -1,4 +1,4 @@
-<div id="record-page" class="h-screen overflow-y-scroll scroll-padding">
+<div id="record-page">
   <datahub-header-record
     [metadata]="mdViewFacade.metadata$ | async"
   ></datahub-header-record>

--- a/apps/datahub/src/app/record/record-page/record-page.component.ts
+++ b/apps/datahub/src/app/record/record-page/record-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core'
 import { MdViewFacade } from '@geonetwork-ui/feature/record'
 
 @Component({
@@ -7,6 +7,11 @@ import { MdViewFacade } from '@geonetwork-ui/feature/record'
   styleUrls: ['./record-page.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RecordPageComponent {
-  constructor(public mdViewFacade: MdViewFacade) {}
+export class RecordPageComponent implements OnDestroy {
+  constructor(public mdViewFacade: MdViewFacade) {
+    document.body.classList.add('record-page-active')
+  }
+  ngOnDestroy() {
+    document.body.classList.remove('record-page-active')
+  }
 }

--- a/apps/datahub/src/index.html
+++ b/apps/datahub/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="overflow-hidden">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Datahub</title>

--- a/apps/datahub/src/styles.css
+++ b/apps/datahub/src/styles.css
@@ -10,9 +10,6 @@ body {
 body {
   margin: 0;
 }
-html {
-  overflow-y: scroll;
-}
 
 .container-sm {
   max-width: 640px;
@@ -22,4 +19,13 @@ html {
 }
 .container-lg {
   max-width: 1024px;
+}
+
+body.record-page-active {
+  scroll-padding-top: 220px;
+}
+@media only screen and (min-width: 640px) {
+  body.record-page-active {
+    scroll-padding-top: 80px;
+  }
 }

--- a/libs/feature/search/src/lib/results-list/results-list.container.component.html
+++ b/libs/feature/search/src/lib/results-list/results-list.container.component.html
@@ -6,6 +6,7 @@
   [infiniteScrollUpDistance]="scrollableConfig.upDistance"
   [infiniteScrollThrottle]="scrollableConfig.throttle"
   [infiniteScrollContainer]="scrollableConfig.container"
+  [scrollWindow]="scrollableConfig.scrollWindow"
   [fromRoot]="scrollableConfig.fromRoot"
   [infiniteScrollDisabled]="scrollDisable$ | async"
   (scrolled)="onScrollDown()"

--- a/libs/ui/layout/src/lib/sticky-header/sticky-header.component.spec.ts
+++ b/libs/ui/layout/src/lib/sticky-header/sticky-header.component.spec.ts
@@ -53,11 +53,11 @@ describe('StickyHeaderComponent', () => {
 
   describe('size update', () => {
     let headerEl: HTMLElement
-    let containerEl: HTMLElement
+    let window: any
     let contentEl: HTMLElement
     beforeEach(() => {
       headerEl = component.innerContainer.nativeElement
-      containerEl = fixture.nativeElement.children[0]
+      window = global.window
       contentEl = fixture.debugElement.query(By.css('.content')).nativeElement
     })
     describe('at initialization', () => {
@@ -70,8 +70,8 @@ describe('StickyHeaderComponent', () => {
     })
     describe('after partial scroll', () => {
       beforeEach(fakeAsync(() => {
-        containerEl.scrollTop = 50
-        containerEl.dispatchEvent(new Event('scroll'))
+        window.scrollY = 50
+        window.dispatchEvent(new Event('scroll'))
         tick(20)
       }))
       it('sets height between full and min height', () => {
@@ -83,8 +83,8 @@ describe('StickyHeaderComponent', () => {
     })
     describe('after complete scroll', () => {
       beforeEach(fakeAsync(() => {
-        containerEl.scrollTop = 250
-        containerEl.dispatchEvent(new Event('scroll'))
+        window.scrollY = 250
+        window.dispatchEvent(new Event('scroll'))
         tick(20)
       }))
       it('sets height at min height', () => {

--- a/libs/ui/layout/src/lib/sticky-header/sticky-header.component.stories.ts
+++ b/libs/ui/layout/src/lib/sticky-header/sticky-header.component.stories.ts
@@ -17,7 +17,7 @@ export default {
     }),
     componentWrapperDecorator(
       (story) =>
-        `<div class="bg-background overflow-y-scroll" style='position: relative; height: 400px'>
+        `<div class="bg-background" style='position: relative; height: 400px'>
   <div style='height: 200vh'>
     <p class='m-4'>
       A top toolbar (this should not stay visible).
@@ -50,9 +50,11 @@ const Template: Story<StickyHeaderComponent> = (
       fullHeightPx='${args.fullHeightPx}'>
       <ng-template let-expandRatio>
         <div class='bg-primary-darker p-8 h-full'>
-          <p class='text-white font-bold' [style.font-size]='22 * (1 + expandRatio) + "px"'>My header</p>
-          <p class='text-white' [style.opacity]='expandRatio * 0.7'>This header should become smaller when scrolling down.</p>
-          <p class='text-white' [style.opacity]='expandRatio * 0.7'>Current expand ratio is {{expandRatio}}</p>
+          <div [style.transform]='"translate(0, " + (1 - expandRatio) * (${args.fullHeightPx} - ${args.minHeightPx} * 0.5 - 50) + "px)"'>
+            <p class='text-white font-bold' [style.font-size]='22 * (1 + expandRatio) + "px"'>My header</p>
+            <p class='text-white' [style.opacity]='expandRatio * 0.7'>This header should become smaller when scrolling down.</p>
+            <p class='text-white' [style.opacity]='expandRatio * 0.7'>Current expand ratio is {{expandRatio}}</p>
+          </div>
         </div>
       </ng-template>
     </gn-ui-sticky-header>`,

--- a/libs/ui/layout/src/lib/sticky-header/sticky-header.component.ts
+++ b/libs/ui/layout/src/lib/sticky-header/sticky-header.component.ts
@@ -42,7 +42,6 @@ export class StickyHeaderComponent
   @ViewChild('outerContainer') outerContainer: ElementRef
   @ViewChild('innerContainer') innerContainer: ElementRef
   placeholderEl: HTMLElement
-  scrollableParent: HTMLElement
   expandRatio: number // 1 means height is full, 0 means height is minimum
   scrollSub: Subscription
   parentScroll: number
@@ -54,7 +53,7 @@ export class StickyHeaderComponent
   ) {}
 
   ngAfterViewInit() {
-    this.scrollSub = fromEvent(this.scrollableParent, 'scroll', {
+    this.scrollSub = fromEvent(window, 'scroll', {
       passive: true,
     })
       .pipe(
@@ -67,7 +66,6 @@ export class StickyHeaderComponent
   }
 
   ngOnInit() {
-    this.scrollableParent = findScrollableParent(this.hostEl.nativeElement)
     this.placeholderEl = document.createElement('div')
     this.placeholderEl.style.position = 'absolute'
     this.placeholderEl.classList.add('sticky-header-placeholder')
@@ -88,8 +86,8 @@ export class StickyHeaderComponent
 
   updateSize() {
     this.zone.runOutsideAngular(() => {
-      if (this.scrollableParent.scrollTop === this.parentScroll) return
-      this.parentScroll = this.scrollableParent.scrollTop
+      if (window.scrollY === this.parentScroll) return
+      this.parentScroll = window.scrollY
 
       const offsetTop = Math.max(
         0,
@@ -108,14 +106,4 @@ export class StickyHeaderComponent
       this.changeDetector.detectChanges()
     })
   }
-}
-
-function findScrollableParent(element: HTMLElement): HTMLElement {
-  const parent = element.parentElement
-  if (!parent) return element
-  const style = getComputedStyle(parent)
-  if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
-    return parent
-  }
-  return findScrollableParent(parent)
 }

--- a/libs/util/shared/src/lib/models/infinite-scroll.model.ts
+++ b/libs/util/shared/src/lib/models/infinite-scroll.model.ts
@@ -5,6 +5,7 @@ export interface InfiniteScrollModel {
   disabled?: boolean
   fromRoot?: boolean
   container?: string | HTMLElement
+  scrollWindow?: boolean
 }
 
 export const InfiniteScrollOptionsDefault = {


### PR DESCRIPTION
This should give a better behaviour on mobile and also allow for inserting a header on top of the whole page (typical geOrchestra use case) while not breaking the general behaviour, specifically the sticky header.