### PR TITLE
Add smart component for showing data as a chart

### DIFF
--- a/libs/feature/dataviz/src/index.ts
+++ b/libs/feature/dataviz/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/feature-dataviz.module'
+export * from './lib/service/data.service'

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.html
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.html
@@ -1,0 +1,47 @@
+<div class="w-full h-full flex flex-col">
+  <div class="flex flex-row justify-between text-[13px]">
+    <gn-ui-dropdown-selector
+      [choices]="typeChoices"
+      (selectValue)="chartType = $event"
+      title="Type"
+    ></gn-ui-dropdown-selector>
+    <gn-ui-dropdown-selector
+      [choices]="xChoices$ | async"
+      (selectValue)="xProperty$.next($event)"
+      title="X Axis"
+    ></gn-ui-dropdown-selector>
+    <gn-ui-dropdown-selector
+      *ngIf="!isCountAggregation"
+      [choices]="yChoices$ | async"
+      (selectValue)="yProperty$.next($event)"
+      title="Y Axis"
+      class="select-y-prop"
+    ></gn-ui-dropdown-selector>
+    <gn-ui-dropdown-selector
+      [choices]="aggregationChoices"
+      (selectValue)="aggregation$.next($event)"
+      title="Aggregation"
+    ></gn-ui-dropdown-selector>
+  </div>
+  <div class="relative h-full">
+    <gn-ui-chart
+      [data]="chartData$ | async"
+      [type]="chartType"
+      [labelProperty]="labelProperty"
+      [valueProperty]="valueProperty"
+    ></gn-ui-chart>
+    <gn-ui-loading-mask
+      *ngIf="loading"
+      class="absolute inset-0"
+      [message]="'chart.loading.data' | translate"
+    ></gn-ui-loading-mask>
+    <gn-ui-popup-alert
+      *ngIf="error"
+      type="warning"
+      icon="error_outline"
+      class="absolute m-2 inset-0"
+    >
+      <span translate>{{ error }}</span>
+    </gn-ui-popup-alert>
+  </div>
+</div>

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.spec.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.spec.ts
@@ -1,0 +1,268 @@
+import {
+  ComponentFixture,
+  fakeAsync,
+  flushMicrotasks,
+  TestBed,
+  tick,
+} from '@angular/core/testing'
+import { ChartViewComponent } from './chart-view.component'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core'
+import { TranslateModule } from '@ngx-translate/core'
+import { DataService } from '../service/data.service'
+import { of } from 'rxjs'
+import { By } from '@angular/platform-browser'
+import { LINK_FIXTURES } from '@geonetwork-ui/util/shared/fixtures'
+
+@Component({
+  selector: 'gn-ui-chart',
+  template: '<div></div>',
+})
+export class MockChartComponent {
+  @Input() data: object[]
+  @Input() labelProperty: string
+  @Input() valueProperty: string
+  @Input() secondaryValueProperty: string
+  @Input() type: string
+}
+
+@Component({
+  selector: 'gn-ui-dropdown-selector',
+  template: '<div></div>',
+})
+export class MockDropdownSelectorComponent {
+  @Input() choices: unknown[]
+  @Output() selectValue = new EventEmitter<any>()
+}
+
+const SAMPLE_DATA_ITEMS = [
+  { type: 'Feature', properties: { id: 1 } },
+  { type: 'Feature', properties: { id: 2 } },
+]
+const SAMPLE_CHART_DATA = [{ id: 1 }, { id: 2 }]
+
+class DatasetReaderMock {
+  constructor() {
+    DatasetReaderMock.instance = this
+  }
+  public static instance: DatasetReaderMock
+  properties = Promise.resolve([
+    {
+      name: 'propNum1',
+      type: 'number',
+    },
+    {
+      name: 'propStr1',
+      type: 'string',
+    },
+    {
+      name: 'propStr2',
+      type: 'string',
+    },
+    {
+      name: 'propDate1',
+      type: 'date',
+    },
+    {
+      name: 'propNum2',
+      type: 'number',
+    },
+  ])
+  groupBy = jest.fn(() => this)
+  aggregate = jest.fn(() => this)
+  read = jest.fn(() => Promise.resolve(SAMPLE_DATA_ITEMS))
+}
+class DataServiceMock {
+  getDataset = jest.fn(() => of(new DatasetReaderMock()))
+}
+
+describe('ChartViewComponent', () => {
+  let component: ChartViewComponent
+  let fixture: ComponentFixture<ChartViewComponent>
+  let dataService: DataService
+  let chartComponent: MockChartComponent
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        ChartViewComponent,
+        MockDropdownSelectorComponent,
+        MockChartComponent,
+      ],
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        {
+          provide: DataService,
+          useClass: DataServiceMock,
+        },
+      ],
+    })
+      .overrideComponent(ChartViewComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents()
+
+    dataService = TestBed.inject(DataService)
+    fixture = TestBed.createComponent(ChartViewComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+  beforeEach(fakeAsync(() => {
+    component.link = LINK_FIXTURES.dataCsv
+    flushMicrotasks()
+    chartComponent = fixture.debugElement.query(
+      By.directive(MockChartComponent)
+    ).componentInstance
+    fixture.detectChanges()
+  }))
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  describe('initial link input', () => {
+    it('creates a dataset reader once from the link', () => {
+      expect(dataService.getDataset).toHaveBeenCalledTimes(1)
+      expect(dataService.getDataset).toHaveBeenCalledWith(LINK_FIXTURES.dataCsv)
+    })
+    it('choses the first string property for X', () => {
+      expect(chartComponent.labelProperty).toBe('distinct(propStr1)')
+    })
+    it('choses the first numeric property for Y', () => {
+      expect(chartComponent.valueProperty).toBe('sum(propNum1)')
+    })
+    it('reads dataset using sum aggregation, grouped by distinct X values', () => {
+      expect(DatasetReaderMock.instance.groupBy).toHaveBeenCalledWith([
+        'distinct',
+        'propStr1',
+      ])
+      expect(DatasetReaderMock.instance.aggregate).toHaveBeenCalledWith([
+        'sum',
+        'propNum1',
+      ])
+      expect(DatasetReaderMock.instance.read).toHaveBeenCalledTimes(1)
+    })
+    it('renders bar chart', () => {
+      expect(chartComponent.type).toBe('bar')
+      expect(chartComponent.data).toEqual(SAMPLE_CHART_DATA)
+    })
+  })
+
+  describe('when link changes', () => {
+    beforeEach(fakeAsync(() => {
+      jest.clearAllMocks()
+      component.link = { ...LINK_FIXTURES.dataCsv, url: 'http://changed/' }
+      flushMicrotasks()
+    }))
+    it('recreates the dataset reader', () => {
+      expect(dataService.getDataset).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when x property changes', () => {
+    beforeEach(fakeAsync(() => {
+      jest.clearAllMocks()
+      component.xProperty$.next('propStr2')
+      tick(10)
+      flushMicrotasks()
+      fixture.detectChanges()
+    }))
+    it('does not re-create the dataset reader', () => {
+      expect(dataService.getDataset).not.toHaveBeenCalled()
+    })
+    it('reads dataset', () => {
+      expect(DatasetReaderMock.instance.groupBy).toHaveBeenCalledWith([
+        'distinct',
+        'propStr2',
+      ])
+      expect(DatasetReaderMock.instance.read).toHaveBeenCalledTimes(1)
+    })
+    it('uses the new value for X', () => {
+      expect(chartComponent.labelProperty).toBe('distinct(propStr2)')
+    })
+  })
+
+  describe('when y property changes', () => {
+    beforeEach(fakeAsync(() => {
+      jest.clearAllMocks()
+      component.yProperty$.next('propNum2')
+      flushMicrotasks()
+      fixture.detectChanges()
+    }))
+    it('does not re-create the dataset reader', () => {
+      expect(dataService.getDataset).not.toHaveBeenCalled()
+    })
+    it('reads dataset', () => {
+      expect(DatasetReaderMock.instance.aggregate).toHaveBeenCalledWith([
+        'sum',
+        'propNum2',
+      ])
+      expect(DatasetReaderMock.instance.read).toHaveBeenCalledTimes(1)
+    })
+    it('uses the new value for Y', () => {
+      expect(chartComponent.valueProperty).toBe('sum(propNum2)')
+    })
+  })
+
+  describe('when chart type changes', () => {
+    beforeEach(fakeAsync(() => {
+      jest.clearAllMocks()
+      component.chartType = 'line'
+      flushMicrotasks()
+      fixture.detectChanges()
+    }))
+    it('does not re-create the dataset reader', () => {
+      expect(dataService.getDataset).not.toHaveBeenCalled()
+    })
+    it('does not read dataset again', () => {
+      expect(DatasetReaderMock.instance.read).not.toHaveBeenCalled()
+    })
+    it('update chart', () => {
+      expect(chartComponent.type).toBe('line')
+    })
+  })
+
+  describe('when aggregation type changes', () => {
+    beforeEach(fakeAsync(() => {
+      jest.clearAllMocks()
+      component.aggregation$.next('average')
+      flushMicrotasks()
+    }))
+    it('does not re-create the dataset reader', () => {
+      expect(dataService.getDataset).not.toHaveBeenCalled()
+    })
+    it('reads dataset', () => {
+      expect(DatasetReaderMock.instance.aggregate).toHaveBeenCalledWith([
+        'average',
+        'propNum1',
+      ])
+      expect(DatasetReaderMock.instance.read).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('count aggregation', () => {
+    beforeEach(fakeAsync(() => {
+      jest.clearAllMocks()
+      component.aggregation$.next('count')
+      flushMicrotasks()
+      fixture.detectChanges()
+    }))
+    it('reads dataset with count() aggregation', () => {
+      expect(DatasetReaderMock.instance.aggregate).toHaveBeenCalledWith([
+        'count',
+      ])
+      expect(DatasetReaderMock.instance.read).toHaveBeenCalledTimes(1)
+    })
+    it('hides the Y property field', () => {
+      const select = fixture.debugElement.query(By.css('.select-y-prop'))
+      expect(select).toBeFalsy()
+    })
+  })
+})

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.stories.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.stories.ts
@@ -1,0 +1,72 @@
+import { HttpClientModule } from '@angular/common/http'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+import { TRANSLATE_DEFAULT_CONFIG } from '@geonetwork-ui/util/i18n'
+import { TranslateModule } from '@ngx-translate/core'
+import {
+  componentWrapperDecorator,
+  Meta,
+  moduleMetadata,
+  Story,
+} from '@storybook/angular'
+import { ChartViewComponent } from './chart-view.component'
+import { ChartComponent, UiDatavizModule } from '@geonetwork-ui/ui/dataviz'
+import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
+import { MetadataLinkType } from '@geonetwork-ui/util/shared'
+
+export default {
+  title: 'Smart/Dataviz/ChartView',
+  component: ChartViewComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        ChartComponent,
+        HttpClientModule,
+        UiDatavizModule,
+        UiWidgetsModule,
+        BrowserAnimationsModule,
+        TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
+      ],
+    }),
+    componentWrapperDecorator(
+      (story) =>
+        `<div class="border border-gray-300 h-[500px] w-[800px] p-[10px]" style="resize: both; overflow: auto">${story}</div>`
+    ),
+  ],
+} as Meta<ChartViewComponent>
+
+const LINKS = {
+  wfs: {
+    description: 'US states',
+    name: 'topp:states',
+    url: 'https://ahocevar.com/geoserver/wfs?service=WFS&version=1.1.0&request=GetCapabilities',
+    type: MetadataLinkType.WFS,
+  },
+  csv: {
+    description: 'France departments',
+    url: 'https://www.data.gouv.fr/fr/datasets/r/70cef74f-70b1-495a-8500-c089229c0254',
+    type: MetadataLinkType.DOWNLOAD,
+  },
+}
+
+type ChartViewComponentInputs = {
+  link: string
+}
+
+const Template: Story<ChartViewComponentInputs> = (
+  args: ChartViewComponentInputs
+) => ({
+  component: ChartViewComponent,
+  props: {
+    link: LINKS[args.link],
+  },
+})
+export const Primary = Template.bind({})
+Primary.args = {
+  link: 'wfs',
+}
+Primary.argTypes = {
+  link: {
+    control: 'radio',
+    options: Object.keys(LINKS),
+  },
+}

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.ts
@@ -1,0 +1,133 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
+import { MetadataLink } from '@geonetwork-ui/util/shared'
+import { BehaviorSubject, combineLatest, EMPTY, Observable } from 'rxjs'
+import {
+  catchError,
+  distinctUntilChanged,
+  filter,
+  finalize,
+  map,
+  shareReplay,
+  startWith,
+  switchMap,
+  tap,
+} from 'rxjs/operators'
+import { InputChartType } from '@geonetwork-ui/ui/dataviz'
+import { DataService } from '../service/data.service'
+import {
+  BaseReader,
+  FieldAggregation,
+  getJsonDataItemsProxy,
+} from '@geonetwork-ui/data-fetcher'
+
+@Component({
+  selector: 'gn-ui-chart-view',
+  templateUrl: './chart-view.component.html',
+  styleUrls: ['./chart-view.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ChartViewComponent {
+  @Input() set link(value: MetadataLink) {
+    this.currentLink$.next(value)
+  }
+  private currentLink$ = new BehaviorSubject<MetadataLink>(null)
+
+  loading = false
+  error = null
+
+  typeChoices = [
+    { label: 'bar chart', value: 'bar' },
+    { label: 'bar chart (horizontal)', value: 'bar-horizontal' },
+    { label: 'line chart', value: 'line' },
+    { label: 'smooth line', value: 'line-interpolated' },
+    { label: 'pie chart', value: 'pie' },
+  ] as const
+  aggregationChoices = [
+    { label: 'sum', value: 'sum' },
+    { label: 'max', value: 'max' },
+    { label: 'min', value: 'min' },
+    { label: 'average', value: 'average' },
+    { label: 'count', value: 'count' },
+  ] as const
+
+  dataset$: Observable<BaseReader> = this.currentLink$.pipe(
+    filter((link) => !!link),
+    switchMap((link) => {
+      this.error = null
+      this.loading = true
+      return this.dataService.getDataset(link).pipe(
+        catchError((error) => {
+          this.error = error.message
+          console.warn(error.stack || error.message)
+          return EMPTY
+        }),
+        finalize(() => {
+          this.loading = false
+        })
+      )
+    }),
+    shareReplay(1)
+  )
+  yChoices$ = this.dataset$.pipe(
+    switchMap((dataset) => dataset.properties),
+    map((properties) =>
+      properties
+        .filter((prop) => prop.type === 'number' || prop.type === 'date')
+        .map((prop) => ({ value: prop.name, label: prop.label || prop.name }))
+    ),
+    tap((choices) => {
+      if (!choices.find((choice) => choice.value === this.yProperty$.value)) {
+        this.yProperty$.next(choices[0].value)
+      }
+    })
+  )
+  xChoices$ = this.dataset$.pipe(
+    switchMap((dataset) => dataset.properties),
+    map((properties) =>
+      properties
+        .filter((prop) => prop.type === 'string')
+        .map((prop) => ({
+          value: prop.name,
+          label: prop.label || prop.name,
+        }))
+    ),
+    tap((choices) => {
+      if (!choices.find((choice) => choice.value === this.xProperty$.value)) {
+        this.xProperty$.next(choices[0].value)
+      }
+    })
+  )
+  chartType: InputChartType = 'bar'
+  xProperty$ = new BehaviorSubject<string>('')
+  yProperty$ = new BehaviorSubject<string>('')
+  aggregation$ = new BehaviorSubject<FieldAggregation[0]>('sum')
+
+  chartData$ = combineLatest([
+    this.dataset$,
+    this.xProperty$.pipe(filter((value) => !!value)),
+    this.yProperty$.pipe(filter((value) => !!value)),
+    this.aggregation$,
+  ]).pipe(
+    switchMap(([dataset, xProp, yProp, aggregation]) => {
+      const fieldAgg: FieldAggregation =
+        aggregation === 'count' ? ['count'] : [aggregation, yProp]
+      return dataset.groupBy(['distinct', xProp]).aggregate(fieldAgg).read()
+    }),
+    map(getJsonDataItemsProxy),
+    startWith([]),
+    shareReplay(1)
+  )
+
+  get labelProperty() {
+    return `distinct(${this.xProperty$.value})`
+  }
+  get valueProperty() {
+    if (this.isCountAggregation) return 'count()'
+    return `${this.aggregation$.value}(${this.yProperty$.value})`
+  }
+  get isCountAggregation() {
+    return this.aggregation$.value === 'count'
+  }
+
+  constructor(private dataService: DataService) {}
+}

--- a/libs/feature/dataviz/src/lib/feature-dataviz.module.ts
+++ b/libs/feature/dataviz/src/lib/feature-dataviz.module.ts
@@ -4,12 +4,16 @@ import { FeatureMapModule } from '@geonetwork-ui/feature/map'
 import { UiMapModule } from '@geonetwork-ui/ui/map'
 import { GeoTableViewComponent } from './geo-table-view/geo-table-view.component'
 import { FigureContainerComponent } from './figure/figure-container/figure-container.component'
-import { TableComponent, UiDatavizModule } from '@geonetwork-ui/ui/dataviz'
+import {
+  ChartComponent,
+  TableComponent,
+  UiDatavizModule,
+} from '@geonetwork-ui/ui/dataviz'
 import { TableViewComponent } from './table-view/table-view.component'
 import { ChartViewComponent } from './chart-view/chart-view.component'
-import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
 import { TranslateModule } from '@ngx-translate/core'
 import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
+import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
 
 @NgModule({
   imports: [
@@ -20,6 +24,8 @@ import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
     TableComponent,
     UiWidgetsModule,
     TranslateModule,
+    ChartComponent,
+    UiInputsModule,
   ],
   declarations: [
     GeoTableViewComponent,

--- a/libs/feature/dataviz/src/lib/feature-dataviz.module.ts
+++ b/libs/feature/dataviz/src/lib/feature-dataviz.module.ts
@@ -5,6 +5,11 @@ import { UiMapModule } from '@geonetwork-ui/ui/map'
 import { GeoTableViewComponent } from './geo-table-view/geo-table-view.component'
 import { FigureContainerComponent } from './figure/figure-container/figure-container.component'
 import { TableComponent, UiDatavizModule } from '@geonetwork-ui/ui/dataviz'
+import { TableViewComponent } from './table-view/table-view.component'
+import { ChartViewComponent } from './chart-view/chart-view.component'
+import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
+import { TranslateModule } from '@ngx-translate/core'
+import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
 
 @NgModule({
   imports: [
@@ -13,8 +18,15 @@ import { TableComponent, UiDatavizModule } from '@geonetwork-ui/ui/dataviz'
     UiMapModule,
     UiDatavizModule,
     TableComponent,
+    UiWidgetsModule,
+    TranslateModule,
   ],
-  declarations: [GeoTableViewComponent, FigureContainerComponent],
+  declarations: [
+    GeoTableViewComponent,
+    FigureContainerComponent,
+    TableViewComponent,
+    ChartViewComponent,
+  ],
   exports: [GeoTableViewComponent, FigureContainerComponent],
 })
 export class FeatureDatavizModule {}

--- a/libs/feature/dataviz/src/lib/feature-dataviz.module.ts
+++ b/libs/feature/dataviz/src/lib/feature-dataviz.module.ts
@@ -33,6 +33,10 @@ import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
     TableViewComponent,
     ChartViewComponent,
   ],
-  exports: [GeoTableViewComponent, FigureContainerComponent],
+  exports: [
+    GeoTableViewComponent,
+    FigureContainerComponent,
+    TableViewComponent,
+  ],
 })
 export class FeatureDatavizModule {}

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -433,11 +433,11 @@ describe('DataService', () => {
             'csv'
           )
         })
-        it('returns an observable that emits the feature collection', async () => {
+        it('returns an observable that emits the array of features', async () => {
           const result = await readFirst(
             service.readDataset('http://sample/csv', 'csv')
           )
-          expect(result).toEqual(SAMPLE_GEOJSON)
+          expect(result).toEqual(SAMPLE_GEOJSON.features)
         })
       })
     })

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@angular/core'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import { WfsEndpoint } from '@camptocamp/ogc-client'
-import { readDataset, SupportedType } from '@geonetwork-ui/data-fetcher'
+import {
+  DataItem,
+  readDataset,
+  SupportedType,
+} from '@geonetwork-ui/data-fetcher'
 import {
   extensionToFormat,
   getMimeTypeForFormat,
@@ -125,10 +129,7 @@ export class DataService {
     }))
   }
 
