### PR TITLE
Datahub / Improve pagination component

### DIFF
--- a/apps/datafeeder/src/app/presentation/components/upload-data/upload-data.component.html
+++ b/apps/datafeeder/src/app/presentation/components/upload-data/upload-data.component.html
@@ -35,7 +35,7 @@
   >
 </div>
 <gn-ui-button
-  (click)="handleUploadBtnClick()"
+  (buttonClick)="handleUploadBtnClick()"
   type="primary"
   extraClass="rounded-full px-20"
   [disabled]="uploading"

--- a/apps/datafeeder/src/app/presentation/pages/dataset-validation-page/dataset-validation-page.html
+++ b/apps/datafeeder/src/app/presentation/pages/dataset-validation-page/dataset-validation-page.html
@@ -44,7 +44,7 @@
     </div>
     <div class="flex justify-end">
       <gn-ui-button
-        (click)="submitValidation()"
+        (buttonClick)="submitValidation()"
         [disabled]="!isValid()"
         type="primary"
         extraClass="rounded-full px-20"

--- a/apps/datafeeder/src/app/presentation/pages/success-publish-page/success-publish-page.component.html
+++ b/apps/datafeeder/src/app/presentation/pages/success-publish-page/success-publish-page.component.html
@@ -15,7 +15,7 @@
           <gn-ui-button
             type="primary"
             extraClass="rounded-full px-20 mb-2"
-            (click)="openGeonetworkLink()"
+            (buttonClick)="openGeonetworkLink()"
             ><span translate class="uppercase text-white font-bold"
               >datafeeder.publishSuccess.geonetworkRecord</span
             ></gn-ui-button
@@ -23,7 +23,7 @@
           <gn-ui-button
             type="primary"
             extraClass="rounded-full px-20"
-            (click)="openGeoserverLink()"
+            (buttonClick)="openGeoserverLink()"
             ><span class="uppercase text-white font-bold" translate
               >datafeeder.publishSuccess.mapViewer</span
             ></gn-ui-button
@@ -33,7 +33,7 @@
         <gn-ui-button
           type="primary"
           extraClass="rounded-full px-20 secondary"
-          (click)="backToHome()"
+          (buttonClick)="backToHome()"
         >
           <span translate class="uppercase font-bold"
             >datafeeder.publishSuccess.uploadAnotherData</span

--- a/apps/datafeeder/src/app/presentation/pages/summarize-page/summarize-page.component.html
+++ b/apps/datafeeder/src/app/presentation/pages/summarize-page/summarize-page.component.html
@@ -19,7 +19,7 @@
             class="pt-10"
             type="primary"
             extraClass="rounded-full px-20"
-            (click)="submit()"
+            (buttonClick)="submit()"
             ><span class="uppercase text-white font-bold" translate
               >datafeeder.summarizePage.submit</span
             ></gn-ui-button
@@ -32,7 +32,7 @@
       <gn-ui-button
         type="primary"
         extraClass="rounded-full px-20 secondary"
-        (click)="previous()"
+        (buttonClick)="previous()"
         ><span class="uppercase font-bold"
           >&lt; <span translate>datafeeder.summarizePage.previous</span></span
         ></gn-ui-button

--- a/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
+++ b/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
@@ -67,8 +67,10 @@
         *ngIf="!isOpen"
         (click)="open()"
         type="outline"
-        >...</gn-ui-button
+        extraClass="p-[10px]"
       >
+        <mat-icon>more_horiz</mat-icon>
+      </gn-ui-button>
       <button
         type="button"
         *ngIf="!isOpen"

--- a/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
+++ b/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
@@ -65,7 +65,7 @@
       <gn-ui-button
         class="hidden sm:block"
         *ngIf="!isOpen"
-        (click)="open()"
+        (buttonClick)="open()"
         type="outline"
         extraClass="p-[10px]"
       >

--- a/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
+++ b/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
@@ -67,7 +67,7 @@
         *ngIf="!isOpen"
         (buttonClick)="open()"
         type="outline"
-        extraClass="p-[10px]"
+        extraClass="!p-[8px]"
       >
         <mat-icon>more_horiz</mat-icon>
       </gn-ui-button>

--- a/apps/webcomponents/src/app/components/gn-aggregated-records/gn-aggregated-records.html
+++ b/apps/webcomponents/src/app/components/gn-aggregated-records/gn-aggregated-records.html
@@ -1,16 +1,6 @@
 <div class="relative">
   <div
