### PR TITLE
Improve organisation icons display

### DIFF
--- a/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.html
+++ b/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.html
@@ -4,8 +4,9 @@
       class="overflow-hidden bg-gray-100 rounded-lg w-full border border-gray-300 h-36"
     >
       <gn-ui-thumbnail
-        class="relative h-full w-full object-cover object-left-top"
+        class="relative h-full w-full"
         [thumbnailUrl]="organisation.logoUrl"
+        [fit]="'contain'"
       ></gn-ui-thumbnail>
     </div>
     <div class="px-3 pb-2 capitalize">

--- a/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.spec.ts
+++ b/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.spec.ts
@@ -10,6 +10,7 @@ import { OrganisationPreviewComponent } from './organisation-preview.component'
 })
 class RecordThumbnailMockComponent {
   @Input() thumbnailUrl: string
+  @Input() fit: string
 }
 
 const organisationMock = {

--- a/libs/ui/elements/src/lib/thumbnail/thumbnail.component.html
+++ b/libs/ui/elements/src/lib/thumbnail/thumbnail.component.html
@@ -1,8 +1,14 @@
-<div class="h-full w-full relative flex-shrink-0 overflow-hidden">
+<div
+  class="h-full w-full relative flex-shrink-0 overflow-hidden"
+  [ngClass]="{
+    'bg-white flex flex-col justify-center': objectFit === 'contain'
+  }"
+>
   <img
     #imageElement
-    class="relative h-full w-full object-center"
-    [ngStyle]="{ objectFit: isPlaceholder ? 'scale-down' : 'cover' }"
+    class="relative w-full object-center"
+    [ngClass]="objectFit === 'contain' ? 'h-4/5' : 'h-full'"
+    [ngStyle]="{ objectFit: objectFit }"
     alt="thumbnail"
     [src]="imgUrl | safe: 'url'"
   />

--- a/libs/ui/elements/src/lib/thumbnail/thumbnail.component.spec.ts
+++ b/libs/ui/elements/src/lib/thumbnail/thumbnail.component.spec.ts
@@ -52,7 +52,7 @@ describe('ThumbnailComponent', () => {
         expect(img.nativeElement.style.objectFit).toEqual('scale-down')
       })
     })
-    describe('When an url is given', () => {
+    describe('When an url is given and no fit is set', () => {
       const url = 'http://test.com/img.png'
       let img
       beforeEach(() => {
@@ -68,6 +68,31 @@ describe('ThumbnailComponent', () => {
       })
       it('sets object cover to cover', () => {
         expect(img.nativeElement.style.objectFit).toEqual('cover')
+      })
+      it('sets img height to 100%', () => {
+        expect(img.nativeElement.classList.contains('h-full')).toBeTruthy()
+      })
+    })
+    describe('When an url is given and fit is set to "contain"', () => {
+      const url = 'http://test.com/img.png'
+      let img
+      beforeEach(() => {
+        component.thumbnailUrl = url
+        component.fit = 'contain'
+        fixture.detectChanges()
+        img = de.query(By.css('img'))
+      })
+      it('is displayed', () => {
+        expect(img).toBeTruthy()
+      })
+      it('url attribute as url @Input', () => {
+        expect(img.nativeElement.src).toEqual(url)
+      })
+      it('sets object cover to contain', () => {
+        expect(img.nativeElement.style.objectFit).toEqual('contain')
+      })
+      it('sets img height to 80%', () => {
+        expect(img.nativeElement.classList.contains('h-4/5')).toBeTruthy()
       })
     })
   })

--- a/libs/ui/elements/src/lib/thumbnail/thumbnail.component.ts
+++ b/libs/ui/elements/src/lib/thumbnail/thumbnail.component.ts
@@ -30,11 +30,16 @@ export class ThumbnailComponent implements AfterViewInit, OnDestroy {
     this.imgUrl = url || this.placeholderUrl
     this.isPlaceholder = !url
   }
+  @Input() fit: 'cover' | 'contain' = 'cover'
   @ViewChild('imageElement') imgElement: ElementRef<HTMLImageElement>
   imgUrl: string
   placeholderUrl = this.optionalPlaceholderUrl || DEFAULT_PLACEHOLDER
   isPlaceholder = false
   sub: Subscription
+
+  get objectFit() {
+    return this.isPlaceholder ? 'scale-down' : this.fit
+  }
 
   constructor(
     @Optional()


### PR DESCRIPTION
The PR makes the `thumbnail.component` `objectFit` configurable which is used to better display the organisations icons via `contain`.

![org-icons](https://user-images.githubusercontent.com/6329425/198564527-477703e4-3024-4865-98e1-d8dd395eabe4.png)
