### PR TITLE
Remove geojson fixtures from bundle

### DIFF
--- a/libs/feature/auth/src/lib/auth.service.spec.ts
+++ b/libs/feature/auth/src/lib/auth.service.spec.ts
@@ -71,7 +71,7 @@ describe('AuthService', () => {
       it('emits a value on subscribe after auth was queried', () => {
         let emitted = false
         service.authReady().subscribe(() => (emitted = true))
-        me$.next()
+        me$.next(null)
         expect(emitted).toBeTruthy()
       })
     })

--- a/libs/feature/auth/src/lib/auth.service.ts
+++ b/libs/feature/auth/src/lib/auth.service.ts
@@ -5,7 +5,6 @@ import {
 } from '@geonetwork-ui/data-access/gn4'
 import { LANG_2_TO_3_MAPPER } from '@geonetwork-ui/util/i18n'
 import { UserModel } from '@geonetwork-ui/util/shared'
-import { USER_FIXTURE } from '@geonetwork-ui/util/shared/fixtures'
 import { TranslateService } from '@ngx-translate/core'
 import { Observable } from 'rxjs'
 import { map, shareReplay } from 'rxjs/operators'
@@ -46,7 +45,6 @@ export class AuthService {
   ) {
     this.user$ = this.meApi.getMe().pipe(
       map((apiUser) => this.mapToUserModel(apiUser)),
-      map((user) => user ?? USER_FIXTURE()),
       shareReplay({ bufferSize: 1, refCount: true })
     )
   }


### PR DESCRIPTION
This removed a reference to the fixtures lib in the feature/auth plugin, and magically removes 2MB from most bundles from gn-ui.

Also fixed a minor type issue in test file.

Note: to be more future proof on this we should put some linting rules in place to prevent this.