### PR TITLE
Allow to prioritize page navigation over map navigation

### DIFF
--- a/libs/feature/map/src/lib/map-context/component/map-context.component.spec.ts
+++ b/libs/feature/map/src/lib/map-context/component/map-context.component.spec.ts
@@ -7,9 +7,16 @@ import { MapContextService } from '../map-context.service'
 import { MapContextComponent } from './map-context.component'
 import { MAP_CONFIG_FIXTURE } from '@geonetwork-ui/util/app-config'
 import { HttpClientModule } from '@angular/common/http'
+import { MapUtilsService } from '../../utils'
+import Collection from 'ol/Collection'
+import { Interaction } from 'ol/interaction'
 
 class MapContextServiceMock {
   resetMapFromContext = jest.fn()
+}
+
+class MapUtilsServiceMock {
+  prioritizePageScroll = jest.fn()
 }
 
 let resizeCallBack
@@ -26,7 +33,12 @@ class OpenLayersMapMock {
   getSize() {
     return this._size
   }
+  getInteractions() {
+    return new InteractionsMock()
+  }
 }
+
+class InteractionsMock implements Collection<Interaction> {}
 class MapManagerMock {
   map = new OpenLayersMapMock()
 }
@@ -35,6 +47,7 @@ describe('MapContextComponent', () => {
   let component: MapContextComponent
   let fixture: ComponentFixture<MapContextComponent>
   let mapContextService
+  let mapUtilsService
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -47,12 +60,17 @@ describe('MapContextComponent', () => {
           useClass: MapContextServiceMock,
         },
         {
+          provide: MapUtilsService,
+          useClass: MapUtilsServiceMock,
+        },
+        {
           provide: MapManagerService,
           useClass: MapManagerMock,
         },
       ],
     }).compileComponents()
     mapContextService = TestBed.inject(MapContextService)
+    mapUtilsService = TestBed.inject(MapUtilsService)
   })
 
   beforeEach(() => {
@@ -78,6 +96,17 @@ describe('MapContextComponent', () => {
         MAP_CTX_FIXTURE,
         MAP_CONFIG_FIXTURE
       )
+    })
+    describe('prioritizePageScroll input', () => {
+      it('does not prioritze page scroll by default', () => {
+        expect(mapUtilsService.prioritizePageScroll).not.toHaveBeenCalled()
+      })
+      it('prioritzes page scroll if input set to true', () => {
+        component.prioritizePageScroll = true
+        expect(mapUtilsService.prioritizePageScroll).toHaveBeenCalledWith(
+          expect.any(InteractionsMock)
+        )
+      })
     })
   })
 

--- a/libs/feature/map/src/lib/map-context/component/map-context.component.ts
+++ b/libs/feature/map/src/lib/map-context/component/map-context.component.ts
@@ -26,6 +26,11 @@ import { MapConfig } from '@geonetwork-ui/util/app-config'
 export class MapContextComponent implements OnChanges {
   @Input() context: MapContextModel
   @Input() mapConfig: MapConfig
+  @Input() set prioritizePageScroll(pagePriority: boolean) {
+    if (pagePriority) {
+      this.utils.prioritizePageScroll(this.map.getInteractions())
+    }
+  }
   @Output() featureClicked = new EventEmitter<Feature<Geometry>[]>()
 
   map: Map

--- a/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
@@ -12,10 +12,13 @@ import XYZ from 'ol/source/XYZ'
 import { of } from 'rxjs'
 import { MapUtilsWMSService } from './map-utils-wms.service'
 
-import { MapUtilsService, dragPanCondition } from './map-utils.service'
+import {
+  MapUtilsService,
+  dragPanCondition,
+  mouseWheelZoomCondition,
+} from './map-utils.service'
 import { readFirst } from '@nrwl/angular/testing'
 import { defaults, DragPan, MouseWheelZoom } from 'ol/interaction'
-import { platformModifierKeyOnly } from 'ol/events/condition'
 
 const wmsUtilsMock = {
   getLayerLonLatBBox: jest.fn(() => of([1.33, 48.81, 4.3, 51.1])),
@@ -230,7 +233,7 @@ describe('MapUtilsService', () => {
       const mouseWheelZoom = interactions
         .getArray()
         .find((interaction) => interaction instanceof MouseWheelZoom)
-      expect(mouseWheelZoom.condition_).toEqual(platformModifierKeyOnly)
+      expect(mouseWheelZoom.condition_).toEqual(mouseWheelZoomCondition)
     })
   })
 })

