### PR TITLE
Dataviz: Prevent chart dropdowns causing horizontal scroll

### DIFF
--- a/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.html
+++ b/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.html
@@ -29,7 +29,7 @@
       </gn-ui-dropdown-selector>
       <span
         *ngIf="footerList.length === 0"
-        class="block uppercase tracking-wide text-gray-800 text-xs font-bold whitespace-no-wrap text-right"
+        class="block uppercase tracking-wide text-gray-800 text-xs font-bold whitespace-nowrap text-right"
       >
         {{ footerLabel | translate }} {{ selectedValue | translate }}
       </span>

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.html
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.html
@@ -1,16 +1,21 @@
 <div class="w-full h-full flex flex-col">
-  <div class="flex flex-row justify-between text-[13px]">
+  <div
+    class="flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-2 justify-between text-[13px]"
+  >
     <gn-ui-dropdown-selector
+      class="basis-1/4"
       [choices]="typeChoices"
       (selectValue)="chartType = $event"
       [title]="'chart.dropdown.type' | translate"
     ></gn-ui-dropdown-selector>
     <gn-ui-dropdown-selector
+      class="basis-1/4"
       [choices]="xChoices$ | async"
       (selectValue)="xProperty$.next($event)"
       [title]="'chart.dropdown.xAxis' | translate"
     ></gn-ui-dropdown-selector>
     <gn-ui-dropdown-selector
+      class="basis-1/4"
       *ngIf="!isCountAggregation"
       [choices]="yChoices$ | async"
       (selectValue)="yProperty$.next($event)"
@@ -18,6 +23,7 @@
       class="select-y-prop"
     ></gn-ui-dropdown-selector>
     <gn-ui-dropdown-selector
+      class="basis-1/4"
       [choices]="aggregationChoices"
       class="aggregation-choices"
       (selectValue)="aggregation$.next($event)"

--- a/libs/ui/dataviz/src/lib/table/table.component.html
+++ b/libs/ui/dataviz/src/lib/table/table.component.html
@@ -17,7 +17,7 @@
         <td
           mat-cell
           *matCellDef="let element"
-          class="whitespace-no-wrap pr-1 truncate"
+          class="whitespace-nowrap pr-1 truncate"
         >
           {{ element[prop] }}
         </td>

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
@@ -1,7 +1,7 @@
 <div class="flex flex-col items-start sm:flex-row sm:items-center relative">
   <label
     *ngIf="showTitle"
-    class="block tracking-wide text-sm mb-2 sm:mb-0 sm:mr-2 whitespace-no-wrap"
+    class="block tracking-wide text-sm mb-2 sm:mb-0 sm:mx-2 whitespace-no-wrap shrink-0"
     [attr.for]="id"
   >
     {{ title }}
@@ -9,7 +9,7 @@
   <select
     [id]="id"
     (change)="this.selectValue.emit($event.target.value)"
-    class="text-main bg-white border border-gray-300 py-[10px] px-[16px] rounded-[0.25em] cursor-pointer leading-tight focus:outline-none hover:text-primary-darker hover:border-primary-lighter focus:ring-primary-lightest focus:ring-4"
+    class="w-full max-w-xs text-main bg-white border border-gray-300 py-[10px] px-[16px] rounded-[0.25em] cursor-pointer leading-tight focus:outline-none hover:text-primary-darker hover:border-primary-lighter focus:ring-primary-lightest focus:ring-4"
     [ngClass]="extraClass"
     [class.w-full]="!showTitle"
   >

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
@@ -1,7 +1,7 @@
 <div class="flex flex-col items-start sm:flex-row sm:items-center relative">
   <label
     *ngIf="showTitle"
-    class="block tracking-wide text-sm mb-2 sm:mb-0 sm:px-2 whitespace-nowrap shrink-0"
+    class="tracking-wide text-sm mb-2 sm:mb-0 sm:mr-2 whitespace-nowrap"
     [attr.for]="id"
   >
     {{ title }}

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
@@ -1,7 +1,7 @@
 <div class="flex flex-col items-start sm:flex-row sm:items-center relative">
   <label
     *ngIf="showTitle"
-    class="block tracking-wide text-sm mb-2 sm:mb-0 sm:mx-2 whitespace-no-wrap shrink-0"
+    class="block tracking-wide text-sm mb-2 sm:mb-0 sm:px-2 whitespace-no-wrap shrink-0"
     [attr.for]="id"
   >
     {{ title }}
@@ -9,7 +9,7 @@
   <select
     [id]="id"
     (change)="this.selectValue.emit($event.target.value)"
-    class="w-full max-w-xs text-main bg-white border border-gray-300 py-[10px] px-[16px] rounded-[0.25em] cursor-pointer leading-tight focus:outline-none hover:text-primary-darker hover:border-primary-lighter focus:ring-primary-lightest focus:ring-4"
+    class="w-full min-w-[66px] truncate text-main bg-white border border-gray-300 py-[10px] px-2 rounded-[0.25em] cursor-pointer leading-tight focus:outline-none hover:text-primary-darker hover:border-primary-lighter focus:ring-primary-lightest focus:ring-4"
     [ngClass]="extraClass"
     [class.w-full]="!showTitle"
   >

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
@@ -1,7 +1,7 @@
 <div class="flex flex-col items-start sm:flex-row sm:items-center relative">
   <label
     *ngIf="showTitle"
-    class="block tracking-wide text-sm mb-2 sm:mb-0 sm:px-2 whitespace-no-wrap shrink-0"
+    class="block tracking-wide text-sm mb-2 sm:mb-0 sm:px-2 whitespace-nowrap shrink-0"
     [attr.for]="id"
   >
     {{ title }}


### PR DESCRIPTION
PR prevents `dropdown-selector` to cause horizontal scroll, while staying big enough to display (at least parts of) the selected value. This is in particular necessary for the `chart-view.component` where dropdowns are displayed without wrapping.

Before:

![before](https://user-images.githubusercontent.com/6329425/228291656-2135e830-3a5a-4292-aab7-917d19b14a5b.png)

After:

![after](https://user-images.githubusercontent.com/6329425/228291718-3bece9e5-24d6-46c1-abe3-5041fe596827.png)
