### PR TITLE
Datahub: use localized sort for organization names

### DIFF
--- a/libs/feature/catalog/src/lib/organisations/organisations.component.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.spec.ts
@@ -124,7 +124,7 @@ describe('OrganisationsComponent', () => {
         expect(orgPreviewComponents[0].organisation.name).toEqual('A Data Org')
       })
       it('should pass 6th organisation (sorted by name-asc) on page to 6th ui preview component', () => {
-        expect(orgPreviewComponents[5].organisation.name).toEqual('F Data Org')
+        expect(orgPreviewComponents[5].organisation.name).toEqual('é Data Org')
       })
     })
     describe('pass params to ui pagination component', () => {
@@ -156,7 +156,7 @@ describe('OrganisationsComponent', () => {
         })
         it('should pass first organisation of second page (sorted by name-asc) to first ui preview component', () => {
           expect(orgPreviewComponents[0].organisation.name).toEqual(
-            'G Data Org'
+            'F Data Org'
           )
         })
         it('should pass last organisation of second page (sorted by name-asc) to last ui preview component', () => {
@@ -181,16 +181,16 @@ describe('OrganisationsComponent', () => {
       it('should call setSortBy', () => {
         expect(setSortBySpy).toHaveBeenCalledWith('recordCount-desc')
       })
-      it('should have organsiation with max recordCount at first position in observable', async () => {
+      it('should have organisation with max recordCount at first position in observable', async () => {
         const organisations = await readFirst(component.organisations$)
         expect(organisations[0]).toEqual(ORGANISATIONS_FIXTURE[5])
       })
-      it('should pass organsiation with max recordCount to first preview component', () => {
+      it('should pass organisation with max recordCount to first preview component', () => {
         expect(orgPreviewComponents[0].organisation).toEqual(
           ORGANISATIONS_FIXTURE[5]
         )
       })
-      it('should pass organsiation with 6th highest recordCount to 6th preview component', () => {
+      it('should pass organisation with 6th highest recordCount to 6th preview component', () => {
         expect(orgPreviewComponents[5].organisation).toEqual(
           ORGANISATIONS_FIXTURE[3]
         )

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.ts
@@ -59,17 +59,17 @@ export class OrganisationsComponent {
     organisations: Organisation[],
     sortBy: string
   ): Organisation[] {
-    const sortValue = sortBy.split('-')
-    const attribute = sortValue[0]
-    const order = sortValue[1]
-    const orderParam = order === 'asc' ? [1, -1] : [-1, 1]
-    return [...organisations].sort((a, b) =>
-      a[`${attribute}`] > b[`${attribute}`]
-        ? orderParam[0]
-        : b[`${attribute}`] > a[`${attribute}`]
-        ? orderParam[1]
-        : 0
-    )
+    const sortParts = sortBy.split('-')
+    const attribute = sortParts[0]
+    const direction = sortParts[1] === 'asc' ? 1 : -1
+    return [...organisations].sort((a, b) => {
+      const valueA = a[attribute]
+      const valueB = b[attribute]
+      if (typeof valueA === 'string' && typeof valueB === 'string') {
+        return direction * valueA.localeCompare(valueB)
+      }
+      return direction * Math.sign(valueA - valueB)
+    })
   }
 
   searchByOrganisation(organisation: Organisation) {

--- a/libs/util/shared/src/lib/fixtures/organisations.fixture.ts
+++ b/libs/util/shared/src/lib/fixtures/organisations.fixture.ts
@@ -61,4 +61,10 @@ export const ORGANISATIONS_FIXTURE = deepFreeze([
     logoUrl: 'https://my-geonetwork.org/logo10.png',
     recordCount: 1,
   },
+  {
+    name: 'é Data Org',
+    description: 'another org for testing',
+    logoUrl: 'https://my-geonetwork.org/logo10.png',
+    recordCount: 2,
+  },
 ])


### PR DESCRIPTION
This is important in languages with accents, e.g.:

![image](https://user-images.githubusercontent.com/10629150/207907388-27f6eec2-ab17-4a46-9fb7-b88cfdaadc7a.png)