--- a/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
@@ -12,8 +12,10 @@ import XYZ from 'ol/source/XYZ'
 import { of } from 'rxjs'
 import { MapUtilsWMSService } from './map-utils-wms.service'
 
-import { MapUtilsService } from './map-utils.service'
+import { MapUtilsService, dragPanCondition } from './map-utils.service'
 import { readFirst } from '@nrwl/angular/testing'
+import { defaults, DragPan, MouseWheelZoom } from 'ol/interaction'
+import { platformModifierKeyOnly } from 'ol/events/condition'
 
 const wmsUtilsMock = {
   getLayerLonLatBBox: jest.fn(() => of([1.33, 48.81, 4.3, 51.1])),
@@ -211,6 +213,24 @@ describe('MapUtilsService', () => {
           ])
         })
       })
+    })
+  })
+  describe('prioritizePageScroll', () => {
+    const interactions = defaults()
+    beforeEach(() => {
+      service.prioritizePageScroll(interactions)
+    })
+    it('adds condition to DragPan', () => {
+      const dragPan = interactions
+        .getArray()
+        .find((interaction) => interaction instanceof DragPan)
+      expect(dragPan.condition_).toEqual(dragPanCondition)
+    })
+    it('adds condition to MouseWheelZoom', () => {
+      const mouseWheelZoom = interactions
+        .getArray()
+        .find((interaction) => interaction instanceof MouseWheelZoom)
+      expect(mouseWheelZoom.condition_).toEqual(platformModifierKeyOnly)
     })
   })
 })

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -13,12 +13,15 @@ import ImageWMS from 'ol/source/ImageWMS'
 import TileWMS from 'ol/source/TileWMS'
 import VectorSource from 'ol/source/Vector'
 import { Options, optionsFromCapabilities } from 'ol/source/WMTS'
+import { DragPan, MouseWheelZoom, defaults, Interaction } from 'ol/interaction'
+import { platformModifierKeyOnly } from 'ol/events/condition'
 import WMTSCapabilities from 'ol/format/WMTSCapabilities'
 import { from, Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { MapContextLayerModel } from '../..'
 import { MapUtilsWMSService } from './map-utils-wms.service'
 import { MetadataLink } from '@geonetwork-ui/util/shared'
+import Collection from 'ol/Collection'
 
 const FEATURE_PROJECTION = 'EPSG:3857'
 const DATA_PROJECTION = 'EPSG:4326'
@@ -167,6 +170,27 @@ export class MapUtilsService {
             matrixSet: 'EPSG:3857',
           })
         })
+    )
+  }
+
+  prioritizePageScroll(interactions: Collection<Interaction>) {
+    interactions.clear()
+    interactions.extend(
+      defaults({ dragPan: false, mouseWheelZoom: false })
+        .extend([
+          new DragPan({
+            condition: function (event) {
+              return (
+                (this as DragPan).getPointerCount() === 2 ||
+                platformModifierKeyOnly(event)
+              )
+            },
+          }),
+          new MouseWheelZoom({
+            condition: platformModifierKeyOnly,
+          }),
+        ])
+        .getArray()
     )
   }
 }

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -179,12 +179,7 @@ export class MapUtilsService {
       defaults({ dragPan: false, mouseWheelZoom: false })
         .extend([
           new DragPan({
-            condition: function (event) {
-              return (
-                (this as DragPan).getPointerCount() === 2 ||
-                platformModifierKeyOnly(event)
-              )
-            },
+            condition: dragPanCondition,
           }),
           new MouseWheelZoom({
             condition: platformModifierKeyOnly,
@@ -193,4 +188,8 @@ export class MapUtilsService {
         .getArray()
     )
   }
+}
+
+export function dragPanCondition(this: DragPan, event) {
+  return this.getPointerCount() === 2 || platformModifierKeyOnly(event)
 }

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -22,6 +22,7 @@ import { MapContextLayerModel } from '../..'
 import { MapUtilsWMSService } from './map-utils-wms.service'
 import { MetadataLink } from '@geonetwork-ui/util/shared'
 import Collection from 'ol/Collection'
+import MapBrowserEvent from 'ol/MapBrowserEvent'
 
 const FEATURE_PROJECTION = 'EPSG:3857'
 const DATA_PROJECTION = 'EPSG:4326'
@@ -182,7 +183,7 @@ export class MapUtilsService {
             condition: dragPanCondition,
           }),
           new MouseWheelZoom({
-            condition: platformModifierKeyOnly,
+            condition: mouseWheelZoomCondition,
           }),
         ])
         .getArray()