-    class="
-      absolute
-      h-full
-      left-0
-      right-0
-      transform
-      bg-background
-      duration-200
-      ease-in-out
-      transition-all
-    "
+    class="absolute h-full left-0 right-0 transform bg-background duration-200 ease-in-out transition-all"
     [ngStyle]="{
       top: !!activeFilter ? '-100px' : '0',
       opacity: !!activeFilter ? '0' : '1',
@@ -25,7 +15,7 @@
     ></gn-ui-records-metrics>
   </div>
   <div>
-    <gn-ui-button type="secondary" (click)="clearFilter()" translate
+    <gn-ui-button type="secondary" (buttonClick)="clearFilter()" translate
       >nav.back</gn-ui-button
     >
     <gn-ui-results-list-container></gn-ui-results-list-container>

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.html
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.html
@@ -5,7 +5,7 @@
   class="grid grid-cols-1 mt-6 mb-20 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3"
 >
   <gn-ui-organisation-preview
-    *ngFor="let organisation of organisations$ | async"
+    *ngFor="let organisation of organisations$ | async; trackBy: trackByIndex"
     [organisation]="organisation"
     (clickedOrganisation)="searchByOrganisation($event)"
   ></gn-ui-organisation-preview>

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.html
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.html
@@ -2,7 +2,7 @@
   (sortBy)="setSortBy($event)"
 ></gn-ui-organisations-sort>
 <div
-  class="grid grid-cols-1 mt-6 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3"
+  class="grid grid-cols-1 mt-6 mb-20 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3"
 >
   <gn-ui-organisation-preview
     *ngFor="let organisation of organisations$ | async"
@@ -11,7 +11,6 @@
   ></gn-ui-organisation-preview>
 </div>
 <gn-ui-pagination
-  class="flex justify-end mt-20"
   [currentPage]="currentPage$ | async"
   [nPages]="totalPages"
   (newCurrentPageEvent)="setCurrentPage($event)"

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.html
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.html
@@ -2,7 +2,7 @@
   (sortBy)="setSortBy($event)"
 ></gn-ui-organisations-sort>
 <div
-  class="grid grid-cols-1 mt-6 mb-20 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3"
+  class="grid grid-cols-1 mt-6 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3"
 >
   <gn-ui-organisation-preview
     *ngFor="let organisation of organisations$ | async; trackBy: trackByIndex"
@@ -10,8 +10,10 @@
     (clickedOrganisation)="searchByOrganisation($event)"
   ></gn-ui-organisation-preview>
 </div>
-<gn-ui-pagination
-  [currentPage]="currentPage$ | async"
-  [nPages]="totalPages"
-  (newCurrentPageEvent)="setCurrentPage($event)"
-></gn-ui-pagination>
+<div class="py-20">
+  <gn-ui-pagination
+    [currentPage]="currentPage$ | async"
+    [nPages]="totalPages"
+    (newCurrentPageEvent)="setCurrentPage($event)"
+  ></gn-ui-pagination>
+</div>

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.spec.ts
@@ -12,11 +12,7 @@ import { By } from '@angular/platform-browser'
 import { Organisation } from '@geonetwork-ui/util/shared'
 import { ORGANISATIONS_FIXTURE } from '@geonetwork-ui/util/shared/fixtures'
 import { of } from 'rxjs'
-
-import {
-  ITEMS_ON_PAGE,
-  OrganisationsComponent,
-} from './organisations.component'
+import { OrganisationsComponent } from './organisations.component'
 import { OrganisationsService } from './organisations.service'
 import { SearchService } from '@geonetwork-ui/feature/search'
 
@@ -61,6 +57,8 @@ const organisationMock = {
   recordCount: 12,
 }
 
