### PR TITLE
filters: fix empty dropdowns

### DIFF
--- a/apps/datahub/src/app/home/search/search-filters/search-filters.component.ts
+++ b/apps/datahub/src/app/home/search/search-filters/search-filters.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
-import { SearchFacade, SearchService } from '@geonetwork-ui/feature/search'
+import { SearchFacade } from '@geonetwork-ui/feature/search'
 import { map, pluck } from 'rxjs/operators'
 
 @Component({
@@ -13,10 +13,7 @@ export class SearchFiltersComponent {
     pluck('OrgForResource'),
     map((orgState) => orgState && Object.keys(orgState)[0])
   )
-  constructor(
-    public searchFacade: SearchFacade,
-    private searchService: SearchService
-  ) {}
+  constructor(public searchFacade: SearchFacade) {}
 
   isOpen = false
 

--- a/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.spec.ts
+++ b/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.spec.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  NO_ERRORS_SCHEMA,
+  Output,
+} from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
 import { BehaviorSubject } from 'rxjs'
@@ -6,8 +13,11 @@ import { SearchFacade } from '../state/search.facade'
 import { SearchService } from '../utils/service/search.service'
 import { FilterDropdownComponent } from './filter-dropdown.component'
 
+let facade: SearchFacadeMock
+
 class SearchFacadeMock {
-  updateConfigAggregations = jest.fn()
+  updateConfigAggregations = jest.fn(() => facade)
+  requestMoreResults = jest.fn()
   resultsAggregations$ = new BehaviorSubject<any>({})
   searchFilters$ = new BehaviorSubject<any>({})
 }
@@ -33,13 +43,13 @@ export class MockDropdownComponent {
 describe('FilterDropdownComponent', () => {
   let component: FilterDropdownComponent
   let dropdown: MockDropdownComponent
-  let facade: SearchFacadeMock
   let searchService: SearchService
   let fixture: ComponentFixture<FilterDropdownComponent>
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [FilterDropdownComponent, MockDropdownComponent],
+      schemas: [NO_ERRORS_SCHEMA],
       providers: [
         {
           provide: SearchFacade,
@@ -50,7 +60,13 @@ describe('FilterDropdownComponent', () => {
           useClass: SearchServiceMock,
         },
       ],
-    }).compileComponents()
+    })
+      .overrideComponent(FilterDropdownComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents()
 
     fixture = TestBed.createComponent(FilterDropdownComponent)
     facade = TestBed.inject(SearchFacade)
@@ -80,6 +96,7 @@ describe('FilterDropdownComponent', () => {
           },
         },
       })
+      expect(facade.requestMoreResults).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.ts
+++ b/libs/feature/search/src/lib/filter-dropdown/filter-dropdown.component.ts
@@ -51,16 +51,18 @@ export class FilterDropdownComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.searchFacade.updateConfigAggregations({
-      [this.fieldName]: {
-        terms: {
-          field: this.fieldName,
-          size: 100,
-          order: {
-            _key: 'asc',
+    this.searchFacade
+      .updateConfigAggregations({
+        [this.fieldName]: {
+          terms: {
+            field: this.fieldName,
+            size: 100,
+            order: {
+              _key: 'asc',
+            },
           },
         },
-      },
-    })
+      })
+      .requestMoreResults()
   }
 }


### PR DESCRIPTION
The `filter-dropdown` component updates ES aggregations payload to be hydrated.
But it does not request a new search. So depending on the order of things loading within the app, it may provides empty filter list, until a new search is done.

This PR fixes this issue by request a new search on each aggregation update.