-  readDataset(
-    url: string,
-    typeHint?: SupportedType
-  ): Observable<FeatureCollection> {
+  readDataset(url: string, typeHint?: SupportedType): Observable<DataItem[]> {
     const proxiedUrl = this.proxy.getProxiedUrl(url)
     return from(readDataset(proxiedUrl, typeHint)).pipe(
       catchError((error) => {
@@ -141,15 +142,16 @@ export class DataService {
         } else {
           return throwError(new Error('dataset.error.unknown'))
         }
-      }),
+      })
+    )
+  }
+
+  readGeoJsonDataset(url: string): Observable<FeatureCollection> {
+    return this.readDataset(url, 'geojson').pipe(
       map((features) => ({
         type: 'FeatureCollection',
         features,
       }))
     )
-  }
-
-  readGeoJsonDataset(url: string): Observable<FeatureCollection> {
-    return this.readDataset(url, 'geojson')
   }
 }

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -2,19 +2,23 @@ import { Injectable } from '@angular/core'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import { WfsEndpoint } from '@camptocamp/ogc-client'
 import {
-  DataItem,
-  readDataset,
+  BaseReader,
+  FetchError,
+  openDataset,
   SupportedType,
+  SupportedTypes,
 } from '@geonetwork-ui/data-fetcher'
 import {
   extensionToFormat,
+  getFileFormat,
   getMimeTypeForFormat,
   MetadataLink,
+  MetadataLinkType,
   ProxyService,
 } from '@geonetwork-ui/util/shared'
 import type { FeatureCollection } from 'geojson'
 import { from, Observable, throwError } from 'rxjs'
