### PR TITLE
Map: Disable rotate interactions

### DIFF
--- a/libs/feature/map/src/lib/map-context/component/map-context.component.spec.ts
+++ b/libs/feature/map/src/lib/map-context/component/map-context.component.spec.ts
@@ -8,8 +8,6 @@ import { MapContextComponent } from './map-context.component'
 import { MAP_CONFIG_FIXTURE } from '@geonetwork-ui/util/app-config'
 import { HttpClientModule } from '@angular/common/http'
 import { MapUtilsService } from '../../utils'
-import Collection from 'ol/Collection'
-import { Interaction } from 'ol/interaction'
 
 class MapContextServiceMock {
   resetMapFromContext = jest.fn()
@@ -33,12 +31,8 @@ class OpenLayersMapMock {
   getSize() {
     return this._size
   }
-  getInteractions() {
-    return new InteractionsMock()
-  }
 }
 
-class InteractionsMock implements Collection<Interaction> {}
 class MapManagerMock {
   map = new OpenLayersMapMock()
 }
@@ -47,7 +41,6 @@ describe('MapContextComponent', () => {
   let component: MapContextComponent
   let fixture: ComponentFixture<MapContextComponent>
   let mapContextService
-  let mapUtilsService
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -70,7 +63,6 @@ describe('MapContextComponent', () => {
       ],
     }).compileComponents()
     mapContextService = TestBed.inject(MapContextService)
-    mapUtilsService = TestBed.inject(MapUtilsService)
   })
 
   beforeEach(() => {
@@ -96,17 +88,6 @@ describe('MapContextComponent', () => {
         MAP_CTX_FIXTURE,
         MAP_CONFIG_FIXTURE
       )
-    })
-    describe('prioritizePageScroll input', () => {
-      it('does not prioritze page scroll by default', () => {
-        expect(mapUtilsService.prioritizePageScroll).not.toHaveBeenCalled()
-      })
-      it('prioritzes page scroll if input set to true', () => {
-        component.prioritizePageScroll = true
-        expect(mapUtilsService.prioritizePageScroll).toHaveBeenCalledWith(
-          expect.any(InteractionsMock)
-        )
-      })
     })
   })
 

--- a/libs/feature/map/src/lib/map-context/component/map-context.component.ts
+++ b/libs/feature/map/src/lib/map-context/component/map-context.component.ts
@@ -26,11 +26,6 @@ import { MapConfig } from '@geonetwork-ui/util/app-config'
 export class MapContextComponent implements OnChanges {
   @Input() context: MapContextModel
   @Input() mapConfig: MapConfig
-  @Input() set prioritizePageScroll(pagePriority: boolean) {
-    if (pagePriority) {
-      this.utils.prioritizePageScroll(this.map.getInteractions())
-    }
-  }
   @Output() featureClicked = new EventEmitter<Feature<Geometry>[]>()
 
   map: Map

--- a/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
@@ -18,7 +18,13 @@ import {
   mouseWheelZoomCondition,
 } from './map-utils.service'
 import { readFirst } from '@nrwl/angular/testing'
-import { defaults, DragPan, MouseWheelZoom } from 'ol/interaction'
+import {
+  defaults,
+  DragPan,
+  DragRotate,
+  MouseWheelZoom,
+  PinchRotate,
+} from 'ol/interaction'
 
 const wmsUtilsMock = {
   getLayerLonLatBBox: jest.fn(() => of([1.33, 48.81, 4.3, 51.1])),
@@ -220,6 +226,8 @@ describe('MapUtilsService', () => {
   })
   describe('prioritizePageScroll', () => {
     const interactions = defaults()
+    let dragRotate
+    let pinchRotate
     beforeEach(() => {
       service.prioritizePageScroll(interactions)
     })
@@ -234,6 +242,24 @@ describe('MapUtilsService', () => {
         .getArray()
         .find((interaction) => interaction instanceof MouseWheelZoom)
       expect(mouseWheelZoom.condition_).toEqual(mouseWheelZoomCondition)
+    })
+    describe('interactions', () => {
+      beforeEach(() => {
+        interactions.forEach((interaction) => {
+          if (interaction instanceof DragRotate) {
+            dragRotate = interaction
+          }
+          if (interaction instanceof PinchRotate) {
+            pinchRotate = interaction
+          }
+        })
+      })
+      it('with no DragRotate interaction', () => {
+        expect(dragRotate).toBeFalsy()
+      })
+      it('with no PinchRotate interaction', () => {
+        expect(pinchRotate).toBeFalsy()
+      })
     })
   })
 })

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -177,7 +177,14 @@ export class MapUtilsService {
   prioritizePageScroll(interactions: Collection<Interaction>) {
     interactions.clear()
     interactions.extend(
-      defaults({ dragPan: false, mouseWheelZoom: false })
+      defaults({
+        // remove rotate interactions
+        altShiftDragRotate: false,
+        pinchRotate: false,
+        // replace drag and zoom interactions
+        dragPan: false,
+        mouseWheelZoom: false,
+      })
         .extend([
           new DragPan({
             condition: dragPanCondition,

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.html
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.html
@@ -20,7 +20,6 @@
     <gn-ui-map-context
       [context]="mapContext$ | async"
       [mapConfig]="mapConfig"
-      [prioritizePageScroll]="true"
     ></gn-ui-map-context>
     <div
       class="top-[1em] right-[1em] p-3 bg-white absolute overflow-y-auto overflow-x-hidden max-h-72 w-56"

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -10,6 +10,7 @@ import {
   MapContextLayerModel,
   MapContextLayerTypeEnum,
   MapContextModel,
+  MapManagerService,
   MapStyleService,
   MapUtilsService,
 } from '@geonetwork-ui/feature/map'
@@ -122,6 +123,7 @@ export class DataViewMapComponent implements OnInit, OnDestroy {
 
   constructor(
     private mdViewFacade: MdViewFacade,
+    private mapManager: MapManagerService,
     private mapUtils: MapUtilsService,
     private dataService: DataService,
     private proxy: ProxyService,
@@ -135,6 +137,7 @@ export class DataViewMapComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    this.mapUtils.prioritizePageScroll(this.mapManager.map.getInteractions())
     this.selectionStyle = this.styleService.styles.defaultHL
     this.featureInfo.handleFeatureInfo()
     this.subscription.add(


### PR DESCRIPTION
PR removes rotate interactions in `prioritizePageScroll`, which are more disturbing than useful in the current use cases.

The `prioritizePageScroll` input has been removed from `map-context.component` and is now called directly from `data-view-map`