### PR TITLE
Datahub / add error handling when loading a WMTS layer on the map

### DIFF
--- a/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
@@ -9,12 +9,12 @@ import Map from 'ol/Map'
 import ImageWMS from 'ol/source/ImageWMS'
 import TileWMS from 'ol/source/TileWMS'
 import XYZ from 'ol/source/XYZ'
+import { Options } from 'ol/source/WMTS'
 import { of } from 'rxjs'
 import { MapUtilsWMSService } from './map-utils-wms.service'
-
 import {
-  MapUtilsService,
   dragPanCondition,
+  MapUtilsService,
   mouseWheelZoomCondition,
 } from './map-utils.service'
 import { readFirst } from '@nrwl/angular/testing'
@@ -25,6 +25,7 @@ import {
   MouseWheelZoom,
   PinchRotate,
 } from 'ol/interaction'
+import { MetadataLinkType } from '@geonetwork-ui/util/shared'
 
 const wmsUtilsMock = {
   getLayerLonLatBBox: jest.fn(() => of([1.33, 48.81, 4.3, 51.1])),
@@ -224,7 +225,8 @@ describe('MapUtilsService', () => {
       })
     })
   })
-  describe('prioritizePageScroll', () => {
+
+  describe('#prioritizePageScroll', () => {
     const interactions = defaults()
     let dragRotate
     let pinchRotate
@@ -259,6 +261,217 @@ describe('MapUtilsService', () => {
       })
       it('with no PinchRotate interaction', () => {
         expect(pinchRotate).toBeFalsy()
+      })
+    })
+  })
+
+  const SAMPLE_WMTS_LINK = {
+    name: 'GEOGRAPHICALGRIDSYSTEMS.ETATMAJOR10',
+    url: 'http://my.server.org/wmts',
+    type: MetadataLinkType.WMTS,
+  }
+  const SAMPLE_WMTS_CAPABILITIES = `<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd">
+  <ows:OperationsMetadata>
+    <ows:Operation name="GetTile">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="https://wxs.ign.fr/cartes/geoportail/wmts?">
+            <ows:Constraint name="GetEncoding">
+              <ows:AllowedValues>
+                <ows:Value>KVP</ows:Value>
+              </ows:AllowedValues>
+            </ows:Constraint>
+          </ows:Get>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+  </ows:OperationsMetadata>
+  <Contents>
+    <Layer>
+      <ows:Title>Carte de l'état-major - environs de Paris (1818 - 1824)</ows:Title>
+      <ows:Abstract>Carte des environs de Paris au 1 : 10 000 établie entre 1818 et 1824.</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>1.82682 48.3847</ows:LowerCorner>
+        <ows:UpperCorner>2.79738 49.5142</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>GEOGRAPHICALGRIDSYSTEMS.ETATMAJOR10</ows:Identifier>
+      <Format>image/jpeg</Format>
+      <Style isDefault="true">
+        <ows:Title>Légende générique</ows:Title>
+        <ows:Abstract>
+          Fichier de légende générique – pour la compatibilité avec certains systèmes
+        </ows:Abstract>
+        <ows:Identifier>normal</ows:Identifier>
+        <LegendURL format="image/jpeg" height="200" maxScaleDenominator="100000000" minScaleDenominator="200" width="200" xlink:href="https://wxs.ign.fr/static/legends/LEGEND.jpg"/>
+      </Style>
+      <TileMatrixSetLink>
+        <TileMatrixSet>PM</TileMatrixSet>
+        <TileMatrixSetLimits>
+          <TileMatrixLimits>
+            <TileMatrix>6</TileMatrix>
+            <MinTileRow>21</MinTileRow>
+            <MaxTileRow>22</MaxTileRow>
+            <MinTileCol>32</MinTileCol>
+            <MaxTileCol>32</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>7</TileMatrix>
+            <MinTileRow>43</MinTileRow>
+            <MaxTileRow>44</MaxTileRow>
+            <MinTileCol>64</MinTileCol>
+            <MaxTileCol>64</MaxTileCol>
+          </TileMatrixLimits>
+          <TileMatrixLimits>
+            <TileMatrix>8</TileMatrix>
+            <MinTileRow>87</MinTileRow>
+            <MaxTileRow>88</MaxTileRow>
+            <MinTileCol>129</MinTileCol>
+            <MaxTileCol>129</MaxTileCol>
+          </TileMatrixLimits>
+        </TileMatrixSetLimits>
+      </TileMatrixSetLink>
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>PM</ows:Identifier>
+      <ows:SupportedCRS>EPSG:3857</ows:SupportedCRS>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.0287178958533332</ScaleDenominator>
+        <TopLeftCorner>
+          -20037508.3427892476320267 20037508.3427892476320267
+        </TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>279541132.0143588959472254</ScaleDenominator>
+        <TopLeftCorner>
+          -20037508.3427892476320267 20037508.3427892476320267
+        </TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2</MatrixWidth>
+        <MatrixHeight>2</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>2</ows:Identifier>
+        <ScaleDenominator>139770566.0071793960087234</ScaleDenominator>
+        <TopLeftCorner>
+        -20037508.3427892476320267 20037508.3427892476320267
+        </TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4</MatrixWidth>
+        <MatrixHeight>4</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>3</ows:Identifier>
+        <ScaleDenominator>69885283.0035897239868063</ScaleDenominator>
+        <TopLeftCorner>
+          -20037508.3427892476320267 20037508.3427892476320267
+        </TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8</MatrixWidth>
+        <MatrixHeight>8</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>`
+
+  describe('#getWmtsOptionsFromCapabilities', () => {
+    let originalFetch
+    beforeEach(() => {
+      originalFetch = window.fetch
+    })
+    afterEach(() => {
+      window.fetch = originalFetch
+    })
+    describe('nominal', () => {
+      let wmtsOptions: Options
+      beforeEach(async () => {
+        ;(window as any).fetch = jest.fn(() =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            text: () => Promise.resolve(SAMPLE_WMTS_CAPABILITIES),
+          })
+        )
+        wmtsOptions = await readFirst(
+          service.getWmtsOptionsFromCapabilities(SAMPLE_WMTS_LINK)
+        )
+      })
+      it('appends query params to the URL', () => {
+        expect(window.fetch).toHaveBeenCalledWith(
+          'http://my.server.org/wmts?SERVICE=WMTS&REQUEST=GetCapabilities'
+        )
+      })
+      it('returns appropriate WMTS options', () => {
+        expect(wmtsOptions).toMatchObject({
+          format: 'image/jpeg',
+          layer: 'GEOGRAPHICALGRIDSYSTEMS.ETATMAJOR10',
+          matrixSet: 'PM',
+          requestEncoding: 'KVP',
+          style: 'normal',
+          urls: ['https://wxs.ign.fr/cartes/geoportail/wmts?'],
+        })
+      })
+    })
+    describe('http error', () => {
+      let error
+      beforeEach(async () => {
+        ;(window as any).fetch = jest.fn(() =>
+          Promise.resolve({
+            ok: false,
+            status: 403,
+            text: () => `<ExceptionReport xmlns="http://www.opengis.net/ows/1.1">
+<Exception exceptionCode="InvalidParameterValue" >
+  Le service est inconnu pour ce serveur.
+</Exception>
+</ExceptionReport>`,
+          })
+        )
+        try {
+          await readFirst(
+            service.getWmtsOptionsFromCapabilities(SAMPLE_WMTS_LINK)
+          )
+        } catch (e) {
+          error = e
+        }
+      })
+      it('throws an explicit error', () => {
+        expect(error).toBeInstanceOf(Error)
+        expect(error.message).toMatch('request failed')
+      })
+    })
+    describe('parsing error', () => {
+      let error
+      beforeEach(async () => {
+        ;(window as any).fetch = jest.fn(() =>
+          Promise.resolve({
+            ok: true,
+            status: 200,
+            text: () =>
+              Promise.resolve(
+                '{ "response": "This is probably not what you expected!" }'
+              ),
+          })
+        )
+        try {
+          await readFirst(
+            service.getWmtsOptionsFromCapabilities(SAMPLE_WMTS_LINK)
+          )
+        } catch (e) {
+          error = e
+        }
+      })
+      it('throws an explicit error', () => {
+        expect(error).toBeInstanceOf(Error)
+        expect(error.message).toMatch('parsing failed')
       })
     })
   })

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -93,6 +93,7 @@ export class DataViewMapComponent implements OnInit, OnDestroy {
         map((layer) => [layer]),
         catchError((e) => {
           this.error = e.message
+          console.warn(e.stack || e.message)
           return of([])
         }),
         finalize(() => (this.loading = false))

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
@@ -61,6 +61,7 @@ export class DataViewTableComponent {
         ? this.fetchData(link).pipe(
             catchError((error) => {
               this.error = error.message
+              console.warn(error.stack || error.message)
               return of([])
             }),
             finalize(() => {


### PR DESCRIPTION
This makes WMTS layer loading more robust in the record view by handling various errors and making sure that the GetCapabilities request is properly built.

Note that WMTS handling should go in https://github.com/camptocamp/ogc-client eventually to streamline error management, check for CORS, etc.