-import { catchError, map, tap } from 'rxjs/operators'
+import { catchError, map, switchMap, tap } from 'rxjs/operators'
 
 marker('wfs.unreachable.cors')
 marker('wfs.unreachable.http')
@@ -84,7 +88,7 @@ export class DataService {
     )
   }
 
-  getGeoJsonDownloadUrlFromWfs(
+  private getGeoJsonDownloadUrlFromWfs(
     wfsUrl: string,
     featureType: string
   ): Observable<string> {
@@ -102,10 +106,6 @@ export class DataService {
     return this.proxy.getProxiedUrl(
       `${apiUrl}/query?f=${format}&where=1=1&outFields=*`
     )
-  }
-
-  getGeoJsonDownloadUrlFromEsriRest(apiUrl: string): string {
-    return this.getDownloadUrlFromEsriRest(apiUrl, 'geojson')
   }
 
   getDownloadLinksFromWfs(wfsLink: MetadataLink): Observable<MetadataLink[]> {
@@ -129,29 +129,51 @@ export class DataService {
     }))
   }
 
-  readDataset(url: string, typeHint?: SupportedType): Observable<DataItem[]> {
-    const proxiedUrl = this.proxy.getProxiedUrl(url)
-    return from(readDataset(proxiedUrl, typeHint)).pipe(
-      catchError((error) => {
-        if (error.isCrossOriginOrNetworkRelated) {
-          return throwError(new Error('dataset.error.network'))
-        } else if (error.httpStatus) {
-          return throwError(new Error('dataset.error.http'))
-        } else if (error.parsingFailed) {
-          return throwError(new Error('dataset.error.parse'))
-        } else {
-          return throwError(new Error('dataset.error.unknown'))
-        }
-      })
-    )
+  private interpretError(error: FetchError) {
+    if (error.isCrossOriginOrNetworkRelated) {
+      return throwError(new Error('dataset.error.network'))
+    } else if (error.httpStatus) {
+      return throwError(new Error('dataset.error.http'))
+    } else if (error.parsingFailed) {
+      return throwError(new Error('dataset.error.parse'))
+    } else {
+      return throwError(new Error('dataset.error.unknown'))
+    }
   }
 
-  readGeoJsonDataset(url: string): Observable<FeatureCollection> {
-    return this.readDataset(url, 'geojson').pipe(
+  readAsGeoJson(link: MetadataLink): Observable<FeatureCollection> {
+    return this.getDataset(link).pipe(
+      catchError(this.interpretError),
+      switchMap((dataset) => dataset.selectAll().read()),
       map((features) => ({
         type: 'FeatureCollection',
         features,
       }))
     )
+  }
+
+  getDataset(link: MetadataLink): Observable<BaseReader> {
+    const linkUrl = this.proxy.getProxiedUrl(link.url)
+    if (link.type === MetadataLinkType.WFS) {
+      return this.getGeoJsonDownloadUrlFromWfs(linkUrl, link.name).pipe(
+        switchMap((url) => openDataset(url, 'geojson')),
+        catchError(this.interpretError)
+      )
+    } else if (link.type === MetadataLinkType.DOWNLOAD) {
+      const format = getFileFormat(link)
+      const supportedType =
+        SupportedTypes.indexOf(format as any) > -1
+          ? (format as SupportedType)
+          : undefined
+      return from(openDataset(linkUrl, supportedType)).pipe(
+        catchError(this.interpretError)
+      )
+    } else if (link.type === MetadataLinkType.ESRI_REST) {
+      const url = this.getDownloadUrlFromEsriRest(linkUrl, 'geojson')
+      return from(openDataset(url, 'geojson')).pipe(
+        catchError(this.interpretError)
+      )
+    }
+    return throwError('protocol not supported')
   }
 }

--- a/libs/feature/dataviz/src/lib/table-view/table-view.component.html
+++ b/libs/feature/dataviz/src/lib/table-view/table-view.component.html
@@ -1,0 +1,22 @@
+<div class="w-full h-full flex flex-col">
+  <div class="relative h-full">
+    <gn-ui-table
+      class="overflow-auto grow"
+      [data]="tableData$ | async"
+      (selected)="onTableSelect($event)"
+    ></gn-ui-table>
+    <gn-ui-loading-mask
+      *ngIf="loading"
+      class="absolute inset-0"
+      [message]="'table.loading.data' | translate"
+    ></gn-ui-loading-mask>
+    <gn-ui-popup-alert
+      *ngIf="error"
+      type="warning"
+      icon="error_outline"
+      class="absolute m-2 inset-0"
+    >
+      <span translate>{{ error }}</span>
+    </gn-ui-popup-alert>
+  </div>
+</div>

--- a/libs/feature/dataviz/src/lib/table-view/table-view.component.spec.ts
+++ b/libs/feature/dataviz/src/lib/table-view/table-view.component.spec.ts
@@ -1,0 +1,187 @@
+import {
+  ComponentFixture,
+  discardPeriodicTasks,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing'
+import { TableViewComponent } from './table-view.component'
+import { MetadataLinkType } from '@geonetwork-ui/util/shared'
+import { of, throwError } from 'rxjs'
+import { delay } from 'rxjs/operators'
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core'
+import { TranslateModule } from '@ngx-translate/core'
+import { By } from '@angular/platform-browser'
+import { DataService } from '../service/data.service'
+import { LINK_FIXTURES } from '@geonetwork-ui/util/shared/fixtures'
+
+const SAMPLE_GEOJSON = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      id: 123,
+      properties: {
+        test: 'abcd',
+      },
+      geometry: {},
+    },
+  ],
+}
+
+class DataServiceMock {
+  getGeoJsonDownloadUrlFromWfs = jest.fn((url) => of(url + '?download'))
+  getGeoJsonDownloadUrlFromEsriRest = jest.fn((url) => of(url + '?download'))
+  readDataset = jest.fn((url) =>
+    url.indexOf('error') > -1
+      ? throwError(new Error('data loading error'))
+      : of(SAMPLE_GEOJSON.features).pipe(delay(50))
+  )
+}
+
+@Component({
+  selector: 'gn-ui-table',
+  template: '<div></div>',
+})
+export class MockTableComponent {
+  @Input() data: []
+  @Input() activeId
+  @Output() selected = new EventEmitter<number>()
+}
+
+@Component({
+  selector: 'gn-ui-loading-mask',
+  template: '<div></div>',
+})
+export class MockLoadingMaskComponent {
+  @Input() message
+}
+
+@Component({
+  selector: 'gn-ui-popup-alert',
+  template: '<div></div>',
+})
+export class MockPopupAlertComponent {}
+
+describe('TableViewComponent', () => {
+  let component: TableViewComponent
+  let fixture: ComponentFixture<TableViewComponent>
+  let dataService: DataService
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        TableViewComponent,
+        MockTableComponent,
+        MockLoadingMaskComponent,
+        MockPopupAlertComponent,
+      ],
+      providers: [
+        {
+          provide: DataService,
+          useClass: DataServiceMock,
+        },
+      ],
+      imports: [TranslateModule.forRoot()],
+    })
+      .overrideComponent(TableViewComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents()
+    dataService = TestBed.inject(DataService)
+    fixture = TestBed.createComponent(TableViewComponent)
+    component = fixture.componentInstance
+    component.link = LINK_FIXTURES.dataCsv
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  describe('initial state', () => {
+    let tableComponent: MockTableComponent
+
+    it('loads the data from the first available link', () => {
+      expect(dataService.readDataset).toHaveBeenCalledWith(
+        'http://my.server/files/abc.csv',
+        'csv'
+      )
+    })
+
+    describe('during data loading', () => {
+      beforeEach(fakeAsync(() => {
+        component.link = LINK_FIXTURES.dataCsv
+        tick(50)
+        discardPeriodicTasks()
+      }))
+
+      it('shows a loading indicator', () => {
+        expect(
+          fixture.debugElement.query(By.directive(MockLoadingMaskComponent))
+        ).toBeTruthy()
+      })
+    })
+
+    describe('when data is loaded', () => {
+      beforeEach(fakeAsync(() => {
+        component.link = LINK_FIXTURES.dataCsv
+        tick(200)
+        fixture.detectChanges()
+        tableComponent = fixture.debugElement.query(
+          By.directive(MockTableComponent)
+        ).componentInstance
+      }))
+
+      it('displays mocked data in the table', () => {
+        expect(tableComponent.data).toEqual([
+          {
+            id: SAMPLE_GEOJSON.features[0].id,
+            ...SAMPLE_GEOJSON.features[0].properties,
+          },
+        ])
+      })
+
+      describe('when switching data link', () => {
+        beforeEach(() => {
+          component.link = LINK_FIXTURES.geodataJson
+          fixture.detectChanges()
+        })
+        it('loads data from selected link', () => {
+          expect(dataService.readDataset).toHaveBeenCalledWith(
+            'http://my.server/files/geographic/dataset.geojson',
+            'geojson'
+          )
+        })
+        it('displays mocked data in the table', () => {
+          expect(tableComponent.data).toEqual([
+            {
+              id: SAMPLE_GEOJSON.features[0].id,
+              ...SAMPLE_GEOJSON.features[0].properties,
+            },
+          ])
+        })
+      })
+    })
+  })
+  describe('error when loading data', () => {
+    beforeEach(() => {
+      component.link = {
+        url: 'http://abcd.com/wfs/error',
+        name: 'featuretype',
+        protocol: 'OGC:WFS',
+        type: MetadataLinkType.WFS,
+      }
+      fixture.detectChanges()
+    })
+    it('shows an error warning', () => {
+      expect(component.error).toEqual('data loading error')
+    })
+  })
+})

