### PR TITLE
Datahub: Do not display map message on 'singleclick' for mobile

### DIFF
--- a/libs/ui/map/src/lib/components/map/map.component.spec.ts
+++ b/libs/ui/map/src/lib/components/map/map.component.spec.ts
@@ -17,6 +17,7 @@ class ResizeObserverMock {
 
 let mapmutedCallback
 let movestartCallback
+let singleclickCallback
 class OpenLayersMapMock {
   _size = undefined
   setTarget = jest.fn()
@@ -32,6 +33,9 @@ class OpenLayersMapMock {
     }
     if (type === 'movestart') {
       movestartCallback = callback
+    }
+    if (type === 'singleclick') {
+      singleclickCallback = callback
     }
   }
   off() {
@@ -76,9 +80,9 @@ describe('MapComponent', () => {
           (value) => (messageDisplayed = value)
         )
       })
-      it('mapmuted event displays message after 200ms (delay for evetually hiding message)', fakeAsync(() => {
+      it('mapmuted event displays message after 300ms (delay for eventually hiding message)', fakeAsync(() => {
         mapmutedCallback()
-        tick(200)
+        tick(300)
         expect(messageDisplayed).toEqual(true)
         discardPeriodicTasks()
       }))
@@ -90,6 +94,13 @@ describe('MapComponent', () => {
       }))
       it('message does not display if map fires movestart event', fakeAsync(() => {
         movestartCallback()
+        tick(300)
+        expect(messageDisplayed).toEqual(false)
+        discardPeriodicTasks()
+      }))
+      it('message does not display if map fires singleclick event', fakeAsync(() => {
+        singleclickCallback()
+        tick(300)
         expect(messageDisplayed).toEqual(false)
         discardPeriodicTasks()
       }))

--- a/libs/ui/map/src/lib/components/map/map.component.ts
+++ b/libs/ui/map/src/lib/components/map/map.component.ts
@@ -32,17 +32,18 @@ export class MapComponent implements OnInit, AfterViewInit {
 
   ngOnInit() {
     // this will show the message when a 'mapmuted' event is received and hide it a few seconds later
-    // 'movestart' will cancel displaying the message in particular for two finger interactions on mobile
+    // 'movestart' and 'singleclick' will cancel displaying the message in particular for two finger interactions on mobile
     this.displayMessage$ = merge(
       fromEvent(this.map, 'mapmuted').pipe(map(() => true)),
-      fromEvent(this.map, 'movestart').pipe(map(() => false))
+      fromEvent(this.map, 'movestart').pipe(map(() => false)),
+      fromEvent(this.map, 'singleclick').pipe(map(() => false))
     ).pipe(
       switchMap((muted) =>
         muted
           ? timer(2000).pipe(
               map(() => false),
               startWith(true),
-              delay(150)
+              delay(300)
             )
           : of(false)
       )


### PR DESCRIPTION
PR cancels displaying the "muted" map message on a `singleclick` for mobile. Just wondering if we could perhaps already exclude this case within the condition in the `map-utils.service`. Raised the delay to 300 ms since the map's `singleclick` has a delay of 250 ms itself.