### PR TITLE
Map: Raise delay for displaying map muted message

### DIFF
--- a/libs/ui/map/src/lib/components/map/map.component.spec.ts
+++ b/libs/ui/map/src/lib/components/map/map.component.spec.ts
@@ -82,7 +82,7 @@ describe('MapComponent', () => {
       })
       it('mapmuted event displays message after 300ms (delay for eventually hiding message)', fakeAsync(() => {
         mapmutedCallback()
-        tick(300)
+        tick(400)
         expect(messageDisplayed).toEqual(true)
         discardPeriodicTasks()
       }))

--- a/libs/ui/map/src/lib/components/map/map.component.ts
+++ b/libs/ui/map/src/lib/components/map/map.component.ts
@@ -43,7 +43,7 @@ export class MapComponent implements OnInit, AfterViewInit {
           ? timer(2000).pipe(
               map(() => false),
               startWith(true),
-              delay(300)
+              delay(400)
             )
           : of(false)
       )


### PR DESCRIPTION
... for better distinguishing singleClick from drag.

This should ensure that the message overlay does not "flash" briefly on a singleClick, which has been observed in particular on mobile.