--- a/libs/feature/dataviz/src/lib/table-view/table-view.component.stories.ts
+++ b/libs/feature/dataviz/src/lib/table-view/table-view.component.stories.ts
@@ -10,7 +10,7 @@ import {
 } from '@storybook/angular'
 import { TableViewComponent } from './table-view.component'
 import { MetadataLinkType } from '@geonetwork-ui/util/shared'
-import { UiDatavizModule } from '@geonetwork-ui/ui/dataviz'
+import { TableComponent, UiDatavizModule } from '@geonetwork-ui/ui/dataviz'
 import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
 
 export default {
@@ -19,6 +19,7 @@ export default {
   decorators: [
     moduleMetadata({
       imports: [
+        TableComponent,
         HttpClientModule,
         UiDatavizModule,
         UiWidgetsModule,

--- a/libs/feature/dataviz/src/lib/table-view/table-view.component.stories.ts
+++ b/libs/feature/dataviz/src/lib/table-view/table-view.component.stories.ts
@@ -1,0 +1,71 @@
+import { HttpClientModule } from '@angular/common/http'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+import { TRANSLATE_DEFAULT_CONFIG } from '@geonetwork-ui/util/i18n'
+import { TranslateModule } from '@ngx-translate/core'
+import {
+  componentWrapperDecorator,
+  Meta,
+  moduleMetadata,
+  Story,
+} from '@storybook/angular'
+import { TableViewComponent } from './table-view.component'
+import { MetadataLinkType } from '@geonetwork-ui/util/shared'
+import { UiDatavizModule } from '@geonetwork-ui/ui/dataviz'
+import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
+
+export default {
+  title: 'Smart/Dataviz/TableView',
+  component: TableViewComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        HttpClientModule,
+        UiDatavizModule,
+        UiWidgetsModule,
+        BrowserAnimationsModule,
+        TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
+      ],
+    }),
+    componentWrapperDecorator(
+      (story) =>
+        `<div class="border border-gray-300 h-[500px] w-[800px] p-[10px]" style="resize: both; overflow: auto">${story}</div>`
+    ),
+  ],
+} as Meta<TableViewComponent>
+
+const LINKS = {
+  wfs: {
+    description: 'US states',
+    name: 'topp:states',
+    url: 'https://ahocevar.com/geoserver/wfs?service=WFS&version=1.1.0&request=GetCapabilities',
+    type: MetadataLinkType.WFS,
+  },
+  csv: {
+    description: 'France departments',
+    url: 'https://www.data.gouv.fr/fr/datasets/r/70cef74f-70b1-495a-8500-c089229c0254',
+    type: MetadataLinkType.DOWNLOAD,
+  },
+}
+
+type TableViewComponentInputs = {
+  link: string
+}
+
+const Template: Story<TableViewComponentInputs> = (
+  args: TableViewComponentInputs
+) => ({
+  component: TableViewComponent,
+  props: {
+    link: LINKS[args.link],
+  },
+})
+export const Primary = Template.bind({})
+Primary.args = {
+  link: 'wfs',
+}
+Primary.argTypes = {
+  link: {
+    control: 'radio',
+    options: Object.keys(LINKS),
+  },
+}

--- a/libs/feature/dataviz/src/lib/table-view/table-view.component.ts
+++ b/libs/feature/dataviz/src/lib/table-view/table-view.component.ts
@@ -1,0 +1,89 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
+import {
+  getFileFormat,
+  MetadataLink,
+  MetadataLinkType,
+} from '@geonetwork-ui/util/shared'
+import { BehaviorSubject, Observable, of, throwError } from 'rxjs'
+import {
+  catchError,
+  finalize,
+  map,
+  shareReplay,
+  startWith,
+  switchMap,
+} from 'rxjs/operators'
+import {
+  DataItem,
+  SupportedType,
+  SupportedTypes,
+} from '@geonetwork-ui/data-fetcher'
+import { DataService } from '../service/data.service'
+import { TableItemModel } from '@geonetwork-ui/ui/dataviz'
+
+@Component({
+  selector: 'gn-ui-table-view',
+  templateUrl: './table-view.component.html',
+  styleUrls: ['./table-view.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TableViewComponent {
+  @Input() set link(value: MetadataLink) {
+    this.currentLink$.next(value)
+  }
+  private currentLink$ = new BehaviorSubject<MetadataLink>(null)
+
+  loading = false
+  error = null
+
+  tableData$ = this.currentLink$.pipe(
+    switchMap((link) => {
+      this.error = null
+      if (!link) return of([] as TableItemModel[])
+      this.loading = true
+      return this.fetchData(link).pipe(
+        map((items) =>
+          items.map((item) => ({
+            id: item.id,
+            ...item.properties,
+          }))
+        ),
+        catchError((error) => {
+          this.error = error.message
+          console.warn(error.stack || error.message)
+          return of([] as TableItemModel[])
+        }),
+        finalize(() => {
+          this.loading = false
+        })
+      )
+    }),
+    startWith([] as TableItemModel[]),
+    shareReplay(1)
+  )
+
+  constructor(private dataService: DataService) {}
+
+  fetchData(link: MetadataLink): Observable<DataItem[]> {
+    if (link.type === MetadataLinkType.WFS) {
+      return this.dataService
+        .getGeoJsonDownloadUrlFromWfs(link.url, link.name)
+        .pipe(switchMap((url) => this.dataService.readDataset(url, 'geojson')))
+    } else if (link.type === MetadataLinkType.DOWNLOAD) {
+      const format = getFileFormat(link)
+      const supportedType =
+        SupportedTypes.indexOf(format as any) > -1
+          ? (format as SupportedType)
+          : undefined
+      return this.dataService.readDataset(link.url, supportedType)
+    } else if (link.type === MetadataLinkType.ESRI_REST) {
+      const url = this.dataService.getGeoJsonDownloadUrlFromEsriRest(link.url)
+      return this.dataService.readDataset(url, 'geojson')
+    }
+    return throwError('protocol not supported')
+  }
+
+  onTableSelect(event) {
+    console.log(event)
+  }
+}

--- a/libs/feature/dataviz/src/lib/table-view/table-view.component.ts
+++ b/libs/feature/dataviz/src/lib/table-view/table-view.component.ts
@@ -1,10 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
-import {
-  getFileFormat,
-  MetadataLink,
-  MetadataLinkType,
-} from '@geonetwork-ui/util/shared'
-import { BehaviorSubject, Observable, of, throwError } from 'rxjs'
+import { MetadataLink } from '@geonetwork-ui/util/shared'
+import { BehaviorSubject, Observable, of } from 'rxjs'
 import {
   catchError,
   finalize,
@@ -13,11 +9,7 @@ import {
   startWith,
   switchMap,
 } from 'rxjs/operators'
-import {
-  DataItem,
-  SupportedType,
-  SupportedTypes,
-} from '@geonetwork-ui/data-fetcher'
+import { DataItem } from '@geonetwork-ui/data-fetcher'
 import { DataService } from '../service/data.service'
 import { TableItemModel } from '@geonetwork-ui/ui/dataviz'
 
@@ -65,22 +57,9 @@ export class TableViewComponent {
   constructor(private dataService: DataService) {}
 
   fetchData(link: MetadataLink): Observable<DataItem[]> {
-    if (link.type === MetadataLinkType.WFS) {
-      return this.dataService
-        .getGeoJsonDownloadUrlFromWfs(link.url, link.name)
-        .pipe(switchMap((url) => this.dataService.readDataset(url, 'geojson')))
-    } else if (link.type === MetadataLinkType.DOWNLOAD) {
-      const format = getFileFormat(link)
-      const supportedType =
-        SupportedTypes.indexOf(format as any) > -1
-          ? (format as SupportedType)
-          : undefined
-      return this.dataService.readDataset(link.url, supportedType)
-    } else if (link.type === MetadataLinkType.ESRI_REST) {
-      const url = this.dataService.getGeoJsonDownloadUrlFromEsriRest(link.url)
-      return this.dataService.readDataset(url, 'geojson')
-    }
-    return throwError('protocol not supported')
+    return this.dataService
+      .getDataset(link)
+      .pipe(switchMap((dataset) => dataset.read()))
   }
 
   onTableSelect(event) {

--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.spec.ts
@@ -10,7 +10,7 @@ import { DataDownloadsComponent } from './data-downloads.component'
 import { MetadataLink, MetadataLinkType } from '@geonetwork-ui/util/shared'
 import { Component, Input, NO_ERRORS_SCHEMA } from '@angular/core'
 import { By } from '@angular/platform-browser'
-import { DataService } from '../service/data.service'
+import { DataService } from '@geonetwork-ui/feature/dataviz'
 
 class MdViewFacadeMock {
   downloadLinks$ = new BehaviorSubject([])

--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { DataService } from '@geonetwork-ui/feature/dataviz'
 import {
   getFileFormat,
   MetadataLink,
@@ -7,7 +8,6 @@ import {
 } from '@geonetwork-ui/util/shared'
 import { combineLatest, of } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
-import { DataService } from '../service/data.service'
 import { MdViewFacade } from '../state'
 
 @Component({

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.spec.ts
@@ -33,13 +33,13 @@ import { DropdownSelectorComponent } from '@geonetwork-ui/ui/inputs'
 import { Observable, of, Subject, throwError } from 'rxjs'
 import { DataViewMapComponent } from './data-view-map.component'
 import { TranslateModule } from '@ngx-translate/core'
-import { DataService } from '../service/data.service'
 import { delay } from 'rxjs/operators'
 import { MetadataLink, MetadataLinkType } from '@geonetwork-ui/util/shared'
 import { MapConfig } from '@geonetwork-ui/util/app-config'
 import { FEATURE_COLLECTION_POINT_FIXTURE_4326 } from '@geonetwork-ui/util/shared/fixtures'
 import { Collection } from 'ol'
 import { Interaction } from 'ol/interaction'
+import { DataService } from '@geonetwork-ui/feature/dataviz'
 
 const mapConfigMock = {
   MAX_ZOOM: 10,
@@ -107,7 +107,7 @@ const SAMPLE_GEOJSON = {
 class DataServiceMock {
   getGeoJsonDownloadUrlFromWfs = jest.fn((url) => of(url + '?download'))
   getGeoJsonDownloadUrlFromEsriRest = jest.fn((url) => url + '?download')
-  readGeoJsonDataset = jest.fn((url) =>
+  readAsGeoJson = jest.fn(({ url }) =>
     url.indexOf('error') > -1
       ? throwError(new Error('data loading error'))
       : of(SAMPLE_GEOJSON).pipe(delay(100))
@@ -124,11 +124,6 @@ const mapStyleServiceMock = {
 
 class OpenLayersMapMock {
   _size = undefined
-  once(type, callback) {
-    if (type === 'change:size') {
-      resizeCallBack = callback
-    }
-  }
   updateSize() {
     this._size = [100, 100]
   }

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -178,26 +178,12 @@ export class DataViewMapComponent implements OnInit, OnDestroy {
           options: options,
         }))
       )
-    } else if (link.type === MetadataLinkType.WFS) {
-      return this.dataService
-        .getGeoJsonDownloadUrlFromWfs(link.url, link.name)
-        .pipe(
-          switchMap((url) => this.dataService.readGeoJsonDataset(url)),
-          map((data) => ({
-            type: MapContextLayerTypeEnum.GEOJSON,
-            data,
-          }))
-        )
-    } else if (link.type === MetadataLinkType.DOWNLOAD) {
-      return this.dataService.readGeoJsonDataset(link.url).pipe(
-        map((data) => ({
-          type: MapContextLayerTypeEnum.GEOJSON,
-          data,
-        }))
-      )
-    } else if (link.type === MetadataLinkType.ESRI_REST) {
-      const url = this.dataService.getGeoJsonDownloadUrlFromEsriRest(link.url)
-      return this.dataService.readGeoJsonDataset(url).pipe(
+    } else if (
+      link.type === MetadataLinkType.WFS ||
+      link.type === MetadataLinkType.DOWNLOAD ||
+      link.type === MetadataLinkType.ESRI_REST
+    ) {
+      return this.dataService.readAsGeoJson(link).pipe(
         map((data) => ({
           type: MapContextLayerTypeEnum.GEOJSON,
           data,

--- a/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
+++ b/libs/feature/record/src/lib/data-view-map/data-view-map.component.ts
@@ -40,8 +40,8 @@ import {
   switchMap,
   tap,
 } from 'rxjs/operators'
-import { DataService } from '../service/data.service'
 import { MdViewFacade } from '../state/mdview.facade'
+import { DataService } from '@geonetwork-ui/feature/dataviz'
 
 @Component({
   selector: 'gn-ui-data-view-map',

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.html
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.html
@@ -6,28 +6,9 @@
     extraClass="!text-primary font-sans font-medium"
     [choices]="choices"
     [showTitle]="false"
-    (selectValue)="selectLinkToDisplay($event)"
+    (selectValue)="selectLink($event)"
   ></gn-ui-dropdown-selector>
   <div class="relative h-full">
-    <gn-ui-table
-      *ngIf="tableData$ | async"
-      class="overflow-auto grow"
-      [data]="tableData$ | async"
-      [activeId]="selectionId"
-      (selected)="onTableSelect($event)"
-    ></gn-ui-table>
-    <gn-ui-loading-mask
-      *ngIf="loading"
-      class="absolute inset-0"
-      [message]="'table.loading.data' | translate"
-    ></gn-ui-loading-mask>
-    <gn-ui-popup-alert
-      *ngIf="error"
-      type="warning"
-      icon="error_outline"
-      class="absolute m-2 inset-0"
-    >
-      <span translate>{{ error }}</span>
-    </gn-ui-popup-alert>
+    <gn-ui-table-view [link]="selectedLink$ | async"></gn-ui-table-view>
   </div>
 </div>

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
@@ -1,17 +1,8 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
-import { DataItem } from '@geonetwork-ui/data-fetcher'
 import { getLinkLabel, MetadataLink } from '@geonetwork-ui/util/shared'
-import { BehaviorSubject, combineLatest, Observable, of } from 'rxjs'
-import {
-  catchError,
-  distinctUntilChanged,
-  finalize,
-  map,
-  shareReplay,
-  switchMap,
-} from 'rxjs/operators'
+import { BehaviorSubject, combineLatest } from 'rxjs'
+import { map, tap } from 'rxjs/operators'
 import { MdViewFacade } from '../state'
-import { DataService } from '@geonetwork-ui/feature/dataviz'
 
 @Component({
   selector: 'gn-ui-data-view-table',
@@ -20,64 +11,28 @@ import { DataService } from '@geonetwork-ui/feature/dataviz'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataViewTableComponent {
-  selectionId = 0
   compatibleDataLinks$ = combineLatest([
     this.mdViewFacade.dataLinks$,
     this.mdViewFacade.geoDataLinks$,
   ]).pipe(map(([dataLinks, geoDataLinks]) => [...dataLinks, ...geoDataLinks]))
   dropdownChoices$ = this.compatibleDataLinks$.pipe(
+    tap((links) => {
+      if (links.indexOf(this.selectedLink$.value) === -1) {
+        this.selectedLink$.next(links[0])
+      }
+    }),
     map((links) =>
-      links.map((link, index) => ({
+      links.map((link) => ({
         label: getLinkLabel(link),
-        value: index,
+        value: JSON.stringify(link),
       }))
     )
   )
-  selectedLinkIndex$ = new BehaviorSubject(0)
+  selectedLink$ = new BehaviorSubject<MetadataLink>(null)
 
-  loading = false
-  error = null
+  constructor(private mdViewFacade: MdViewFacade) {}
 
-  tableData$ = combineLatest([
-    this.compatibleDataLinks$,
-    this.selectedLinkIndex$.pipe(distinctUntilChanged()),
-  ]).pipe(
-    map(([links, index]) => links[index]),
-    switchMap((link) => {
-      this.loading = true
-      this.error = null
-      return link
-        ? this.fetchData(link).pipe(
-            catchError((error) => {
-              this.error = error.message
-              console.warn(error.stack || error.message)
-              return of([])
-            }),
-            finalize(() => {
-              this.loading = false
-            })
-          )
-        : of([])
-    }),
-    shareReplay(1)
-  )
-
-  constructor(
-    private mdViewFacade: MdViewFacade,
-    private dataService: DataService
-  ) {}
-
-  fetchData(link: MetadataLink): Observable<DataItem[]> {
-    return this.dataService
-      .getDataset(link)
-      .pipe(switchMap((dataset) => dataset.read()))
-  }
-
-  selectLinkToDisplay(link: number) {
-    this.selectedLinkIndex$.next(link)
-  }
-
-  onTableSelect(event) {
-    console.log(event)
+  selectLink(linkAsString: string) {
+    this.selectedLink$.next(JSON.parse(linkAsString) as MetadataLink)
   }
 }

--- a/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
+++ b/libs/feature/record/src/lib/data-view-table/data-view-table.component.ts
@@ -22,7 +22,7 @@ import {
   switchMap,
 } from 'rxjs/operators'
 import { MdViewFacade } from '../state'
-import { DataService } from '../service/data.service'
+import { DataService } from '@geonetwork-ui/feature/dataviz'
 
 @Component({
   selector: 'gn-ui-data-view-table',
@@ -84,9 +84,9 @@ export class DataViewTableComponent {
         .getGeoJsonDownloadUrlFromWfs(link.url, link.name)
         .pipe(
           switchMap((url) =>
-            this.dataService.readGeoJsonDataset(url).pipe(
-              map((featureCollection) =>
-                featureCollection.features.map((f) => ({
+            this.dataService.readDataset(url, 'geojson').pipe(
+              map((features) =>
+                features.map((f) => ({
                   id: f.id,
                   ...f.properties,
                 }))
@@ -101,8 +101,8 @@ export class DataViewTableComponent {
           ? (format as SupportedType)
           : undefined
       return this.dataService.readDataset(link.url, supportedType).pipe(
-        map((featureCollection) =>
-          featureCollection.features.map((f) => ({
+        map((features) =>
+          features.map((f) => ({
             id: f.id,
             ...f.properties,
           }))
@@ -110,9 +110,9 @@ export class DataViewTableComponent {
       )
     } else if (link.type === MetadataLinkType.ESRI_REST) {
       const url = this.dataService.getGeoJsonDownloadUrlFromEsriRest(link.url)
-      return this.dataService.readGeoJsonDataset(url).pipe(
-        map((featureCollection) =>
-          featureCollection.features.map((f) => ({
+      return this.dataService.readDataset(url, 'geojson').pipe(
+        map((features) =>
+          features.map((f) => ({
             id: f.id,
             ...f.properties,
           }))

--- a/libs/feature/record/src/lib/feature-record.module.ts
+++ b/libs/feature/record/src/lib/feature-record.module.ts
@@ -25,6 +25,7 @@ import { RelatedRecordsComponent } from './related-records/related-records.compo
 import { ExternalViewerButtonComponent } from './external-viewer-button/external-viewer-button.component'
 import { FeatureCatalogModule } from '@geonetwork-ui/feature/catalog'
 import { TableComponent } from '@geonetwork-ui/ui/dataviz'
+import { FeatureDatavizModule } from '@geonetwork-ui/feature/dataviz'
 
 @NgModule({
   declarations: [
@@ -53,6 +54,7 @@ import { TableComponent } from '@geonetwork-ui/ui/dataviz'
     UiWidgetsModule,
     TranslateModule,
     TableComponent,
+    FeatureDatavizModule,
   ],
   providers: [MdViewFacade],
   exports: [

--- a/libs/ui/dataviz/src/lib/chart/chart.component.spec.ts
+++ b/libs/ui/dataviz/src/lib/chart/chart.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { CHART_ITEM_FIXTURE } from './chart.fixtures'
 import { ChartComponent } from './chart.component'
 import { Chart } from 'chart.js'
+import { ChangeDetectionStrategy } from '@angular/core'
 
 jest.mock('chart.js')
 Chart.register = jest.fn()
@@ -10,49 +11,245 @@ describe('ChartComponent', () => {
   let component: ChartComponent
   let fixture: ComponentFixture<ChartComponent>
 
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ChartComponent],
-    }).compileComponents()
+    })
+      .overrideComponent(ChartComponent, {
+        set: {
+          changeDetection: ChangeDetectionStrategy.Default,
+        },
+      })
+      .compileComponents()
 
     fixture = TestBed.createComponent(ChartComponent)
     component = fixture.componentInstance
     component.data = CHART_ITEM_FIXTURE
-    component.xAxis = 'name'
-    component.yAxis = 'age'
-    component.chartType = 'bar'
+    component.labelProperty = 'name'
+    component.valueProperty = 'age'
+    component.type = 'bar'
+    component.ngOnChanges()
   })
 
-  describe('create chart', () => {
-    let createChartSpy
-    let getChartTypeSpy
-    let getOptionsSpy
+  it('should create', () => {
+    fixture.detectChanges()
+    expect(component).toBeTruthy()
+  })
 
+  describe('before view is ready', () => {
+    it('does not create a chart', () => {
+      expect(Chart).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when view is ready', () => {
     beforeEach(() => {
-      createChartSpy = jest.spyOn(component, 'createChart')
-      getChartTypeSpy = jest.spyOn(component, 'getChartType')
-      getOptionsSpy = jest.spyOn(component, 'getOptions')
       fixture.detectChanges()
     })
-
-    it('should create', () => {
-      expect(component).toBeTruthy()
+    it('should create chart', () => {
+      expect(Chart).toHaveBeenCalledWith(expect.any(HTMLElement), {
+        data: {
+          datasets: [
+            {
+              data: [15, 10, 55],
+              label: 'age',
+            },
+          ],
+          labels: ['name 1', 'name 2', 'name 3'],
+        },
+        options: {
+          aspectRatio: 2.5,
+          parsing: {},
+          scales: {
+            x: {
+              position: 'bottom',
+              type: 'category',
+            },
+          },
+        },
+        type: 'bar',
+      })
     })
 
-    it('should call create chart', () => {
-      expect(createChartSpy).toHaveBeenCalled()
+    describe('when data changes', () => {
+      beforeEach(() => {
+        component.data = CHART_ITEM_FIXTURE.slice(0, 2)
+        component.ngOnChanges()
+        fixture.detectChanges()
+      })
+      it('should create chart with new data', () => {
+        expect(Chart).toHaveBeenCalledTimes(2)
+        expect(Chart).toHaveBeenLastCalledWith(
+          expect.any(HTMLElement),
+          expect.objectContaining({
+            data: {
+              datasets: [
+                {
+                  data: [15, 10],
+                  label: 'age',
+                },
+              ],
+              labels: ['name 1', 'name 2'],
+            },
+          })
+        )
+      })
     })
 
-    it('should call getChartType for mapping', () => {
-      expect(getChartTypeSpy).toHaveBeenCalled()
+    describe('when axis values change', () => {
+      beforeEach(() => {
+        component.labelProperty = 'id'
+        component.valueProperty = 'amount'
+        component.ngOnChanges()
+        fixture.detectChanges()
+      })
+      it('should create chart with new data', () => {
+        expect(Chart).toHaveBeenCalledTimes(2)
+        expect(Chart).toHaveBeenLastCalledWith(
+          expect.any(HTMLElement),
+          expect.objectContaining({
+            data: {
+              datasets: [
+                {
+                  data: [100, 101, 102],
+                  label: 'amount',
+                },
+              ],
+              labels: ['id 1', 'id 2', 'id 3'],
+            },
+          })
+        )
+      })
     })
 
-    it('should call getOptions for ChartType dependent options', () => {
-      expect(getOptionsSpy).toHaveBeenCalled()
+    describe('when chart type changes', () => {
+      beforeEach(() => {
+        component.type = 'pie'
+        component.ngOnChanges()
+        fixture.detectChanges()
+      })
+      it('should create chart with new data', () => {
+        expect(Chart).toHaveBeenCalledTimes(2)
+        expect(Chart).toHaveBeenLastCalledWith(
+          expect.any(HTMLElement),
+          expect.objectContaining({
+            type: 'pie',
+          })
+        )
+      })
     })
+  })
 
-    it('should create a chart', () => {
-      expect(component.chart).toBeTruthy()
+  describe('chart with secondary value', () => {
+    beforeEach(() => {
+      component.type = 'scatter'
+      component.labelProperty = 'id'
+      component.secondaryValueProperty = 'amount'
+      fixture.detectChanges()
+    })
+    it('should create chart', () => {
+      expect(Chart).toHaveBeenCalledWith(expect.any(HTMLElement), {
+        data: {
+          datasets: [
+            {
+              data: [
+                {
+                  x: 100,
+                  y: 15,
+                },
+                {
+                  x: 101,
+                  y: 10,
+                },
+                {
+                  x: 102,
+                  y: 55,
+                },
+              ],
+              label: 'age',
+            },
+          ],
+          labels: ['id 1', 'id 2', 'id 3'],
+        },
+        options: {
+          aspectRatio: 2.5,
+          parsing: {},
+          scales: {
+            x: {
+              position: 'bottom',
+              type: 'linear',
+            },
+          },
+        },
+        type: 'scatter',
+      })
+    })
+  })
+
+  describe('chart types', () => {
+    describe('scatter chart (no secondary value)', () => {
+      beforeEach(() => {
+        component.type = 'scatter'
+        fixture.detectChanges()
+      })
+      it('should create chart', () => {
+        expect(Chart).toHaveBeenCalledWith(
+          expect.any(HTMLElement),
+          expect.objectContaining({
+            options: expect.objectContaining({
+              scales: {
+                x: {
+                  position: 'bottom',
+                  type: 'category',
+                },
+              },
+            }),
+            type: 'scatter',
+          })
+        )
+      })
+    })
+    describe('line interpolated chart', () => {
+      beforeEach(() => {
+        component.type = 'line-interpolated'
+        fixture.detectChanges()
+      })
+      it('should create chart', () => {
+        expect(Chart).toHaveBeenCalledWith(
+          expect.any(HTMLElement),
+          expect.objectContaining({
+            options: expect.objectContaining({
+              elements: {
+                line: {
+                  cubicInterpolationMode: 'monotone',
+                },
+              },
+            }),
+            type: 'line',
+          })
+        )
+      })
+    })
+    describe('horizontal bar chart', () => {
+      beforeEach(() => {
+        component.type = 'bar-horizontal'
+        fixture.detectChanges()
+      })
+      it('should create chart', () => {
+        expect(Chart).toHaveBeenCalledWith(
+          expect.any(HTMLElement),
+          expect.objectContaining({
+            options: expect.objectContaining({
+              indexAxis: 'y',
+            }),
+            type: 'bar',
+          })
+        )
+      })
     })
   })
 })

--- a/libs/ui/dataviz/src/lib/chart/chart.component.stories.ts
+++ b/libs/ui/dataviz/src/lib/chart/chart.component.stories.ts
@@ -29,7 +29,7 @@ export default {
     ),
   ],
   argTypes: {
-    chartType: { control: { type: 'select', options: CHART_TYPE_VALUES } },
+    type: { control: { type: 'select', options: CHART_TYPE_VALUES } },
   },
 } as Meta<ChartComponent>
 
@@ -38,35 +38,50 @@ const Template: Story<ChartComponent> = (args: ChartComponent) => ({
   props: args,
 })
 
+const SAMPLE_DATA = [
+  {
+    id: '0001',
+    firstName: 'John',
+    lastName: 'Lennon',
+    discsSold: 10,
+    age: 65,
+  },
+  {
+    id: '0002',
+    firstName: 'Ozzy',
+    lastName: 'Osbourne',
+    discsSold: 8,
+    age: 45,
+  },
+  {
+    id: '0003',
+    firstName: 'Claude',
+    lastName: 'François',
+    discsSold: 5,
+    age: 72,
+  },
+  {
+    id: '0004',
+    firstName: 'Michael',
+    lastName: 'Jackson',
+    discsSold: 15,
+    age: 48,
+  },
+]
+
 export const Primary = Template.bind({})
 Primary.args = {
-  data: [
-    {
-      id: '0001',
-      firstName: 'John',
-      lastName: 'Lennon',
-      discsSold: '10',
-    },
-    {
-      id: '0002',
-      firstName: 'Ozzy',
-      lastName: 'Osbourne',
-      discsSold: '8',
-    },
-    {
-      id: '0003',
-      firstName: 'Claude',
-      lastName: 'François',
-      discsSold: '5',
-    },
-    {
-      id: '0004',
-      firstName: 'Michael',
-      lastName: 'Jackson',
-      discsSold: '15',
-    },
-  ],
-  xAxis: 'firstName',
-  yAxis: 'discsSold',
-  chartType: 'bar',
+  data: SAMPLE_DATA,
+  labelProperty: 'firstName',
+  valueProperty: 'discsSold',
+  secondaryValueProperty: '',
+  type: 'bar',
+}
+const options = Object.keys(SAMPLE_DATA[0])
+Primary.argTypes = {
+  labelProperty: { control: { type: 'select', options } },
+  valueProperty: { control: { type: 'select', options } },
+  secondaryValueProperty: {
+    control: { type: 'select', options: [''].concat(options) },
+  },
 }

--- a/libs/ui/dataviz/src/lib/chart/chart.fixtures.ts
+++ b/libs/ui/dataviz/src/lib/chart/chart.fixtures.ts
@@ -3,16 +3,19 @@ export const CHART_ITEM_FIXTURE = [
     name: 'name 1',
     id: 'id 1',
     age: 15,
+    amount: 100,
   },
   {
     name: 'name 2',
     id: 'id 2',
     age: 10,
+    amount: 101,
   },
   {
     name: 'name 3',
     id: 'id 3',
     age: 55,
+    amount: 102,
   },
 ]
 

--- a/libs/ui/dataviz/src/lib/chart/chart.model.ts
+++ b/libs/ui/dataviz/src/lib/chart/chart.model.ts
@@ -1,8 +1,8 @@
 export const CHART_TYPE_VALUES = [
-  'column',
   'bar',
+  'bar-horizontal',
   'line',
-  'curve',
+  'line-interpolated',
   'scatter',
   'pie',
 ] as const

--- a/libs/util/data-fetcher/src/index.ts
+++ b/libs/util/data-fetcher/src/index.ts
@@ -1,2 +1,9 @@
 export * from './lib/data-fetcher'
-export { SupportedType, SupportedTypes, DataItem } from './lib/model'
+export {
+  SupportedType,
+  SupportedTypes,
+  DataItem,
+  FetchError,
+} from './lib/model'
+export { getJsonDataItemsProxy } from './lib/utils'
+export { BaseReader } from './lib/readers/base'

--- a/libs/util/data-fetcher/src/index.ts
+++ b/libs/util/data-fetcher/src/index.ts
@@ -4,6 +4,7 @@ export {
   SupportedTypes,
   DataItem,
   FetchError,
+  FieldAggregation,
 } from './lib/model'
 export { getJsonDataItemsProxy } from './lib/utils'
 export { BaseReader } from './lib/readers/base'

--- a/libs/util/data-fetcher/src/index.ts
+++ b/libs/util/data-fetcher/src/index.ts
@@ -1,2 +1,2 @@
 export * from './lib/data-fetcher'
-export { SupportedType, SupportedTypes } from './lib/model'
+export { SupportedType, SupportedTypes, DataItem } from './lib/model'

--- a/libs/util/data-fetcher/src/lib/utils.ts
+++ b/libs/util/data-fetcher/src/lib/utils.ts
@@ -228,8 +228,12 @@ export function getJsonDataItemsProxy(
   items: DataItem[]
 ): Record<string, unknown>[] {
   return new Proxy<Record<string, unknown>[]>(items as any, {
-    get(target: Record<string, unknown>[], p: string) {
-      if (!Number.isNaN(parseInt(p)) && target[p]?.properties) {
+    get(target: Record<string, unknown>[], p: string | symbol) {
+      if (
+        typeof p === 'string' &&
+        !Number.isNaN(parseInt(p)) &&
+        target[p]?.properties
+      ) {
         return target[p].properties
       }
       return target[p]


### PR DESCRIPTION
This adds a smart component in `feature/dataviz` which shows a chart where the user can change which properties they want to see represented. Currently only supports grouping by distinct values on X and showing sum, min, max, average and count on Y.

This PR also does:
* move the data service from `feature/record` to `feature/dataviz`, and simplify it a little
* creates a new `table-view` smart component based on the table view component from `feature/record`
* small improvements to the chart presentation component

![image](https://user-images.githubusercontent.com/10629150/223129345-30bbccfc-fedb-4e59-8d3b-e6565d5c7880.png)


This PR will be followed by another one to use the chart in the datahub record view.