### PR TITLE
Elasticsearch: Exclude map resourceTypes

### DIFF
--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -88,6 +88,16 @@ describe('ElasticsearchService', () => {
               },
             },
             {
+              terms: {
+                resourceType: [
+                  'dataset',
+                  'series',
+                  'publication',
+                  'nonGeographicDataset',
+                ],
+              },
+            },
+            {
               query_string: {
                 default_operator: 'AND',
                 fields: [
@@ -107,11 +117,6 @@ describe('ElasticsearchService', () => {
               },
             },
           ],
-          must_not: {
-            terms: {
-              resourceType: ['service', 'featureCatalog'],
-            },
-          },
         },
       })
     })
@@ -134,6 +139,16 @@ describe('ElasticsearchService', () => {
             {
               terms: {
                 isTemplate: ['n'],
+              },
+            },
+            {
+              terms: {
+                resourceType: [
+                  'dataset',
+                  'series',
+                  'publication',
+                  'nonGeographicDataset',
+                ],
               },
             },
             {
@@ -161,11 +176,6 @@ describe('ElasticsearchService', () => {
               },
             },
           ],
-          must_not: {
-            terms: {
-              resourceType: ['service', 'featureCatalog'],
-            },
-          },
         },
       })
     })
@@ -181,7 +191,7 @@ describe('ElasticsearchService', () => {
         )
       })
       it('escapes special char', () => {
-        expect(query.bool.must[1].query_string.query).toEqual(
+        expect(query.bool.must[2].query_string.query).toEqual(
           `scot \\(\\)\\{\\?\\[ \\/ test`
         )
       })
@@ -232,6 +242,16 @@ describe('ElasticsearchService', () => {
                 },
               },
               {
+                terms: {
+                  resourceType: [
+                    'dataset',
+                    'series',
+                    'publication',
+                    'nonGeographicDataset',
+                  ],
+                },
+              },
+              {
                 query_string: {
                   default_operator: 'AND',
                   fields: [
@@ -251,11 +271,6 @@ describe('ElasticsearchService', () => {
                 },
               },
             ],
-            must_not: {
-              terms: {
-                resourceType: ['service', 'featureCatalog'],
-              },
-            },
             should: [
               {
                 geo_shape: {
@@ -340,6 +355,16 @@ describe('ElasticsearchService', () => {
                   },
                 },
                 {
+                  terms: {
+                    resourceType: [
+                      'dataset',
+                      'series',
+                      'publication',
+                      'nonGeographicDataset',
+                    ],
+                  },
+                },
+                {
                   multi_match: {
                     fields: [
                       'resourceTitleObject.langfre',
@@ -352,11 +377,6 @@ describe('ElasticsearchService', () => {
                   },
                 },
               ],
-              must_not: {
-                terms: {
-                  resourceType: ['service', 'featureCatalog'],
-                },
-              },
             },
           },
           from: 0,

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -126,18 +126,17 @@ export class ElasticsearchService {
     geometry?: Geometry
   ) {
     const queryFilters = this.stateFiltersToQueryString(fieldSearchFilters)
-    const must = [this.queryFilterOnValues('isTemplate', 'n')] as Record<
-      string,
-      unknown
-    >[]
+    const must = [
+      this.queryFilterOnValues('isTemplate', 'n'),
+      this.queryFilterOnValues('resourceType', [
+        'dataset',
+        'series',
+        'publication',
+        'nonGeographicDataset',
+      ]),
+    ] as Record<string, unknown>[]
     const should = [] as Record<string, unknown>[]
     const filter = this.buildPayloadFilter(configFilters)
-    const must_not = {
-      ...this.queryFilterOnValues('resourceType', [
-        'service',
-        'featureCatalog',
-      ]),
-    }
 
     if (any) {
       must.push({
@@ -188,7 +187,6 @@ export class ElasticsearchService {
     return {
       bool: {
         must,
-        must_not,
         should,
         filter,
       },
@@ -242,6 +240,12 @@ export class ElasticsearchService {
         bool: {
           must: [
             this.queryFilterOnValues('isTemplate', 'n'),
+            this.queryFilterOnValues('resourceType', [
+              'dataset',
+              'series',
+              'publication',
+              'nonGeographicDataset',
+            ]),
             {
               multi_match: {
                 query,
@@ -258,12 +262,6 @@ export class ElasticsearchService {
               },
             },
           ],
-          must_not: {
-            ...this.queryFilterOnValues('resourceType', [
-              'service',
-              'featureCatalog',
-            ]),
-          },
         },
       },
       _source: ['resourceTitleObject', 'uuid'],

--- a/tailwind.base.config.js
+++ b/tailwind.base.config.js
@@ -64,6 +64,9 @@ module.exports = {
       opacity: {
         45: 0.45,
       },
+      boxShadow: {
+        'xl-hover': '0 20px 25px -5px rgb(0 0 0 / 0.2)',
+      },
     },
   },
   plugins: [require('@tailwindcss/line-clamp')],


### PR DESCRIPTION
PR excludes map `resourceTypes` from search and autocomplete. Also, inverses the blacklist to a whitelist, as there are now more `resourceTypes` values excluded than included.

Thus, the following `resourceTypes` are now included:
- `dataset`
- `series`
- `publication`
- `nonGeographicDataset`

The `resourceTypes` NOT included are:
- `map`
- `map/static`
- `mapDigital`
- `service`
- `featureCatalog`