### PR TITLE
Elasticsearch: Invert `recourceType` exclusion whitelist to blacklist

### DIFF
--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -109,13 +109,7 @@ describe('ElasticsearchService', () => {
           ],
           must_not: {
             terms: {
-              resourceType: [
-                'service',
-                'featureCatalog',
-                'map',
-                'map/static',
-                'mapDigital',
-              ],
+              resourceType: ['service', 'map', 'map/static', 'mapDigital'],
             },
           },
         },
@@ -169,13 +163,7 @@ describe('ElasticsearchService', () => {
           ],
           must_not: {
             terms: {
-              resourceType: [
-                'service',
-                'featureCatalog',
-                'map',
-                'map/static',
-                'mapDigital',
-              ],
+              resourceType: ['service', 'map', 'map/static', 'mapDigital'],
             },
           },
         },
@@ -256,13 +244,7 @@ describe('ElasticsearchService', () => {
             ],
             must_not: {
               terms: {
-                resourceType: [
-                  'service',
-                  'featureCatalog',
-                  'map',
-                  'map/static',
-                  'mapDigital',
-                ],
+                resourceType: ['service', 'map', 'map/static', 'mapDigital'],
               },
             },
             should: [
@@ -372,13 +354,7 @@ describe('ElasticsearchService', () => {
               ],
               must_not: {
                 terms: {
-                  resourceType: [
-                    'service',
-                    'featureCatalog',
-                    'map',
-                    'map/static',
-                    'mapDigital',
-                  ],
+                  resourceType: ['service', 'map', 'map/static', 'mapDigital'],
                 },
               },
             },

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -88,16 +88,6 @@ describe('ElasticsearchService', () => {
               },
             },
             {
-              terms: {
-                resourceType: [
-                  'dataset',
-                  'series',
-                  'publication',
-                  'nonGeographicDataset',
-                ],
-              },
-            },
-            {
               query_string: {
                 default_operator: 'AND',
                 fields: [
@@ -117,6 +107,17 @@ describe('ElasticsearchService', () => {
               },
             },
           ],
+          must_not: {
+            terms: {
+              resourceType: [
+                'service',
+                'featureCatalog',
+                'map',
+                'map/static',
+                'mapDigital',
+              ],
+            },
+          },
         },
       })
     })
@@ -139,16 +140,6 @@ describe('ElasticsearchService', () => {
             {
               terms: {
                 isTemplate: ['n'],
-              },
-            },
-            {
-              terms: {
-                resourceType: [
-                  'dataset',
-                  'series',
-                  'publication',
-                  'nonGeographicDataset',
-                ],
               },
             },
             {
@@ -176,6 +167,17 @@ describe('ElasticsearchService', () => {
               },
             },
           ],
+          must_not: {
+            terms: {
+              resourceType: [
+                'service',
+                'featureCatalog',
+                'map',
+                'map/static',
+                'mapDigital',
+              ],
+            },
+          },
         },
       })
     })
@@ -191,7 +193,7 @@ describe('ElasticsearchService', () => {
         )
       })
       it('escapes special char', () => {
-        expect(query.bool.must[2].query_string.query).toEqual(
+        expect(query.bool.must[1].query_string.query).toEqual(
           `scot \\(\\)\\{\\?\\[ \\/ test`
         )
       })
@@ -233,16 +235,6 @@ describe('ElasticsearchService', () => {
                 },
               },
               {
-                terms: {
-                  resourceType: [
-                    'dataset',
-                    'series',
-                    'publication',
-                    'nonGeographicDataset',
-                  ],
-                },
-              },
-              {
                 query_string: {
                   default_operator: 'AND',
                   fields: [
@@ -262,6 +254,17 @@ describe('ElasticsearchService', () => {
                 },
               },
             ],
+            must_not: {
+              terms: {
+                resourceType: [
+                  'service',
+                  'featureCatalog',
+                  'map',
+                  'map/static',
+                  'mapDigital',
+                ],
+              },
+            },
             should: [
               {
                 geo_shape: {
@@ -355,16 +358,6 @@ describe('ElasticsearchService', () => {
                   },
                 },
                 {
-                  terms: {
-                    resourceType: [
-                      'dataset',
-                      'series',
-                      'publication',
-                      'nonGeographicDataset',
-                    ],
-                  },
-                },
-                {
                   multi_match: {
                     fields: [
                       'resourceTitleObject.langfre',
@@ -377,6 +370,17 @@ describe('ElasticsearchService', () => {
                   },
                 },
               ],
+              must_not: {
+                terms: {
+                  resourceType: [
+                    'service',
+                    'featureCatalog',
+                    'map',
+                    'map/static',
+                    'mapDigital',
+                  ],
+                },
+              },
             },
           },
           from: 0,

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -133,7 +133,6 @@ export class ElasticsearchService {
     const must_not = {
       ...this.queryFilterOnValues('resourceType', [
         'service',
-        'featureCatalog',
         'map',
         'map/static',
         'mapDigital',
@@ -267,7 +266,6 @@ export class ElasticsearchService {
           must_not: {
             ...this.queryFilterOnValues('resourceType', [
               'service',
-              'featureCatalog',
               'map',
               'map/static',
               'mapDigital',

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -126,15 +126,19 @@ export class ElasticsearchService {
     geometry?: Geometry
   ) {
     const queryFilters = this.stateFiltersToQueryString(fieldSearchFilters)
-    const must = [
-      this.queryFilterOnValues('isTemplate', 'n'),
-      this.queryFilterOnValues('resourceType', [
-        'dataset',
-        'series',
-        'publication',
-        'nonGeographicDataset',
+    const must = [this.queryFilterOnValues('isTemplate', 'n')] as Record<
+      string,
+      unknown
+    >[]
+    const must_not = {
+      ...this.queryFilterOnValues('resourceType', [
+        'service',
+        'featureCatalog',
+        'map',
+        'map/static',
+        'mapDigital',
       ]),
-    ] as Record<string, unknown>[]
+    }
     const should = [] as Record<string, unknown>[]
     const filter = this.buildPayloadFilter(configFilters)
 
@@ -190,6 +194,7 @@ export class ElasticsearchService {
     return {
       bool: {
         must,
+        must_not,
         should,
         filter,
       },
@@ -243,12 +248,6 @@ export class ElasticsearchService {
         bool: {
           must: [
             this.queryFilterOnValues('isTemplate', 'n'),
-            this.queryFilterOnValues('resourceType', [
-              'dataset',
-              'series',
-              'publication',
-              'nonGeographicDataset',
-            ]),
             {
               multi_match: {
                 query,
@@ -265,6 +264,15 @@ export class ElasticsearchService {
               },
             },
           ],
+          must_not: {
+            ...this.queryFilterOnValues('resourceType', [
+              'service',
+              'featureCatalog',
+              'map',
+              'map/static',
+              'mapDigital',
+            ]),
+          },
         },
       },
       _source: ['resourceTitleObject', 'uuid'],


### PR DESCRIPTION
PR inverts `recourceType` exclusion whitelist to blacklist (to include records without `resourceType`) and removes exclusion for `recourceType` `featureCatalog`.

Thus, the following `resourceTypes` are now included:
- `dataset`
- `series`
- `publication`
- `nonGeographicDataset`
- `featureCatalog`
- `null`

The `resourceTypes` NOT included are:
- `map`
- `map/static`
- `mapDigital`
- `service`
