### PR TITLE
Datahub: Boost results with intersecting geom

### DIFF
--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -211,7 +211,7 @@ describe('ElasticsearchService', () => {
           type: 'Polygon',
         }
       })
-      it('adds a criteria for intersecting with it and boosting on geoms within', () => {
+      it('adds boosting of 7 for intersecting with it and boosting of 10 on geoms within', () => {
         const query = service['buildPayloadQuery'](
           {
             Org: {
@@ -225,16 +225,7 @@ describe('ElasticsearchService', () => {
         )
         expect(query).toEqual({
           bool: {
-            filter: [
-              {
-                geo_shape: {
-                  geom: {
-                    shape: geojsonPolygon,
-                    relation: 'intersects',
-                  },
-                },
-              },
-            ],
+            filter: [],
             must: [
               {
                 terms: {
@@ -279,6 +270,15 @@ describe('ElasticsearchService', () => {
                     relation: 'within',
                   },
                   boost: 10.0,
+                },
+              },
+              {
+                geo_shape: {
+                  geom: {
+                    shape: geojsonPolygon,
+                    relation: 'intersects',
+                  },
+                  boost: 7.0,
                 },
               },
             ],

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -165,23 +165,26 @@ export class ElasticsearchService {
       })
     }
     if (geometry) {
-      should.push({
-        geo_shape: {
-          geom: {
-            shape: geometry,
-            relation: 'within',
-          },
-          boost: 10.0,
-        },
-      })
-      filter.push({
-        geo_shape: {
-          geom: {
-            shape: geometry,
-            relation: 'intersects',
+      should.push(
+        {
+          geo_shape: {
+            geom: {
+              shape: geometry,
+              relation: 'within',
+            },
+            boost: 10.0,
           },
         },
-      })
+        {
+          geo_shape: {
+            geom: {
+              shape: geometry,
+              relation: 'intersects',
+            },
+            boost: 7.0,
+          },
+        }
+      )
     }
 
     return {


### PR DESCRIPTION
PR boosts results with an intersecting geom with a value of `7` and includes also results without intersecting geom instead of excluding them.

Results with geo boost active are thus ordered as follows :
- `within`: boost `10`
- `intersects`: boost `7`
- not intersecting