### PR TITLE
Dataviz: Fix chart type bar-horizontal

### DIFF
--- a/libs/ui/dataviz/src/lib/chart/chart.component.spec.ts
+++ b/libs/ui/dataviz/src/lib/chart/chart.component.spec.ts
@@ -64,12 +64,6 @@ describe('ChartComponent', () => {
         options: {
           aspectRatio: 2.5,
           parsing: {},
-          scales: {
-            x: {
-              position: 'bottom',
-              type: 'category',
-            },
-          },
         },
         type: 'bar',
       })
@@ -178,12 +172,6 @@ describe('ChartComponent', () => {
         options: {
           aspectRatio: 2.5,
           parsing: {},
-          scales: {
-            x: {
-              position: 'bottom',
-              type: 'linear',
-            },
-          },
         },
         type: 'scatter',
       })
@@ -200,14 +188,6 @@ describe('ChartComponent', () => {
         expect(Chart).toHaveBeenCalledWith(
           expect.any(HTMLElement),
           expect.objectContaining({
-            options: expect.objectContaining({
-              scales: {
-                x: {
-                  position: 'bottom',
-                  type: 'category',
-                },
-              },
-            }),
             type: 'scatter',
           })
         )

--- a/libs/ui/dataviz/src/lib/chart/chart.component.ts
+++ b/libs/ui/dataviz/src/lib/chart/chart.component.ts
@@ -105,12 +105,6 @@ export class ChartComponent implements OnChanges, AfterViewInit {
     const options: ChartOptions = {
       aspectRatio: 2.5,
       parsing: {},
-      scales: {
-        x: {
-          type: this.handlesSecondaryValue() ? 'linear' : 'category',
-          position: 'bottom',
-        },
-      },
     }
     switch (this.type) {
       case 'line-interpolated':


### PR DESCRIPTION
PR removes scales from options to fix `bar-horizontal` chart type. I chose to remove it, as I have the impression chartjs handles this automatically if not indicated in the options. 

If I missed something and we really need the `scales`, an alternative would be to set it for `y` in the `bar-horizontal` options:
```
scales: {
  y: {
    type: this.handlesSecondaryValue() ? 'linear' : 'category',
    position: 'bottom',
  },
},
```