### PR TITLE
Datahub (v1.0.1): Fix i18n by adding availabe langs to translate.service

### DIFF
--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -27,6 +27,7 @@ import {
   getThemeConfig,
 } from '@geonetwork-ui/util/app-config'
 import {
+  AVAILABLE_LANGS,
   getDefaultLang,
   getLangFromBrowser,
   TRANSLATE_DEFAULT_CONFIG,
@@ -170,6 +171,7 @@ export class AppModule {
     router: Router,
     @Inject(DOCUMENT) private document: Document
   ) {
+    translate.addLangs(AVAILABLE_LANGS)
     translate.setDefaultLang(getDefaultLang())
     translate.use(getLangFromBrowser() || getDefaultLang())
     ThemeService.applyCssVariables(

--- a/libs/util/i18n/src/lib/i18n.constants.ts
+++ b/libs/util/i18n/src/lib/i18n.constants.ts
@@ -9,6 +9,8 @@ import { FileTranslateLoader } from './file.translate.loader'
 
 export const DEFAULT_LANG = 'en'
 
+export const AVAILABLE_LANGS = ['de', 'en', 'es', 'fr', 'it', 'nl', 'pt']
+
 export const LANG_3_TO_2_MAPPER = {
   eng: 'en',
   dut: 'nl',


### PR DESCRIPTION
PR attempts to fix a bug where the datahub application falls back to the default translations in `en` even though the browser language is `fr`. Unfortunately, the behaviour does not reproduce systematically.

I noticed that `translate.getLangs()` was empty at the moment we call `translate.use()` in the `app.module`, so I added `translate.addLangs()`. Couldn't really find in the ngx-translate docs if this is mandatory to call, but it's worth a try IMO.

I propose to fix this on a `v1.0.x` branch to create a `v1.0.2` tag we can test on dev/prod.