### PR TITLE
Map Viewer / Improve button appearance in "Add Layer" dialog

### DIFF
--- a/libs/feature/map/src/lib/add-layer-from-catalog/add-layer-record-preview/add-layer-record-preview.component.html
+++ b/libs/feature/map/src/lib/add-layer-from-catalog/add-layer-record-preview/add-layer-record-preview.component.html
@@ -11,10 +11,12 @@
     <ng-container *ngFor="let link of mapLinks">
       <gn-ui-button
         [type]="'outline'"
-        (click)="handleLinkClick(link)"
-        extraClass="p-1 text-[11px] truncate"
+        (buttonClick)="handleLinkClick(link)"
+        extraClass="!py-[8px] !px-[12px]"
       >
-        {{ getLinkLabel(link) }}
+        <div class="text-left text-[12px] line-clamp-2">
+          {{ getLinkLabel(link) }}
+        </div>
       </gn-ui-button>
     </ng-container>
   </div>


### PR DESCRIPTION
The buttons added in #354 were not working after the merge since the event name for `gn-ui-button` has changed to `(buttonClick)`. This PR also improves the appearance by setting a 2-lines max height:

![image](https://user-images.githubusercontent.com/10629150/200342627-b3499a10-c057-4da5-a0e6-69ebf3eee3ba.png)
