### PR TITLE
Datahub: Make download filter badges responsive

### DIFF
--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
@@ -8,10 +8,10 @@
   >
     record.metadata.download
   </p>
-  <div class="w-[420px] flex flex-wrap justify-between sm:pb-4">
+  <div class="flex flex-wrap justify-start sm:justify-end sm:pb-4">
     <span
       [class.opacity-100]="isFilterActive(format)"
-      class="bg-gray-200 cursor-pointer p-2 mb-2 rounded opacity-50 text-sm"
+      class="bg-gray-200 cursor-pointer p-2 m-2 rounded opacity-50 text-sm"
       (click)="toggleFilterFormat($event.target.value)"
       [value]="format"
       *ngFor="let format of filterFormats"

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
@@ -1,14 +1,17 @@
-<div class="flex justify-between" *ngIf="links && links.length > 0">
+<div
+  class="flex flex-wrap justify-between mt-8 mb-6 sm:mt-12 sm:mb-2"
+  *ngIf="links && links.length > 0"
+>
   <p
-    class="font-title text-[28px] text-title font-medium mt-8 mb-6 text-center sm:mt-12 sm:mb-4 sm:text-left"
+    class="font-title text-[28px] text-title font-medium mr-4 pb-4 text-center sm:text-left"
     translate
   >
     record.metadata.download
   </p>
-  <div class="mt-8 mb-6 sm:mt-12 sm:mb-3">
+  <div class="w-[420px] flex flex-wrap justify-between sm:pb-4">
     <span
       [class.opacity-100]="isFilterActive(format)"
-      class="bg-gray-200 ml-6 cursor-pointer p-2 rounded opacity-50 text-sm"
+      class="bg-gray-200 cursor-pointer p-2 mb-2 rounded opacity-50 text-sm"
       (click)="toggleFilterFormat($event.target.value)"
       [value]="format"
       *ngFor="let format of filterFormats"


### PR DESCRIPTION
PR uses flex layout to prevent breaking the download filter badges on small screens:

![download-filter](https://user-images.githubusercontent.com/6329425/199543938-9e0ce466-47fa-4f22-923b-d961af7ae8cb.png)
