### PR TITLE
Fix filter dropdown clear

### DIFF
--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -27,7 +27,6 @@
           (action)="listFavorites($event)"
         ></datahub-header-badge-button>
         <datahub-header-badge-button
-          [routerLink]="ROUTE_SEARCH"
           class="mr-3"
           label="datahub.header.lastRecords"
           [toggled]="
@@ -36,7 +35,6 @@
           (action)="setSortBy($event, SORT_BY_PARAMS.CREATE_DATE)"
         ></datahub-header-badge-button>
         <datahub-header-badge-button
-          [routerLink]="ROUTE_SEARCH"
           class="mr-3"
           label="datahub.header.popularRecords"
           [toggled]="

--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -32,7 +32,7 @@
           [toggled]="
             (searchFacade.sortBy$ | async) === SORT_BY_PARAMS.CREATE_DATE
           "
-          (action)="setSortBy($event, SORT_BY_PARAMS.CREATE_DATE)"
+          (action)="clearSearchAndSort($event, SORT_BY_PARAMS.CREATE_DATE)"
         ></datahub-header-badge-button>
         <datahub-header-badge-button
           class="mr-3"
@@ -40,7 +40,7 @@
           [toggled]="
             (searchFacade.sortBy$ | async) === SORT_BY_PARAMS.USER_SAVED_COUNT
           "
-          (action)="setSortBy($event, SORT_BY_PARAMS.USER_SAVED_COUNT)"
+          (action)="clearSearchAndSort($event, SORT_BY_PARAMS.USER_SAVED_COUNT)"
         ></datahub-header-badge-button>
       </div>
     </div>

--- a/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
@@ -84,16 +84,6 @@ describe('HeaderComponent', () => {
     expect(component).toBeTruthy()
   })
 
