### PR TITLE
Elasticsearch: Also add empty array of uuids to search query

### DIFF
--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.spec.ts
@@ -169,6 +169,60 @@ describe('ElasticsearchService', () => {
         },
       })
     })
+    it('add any and other fields query_strings and limit search payload by ids (also if id array is empty)', () => {
+      const query = service['buildPayloadQuery'](
+        {
+          Org: {
+            world: true,
+          },
+          any: 'hello',
+        },
+        {},
+        []
+      )
+      expect(query).toEqual({
+        bool: {
+          filter: [],
+          should: [],
+          must: [
+            {
+              terms: {
+                isTemplate: ['n'],
+              },
+            },
+            {
+              query_string: {
+                default_operator: 'AND',
+                fields: [
+                  'resourceTitleObject.langfre^5',
+                  'tag.langfre^4',
+                  'resourceAbstractObject.langfre^3',
+                  'lineageObject.langfre^2',
+                  'any.langfre',
+                  'uuid',
+                ],
+                query: 'hello',
+              },
+            },
+            {
+              query_string: {
+                query: '(Org:"world")',
+              },
+            },
+            {
+              ids: {
+                values: [],
+              },
+            },
+          ],
+          must_not: {
+            terms: {
+              resourceType: ['service', 'map', 'map/static', 'mapDigital'],
+            },
+          },
+        },
+      })
+    })
     describe('any has special characters', () => {
       let query
       beforeEach(() => {

--- a/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
+++ b/libs/util/shared/src/lib/elasticsearch/elasticsearch.service.ts
@@ -160,7 +160,7 @@ export class ElasticsearchService {
         },
       })
     }
-    if (uuids?.length > 0) {
+    if (uuids) {
       must.push({
         ids: {
           values: uuids,


### PR DESCRIPTION
PR also adds the `uuid` to the payload if it is an empty array, which is necessary when the favorite filter is active, but no favorites are present (to return 0 results, instead of all).