### PR TITLE
Search: use the 'format' field from index instead of 'linkProtocol'

### DIFF
--- a/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
+++ b/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
@@ -37,7 +37,7 @@
     <gn-ui-filter-dropdown
       class="w-full"
       [ngClass]="isOpen ? 'block' : 'hidden sm:block'"
-      [fieldName]="'linkProtocol'"
+      [fieldName]="'format'"
       [title]="'search.filters.byFormat' | translate"
     ></gn-ui-filter-dropdown>
     <div

--- a/libs/feature/router/src/lib/default/constants.ts
+++ b/libs/feature/router/src/lib/default/constants.ts
@@ -15,5 +15,5 @@ export const ROUTE_PARAMS_MAPPING: SearchRouteParams = {
   [ROUTE_PARAMS.ANY]: 'any',
   [ROUTE_PARAMS.PUBLISHER]: 'OrgForResource',
   [ROUTE_PARAMS.RESOLUTION]: 'resolutionScaleDenominator',
-  [ROUTE_PARAMS.FORMAT]: 'linkProtocol',
+  [ROUTE_PARAMS.FORMAT]: 'format',
 }

--- a/libs/feature/router/src/lib/default/router.mapper.spec.ts
+++ b/libs/feature/router/src/lib/default/router.mapper.spec.ts
@@ -18,7 +18,7 @@ describe('RouterMapper', () => {
           resolutionScaleDenominator: {
             '10000': true,
           },
-          linkProtocol: {
+          format: {
             'OGC:WFS': true,
           },
           keyword: {},
@@ -75,7 +75,7 @@ describe('RouterMapper', () => {
           resolutionScaleDenominator: {
             '10000': true,
           },
-          linkProtocol: {
+          format: {
             'OGC:WFS': true,
           },
         })
@@ -103,7 +103,7 @@ describe('RouterMapper', () => {
             '10000': true,
             '200000': true,
           },
-          linkProtocol: {
+          format: {
             'OGC:WFS': true,
             'WWW:DOWNLOAD:application/json': true,
           },


### PR DESCRIPTION
The "formats" dropdown in the Datahub now looks like this:

![image](https://user-images.githubusercontent.com/10629150/207571177-7e3c1415-a057-40df-8d20-0eb3db6f59b7.png)

It used to be like that:

![image](https://user-images.githubusercontent.com/10629150/207571500-122d97c6-7e74-4152-980f-70cbc667b48e.png)
