### PR TITLE
Fix i18n (v1.0.1): Let util-18n.module handle language detection

### DIFF
--- a/apps/datafeeder/src/app/app.module.ts
+++ b/apps/datafeeder/src/app/app.module.ts
@@ -10,8 +10,6 @@ import { AppRoutingModule } from './app-routing.module'
 import { AppComponent } from './app.component'
 import { UploadDataComponent } from './presentation/components/upload-data/upload-data.component'
 import {
-  getDefaultLang,
-  getLangFromBrowser,
   TRANSLATE_DEFAULT_CONFIG,
   UtilI18nModule,
 } from '@geonetwork-ui/util/i18n'
@@ -19,7 +17,7 @@ import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
 import { UploadDataPageComponent } from './presentation/pages/upload-data-page/upload-data.page'
 import { UploadDataRulesComponent } from './presentation/components/upload-data-rules/upload-data-rules.component'
 import { HttpClientModule } from '@angular/common/http'
-import { TranslateModule, TranslateService } from '@ngx-translate/core'
+import { TranslateModule } from '@ngx-translate/core'
 import { DatasetValidationPageComponent } from './presentation/pages/dataset-validation-page/dataset-validation-page'
 import { DataImportValidationMapPanelComponent } from './presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component'
 import { AnalysisProgressPageComponent } from './presentation/pages/analysis-progress-page/analysis-progress.page'
@@ -84,8 +82,4 @@ export function apiConfigurationFactory() {
   ],
   bootstrap: [AppComponent],
 })
-export class AppModule {
-  constructor(translate: TranslateService) {
-    translate.use(getLangFromBrowser() || getDefaultLang())
-  }
-}
+export class AppModule {}

--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -27,8 +27,6 @@ import {
   getThemeConfig,
 } from '@geonetwork-ui/util/app-config'
 import {
-  getDefaultLang,
-  getLangFromBrowser,
   TRANSLATE_DEFAULT_CONFIG,
   UtilI18nModule,
 } from '@geonetwork-ui/util/i18n'
@@ -43,7 +41,7 @@ import { LOGIN_URL } from '@geonetwork-ui/feature/auth'
 import { EffectsModule } from '@ngrx/effects'
 import { MetaReducer, StoreModule } from '@ngrx/store'
 import { StoreDevtoolsModule } from '@ngrx/store-devtools'
-import { TranslateModule, TranslateService } from '@ngx-translate/core'
+import { TranslateModule } from '@ngx-translate/core'
 import { filter } from 'rxjs/operators'
 import { environment } from '../environments/environment'
 