-  describe('tabs navigation', () => {
-    describe('click datasets tab', () => {
-      beforeEach(() => {
-        component.updateSearch()
-      })
-      it('calls searchService updateSearch with empty object', () => {
-        expect(searchServiceMock.updateSearch).toHaveBeenCalledWith({})
-      })
-    })
-  })
   describe('favorites badge', () => {
     describe('isAuthenticated$', () => {
       describe('user is authenticated', () => {

--- a/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
@@ -1,10 +1,12 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core'
+import { Component, NO_ERRORS_SCHEMA } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { By } from '@angular/platform-browser'
 import { AuthService } from '@geonetwork-ui/feature/auth'
 import { RouterFacade } from '@geonetwork-ui/feature/router'
 import { SearchFacade, SearchService } from '@geonetwork-ui/feature/search'
 import { TranslateModule } from '@ngx-translate/core'
 import { BehaviorSubject } from 'rxjs'
+import { HeaderBadgeButtonComponent } from '../header-badge-button/header-badge-button.component'
 import { HomeHeaderComponent, SortByParams } from './home-header.component'
 import { readFirst } from '@nrwl/angular/testing'
 
@@ -26,12 +28,19 @@ const searchFacadeMock = {
 
 const searchServiceMock = {
   updateSearch: jest.fn(),
+  setSearch: jest.fn(),
 }
 
 class AuthServiceMock {
   authReady = jest.fn(() => this._authSubject$)
   _authSubject$ = new BehaviorSubject({})
 }
+
+@Component({
+  selector: 'gn-ui-popup-alert',
+  template: '<div></div>',
+})
+export class MockHeaderBadgeButtonComponent {}
 
 describe('HeaderComponent', () => {
   let component: HomeHeaderComponent
@@ -41,7 +50,7 @@ describe('HeaderComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TranslateModule.forRoot()],
-      declarations: [HomeHeaderComponent],
+      declarations: [HomeHeaderComponent, HeaderBadgeButtonComponent],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
         {
@@ -119,32 +128,64 @@ describe('HeaderComponent', () => {
     })
   })
   describe('sort badges', () => {
-    describe('#setsortBy CREATE_DATE', () => {
+    describe('enable sort on CREATE_DATE', () => {
       beforeEach(() => {
-        component.setSortBy(true, SortByParams.CREATE_DATE)
+        const latestBadge = fixture.debugElement.queryAll(
+          By.directive(HeaderBadgeButtonComponent)
+        )[0]
+        latestBadge.componentInstance.action.emit(true)
       })
       it('calls searchFacade setSortBy with correct value', () => {
         expect(searchFacadeMock.setSortBy).toHaveBeenCalledWith(
           SortByParams.CREATE_DATE
         )
       })
-    })
-    describe('#setsortBy empty', () => {
-      beforeEach(() => {
-        component.setSortBy(false, SortByParams.CREATE_DATE)
+      it('resets search filters', () => {
+        expect(searchServiceMock.setSearch).toHaveBeenCalledWith({})
       })
-      it('calls searchFacade setSortBy with correct value', () => {
+    })
+    describe('disable sort on CREATE_DATE', () => {
+      beforeEach(() => {
+        const latestBadge = fixture.debugElement.queryAll(
+          By.directive(HeaderBadgeButtonComponent)
+        )[0]
+        latestBadge.componentInstance.action.emit(false)
+      })
+      it('sorts on create date', () => {
         expect(searchFacadeMock.setSortBy).toHaveBeenCalledWith('')
       })
-    })
-    describe('#setsortBy USER_SAVED_COUNT', () => {
-      beforeEach(() => {
-        component.setSortBy(true, SortByParams.USER_SAVED_COUNT)
+      it('resets search filters', () => {
+        expect(searchServiceMock.setSearch).toHaveBeenCalledWith({})
       })
-      it('calls searchFacade setSortBy with correct value', () => {
+    })
+    describe('enable sort on USER_SAVED_COUNT', () => {
+      beforeEach(() => {
+        const mostPopularBadge = fixture.debugElement.queryAll(
+          By.directive(HeaderBadgeButtonComponent)
+        )[1]
+        mostPopularBadge.componentInstance.action.emit(true)
+      })
+      it('sort on popularity', () => {
         expect(searchFacadeMock.setSortBy).toHaveBeenCalledWith(
           SortByParams.USER_SAVED_COUNT
         )
+      })
+      it('resets search filters', () => {
+        expect(searchServiceMock.setSearch).toHaveBeenCalledWith({})
+      })
+    })
+    describe('disable sort on USER_SAVED_COUNT', () => {
+      beforeEach(() => {
+        const mostPopularBadge = fixture.debugElement.queryAll(
+          By.directive(HeaderBadgeButtonComponent)
+        )[1]
+        mostPopularBadge.componentInstance.action.emit(true)
+      })
+      it('sorts on popularity', () => {
+        expect(searchFacadeMock.setSortBy).toHaveBeenCalledWith('')
+      })
+      it('resets search filters', () => {
+        expect(searchServiceMock.setSearch).toHaveBeenCalledWith({})
       })
     })
   })

--- a/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
@@ -9,6 +9,7 @@ import { BehaviorSubject } from 'rxjs'
 import { HeaderBadgeButtonComponent } from '../header-badge-button/header-badge-button.component'
 import { HomeHeaderComponent, SortByParams } from './home-header.component'
 import { readFirst } from '@nrwl/angular/testing'
+import resetAllMocks = jest.resetAllMocks
 
 jest.mock('@geonetwork-ui/util/app-config', () => ({
   getThemeConfig: () => ({
@@ -35,12 +36,6 @@ class AuthServiceMock {
   authReady = jest.fn(() => this._authSubject$)
   _authSubject$ = new BehaviorSubject({})
 }
-
-@Component({
-  selector: 'gn-ui-popup-alert',
-  template: '<div></div>',
-})
-export class MockHeaderBadgeButtonComponent {}
 
 describe('HeaderComponent', () => {
   let component: HomeHeaderComponent
@@ -78,6 +73,9 @@ describe('HeaderComponent', () => {
     fixture = TestBed.createComponent(HomeHeaderComponent)
     component = fixture.componentInstance
     fixture.detectChanges()
+  })
+  afterEach(() => {
+    resetAllMocks()
   })
 
   it('should create', () => {
@@ -169,10 +167,11 @@ describe('HeaderComponent', () => {
         const mostPopularBadge = fixture.debugElement.queryAll(
           By.directive(HeaderBadgeButtonComponent)
         )[1]
-        mostPopularBadge.componentInstance.action.emit(true)
+        mostPopularBadge.componentInstance.action.emit(false)
       })
       it('sorts on popularity', () => {
         expect(searchFacadeMock.setSortBy).toHaveBeenCalledWith('')
+        expect(searchFacadeMock.setSortBy).toHaveBeenCalledTimes(1)
       })
       it('resets search filters', () => {
         expect(searchServiceMock.setSearch).toHaveBeenCalledWith({})

--- a/apps/datahub/src/app/home/home-header/home-header.component.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.ts
@@ -56,15 +56,11 @@ export class HomeHeaderComponent {
     this.routerFacade.goToMetadata(record)
   }
 
-  updateSearch(): void {
-    this.searchService.updateSearch({})
-  }
-
   listFavorites(toggled: boolean): void {
     this.searchFacade.setFavoritesOnly(toggled)
   }
 
-  setSortBy(toggled: boolean, param: SortByParams): void {
+  clearSearchAndSort(toggled: boolean, param: SortByParams): void {
     const sortBy = toggled ? param : ''
     this.searchService.setSearch({})
     this.searchFacade.setSortBy(sortBy)

--- a/apps/datahub/src/app/home/home-header/home-header.component.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.ts
@@ -66,6 +66,7 @@ export class HomeHeaderComponent {
 
   setSortBy(toggled: boolean, param: SortByParams): void {
     const sortBy = toggled ? param : ''
+    this.searchService.setSearch({})
     this.searchFacade.setSortBy(sortBy)
   }
 }

--- a/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.spec.ts
+++ b/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.spec.ts
@@ -33,7 +33,7 @@ export class MockDropdownComponent {
 describe('FilterDropdownComponent', () => {
   let component: FilterDropdownComponent
   let dropdown: MockDropdownComponent
-  let facade: SearchFacade
+  let facade: SearchFacadeMock
   let searchService: SearchService
   let fixture: ComponentFixture<FilterDropdownComponent>
 
@@ -143,7 +143,7 @@ describe('FilterDropdownComponent', () => {
   describe('selected values', () => {
     describe('when a filter is available', () => {
       beforeEach(() => {
-        ;(facade as any).searchFilters$.next({
+        facade.searchFilters$.next({
           Org: {
             'First Org': true,
             'Second Org': true,
@@ -154,10 +154,24 @@ describe('FilterDropdownComponent', () => {
       it('reads selected values from the search filters', () => {
         expect(dropdown.selected).toEqual(['First Org', 'Second Org'])
       })
+      describe('then the  filter is clear', () => {
+        beforeEach(() => {
+          facade.searchFilters$.next({
+            anoterField: {
+              value1: true,
+            },
+          })
+          fixture.detectChanges()
+        })
+
+        it('it removes the filter from the dropdown', () => {
+          expect(dropdown.selected).toEqual([])
+        })
+      })
     })
     describe('when a filter is not available', () => {
       beforeEach(() => {
-        ;(facade as any).searchFilters$.next({
+        facade.searchFilters$.next({
           anoterField: {
             value1: true,
           },

--- a/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.ts
+++ b/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.ts
@@ -33,13 +33,8 @@ export class FilterDropdownComponent implements OnInit {
     startWith([])
   )
   selected$ = this.searchFacade.searchFilters$.pipe(
-    map(
-      (filters) =>
-        filters[this.fieldName] && Object.keys(filters[this.fieldName])
-    ),
-    filter((selected) => !!selected),
-    take(1),
-    startWith([])
+    map((filters) => Object.keys(filters[this.fieldName] ?? {})),
+    filter((selected) => !!selected)
   )
 
   onSelectedValues(values: unknown[]) {


### PR DESCRIPTION
There was an issue within the Observable stream. Now if you clear the filters from the search, all selected filter from the dropdown are cleared as well.

Some refactor on the badges button as well to explicitly call search facade function instead of using the `routerLink`.