### PR TITLE
Datahub Login tootip: add a special case for georchestra login URL

### DIFF
--- a/libs/feature/auth/src/lib/auth.service.spec.ts
+++ b/libs/feature/auth/src/lib/auth.service.spec.ts
@@ -13,9 +13,18 @@ const meApiMock = {
   getMe: () => me$,
 }
 
+let windowLocation
+Object.defineProperties((global as any).window, {
+  location: {
+    get: () => new URL(windowLocation),
+  },
+})
+
 describe('AuthService', () => {
   let service: AuthService
   beforeEach(() => {
+    windowLocation = 'http://localhost'
+
     TestBed.configureTestingModule({
       providers: [
         {
@@ -75,6 +84,19 @@ describe('AuthService', () => {
     })
     it('should construct a login URL based on the injected value', () => {
       expect(service.loginUrl).toEqual('http://localhost/?login')
+    })
+  })
+  describe('login URL from config (special georchestra case, appending a query param with existing query params)', () => {
+    beforeEach(() => {
+      windowLocation =
+        'https://my.georchestra/datahub/?org=Abcd&keywords=bla;bla&location'
+      loginUrlTokenMock = '${current_url}?login&something=else'
+      service = TestBed.inject(AuthService)
+    })
+    it('should construct a login URL based on the injected value', () => {
+      expect(service.loginUrl).toEqual(
+        'https://my.georchestra/datahub/?org=Abcd&keywords=bla;bla&location&login&something=else'
+      )
     })
   })
   describe('#mapToUserModel', () => {

--- a/libs/feature/auth/src/lib/auth.service.ts
+++ b/libs/feature/auth/src/lib/auth.service.ts
@@ -22,7 +22,13 @@ export class AuthService {
 
   baseLoginUrl = this.baseLoginUrlToken || DEFAULT_GN4_LOGIN_URL
   get loginUrl() {
-    return this.baseLoginUrl
+    let baseUrl = this.baseLoginUrl
+    const locationHasQueryParams = !!window.location.search
+    // this is specific to georchestra login URL based on a ?login query param
+    if (baseUrl.startsWith('${current_url}?') && locationHasQueryParams) {
+      baseUrl = baseUrl.replace('?', '&')
+    }
+    return baseUrl
       .replace('${current_url}', window.location.toString())
       .replace('${lang2}', this.translateService.currentLang)
       .replace(


### PR DESCRIPTION
Login urls in geOrchestra rely on a "login" query param, but appending query params is awkward with the current login_url system; we might typically end up with something like:

https://my.georchestra/datahub/?org=Abc&keyword=Def?login

This PR handles this specific case to obtain:

https://my.georchestra/datahub/?org=Abc&keyword=Def&login