### PR TITLE
Datahub: Improve map navigation 

### DIFF
--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -14,7 +14,7 @@ import TileWMS from 'ol/source/TileWMS'
 import VectorSource from 'ol/source/Vector'
 import { Options, optionsFromCapabilities } from 'ol/source/WMTS'
 import { DragPan, MouseWheelZoom, defaults, Interaction } from 'ol/interaction'
-import { platformModifierKeyOnly } from 'ol/events/condition'
+import { mouseOnly, platformModifierKeyOnly } from 'ol/events/condition'
 import WMTSCapabilities from 'ol/format/WMTSCapabilities'
 import { from, Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
@@ -193,10 +193,9 @@ export class MapUtilsService {
 
 export function dragPanCondition(
   this: DragPan,
-  event: MapBrowserEvent<UIEvent>
+  event: MapBrowserEvent<PointerEvent>
 ) {
-  const dragPanCondition =
-    this.getPointerCount() === 2 || platformModifierKeyOnly(event)
+  const dragPanCondition = this.getPointerCount() === 2 || mouseOnly(event)
   if (!dragPanCondition) {
     this.getMap().dispatchEvent('mapmuted')
   }

--- a/libs/ui/map/src/lib/components/map/map.component.ts
+++ b/libs/ui/map/src/lib/components/map/map.component.ts
@@ -8,8 +8,8 @@ import {
   ViewChild,
 } from '@angular/core'
 import Map from 'ol/Map'
-import { fromEvent, Observable, timer } from 'rxjs'
-import { map, startWith, switchMap } from 'rxjs/operators'
+import { fromEvent, merge, Observable, of, timer } from 'rxjs'
+import { delay, map, startWith, switchMap } from 'rxjs/operators'
 
 @Component({
   selector: 'gn-ui-map',
@@ -24,18 +24,27 @@ export class MapComponent implements OnInit, AfterViewInit {
     this.map.updateSize()
     this.resizeObserver.unobserve(this.container.nativeElement)
   })
+  mapMuted$: Observable<boolean>
+  cancelMapmuted$: Observable<boolean>
   displayMessage$: Observable<boolean>
 
   constructor(private _element: ElementRef) {}
 
   ngOnInit() {
     // this will show the message when a 'mapmuted' event is received and hide it a few seconds later
-    this.displayMessage$ = fromEvent(this.map, 'mapmuted').pipe(
-      switchMap(() =>
-        timer(2000).pipe(
-          map(() => false),
-          startWith(true)
-        )
+    // 'movestart' will cancel displaying the message in particular for two finger interactions on mobile
+    this.displayMessage$ = merge(
+      fromEvent(this.map, 'mapmuted').pipe(map(() => true)),
+      fromEvent(this.map, 'movestart').pipe(map(() => false))
+    ).pipe(
+      switchMap((muted) =>
+        muted
+          ? timer(2000).pipe(
+              map(() => false),
+              startWith(true),
+              delay(150)
+            )
+          : of(false)
       )
     )
   }


### PR DESCRIPTION
The PR allows using the `DragPan` tool via pointerdown events on desktop and thus prevents displaying the "map mute" message when clicking on the map on desktop.

One further improvement could be to prevent, displaying the message (for the initial 2 sec) when using 2 fingers on mobile. This is currently the case, because a two finger touch dispatches a first `pointerdown` event with one `activePointer` and only a second `pointerdown` event with two `activePointers`. => Implemented in e7b02160671af8a7d853993cc30f35be6f706cc7