@@ -190,6 +191,24 @@ export class MapUtilsService {
   }
 }
 
-export function dragPanCondition(this: DragPan, event) {
-  return this.getPointerCount() === 2 || platformModifierKeyOnly(event)
+export function dragPanCondition(
+  this: DragPan,
+  event: MapBrowserEvent<UIEvent>
+) {
+  const dragPanCondition =
+    this.getPointerCount() === 2 || platformModifierKeyOnly(event)
+  if (!dragPanCondition) {
+    this.getMap().dispatchEvent('mapmuted')
+  }
+  return dragPanCondition
+}
+
+export function mouseWheelZoomCondition(
+  this: MouseWheelZoom,
+  event: MapBrowserEvent<UIEvent>
+) {
+  if (!platformModifierKeyOnly(event) && event.type === 'wheel') {
+    this.getMap().dispatchEvent('mapmuted')
+  }
+  return platformModifierKeyOnly(event)
 }

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.html
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.html
@@ -20,6 +20,7 @@
     <gn-ui-map-context
       [context]="mapContext$ | async"
       [mapConfig]="mapConfig"
+      [prioritizePageScroll]="true"
     ></gn-ui-map-context>
     <div
       class="top-[1em] right-[1em] p-3 bg-white absolute overflow-y-auto overflow-x-hidden max-h-72 w-56"

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
@@ -11,7 +11,7 @@
   <div class="flex flex-wrap justify-start sm:justify-end sm:pb-4">
     <span
       [class.opacity-100]="isFilterActive(format)"
-      class="bg-gray-200 cursor-pointer p-2 m-2 rounded opacity-50 text-sm"
+      class="bg-gray-200 cursor-pointer p-2 m-1 rounded opacity-50 text-sm sm:2"
       (click)="toggleFilterFormat($event.target.value)"
       [value]="format"
       *ngFor="let format of filterFormats"

--- a/libs/ui/map/src/lib/components/map/map.component.html
+++ b/libs/ui/map/src/lib/components/map/map.component.html
@@ -1,7 +1,11 @@
 <div class="h-full w-full" #map></div>
-<div
-  [ngClass]="(displayMessage$ | async) ? 'block' : 'hidden'"
-  class="absolute bottom-14 left-2 right-2 min-h-fit p-2 rounded z-50 bg-primary-opacity-25 text-white sm:right-auto sm:max-w-fit"
->
-  <p class="text-black" translate>map.navigation.message</p>
+<div [ngClass]="(displayMessage$ | async) ? 'block' : 'hidden'">
+  <div
+    class="absolute inset-0 p-2 rounded z-40 bg-gradient-to-b from-white to-primary-lightest opacity-75 flex flex-col justify-center text-primary select-none"
+  >
+    <mat-icon class="mx-auto !w-16 !h-16 text-[64px] mb-4 opacity-75"
+      >swipe</mat-icon
+    >
+    <p class="text-center" translate>map.navigation.message</p>
+  </div>
 </div>

--- a/libs/ui/map/src/lib/components/map/map.component.html
+++ b/libs/ui/map/src/lib/components/map/map.component.html
@@ -1,11 +1,13 @@
 <div class="h-full w-full" #map></div>
-<div [ngClass]="(displayMessage$ | async) ? 'block' : 'hidden'">
+<div
+  class="absolute inset-0 p-2 rounded z-40 transition-all flex flex-col justify-center items-center text-primary font-sans pointer-events-none"
+  [ngClass]="
+    (displayMessage$ | async) ? 'visible opacity-100' : 'invisible opacity-0'
+  "
+>
   <div
-    class="absolute inset-0 p-2 rounded z-40 bg-gradient-to-b from-white to-primary-lightest opacity-75 flex flex-col justify-center text-primary select-none"
-  >
-    <mat-icon class="mx-auto !w-16 !h-16 text-[64px] mb-4 opacity-75"
-      >swipe</mat-icon
-    >
-    <p class="text-center" translate>map.navigation.message</p>
-  </div>
+    class="absolute z-[-1] inset-0 bg-gradient-to-b from-white to-primary-lightest opacity-[60%]"
+  ></div>
+  <mat-icon class="!w-16 !h-16 text-[64px] mb-4">swipe</mat-icon>
+  <p translate>map.navigation.message</p>
 </div>

--- a/libs/ui/map/src/lib/components/map/map.component.html
+++ b/libs/ui/map/src/lib/components/map/map.component.html
@@ -1,1 +1,7 @@
 <div class="h-full w-full" #map></div>
+<div
+  [ngClass]="(displayMessage$ | async) ? 'block' : 'hidden'"
+  class="absolute bottom-14 left-2 right-2 min-h-fit p-2 rounded z-50 bg-primary-opacity-25 text-white sm:right-auto sm:max-w-fit"
+>
+  <p class="text-black" translate>map.navigation.message</p>
+</div>

--- a/libs/ui/map/src/lib/components/map/map.component.spec.ts
+++ b/libs/ui/map/src/lib/components/map/map.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { MapComponent } from './map.component'
-import Map from 'ol/Map'
+import { readFirst } from '@nrwl/angular/testing'
 
 class ResizeObserverMock {
   observe = jest.fn()
@@ -8,6 +8,7 @@ class ResizeObserverMock {
 }
 window.ResizeObserver = ResizeObserverMock
 
+let mapmutedCallback
 class OpenLayersMapMock {
   _size = undefined
   setTarget = jest.fn()
@@ -16,6 +17,11 @@ class OpenLayersMapMock {
   }
   getSize() {
     return this._size
+  }
+  on(type, callback) {
+    if (type === 'mapmuted') {
+      mapmutedCallback = callback
+    }
   }
 }
 
@@ -46,6 +52,15 @@ describe('MapComponent', () => {
     })
     it('observes div element of map to update map size', () => {
       expect(component.resizeObserver.observe).toHaveBeenCalled()
+    })
+    describe('display message that map navigation has been muted', () => {
+      beforeEach(() => {
+        mapmutedCallback()
+      })
+      it('mapmuted event displays message', async () => {
+        const displayMessage = await readFirst(component.displayMessage$)
+        expect(displayMessage).toEqual(true)
+      })
     })
   })
 })