@@ -165,13 +163,7 @@ export const metaReducers: MetaReducer[] = !environment.production ? [] : []
   bootstrap: [AppComponent],
 })
 export class AppModule {
-  constructor(
-    translate: TranslateService,
-    router: Router,
-    @Inject(DOCUMENT) private document: Document
-  ) {
-    translate.setDefaultLang(getDefaultLang())
-    translate.use(getLangFromBrowser() || getDefaultLang())
+  constructor(router: Router, @Inject(DOCUMENT) private document: Document) {
     ThemeService.applyCssVariables(
       getThemeConfig().PRIMARY_COLOR,
       getThemeConfig().SECONDARY_COLOR,

--- a/apps/search/src/app/app.module.ts
+++ b/apps/search/src/app/app.module.ts
@@ -7,7 +7,6 @@ import { FeatureMapModule } from '@geonetwork-ui/feature/map'
 import { UiLayoutModule } from '@geonetwork-ui/ui/layout'
 import { UiMapModule } from '@geonetwork-ui/ui/map'
 import {
-  getDefaultLang,
   UtilI18nModule,
   TRANSLATE_GEONETWORK_CONFIG,
 } from '@geonetwork-ui/util/i18n'
@@ -16,7 +15,7 @@ import { FeatureSearchModule } from '@geonetwork-ui/feature/search'
 import { EffectsModule } from '@ngrx/effects'
 import { MetaReducer, StoreModule } from '@ngrx/store'
 import { StoreDevtoolsModule } from '@ngrx/store-devtools'
-import { TranslateModule, TranslateService } from '@ngx-translate/core'
+import { TranslateModule } from '@ngx-translate/core'
 import { storeFreeze } from 'ngrx-store-freeze'
 import { environment } from '../environments/environment'
 import { AppRoutingModule } from './app-routing.module'
@@ -57,10 +56,4 @@ export const metaReducers: MetaReducer<any>[] = !environment.production
   ],
   bootstrap: [AppComponent],
 })
-export class AppModule {
-  constructor(translate: TranslateService) {
-    const lang = getDefaultLang()
-    translate.setDefaultLang(lang)
-    translate.use(lang)
-  }
-}
+export class AppModule {}

--- a/libs/util/i18n/src/lib/i18n.constants.ts
+++ b/libs/util/i18n/src/lib/i18n.constants.ts
@@ -1,10 +1,8 @@
 import { HttpClient } from '@angular/common/http'
 import { ToolsApiService } from '@geonetwork-ui/data-access/gn4'
 import { TranslateCompiler, TranslateLoader } from '@ngx-translate/core'
-import { TranslateHttpLoader } from '@ngx-translate/http-loader'
 import { TranslateMessageFormatCompiler } from 'ngx-translate-messageformat-compiler'
 import { Gn4TranslateLoader } from './gn4.translate.loader'
-import { map } from 'rxjs/operators'
 import { FileTranslateLoader } from './file.translate.loader'
 
 export const DEFAULT_LANG = 'en'
@@ -37,19 +35,10 @@ export const LANG_2_TO_3_MAPPER = Object.entries(LANG_3_TO_2_MAPPER).reduce(
 export function HttpLoaderFactory(http: HttpClient) {
   return new FileTranslateLoader(http, './assets/i18n/')
 }
-
-export function getLangFromHtml() {
-  const html: HTMLElement = document.getElementsByTagName('html')[0]
-  const lang = html.getAttribute('lang')
-  return lang.substr(0, 2)
-}
+//Deprecated, but currently still used in datafeeder
 export function getLangFromBrowser() {
   return navigator.language.substr(0, 2)
 }
-export function getDefaultLang() {
-  return getLangFromHtml() || 'en'
-}
-
 export const TRANSLATE_DEFAULT_CONFIG = {
   compiler: {
     provide: TranslateCompiler,

--- a/libs/util/i18n/src/lib/util-i18n.module.ts
+++ b/libs/util/i18n/src/lib/util-i18n.module.ts
@@ -2,7 +2,7 @@ import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http'
 import { NgModule } from '@angular/core'
 import { ApiModule } from '@geonetwork-ui/data-access/gn4'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
-import { DEFAULT_LANG } from './i18n.constants'
+import { getDefaultLang } from './i18n.constants'
 import { I18nInterceptor } from './i18n.interceptor'
 import { CommonModule } from '@angular/common'
 
@@ -20,7 +20,7 @@ import { CommonModule } from '@angular/common'
 })
 export class UtilI18nModule {
   constructor(translate: TranslateService) {
-    translate.setDefaultLang(DEFAULT_LANG)
-    translate.use(DEFAULT_LANG)
+    translate.setDefaultLang(getDefaultLang())
+    translate.use(translate.getBrowserLang() || getDefaultLang())
   }
 }

--- a/libs/util/i18n/src/lib/util-i18n.module.ts
+++ b/libs/util/i18n/src/lib/util-i18n.module.ts
@@ -2,7 +2,7 @@ import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http'
 import { NgModule } from '@angular/core'
 import { ApiModule } from '@geonetwork-ui/data-access/gn4'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
-import { getDefaultLang } from './i18n.constants'
+import { DEFAULT_LANG } from './i18n.constants'
 import { I18nInterceptor } from './i18n.interceptor'
 import { CommonModule } from '@angular/common'
 
@@ -20,7 +20,7 @@ import { CommonModule } from '@angular/common'
 })
 export class UtilI18nModule {
   constructor(translate: TranslateService) {
-    translate.setDefaultLang(getDefaultLang())
-    translate.use(translate.getBrowserLang() || getDefaultLang())
+    translate.setDefaultLang(DEFAULT_LANG)
+    translate.use(translate.getBrowserLang() || DEFAULT_LANG)
   }
 }


### PR DESCRIPTION
Follow-up PR on #435 to avoid util-18n.module setting default language over apps' detected language.

Only tested in datahub app.