### PR TITLE
Datahub: Adapt search filter sort by popularity

### DIFF
--- a/libs/feature/search/src/lib/sort-by/sort-by.component.ts
+++ b/libs/feature/search/src/lib/sort-by/sort-by.component.ts
@@ -22,7 +22,7 @@ export class SortByComponent {
     },
     {
       label: 'results.sortBy.popularity',
-      value: 'popularity',
+      value: '-userSavedCount',
     },
   ]
   currentSortBy$ = this.facade.sortBy$

--- a/translations/en.json
+++ b/translations/en.json
@@ -77,7 +77,7 @@
   "datahub.header.datasets": "Datasets",
   "datahub.header.lastRecords": "The latest",
   "datahub.header.myfavorites": "My favorites",
-  "datahub.header.news": "News",
+  "datahub.header.news": "Home",
   "datahub.header.organisations": "Organisations",
   "datahub.header.popularRecords": "The most popular",
   "datahub.header.title.html": "<div class=\"text-white\">Discover open<br> data from my Organization</div>",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -77,7 +77,7 @@
   "datahub.header.datasets": "Jeux de données",
   "datahub.header.lastRecords": "Les plus récentes",
   "datahub.header.myfavorites": "Mes favoris",
-  "datahub.header.news": "Fil d'activité",
+  "datahub.header.news": "Accueil",
   "datahub.header.organisations": "Organisations",
   "datahub.header.popularRecords": "Les plus appréciées",
   "datahub.header.title.html": "<div class=\"text-white\">Toutes les données<br>publiques de mon organisation</div>",


### PR DESCRIPTION
PR

- uses `-userSavedCount` when sorting by popularity in search filter (and is thus consistent with badge)
- also renames "News" to "Home" (EN/FR) in navigation menu