### PR TITLE
Datahub: Change organisations intro text

### DIFF
--- a/apps/datahub/src/app/home/search/search-page/search-page.component.html
+++ b/apps/datahub/src/app/home/search/search-page/search-page.component.html
@@ -1,6 +1,6 @@
 <div class="container-lg mx-auto mt-8">
   <datahub-search-filters></datahub-search-filters>
-  <div class="mt-4 rounded-lg text-gray-800 p-4 bg-slate-100">
+  <div class="mt-6 rounded-lg text-gray-800 p-4 bg-slate-100">
     <gn-ui-results-hits></gn-ui-results-hits>
   </div>
   <div class="mt-8">

--- a/translations/en.json
+++ b/translations/en.json
@@ -125,7 +125,7 @@
   "nav.back": "Back",
   "new record": "New record",
   "next": "next",
-  "organisation.sort.intro": "The organisations are the providers of metadata records and their corresponding data. They may be owners of metadata catalogs harvested by this instance or owners of (meta-)data referenced by another catalog.",
+  "organisation.sort.intro": "Organisations are data providers. They can be owners, suppliers, or a simple point of contact for the data offered.",
   "organisation.sort.sortBy": "Sort by:",
   "organisations.sortBy.nameAsc": "Name A → Z",
   "organisations.sortBy.nameDesc": "Name Z → A",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -125,7 +125,7 @@
   "nav.back": "Retour",
   "new record": "",
   "next": "suivant",
-  "organisation.sort.intro": "Les organisations sont les fournisseurs des métadonnées et de leurs données correspondantes. Ils peuvent être propriétaires des catalogues des métadonnées récoltés par cette instance ou propriétaires des (méta-)données référencées par un autre catalogue.",
+  "organisation.sort.intro": "Les organisations sont les fournisseurs de données. Ils peuvent être propriétaires, fournisseurs, ou simple point de contact des données proposées.",
   "organisation.sort.sortBy": "Trier par :",
   "organisations.sortBy.nameAsc": "Nom A → Z",
   "organisations.sortBy.nameDesc": "Nom Z → A",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -152,7 +152,7 @@
   "record.metadata.origin": "D'où viennent ces données ?",
   "record.metadata.preview": "Aperçu",
   "record.metadata.publications": "données",
-  "record.metadata.related": "Fiches associées",
+  "record.metadata.related": "Voir aussi",
   "record.metadata.sheet": "Fiche de métadonnées d'origine",
   "record.metadata.status": "statut",
   "record.metadata.title": "titre",


### PR DESCRIPTION
PR changes 
- the organisations intro text (FR/EN)
- the related record label (FR)
- adds more margin over results hits