### PR TITLE
Datahub: Sort filter-dropdown by key

### DIFF
--- a/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.spec.ts
+++ b/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.spec.ts
@@ -70,7 +70,15 @@ describe('FilterDropdownComponent', () => {
   describe('at initialization', () => {
     it('adds an aggregation in the search config', () => {
       expect(facade.updateConfigAggregations).toHaveBeenCalledWith({
-        Org: { terms: { field: 'Org', size: 100 } },
+        Org: {
+          terms: {
+            field: 'Org',
+            size: 100,
+            order: {
+              _key: 'asc',
+            },
+          },
+        },
       })
     })
   })

--- a/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.ts
+++ b/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.ts
@@ -52,7 +52,15 @@ export class FilterDropdownComponent implements OnInit {
 
   ngOnInit() {
     this.searchFacade.updateConfigAggregations({
-      [this.fieldName]: { terms: { field: this.fieldName, size: 100 } },
+      [this.fieldName]: {
+        terms: {
+          field: this.fieldName,
+          size: 100,
+          order: {
+            _key: 'asc',
+          },
+        },
+      },
     })
   }
 }


### PR DESCRIPTION
PR adds `order` param with `_key: 'asc'` to component's payload to query aggregations.