+const ITEMS_ON_PAGE = 6
+
 describe('OrganisationsComponent', () => {
   let component: OrganisationsComponent
   let fixture: ComponentFixture<OrganisationsComponent>
@@ -96,6 +94,7 @@ describe('OrganisationsComponent', () => {
     searchService = TestBed.inject(SearchService)
     fixture = TestBed.createComponent(OrganisationsComponent)
     component = fixture.componentInstance
+    component.itemsOnPage = ITEMS_ON_PAGE
     de = fixture.debugElement
     fixture.detectChanges()
   })

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.ts
@@ -1,11 +1,9 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { SearchService } from '@geonetwork-ui/feature/search'
 import { Organisation } from '@geonetwork-ui/util/shared'
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs'
 import { map, tap } from 'rxjs/operators'
 import { OrganisationsService } from './organisations.service'
-
-export const ITEMS_ON_PAGE = 6
 
 @Component({
   selector: 'gn-ui-organisations',
@@ -14,6 +12,8 @@ export const ITEMS_ON_PAGE = 6
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OrganisationsComponent {
+  @Input() itemsOnPage = 12
+
   constructor(
     private organisationsService: OrganisationsService,
     private searchService: SearchService
@@ -37,10 +37,13 @@ export class OrganisationsComponent {
   ]).pipe(
     tap(
       ([organisations]) =>
-        (this.totalPages = Math.ceil(organisations.length / ITEMS_ON_PAGE))
+        (this.totalPages = Math.ceil(organisations.length / this.itemsOnPage))
     ),
     map(([organisations, page]) =>
-      organisations.slice((page - 1) * ITEMS_ON_PAGE, page * ITEMS_ON_PAGE)
+      organisations.slice(
+        (page - 1) * this.itemsOnPage,
+        page * this.itemsOnPage
+      )
     )
   )
 

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.ts
@@ -77,4 +77,8 @@ export class OrganisationsComponent {
       OrgForResource: { [organisation.name]: true },
     })
   }
+
+  trackByIndex(index: number) {
+    return index
+  }
 }

--- a/libs/feature/editor/src/lib/components/wizard/wizard.component.html
+++ b/libs/feature/editor/src/lib/components/wizard/wizard.component.html
@@ -9,7 +9,7 @@
 </div>
 <div class="flex pt-24 pl-8">
   <gn-ui-button
-    (click)="handlePreviousBtnClick()"
+    (buttonClick)="handlePreviousBtnClick()"
     type="primary"
     class="pr-8"
     extraClass="rounded-full px-20"
@@ -17,7 +17,7 @@
     <span class="uppercase text-white font-bold" translate>previous</span>
   </gn-ui-button>
   <gn-ui-button
-    (click)="handleNextBtnClick()"
+    (buttonClick)="handleNextBtnClick()"
     type="primary"
     extraClass="rounded-full px-20"
   >

--- a/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.html
+++ b/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.html
@@ -1,6 +1,6 @@
 <gn-ui-button
   *ngIf="externalViewer"
-  (click)="openInExternalViewer()"
+  (buttonClick)="openInExternalViewer()"
   type="primary"
   extraClass="m-2 flex"
 >

--- a/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.spec.ts
+++ b/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core'
+import { Component, EventEmitter, Output } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
 import { LinkHelperService } from '@geonetwork-ui/util/shared'
@@ -15,7 +15,9 @@ class LinkHelperServiceMock {
   selector: 'gn-ui-button',
   template: '<div></div>',
 })
-export class MockButtonComponent {}
+export class MockButtonComponent {
+  @Output() buttonClick = new EventEmitter()
+}
 
 describe('ExternalViewerButtonComponent', () => {
   let component: ExternalViewerButtonComponent
@@ -73,7 +75,7 @@ describe('ExternalViewerButtonComponent', () => {
       beforeEach(() => {
         buttonComponent = fixture.debugElement.query(
           By.directive(MockButtonComponent)
-        )
+        ).componentInstance
         componentSpy = jest.spyOn(component, 'openInExternalViewer')
         windowSpy = jest
           .spyOn(global, 'window', 'get')
@@ -81,7 +83,7 @@ describe('ExternalViewerButtonComponent', () => {
             open: openMock,
             focus: focusMock,
           }))
-        buttonComponent.nativeElement.click()
+        buttonComponent.buttonClick.emit()
       })
 
       afterEach(() => {

--- a/libs/feature/search/src/lib/results-list/results-list.container.component.html
+++ b/libs/feature/search/src/lib/results-list/results-list.container.component.html
@@ -9,7 +9,7 @@
 
   <ng-container *ngIf="(facade.isLoading$ | async) === false">
     <div class="show-more" *ngIf="showMore === 'button'">
-      <gn-ui-button type="primary" (click)="onShowMore()">
+      <gn-ui-button type="primary" (buttonClick)="onShowMore()">
         <span translate>results.showMore</span>
       </gn-ui-button>
     </div>

--- a/libs/ui/elements/src/lib/pagination/pagination.component.html
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.html
@@ -17,9 +17,14 @@
     <span class="mr-3 capitalize text-sm text-gray-900" translate
       >pagination.page</span
     >
-    <span class="border border-gray-300 rounded w-14 py-1 px-5 mr-3">{{
-      currentPage
-    }}</span>
+    <input
+      type="number"
+      [ngModel]="currentPage"
+      [min]="1"
+      [max]="nPages"
+      (ngModelChange)="setPage($event)"
+      class="border border-gray-300 rounded w-[54px] h-[34px] pl-[12px] mr-3 text-center"
+    />
     <span class="mr-3 text-sm text-gray-900"
       ><span translate>pagination.pageOf</span> {{ nPages }}</span
     >

--- a/libs/ui/elements/src/lib/pagination/pagination.component.html
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.html
@@ -1,40 +1,46 @@
-<div class="h-24 flex justify-center items-center">
-  <button
-    (click)="nextPage()"
-    [disabled]="currentPage === nPages"
-    class="uppercase text-white justify-center items-center p-3 rounded-lg cursor-pointer h-14 w-44 bg-secondary hidden sm:flex sm:mr-28 disabled:bg-gray-100 disabled:cursor-default"
-    translate
+<div class="relative">
+  <div class="sm:absolute sm:inset-0">
+    <gn-ui-button
+      (click)="nextPage()"
+      [type]="'secondary'"
+      [disabled]="currentPage === nPages"
+      extraClass="lg:m-auto !p-[22px]"
+    >
+      <span class="uppercase font-medium tracking-widest" translate
+        >pagination.nextPage</span
+      >
+    </gn-ui-button>
+  </div>
+  <div
+    class="relative flex flex-row justify-start sm:justify-end items-center py-[13px]"
   >
-    pagination.nextPage
-  </button>
-  <div class="flex items-center" translate>
-    <span class="m-3" translate> pagination.page </span>
+    <span class="mr-3 capitalize text-sm text-gray-900" translate
+      >pagination.page</span
+    >
     <span class="border border-gray-300 rounded w-14 py-1 px-5 mr-3">{{
       currentPage
     }}</span>
-    <span class="mr-3" translate> pagination.pageOf </span>
-    <span class="mr-3">{{ nPages }}</span>
-  </div>
-
-  <mat-icon class="mr-3 flex" style="display: flex">
-    <button
+    <span class="mr-3 text-sm text-gray-900"
+      ><span translate>pagination.pageOf</span> {{ nPages }}</span
+    >
+    <gn-ui-button
       (click)="previousPage()"
       id="navigate_previous"
-      class="text-2xl disabled:opacity-50 disabled:cursor-default flex items-center"
+      class="mr-2"
       [disabled]="currentPage === 1"
+      [type]="'light'"
+      extraClass="!p-[3px]"
     >
-      navigate_before
-    </button>
-  </mat-icon>
-
-  <mat-icon style="display: flex">
-    <button
+      <mat-icon>navigate_before</mat-icon>
+    </gn-ui-button>
+    <gn-ui-button
       (click)="nextPage()"
       id="navigate_next"
-      class="text-2xl disabled:opacity-50 disabled:cursor-default flex items-center"
       [disabled]="currentPage === nPages"
+      [type]="'light'"
+      extraClass="!p-[3px]"
     >
-      navigate_next
-    </button>
-  </mat-icon>
+      <mat-icon>navigate_next</mat-icon>
+    </gn-ui-button>
+  </div>
 </div>

--- a/libs/ui/elements/src/lib/pagination/pagination.component.html
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.html
@@ -1,7 +1,7 @@
 <div class="relative">
   <div class="sm:absolute sm:inset-0">
     <gn-ui-button
-      (click)="nextPage()"
+      (buttonClick)="nextPage()"
       [type]="'secondary'"
       [disabled]="currentPage === nPages"
       extraClass="lg:m-auto !p-[22px]"
@@ -29,7 +29,7 @@
       ><span translate>pagination.pageOf</span> {{ nPages }}</span
     >
     <gn-ui-button
-      (click)="previousPage()"
+      (buttonClick)="previousPage()"
       id="navigate_previous"
       class="mr-2"
       [disabled]="currentPage === 1"
@@ -39,7 +39,7 @@
       <mat-icon>navigate_before</mat-icon>
     </gn-ui-button>
     <gn-ui-button
-      (click)="nextPage()"
+      (buttonClick)="nextPage()"
       id="navigate_next"
       [disabled]="currentPage === nPages"
       [type]="'light'"

--- a/libs/ui/elements/src/lib/pagination/pagination.component.html
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.html
@@ -12,40 +12,42 @@
     </gn-ui-button>
   </div>
   <div
-    class="relative flex flex-row justify-start sm:justify-end items-center py-[13px]"
+    class="relative pointer-events-none flex flex-row justify-start sm:justify-end"
   >
-    <span class="mr-3 capitalize text-sm text-gray-900" translate
-      >pagination.page</span
-    >
-    <input
-      type="number"
-      [ngModel]="currentPage"
-      [min]="1"
-      [max]="nPages"
-      (ngModelChange)="setPage($event)"
-      class="border border-gray-300 rounded w-[54px] h-[34px] pl-[12px] mr-3 text-center"
-    />
-    <span class="mr-3 text-sm text-gray-900"
-      ><span translate>pagination.pageOf</span> {{ nPages }}</span
-    >
-    <gn-ui-button
-      (buttonClick)="previousPage()"
-      id="navigate_previous"
-      class="mr-2"
-      [disabled]="currentPage === 1"
-      [type]="'light'"
-      extraClass="!p-[3px]"
-    >
-      <mat-icon>navigate_before</mat-icon>
-    </gn-ui-button>
-    <gn-ui-button
-      (buttonClick)="nextPage()"
-      id="navigate_next"
-      [disabled]="currentPage === nPages"
-      [type]="'light'"
-      extraClass="!p-[3px]"
-    >
-      <mat-icon>navigate_next</mat-icon>
-    </gn-ui-button>
+    <div class="pointer-events-auto flex flex-row items-center py-[13px]">
+      <span class="mr-3 capitalize text-sm text-gray-900" translate
+        >pagination.page</span
+      >
+      <input
+        type="number"
+        [ngModel]="currentPage"
+        [min]="1"
+        [max]="nPages"
+        (ngModelChange)="setPage($event)"
+        class="border border-gray-300 rounded w-[54px] h-[34px] pl-[12px] mr-3 text-center"
+      />
+      <span class="mr-3 text-sm text-gray-900"
+        ><span translate>pagination.pageOf</span> {{ nPages }}</span
+      >
+      <gn-ui-button
+        (buttonClick)="previousPage()"
+        id="navigate_previous"
+        class="mr-2"
+        [disabled]="currentPage === 1"
+        [type]="'light'"
+        extraClass="!p-[3px]"
+      >
+        <mat-icon>navigate_before</mat-icon>
+      </gn-ui-button>
+      <gn-ui-button
+        (buttonClick)="nextPage()"
+        id="navigate_next"
+        [disabled]="currentPage === nPages"
+        [type]="'light'"
+        extraClass="!p-[3px]"
+      >
+        <mat-icon>navigate_next</mat-icon>
+      </gn-ui-button>
+    </div>
   </div>
 </div>

--- a/libs/ui/elements/src/lib/pagination/pagination.component.spec.ts
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.spec.ts
@@ -4,6 +4,8 @@ import { By } from '@angular/platform-browser'
 import { PaginationComponent } from './pagination.component'
 import { TranslateModule } from '@ngx-translate/core'
 import { ButtonComponent } from '@geonetwork-ui/ui/inputs'
+import { MatIconModule } from '@angular/material/icon'
+import { FormsModule } from '@angular/forms'
 
 describe('PaginationComponent', () => {
   let component: PaginationComponent
@@ -12,7 +14,7 @@ describe('PaginationComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [PaginationComponent, ButtonComponent],
-      imports: [TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot(), MatIconModule, FormsModule],
     }).compileComponents()
 
     fixture = TestBed.createComponent(PaginationComponent)

--- a/libs/ui/elements/src/lib/pagination/pagination.component.spec.ts
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
-
 import { PaginationComponent } from './pagination.component'
 import { TranslateModule } from '@ngx-translate/core'
 import { ButtonComponent } from '@geonetwork-ui/ui/inputs'

--- a/libs/ui/elements/src/lib/pagination/pagination.component.spec.ts
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
 
 import { PaginationComponent } from './pagination.component'
+import { TranslateModule } from '@ngx-translate/core'
+import { ButtonComponent } from '@geonetwork-ui/ui/inputs'
 
 describe('PaginationComponent', () => {
   let component: PaginationComponent
@@ -9,7 +11,8 @@ describe('PaginationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [PaginationComponent],
+      declarations: [PaginationComponent, ButtonComponent],
+      imports: [TranslateModule.forRoot()],
     }).compileComponents()
 
     fixture = TestBed.createComponent(PaginationComponent)
@@ -26,14 +29,14 @@ describe('PaginationComponent', () => {
   it('should navigation_next be disabled', () => {
     fixture.detectChanges()
     const isDisabled = fixture.debugElement.query(By.css('#navigate_next'))
-      .nativeElement.disabled
+      .componentInstance.disabled
     expect(isDisabled).toBeTruthy()
   })
 
   it('should navigate_previous be enabled', () => {
     fixture.detectChanges()
     const isDisabled = fixture.debugElement.query(By.css('#navigate_previous'))
-      .nativeElement.disabled
+      .componentInstance.disabled
     expect(isDisabled).toBeFalsy()
   })
 })

--- a/libs/ui/elements/src/lib/pagination/pagination.component.ts
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.ts
@@ -32,19 +32,17 @@ export class PaginationComponent implements OnChanges {
     }
   }
 
-  nextPage() {
-    this.currentPage++
+  setPage(newPage) {
+    this.currentPage = newPage
     this.applyPageBounds()
-    this.emitCurrentPage()
+    this.newCurrentPageEvent.emit(this.currentPage)
+  }
+
+  nextPage() {
+    this.setPage(this.currentPage + 1)
   }
 
   previousPage() {
-    this.currentPage--
-    this.applyPageBounds()
-    this.emitCurrentPage()
-  }
-
-  emitCurrentPage() {
-    this.newCurrentPageEvent.emit(this.currentPage)
+    this.setPage(this.currentPage - 1)
   }
 }

--- a/libs/ui/elements/src/lib/pagination/pagination.component.ts
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.ts
@@ -3,7 +3,9 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnChanges,
   Output,
+  SimpleChanges,
 } from '@angular/core'
 
 @Component({
@@ -12,23 +14,34 @@ import {
   styleUrls: ['./pagination.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PaginationComponent {
-  @Input() currentPage: number
-  @Input() nPages: number
+export class PaginationComponent implements OnChanges {
+  @Input() currentPage = 1
+  @Input() nPages = 1
   @Output() newCurrentPageEvent = new EventEmitter<number>()
 
-  nextPage() {
-    if (this.currentPage < this.nPages) {
-      this.currentPage++
-      this.emitCurrentPage()
+  private applyPageBounds() {
+    // make sure this works with NaN inputs as well by adding `|| 1`
+    this.nPages = Math.max(1, this.nPages || 1)
+    this.currentPage = Math.max(1, Math.min(this.nPages, this.currentPage || 1))
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    // make sure the inputs are valid
+    if ('currentPage' in changes || 'nPages' in changes) {
+      this.applyPageBounds()
     }
   }
 
+  nextPage() {
+    this.currentPage++
+    this.applyPageBounds()
+    this.emitCurrentPage()
+  }
+
   previousPage() {
-    if (this.currentPage > 1) {
-      this.currentPage--
-      this.emitCurrentPage()
-    }
+    this.currentPage--
+    this.applyPageBounds()
+    this.emitCurrentPage()
   }
 
   emitCurrentPage() {

--- a/libs/ui/elements/src/lib/pagination/pagination.component.ts
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.ts
@@ -33,6 +33,7 @@ export class PaginationComponent implements OnChanges {
   }
 
   setPage(newPage) {
+    if (!Number.isInteger(newPage)) return
     this.currentPage = newPage
     this.applyPageBounds()
     this.newCurrentPageEvent.emit(this.currentPage)

--- a/libs/ui/elements/src/lib/ui-elements.module.ts
+++ b/libs/ui/elements/src/lib/ui-elements.module.ts
@@ -20,6 +20,7 @@ import { SearchResultsErrorComponent } from './search-results-error/search-resul
 import { PaginationComponent } from './pagination/pagination.component'
 import { ThumbnailComponent } from './thumbnail/thumbnail.component'
 import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
+import { FormsModule } from '@angular/forms'
 
 @NgModule({
   imports: [
@@ -32,6 +33,7 @@ import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
     UtilSharedModule,
     RouterModule,
     UiInputsModule,
+    FormsModule,
   ],
   declarations: [
     MetadataInfoComponent,

--- a/libs/ui/elements/src/lib/ui-elements.module.ts
+++ b/libs/ui/elements/src/lib/ui-elements.module.ts
@@ -19,6 +19,7 @@ import { MetadataCatalogComponent } from './metadata-catalog/metadata-catalog.co
 import { SearchResultsErrorComponent } from './search-results-error/search-results-error.component'
 import { PaginationComponent } from './pagination/pagination.component'
 import { ThumbnailComponent } from './thumbnail/thumbnail.component'
+import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
 
 @NgModule({
   imports: [
@@ -30,6 +31,7 @@ import { ThumbnailComponent } from './thumbnail/thumbnail.component'
     TranslateModule.forChild(),
     UtilSharedModule,
     RouterModule,
+    UiInputsModule,
   ],
   declarations: [
     MetadataInfoComponent,

--- a/libs/ui/inputs/src/lib/button/button.component.html
+++ b/libs/ui/inputs/src/lib/button/button.component.html
@@ -1,6 +1,6 @@
 <button
   type="button"
-  class="py-2 px-4 rounded transition-all duration-100 focus:outline-none"
+  class="flex flex-row items-center text-[1em] leading-none p-[1em] rounded-[0.25em] transition-all duration-100 focus:outline-none disabled:opacity-50 disabled:pointer-events-none"
   [class]="classList"
   [disabled]="disabled"
 >

--- a/libs/ui/inputs/src/lib/button/button.component.html
+++ b/libs/ui/inputs/src/lib/button/button.component.html
@@ -3,6 +3,7 @@
   class="flex flex-row items-center text-[1em] leading-none p-[1em] rounded-[0.25em] transition-all duration-100 focus:outline-none disabled:opacity-50 disabled:pointer-events-none"
   [class]="classList"
   [disabled]="disabled"
+  (click)="handleClick($event)"
 >
   <ng-content></ng-content>
 </button>

--- a/libs/ui/inputs/src/lib/button/button.component.stories.ts
+++ b/libs/ui/inputs/src/lib/button/button.component.stories.ts
@@ -38,6 +38,6 @@ Primary.args = {
 Primary.argTypes = {
   type: {
     control: 'radio',
-    options: ['primary', 'secondary', 'default', 'outline'],
+    options: ['primary', 'secondary', 'default', 'outline', 'light'],
   },
 }

--- a/libs/ui/inputs/src/lib/button/button.component.ts
+++ b/libs/ui/inputs/src/lib/button/button.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core'
 
 @Component({
   selector: 'gn-ui-button',
@@ -11,6 +17,7 @@ export class ButtonComponent {
     'default'
   @Input() disabled = false
   @Input() extraClass = ''
+  @Output() buttonClick = new EventEmitter<void>()
 
   get classList() {
     return `${this.color} ${this.textColor} ${this.borderColor} ${this.extraClass}`
@@ -57,5 +64,11 @@ export class ButtonComponent {
       case 'light':
         return 'focus:ring-4 focus:ring-gray-300'
     }
+  }
+
+  handleClick(event: Event) {
+    this.buttonClick.emit()
+    event.preventDefault()
+    event.stopPropagation()
   }
 }

--- a/libs/ui/inputs/src/lib/button/button.component.ts
+++ b/libs/ui/inputs/src/lib/button/button.component.ts
@@ -7,7 +7,8 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ButtonComponent {
-  @Input() type: 'primary' | 'secondary' | 'default' | 'outline' = 'default'
+  @Input() type: 'primary' | 'secondary' | 'default' | 'outline' | 'light' =
+    'default'
   @Input() disabled = false
   @Input() extraClass = ''
 
@@ -16,32 +17,18 @@ export class ButtonComponent {
   }
 
   get color() {
-    let classes = ''
     switch (this.type) {
       case 'default':
-        classes =
-          'bg-gray-700 hover:bg-gray-800 hover:bg-gray-800 active:bg-gray-900'
-        break
+        return 'bg-gray-700 hover:bg-gray-800 hover:bg-gray-800 active:bg-gray-900'
       case 'primary':
-        classes =
-          'bg-primary-darker hover:bg-primary-darkest focus:bg-primary-darkest active:bg-primary-black'
-        break
+        return 'bg-primary-darker hover:bg-primary-darkest focus:bg-primary-darkest active:bg-primary-black'
       case 'secondary':
-        classes =
-          'bg-secondary-darker hover:bg-secondary-darkest focus:bg-secondary-darkest active:bg-secondary-black'
-        break
+        return 'bg-secondary-darker hover:bg-secondary-darkest focus:bg-secondary-darkest active:bg-secondary-black'
       case 'outline':
-        classes = 'bg-white'
-        break
+        return 'bg-white'
+      case 'light':
+        return 'bg-white hover:bg-gray-50 focus:bg-gray-50 active:bg-gray-100'
     }
-    if (this.disabled) {
-      classes = [
-        classes.split(' ').filter((cls) => !cls.startsWith('hover:')),
-        'disabled:opacity-50',
-        'cursor-auto',
-      ].join(' ')
-    }
-    return classes
   }
 
   get textColor() {
@@ -52,32 +39,23 @@ export class ButtonComponent {
         return 'text-white'
       case 'outline':
         return 'text-main hover:text-primary-darker focus:text-primary-darker active:text-primary-black'
+      case 'light':
+        return 'text-main'
     }
   }
 
   get borderColor() {
-    let classes = ''
     switch (this.type) {
       case 'default':
-        classes = 'focus:ring-4 focus:ring-gray-200'
-        break
+        return 'focus:ring-4 focus:ring-gray-200'
       case 'secondary':
-        classes = 'focus:ring-4 focus:ring-secondary-lightest'
-        break
+        return 'focus:ring-4 focus:ring-secondary-lightest'
       case 'primary':
-        classes = 'focus:ring-4 focus:ring-primary-lightest'
-        break
+        return 'focus:ring-4 focus:ring-primary-lightest'
       case 'outline':
-        classes =
-          'border border-gray-300 hover:border-primary-lighter focus:border-primary-lighter focus:ring-4 focus:ring-primary-lightest active:border-primary-darker'
-        break
+        return 'border border-gray-300 hover:border-primary-lighter focus:border-primary-lighter focus:ring-4 focus:ring-primary-lightest active:border-primary-darker'
+      case 'light':
+        return 'focus:ring-4 focus:ring-gray-300'
     }
-    if (this.disabled) {
-      classes = classes
-        .split(' ')
-        .filter((cls) => !cls.startsWith('hover:'))
-        .join(' ')
-    }
-    return classes
   }
 }

--- a/libs/ui/inputs/src/lib/dropdown-multiselect/dropdown-multiselect.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-multiselect/dropdown-multiselect.component.html
@@ -3,7 +3,7 @@
   extraClass="w-full p-[10px] pl-[14px]"
   [title]="title"
   [attr.aria-owns]="id"
-  (click)="openOverlay()"
+  (buttonClick)="openOverlay()"
   (keydown)="handleTriggerKeydown($event)"
   cdkOverlayOrigin
   #overlayOrigin="cdkOverlayOrigin"

--- a/libs/ui/inputs/src/lib/dropdown-multiselect/dropdown-multiselect.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-multiselect/dropdown-multiselect.component.html
@@ -1,6 +1,6 @@
 <gn-ui-button
   type="outline"
-  extraClass="w-full flex flex-row"
+  extraClass="w-full p-[10px] pl-[14px]"
   [title]="title"
   [attr.aria-owns]="id"
   (click)="openOverlay()"
@@ -13,7 +13,7 @@
   </div>
   <div
     *ngIf="hasSelectedChoices"
-    class="flex-shrink-0 rounded-full bg-primary text-white font-bold text-[13px] w-6 h-6 py-[3px] mr-1 selected-count"
+    class="flex-shrink-0 rounded-full bg-primary text-white font-bold text-[13px] w-6 h-6 p-[6px] mr-1 selected-count"
   >
     {{ selected.length }}
   </div>

--- a/libs/ui/inputs/src/lib/dropdown-multiselect/dropdown-multiselect.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-multiselect/dropdown-multiselect.component.html
@@ -1,6 +1,6 @@
 <gn-ui-button
   type="outline"
-  extraClass="w-full p-[10px] pl-[14px]"
+  extraClass="w-full !p-[8px] !pl-[16px]"
   [title]="title"
   [attr.aria-owns]="id"
   (buttonClick)="openOverlay()"

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
@@ -9,7 +9,7 @@
   <select
     [id]="id"
     (change)="this.selectValue.emit($event.target.value)"
-    class="text-main bg-white border border-gray-300 py-3 px-4 rounded-lg leading-tight focus:outline-none focus:border-primary"
+    class="text-main bg-white border border-gray-300 py-[10px] px-[16px] rounded-lg leading-tight focus:outline-none focus:border-primary"
     [class.w-full]="!showTitle"
   >
     <option


### PR DESCRIPTION
In this PR:
* improve the UX of the pagination component by relying more on the `gn-ui-button` component
  * this required adding a `light` button style without outline, so the button component was reworked a bit as well
  * also the button component now has its own `buttonClick` output event instead of relying on the native `click` event, which might have caused side effects sometimes
* makes the pagination layout responsive (and actually center the button)
* allows inputting the page number manually
* shows 12 orgs instead of 6 in the organisations page of the datahub

![image](https://user-images.githubusercontent.com/10629150/198667553-b9359be6-2276-4c7e-9dc3-8d862b04685f.png)
