### PR TITLE
Clarify optional sections in app config

### DIFF
--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -24,7 +24,7 @@ import { UiLayoutModule } from '@geonetwork-ui/ui/layout'
 import { RESULTS_LAYOUT_CONFIG, UiSearchModule } from '@geonetwork-ui/ui/search'
 import {
   getGlobalConfig,
-  getSearchConfig,
+  getOptionalSearchConfig,
   getThemeConfig,
 } from '@geonetwork-ui/util/app-config'
 import {
@@ -143,13 +143,13 @@ export const metaReducers: MetaReducer[] = !environment.production ? [] : []
     {
       provide: FILTER_GEOMETRY,
       useFactory: () => {
-        if (getSearchConfig().FILTER_GEOMETRY_DATA) {
+        if (getOptionalSearchConfig()?.FILTER_GEOMETRY_DATA) {
           return Promise.resolve(
-            JSON.parse(getSearchConfig().FILTER_GEOMETRY_DATA)
+            JSON.parse(getOptionalSearchConfig().FILTER_GEOMETRY_DATA)
           ).then(getGeometryFromGeoJSON)
         }
-        if (getSearchConfig().FILTER_GEOMETRY_URL) {
-          return fetch(getSearchConfig().FILTER_GEOMETRY_URL)
+        if (getOptionalSearchConfig()?.FILTER_GEOMETRY_URL) {
+          return fetch(getOptionalSearchConfig().FILTER_GEOMETRY_URL)
             .then((resp) => resp.json())
             .then(getGeometryFromGeoJSON)
         }

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
@@ -60,7 +60,7 @@ const mapConfigMock = {
   ],
 }
 jest.mock('@geonetwork-ui/util/app-config', () => ({
-  getMapConfig: () => mapConfigMock,
+  getOptionalMapConfig: () => mapConfigMock,
   isConfigLoaded: jest.fn(() => true),
 }))
 

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -13,7 +13,7 @@ import {
   MapStyleService,
   MapUtilsService,
 } from '@geonetwork-ui/feature/map'
-import { getMapConfig, MapConfig } from '@geonetwork-ui/util/app-config'
+import { getOptionalMapConfig, MapConfig } from '@geonetwork-ui/util/app-config'
 import {
   getLinkLabel,
   MetadataLink,
@@ -49,7 +49,7 @@ import { MdViewFacade } from '../state/mdview.facade'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataViewMapComponent implements OnInit, OnDestroy {
-  mapConfig: MapConfig = getMapConfig()
+  mapConfig: MapConfig = getOptionalMapConfig()
   selection: Feature<Geometry>
   private subscription = new Subscription()
   private selectionStyle: StyleLike

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -1,11 +1,12 @@
 import fetchMock from 'fetch-mock-jest'
-import { getMapConfig, getSearchConfig } from '..'
 import {
   _reset,
   getCustomTranslations,
   getGlobalConfig,
   getThemeConfig,
   loadAppConfig,
+  getOptionalMapConfig,
+  getOptionalSearchConfig,
 } from './app-config'
 import {
   CONFIG_MALFORMED,
@@ -151,9 +152,9 @@ describe('app config utils', () => {
         })
       })
     })
-    describe('getSearchConfig', () => {
+    describe('getOptionalSearchConfig', () => {
       it('returns the search config', () => {
-        expect(getSearchConfig()).toEqual({
+        expect(getOptionalSearchConfig()).toEqual({
           FILTER_GEOMETRY_URL: 'https://my.domain.org/geom.json',
         })
       })
@@ -190,9 +191,37 @@ describe('app config utils', () => {
         })
       })
     })
+    describe('getGlobalConfig', () => {
+      it('returns config', () => {
+        expect(getGlobalConfig()).toEqual({
+          GN4_API_URL: '/geonetwork/srv/api',
+          PROXY_PATH: '/proxy/?url=',
+        })
+      })
+    })
+    describe('getThemeConfig', () => {
+      it('returns config', () => {
+        expect(getThemeConfig()).toEqual({
+          BACKGROUND_COLOR: '#fdfbff',
+          MAIN_COLOR: '#212029',
+          PRIMARY_COLOR: '#093564',
+          SECONDARY_COLOR: '#c2e9dc',
+        })
+      })
+    })
+    describe('getOptionalMapConfig', () => {
+      it('returns null', () => {
+        expect(getOptionalMapConfig()).toEqual(null)
+      })
+    })
+    describe('getOptionalSearchConfig', () => {
+      it('returns null', () => {
+        expect(getOptionalSearchConfig()).toEqual(null)
+      })
+    })
   })
 
-  describe('getMapConfig', () => {
+  describe('getOptionalMapConfig', () => {
     const baseConfig = `
     [global]
     geonetwork4_api_url = "/geonetwork/srv/api"
@@ -231,7 +260,7 @@ describe('app config utils', () => {
       })
 
       it('returns the map config', () => {
-        expect(getMapConfig()).toEqual({
+        expect(getOptionalMapConfig()).toEqual({
           MAX_ZOOM: 10,
           MAX_EXTENT: [
             -418263.418776, 5251529.591305, 961272.067714, 6706890.609855,
@@ -267,7 +296,7 @@ describe('app config utils', () => {
       })
 
       it('returns the map config', () => {
-        expect(getMapConfig()).toEqual({
+        expect(getOptionalMapConfig()).toEqual({
           MAX_ZOOM: undefined,
           MAX_EXTENT: undefined,
           EXTERNAL_VIEWER_URL_TEMPLATE: undefined,

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -26,21 +26,19 @@ export function getGlobalConfig(): GlobalConfig {
   return globalConfig
 }
 
-let mapConfig: MapConfig = null
-export function getMapConfig(): MapConfig {
-  if (mapConfig === null) throw new Error(MISSING_CONFIG_ERROR)
-  return mapConfig
-}
-
 let themeConfig: ThemeConfig = null
 export function getThemeConfig(): ThemeConfig {
   if (themeConfig === null) throw new Error(MISSING_CONFIG_ERROR)
   return themeConfig
 }
 
+let mapConfig: MapConfig = null
+export function getOptionalMapConfig(): MapConfig | null {
+  return mapConfig
+}
+
 let searchConfig: SearchConfig = null
-export function getSearchConfig(): SearchConfig {
-  if (searchConfig === null) throw new Error(MISSING_CONFIG_ERROR)
+export function getOptionalSearchConfig(): SearchConfig | null {
   return searchConfig
 }
 


### PR DESCRIPTION
This PR fixes an error at startup in the Datahub, if the `[search]` section of the app config is not defined (which is valid). I also clarified which sections were optional, and hopefully this should help us avoid this in the future.