### PR TITLE
Datahub: Update label of burger menu on route changes

### DIFF
--- a/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.html
+++ b/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.html
@@ -22,7 +22,6 @@
   >
     <div *ngFor="let l of tabLinks">
       <button
-        (click)="setActiveLabel($event.target)"
         [routerLink]="l.link"
         class="block pl-5 pr-3 py-3 rounded-md text-[18px] font-medium uppercase tracking-wider w-full text-left truncate"
         translate
@@ -34,8 +33,7 @@
   <button
     class="block pl-5 pr-3 py-3 rounded-md text-[18px] font-medium uppercase tracking-wider flex-shrink truncate"
     [class]="displayMobileMenu ? 'hidden' : 'block'"
-    translate
   >
-    {{ activeLabel }}
+    {{ activeLabel$ | async | translate }}
   </button>
 </button>

--- a/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.spec.ts
+++ b/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.spec.ts
@@ -1,7 +1,24 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import {
+  RouterFacade,
+  ROUTER_ROUTE_SEARCH,
+} from '@geonetwork-ui/feature/router'
+import { TranslateModule } from '@ngx-translate/core'
+import { readFirst } from '@nrwl/angular/testing'
+import { BehaviorSubject } from 'rxjs'
+import {
+  ROUTER_ROUTE_NEWS,
+  ROUTER_ROUTE_ORGANISATIONS,
+} from '../../router/constants'
 
 import { NavigationMenuComponent } from './navigation-menu.component'
+
+const routerFacadeMock = {
+  currentRoute$: new BehaviorSubject({
+    url: [{ path: ROUTER_ROUTE_NEWS }],
+  }),
+}
 
 describe('NavigationMenuComponent', () => {
   let component: NavigationMenuComponent
@@ -9,7 +26,14 @@ describe('NavigationMenuComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
       declarations: [NavigationMenuComponent],
+      providers: [
+        {
+          provide: RouterFacade,
+          useValue: routerFacadeMock,
+        },
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents()
   })
@@ -22,5 +46,45 @@ describe('NavigationMenuComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  describe('should display activeLabel$', () => {
+    it('displays initially activeLabel for news', async () => {
+      const activeLabel = await readFirst(component.activeLabel$)
+      expect(activeLabel).toEqual('datahub.header.news')
+    })
+    describe('navigate to search route', () => {
+      beforeEach(() => {
+        routerFacadeMock.currentRoute$.next({
+          url: [{ path: ROUTER_ROUTE_SEARCH }],
+        })
+      })
+      it('displays activeLabel for search', async () => {
+        const activeLabel = await readFirst(component.activeLabel$)
+        expect(activeLabel).toEqual('datahub.header.datasets')
+      })
+    })
+    describe('navigate to organisations route', () => {
+      beforeEach(() => {
+        routerFacadeMock.currentRoute$.next({
+          url: [{ path: ROUTER_ROUTE_ORGANISATIONS }],
+        })
+      })
+      it('displays activeLabel for organisations', async () => {
+        const activeLabel = await readFirst(component.activeLabel$)
+        expect(activeLabel).toEqual('datahub.header.organisations')
+      })
+    })
+    describe('navigate to a route with missing label', () => {
+      beforeEach(() => {
+        routerFacadeMock.currentRoute$.next({
+          url: [{ path: 'ROUTE_WITHOUT_LABEL' }],
+        })
+      })
+      it('displays empty string as activeLabel', async () => {
+        const activeLabel = await readFirst(component.activeLabel$)
+        expect(activeLabel).toEqual('')
+      })
+    })
   })
 })

--- a/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.ts
+++ b/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.ts
@@ -1,6 +1,10 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
-import { ROUTER_ROUTE_SEARCH } from '@geonetwork-ui/feature/router'
+import {
+  RouterFacade,
+  ROUTER_ROUTE_SEARCH,
+} from '@geonetwork-ui/feature/router'
+import { map } from 'rxjs/operators'
 import {
   ROUTER_ROUTE_NEWS,
   ROUTER_ROUTE_ORGANISATIONS,
@@ -31,10 +35,20 @@ export class NavigationMenuComponent {
       label: 'datahub.header.organisations',
     },
   ]
-  activeLabel = this.tabLinks[0].label
-  setActiveLabel(el: HTMLElement) {
-    this.activeLabel = el.textContent
-  }
+  activeLabel$ = this.routerFacade.currentRoute$.pipe(
+    map(
+      (route) =>
+        (
+          this.tabLinks.find((tab) => tab.link === route.url[0].path) || {
+            link: '',
+            label: '',
+          }
+        ).label
+    )
+  )
+
+  constructor(private routerFacade: RouterFacade) {}
+
   toggleMobileMenu() {
     this.displayMobileMenu = !this.displayMobileMenu
   }


### PR DESCRIPTION
PR updates the active label of the (mobile) navigation menu by listening to route changes, instead of setting the label in the component. This is necessary for cases such as executing a search, where tabs are changed on another action.