### PR TITLE
Dataviz / fix translation bug in table component

### DIFF
--- a/libs/ui/dataviz/src/lib/table/table.component.spec.ts
+++ b/libs/ui/dataviz/src/lib/table/table.component.spec.ts
@@ -4,10 +4,10 @@ import { MatSortModule } from '@angular/material/sort'
 import { MatTableModule } from '@angular/material/table'
 import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 import { TABLE_ITEM_FIXTURE, TABLE_ITEM_FIXTURE_HAB } from './table.fixtures'
-
 import { TableComponent } from './table.component'
 import { By } from '@angular/platform-browser'
 import { TableItemSizeDirective } from 'ng-table-virtual-scroll'
+import { TranslateModule } from '@ngx-translate/core'
 
 describe('TableComponent', () => {
   let component: TableComponent
@@ -15,7 +15,12 @@ describe('TableComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, MatTableModule, MatSortModule],
+      imports: [
+        NoopAnimationsModule,
+        MatTableModule,
+        MatSortModule,
+        TranslateModule.forRoot(),
+      ],
       declarations: [TableItemSizeDirective],
     })
       .overrideComponent(TableComponent, {

--- a/libs/ui/dataviz/src/lib/table/table.component.ts
+++ b/libs/ui/dataviz/src/lib/table/table.component.ts
@@ -16,6 +16,7 @@ import {
   TableVirtualScrollDataSource,
   TableVirtualScrollModule,
 } from 'ng-table-virtual-scroll'
+import { TranslateModule } from '@ngx-translate/core'
 
 const rowIdPrefix = 'table-item-'
 
@@ -35,6 +36,7 @@ export interface TableItemModel {
     TableVirtualScrollModule,
     ScrollingModule,
     NgForOf,
+    TranslateModule,
   ],
   selector: 'gn-ui-table',
   templateUrl: './table.component.html',

--- a/libs/ui/dataviz/src/lib/ui-dataviz.module.ts
+++ b/libs/ui/dataviz/src/lib/ui-dataviz.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { FigureComponent } from './figure/figure.component'
 import { MatIconModule } from '@angular/material/icon'
+
 @NgModule({
   imports: [CommonModule, MatIconModule],
   declarations: [FigureComponent],


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10629150/227769870-b311e9d6-b565-47d4-b3f4-992d4c3e208a.png)

After:
![image](https://user-images.githubusercontent.com/10629150/227769830-34ea5f97-5a56-4036-9d9c-d4def9942cb1.png)

Because the table component is standalone, it needs to explicitly import the translate module on its own. I feel like this might happen again in the future, since without standalone components these imports were only made once in the lib module.