### PR TITLE
Datahub: Ignore search params content after a '?'

### DIFF
--- a/libs/feature/router/src/lib/default/router.mapper.spec.ts
+++ b/libs/feature/router/src/lib/default/router.mapper.spec.ts
@@ -62,7 +62,7 @@ describe('RouterMapper', () => {
           publisher: 'org sample',
           q: 'scot',
           resolution: '10000',
-          format: 'OGC:WFS',
+          format: 'OGC:WFS?ignore-after-questionmark',
           ticket: 'should be ignored',
         }
       })
@@ -86,7 +86,7 @@ describe('RouterMapper', () => {
         routeParams = {
           publisher: ['org 1', 'org (%2)', '123[]<>;:!'],
           q: 'scot',
-          resolution: ['10000', '200000'],
+          resolution: ['10000', '200000?ignore-after-questionmark'],
           format: ['OGC:WFS', 'WWW:DOWNLOAD:application/json'],
           ticket: ['should', 'also', 'be', 'ignored'],
         }

--- a/libs/feature/router/src/lib/default/router.mapper.ts
+++ b/libs/feature/router/src/lib/default/router.mapper.ts
@@ -2,6 +2,18 @@ import { Params } from '@angular/router'
 import { SearchFilters } from '@geonetwork-ui/util/shared'
 import { ROUTE_PARAMS, ROUTE_PARAMS_MAPPING } from './constants'
 
+const DEFAULT_IGNORE_SEPARATOR = '?'
+
+function sanitizeParam(param: string | Array<string>) {
+  let paramValue
+  if (typeof param === 'string') {
+    paramValue = param.split(DEFAULT_IGNORE_SEPARATOR)[0]
+  } else {
+    paramValue = param.map((value) => value.split(DEFAULT_IGNORE_SEPARATOR)[0])
+  }
+  return paramValue
+}
+
 function isSearchFilterParam(param: string): boolean {
   return !param.startsWith('_')
 }
@@ -24,7 +36,7 @@ export function getSortBy(routeSearchParams: Params) {
 
 export function routeParamsToState(filters: Params) {
   return Object.keys(filters).reduce((state, key) => {
-    const paramValue = filters[key]
+    const paramValue = sanitizeParam(filters[key])
     const filterName = ROUTE_PARAMS_MAPPING[key]
 
     if (!filterName) {


### PR DESCRIPTION
Not sure if this is the right way to go. This PR ignores everything after a `?` within a search param. This would allow adding things such as `?login` to the url without breaking the search, but could break search params that intentionally include a `?`, if such exist !? Also adds logic which should perhaps not be handled by the frontend.