### PR TITLE
Search: Add filter for data with or without spatial reference

### DIFF
--- a/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
+++ b/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
@@ -52,6 +52,10 @@
       [fieldName]="'format'"
       [title]="'search.filters.byFormat' | translate"
     ></gn-ui-filter-dropdown>
+    <gn-ui-filter-spatialdata
+      class="w-full"
+      [ngClass]="isOpen ? 'block' : 'hidden sm:block'"
+    ></gn-ui-filter-spatialdata>
     <div
       class="spatial-filter-toggle sm:col-span-2"
       *ngIf="isOpen && searchFacade.hasSpatialFilter$ | async"

--- a/libs/feature/search/src/lib/feature-search.module.ts
+++ b/libs/feature/search/src/lib/feature-search.module.ts
@@ -23,6 +23,7 @@ import { MatIconModule } from '@angular/material/icon'
 import { FilterDropdownComponent } from './filter-dropdown/filter-dropdown.component'
 import { Geometry } from 'geojson'
 import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
+import { FilterSpatialdataComponent } from './filter-spatialdata/filter-spatialdata.component'
 
 // this geometry will be used to filter & boost results accordingly
 export const FILTER_GEOMETRY = new InjectionToken<Promise<Geometry>>(
@@ -40,6 +41,7 @@ export const FILTER_GEOMETRY = new InjectionToken<Promise<Geometry>>(
     SearchStateContainerDirective,
     FavoriteStarComponent,
     FilterDropdownComponent,
+    FilterSpatialdataComponent,
   ],
   imports: [
     CommonModule,
@@ -69,6 +71,7 @@ export const FILTER_GEOMETRY = new InjectionToken<Promise<Geometry>>(
     SearchStateContainerDirective,
     FavoriteStarComponent,
     FilterDropdownComponent,
+    FilterSpatialdataComponent,
   ],
 })
 export class FeatureSearchModule {}

--- a/libs/feature/search/src/lib/filter-spatialdata/filter-spatialdata.component.html
+++ b/libs/feature/search/src/lib/filter-spatialdata/filter-spatialdata.component.html
@@ -1,0 +1,8 @@
+<gn-ui-dropdown-selector
+  [title]="'search.filter.spatialdata' | translate"
+  [showTitle]="false"
+  [choices]="choices"
+  (selectValue)="changeFilterBySpatialRef($event)"
+  [selected]="currentFilter$ | async"
+  ariaName=""
+></gn-ui-dropdown-selector>

--- a/libs/feature/search/src/lib/filter-spatialdata/filter-spatialdata.component.spec.ts
+++ b/libs/feature/search/src/lib/filter-spatialdata/filter-spatialdata.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { FilterSpatialdataComponent } from './filter-spatialdata.component'
+
+describe('FilterSpatialdataComponent', () => {
+  let component: FilterSpatialdataComponent
+  let fixture: ComponentFixture<FilterSpatialdataComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [FilterSpatialdataComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(FilterSpatialdataComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/feature/search/src/lib/filter-spatialdata/filter-spatialdata.component.ts
+++ b/libs/feature/search/src/lib/filter-spatialdata/filter-spatialdata.component.ts
@@ -1,0 +1,74 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { marker } from '@biesbjerg/ngx-translate-extract-marker'
+import { of } from 'rxjs'
+import { SearchFacade } from '../state/search.facade'
+import { SearchService } from '../utils/service/search.service'
+
+marker('search.filter.hasSpatialRef')
+marker('search.filter.hasNoSpatialRef')
+marker('search.filter.all')
+
+enum SpatialRefFilter {
+  HAS_SPATIAL_REF = 'hasSpatialRef',
+  NO_SPATIAL_REF = 'noSpatialRef',
+  ALL = 'all',
+}
+
+@Component({
+  selector: 'gn-ui-filter-spatialdata',
+  templateUrl: './filter-spatialdata.component.html',
+  styleUrls: ['./filter-spatialdata.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FilterSpatialdataComponent {
+  choices = [
+    {
+      label: 'search.filter.hasSpatialRef',
+      value: SpatialRefFilter.HAS_SPATIAL_REF,
+    },
+    {
+      label: 'search.filter.noSpatialRef',
+      value: SpatialRefFilter.NO_SPATIAL_REF,
+    },
+    {
+      label: 'search.filter.all',
+      value: SpatialRefFilter.ALL,
+    },
+  ]
+  currentFilter$ = of(SpatialRefFilter.ALL)
+
+  constructor(
+    private facade: SearchFacade,
+    private searchService: SearchService
+  ) {}
+
+  changeFilterBySpatialRef(filter: SpatialRefFilter) {
+    let params = { format: {} }
+    //TODO: need to be generated dynamically via AggregationService
+    const formatsSpatial = ['geojson', 'geopackage']
+    const formatsNonSpatial = ['json', 'csv']
+    switch (filter) {
+      case SpatialRefFilter.ALL:
+        break
+      case SpatialRefFilter.HAS_SPATIAL_REF:
+        params = {
+          ...params,
+          format: this.toParamsObject(formatsSpatial),
+        }
+        break
+      case SpatialRefFilter.NO_SPATIAL_REF:
+        params = {
+          ...params,
+          format: this.toParamsObject(formatsNonSpatial),
+        }
+        break
+    }
+    this.searchService.updateFilters(params)
+  }
+
+  toParamsObject(params: string[]) {
+    return params.reduce<Record<string, boolean>>((acc, val) => {
+      return { ...acc, [val.toString()]: true }
+    }, {})
+  }
+}


### PR DESCRIPTION
Opened this PR for discussion, as I don't have the impression that updating the `format` filter goes into the right direction. In terms of user experience, this creates a cross filter behavior: Changing values in one filter modifies values in another one, something which should be prevented IMO. Representing the state of the spatial/non-spatial filter in the URL also becomes impossible, this way.