--- a/libs/ui/map/src/lib/components/map/map.component.spec.ts
+++ b/libs/ui/map/src/lib/components/map/map.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { MapComponent } from './map.component'
 import { readFirst } from '@nrwl/angular/testing'
+import { MatIconModule } from '@angular/material/icon'
 
 class ResizeObserverMock {
   observe = jest.fn()
@@ -31,6 +32,7 @@ describe('MapComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [MatIconModule],
       declarations: [MapComponent],
     }).compileComponents()
   })

--- a/libs/ui/map/src/lib/components/map/map.component.ts
+++ b/libs/ui/map/src/lib/components/map/map.component.ts
@@ -1,20 +1,31 @@
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
   ElementRef,
   Input,
   ViewChild,
 } from '@angular/core'
 import Map from 'ol/Map'
+import { BehaviorSubject, merge } from 'rxjs'
+import { debounceTime, map } from 'rxjs/operators'
 
 @Component({
   selector: 'gn-ui-map',
   templateUrl: './map.component.html',
   styleUrls: ['./map.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MapComponent implements AfterViewInit {
   @Input() map: Map
   @ViewChild('map') container: ElementRef
+  show$ = new BehaviorSubject(false)
+  showMessage$ = this.show$.pipe(map((bool) => bool))
+  hideMessage$ = this.show$.pipe(
+    debounceTime(2000),
+    map(() => false)
+  )
+  displayMessage$ = merge(this.showMessage$, this.hideMessage$)
 
   resizeObserver = new ResizeObserver(() => {
     this.map.updateSize()
@@ -25,6 +36,7 @@ export class MapComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     this.map.setTarget(this.container.nativeElement)
+    this.map.on('mapmuted' as any, () => this.show$.next(true))
     this.resizeObserver.observe(this.container.nativeElement)
   }
 }

--- a/libs/ui/map/src/lib/ui-map.module.ts
+++ b/libs/ui/map/src/lib/ui-map.module.ts
@@ -3,10 +3,11 @@ import { NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { MapComponent } from './components/map/map.component'
 import { FeatureDetailComponent } from './components/feature-detail/feature-detail.component'
+import { TranslateModule } from '@ngx-translate/core'
 
 @NgModule({
   declarations: [MapComponent, FeatureDetailComponent],
-  imports: [CommonModule, HttpClientModule],
+  imports: [CommonModule, HttpClientModule, TranslateModule.forRoot()],
   exports: [MapComponent, FeatureDetailComponent],
 })
 export class UiMapModule {}

--- a/libs/ui/map/src/lib/ui-map.module.ts
+++ b/libs/ui/map/src/lib/ui-map.module.ts
@@ -4,10 +4,16 @@ import { CommonModule } from '@angular/common'
 import { MapComponent } from './components/map/map.component'
 import { FeatureDetailComponent } from './components/feature-detail/feature-detail.component'
 import { TranslateModule } from '@ngx-translate/core'
+import { MatIconModule } from '@angular/material/icon'
 
 @NgModule({
   declarations: [MapComponent, FeatureDetailComponent],
-  imports: [CommonModule, HttpClientModule, TranslateModule.forRoot()],
+  imports: [
+    CommonModule,
+    HttpClientModule,
+    MatIconModule,
+    TranslateModule.forRoot(),
+  ],
   exports: [MapComponent, FeatureDetailComponent],
 })
 export class UiMapModule {}

--- a/translations/de.json
+++ b/translations/de.json
@@ -113,6 +113,7 @@
   "map.add.layer.wms": "",
   "map.layers.list": "",
   "map.loading.data": "",
+  "map.navigation.message": "",
   "map.select.layer": "",
   "nav.back": "",
   "next": "",

--- a/translations/en.json
+++ b/translations/en.json
@@ -113,6 +113,7 @@
   "map.add.layer.wms": "From WMS",
   "map.layers.list": "Layers",
   "map.loading.data": "Loading map data...",
+  "map.navigation.message": "Please use CTRL + mouse (or two fingers on mobile) to navigate the map",
   "map.select.layer": "Select the layer to display",
   "nav.back": "Back",
   "next": "next",

--- a/translations/es.json
+++ b/translations/es.json
@@ -113,6 +113,7 @@
   "map.add.layer.wms": "",
   "map.layers.list": "",
   "map.loading.data": "",
+  "map.navigation.message": "",
   "map.select.layer": "",
   "nav.back": "",
   "next": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -113,6 +113,7 @@
   "map.add.layer.wms": "",
   "map.layers.list": "",
   "map.loading.data": "Chargement des données...",
+  "map.navigation.message": "Veuillez utiliser CTRL + souris (ou deux doigts sur mobile) pour naviguer sur la carte",
   "map.select.layer": "Choisir la couche à afficher",
   "nav.back": "Retour",
   "next": "suivant",

--- a/translations/it.json
+++ b/translations/it.json
@@ -113,6 +113,7 @@
   "map.add.layer.wms": "",
   "map.layers.list": "",
   "map.loading.data": "",
+  "map.navigation.message": "",
   "map.select.layer": "",
   "nav.back": "",
   "next": "",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -113,6 +113,7 @@
   "map.add.layer.wms": "",
   "map.layers.list": "",
   "map.loading.data": "",
+  "map.navigation.message": "",
   "map.select.layer": "",
   "nav.back": "",
   "next": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -113,6 +113,7 @@
   "map.add.layer.wms": "",
   "map.layers.list": "",
   "map.loading.data": "",
+  "map.navigation.message": "",
   "map.select.layer": "",
   "nav.back": "",
   "next": "",


### PR DESCRIPTION
PR allows prioritizing page navigation over map navigation via an additional input for the `MapContextComponent`. This makes two finger interaction (on mobile) or ctrl + mousewheel (on desktop) necessary to navigate on the map, in order to facilitate page scrolling. It allows setting the parameter according to the application implemented, when using the `MapContextComponent`.

To-do:
- [x] improve UI of displayed message