### PR TITLE
Datafeeder / Fix the list of keywords not appearing any more on step 2

### DIFF
--- a/apps/datafeeder/src/app/configs/wizard.config.ts
+++ b/apps/datafeeder/src/app/configs/wizard.config.ts
@@ -3,9 +3,8 @@ import { WizardFieldType } from '@geonetwork-ui/feature/editor'
 import { WizardFieldModel } from '@geonetwork-ui/feature/editor'
 import SETTINGS from '../../settings'
 
-export const DEFAULT_CHIPS_ITEMS_URL = (keys) =>
-  `https://www.pigma.org/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.inspire-theme&rows=200&q=${keys}&uri=**&lang=` +
-  '${lang}'
+export const DEFAULT_CHIPS_ITEMS_URL = (q: string): string =>
+  SETTINGS.thesaurusUrl.replace('${q}', q)
 
 export const STORAGE_KEY = 'datafeeder-state'
 

--- a/apps/datafeeder/src/settings.ts
+++ b/apps/datafeeder/src/settings.ts
@@ -34,6 +34,7 @@ class Settings {
     { value: '50000', label: '1:50000' },
     { value: '100000', label: '1:100000' },
   ]
+  thesaurusUrl = `/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.inspire-theme&rows=200&q=$\{q}&uri=**&lang=$\{lang}`
 
   init() {
     return fetch(SETTING_API)

--- a/libs/ui/inputs/src/lib/chips-input/chips-input.component.html
+++ b/libs/ui/inputs/src/lib/chips-input/chips-input.component.html
@@ -6,7 +6,7 @@
   [secondaryPlaceholder]="placeholder"
   [ripple]="false"
   [animationDuration]="{ enter: '0ms', leave: '0ms' }"
-  onTextChangeDebounce="100"
+  [onTextChangeDebounce]="100"
   class="border-2 border-primary h-full rounded-lg p-2 bg-white text-sm focus:border-primary"
   [ngClass]="{ invalid: invalid }"
 >
@@ -19,6 +19,5 @@
     <ng-template let-item="item" let-index="index">
       {{ item.display }}
     </ng-template>
-    >
   </tag-input-dropdown>
 </tag-input>

--- a/libs/ui/inputs/src/lib/chips-input/chips-input.component.spec.ts
+++ b/libs/ui/inputs/src/lib/chips-input/chips-input.component.spec.ts
@@ -4,36 +4,122 @@ import { TranslateService } from '@ngx-translate/core'
 
 import { ChipsInputComponent } from './chips-input.component'
 import { NO_ERRORS_SCHEMA } from '@angular/core'
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing'
+import { TagInputModule } from 'ngx-chips'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 
-const translateServiceMock = {
-  currentLang: 'en',
+class TranslateServiceMock {
+  currentLang = 'en'
 }
+
+const VALUES_RESPONSE = [
+  {
+    values: { eng: 'Addresses' },
+    definitions: {
+      eng: 'Location of properties based on address identifiers, usually by road name, house number, postal code.',
+    },
+    coordEast: '',
+    coordWest: '',
+    coordSouth: '',
+    coordNorth: '',
+    thesaurusKey: 'external.theme.httpinspireeceuropaeutheme-theme',
+    value: 'Addresses',
+    definition:
+      'Location of properties based on address identifiers, usually by road name, house number, postal code.',
+    uri: 'http://inspire.ec.europa.eu/theme/ad',
+  },
+  {
+    values: { eng: 'Administrative units' },
+    definitions: {
+      eng: 'Units of administration, dividing areas where Member States have and/or exercise jurisdictional rights, for local, regional and national governance, separated by administrative boundaries.',
+    },
+    coordEast: '',
+    coordWest: '',
+    coordSouth: '',
+    coordNorth: '',
+    thesaurusKey: 'external.theme.httpinspireeceuropaeutheme-theme',
+    value: 'Administrative units',
+    definition:
+      'Units of administration, dividing areas where Member States have and/or exercise jurisdictional rights, for local, regional and national governance, separated by administrative boundaries.',
+    uri: 'http://inspire.ec.europa.eu/theme/au',
+  },
+  {
+    values: { eng: 'Agricultural and aquaculture facilities' },
+    definitions: {
+      eng: 'Farming equipment and production facilities (including irrigation systems, greenhouses and stables).',
+    },
+    coordEast: '',
+    coordWest: '',
+    coordSouth: '',
+    coordNorth: '',
+    thesaurusKey: 'external.theme.httpinspireeceuropaeutheme-theme',
+    value: 'Agricultural and aquaculture facilities',
+    definition:
+      'Farming equipment and production facilities (including irrigation systems, greenhouses and stables).',
+    uri: 'http://inspire.ec.europa.eu/theme/af',
+  },
+]
 
 describe('ChipsInputComponent', () => {
   let component: ChipsInputComponent
   let fixture: ComponentFixture<ChipsInputComponent>
+  let httpController: HttpTestingController
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [ChipsInputComponent],
-      imports: [HttpClientModule],
+      imports: [
+        HttpClientModule,
+        HttpClientTestingModule,
+        TagInputModule,
+        NoopAnimationsModule,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
         {
           provide: TranslateService,
-          useValue: translateServiceMock,
+          useClass: TranslateServiceMock,
         },
       ],
     }).compileComponents()
+    httpController = TestBed.inject(HttpTestingController)
   })
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ChipsInputComponent)
     component = fixture.componentInstance
-    fixture.detectChanges()
+    component.url = (search) => `http://my.registries.org/list/q=${search}`
+    component.loadOnce = true
   })
 
   it('should create', () => {
+    fixture.detectChanges()
     expect(component).toBeTruthy()
+  })
+
+  describe('options loading', () => {
+    let items
+    beforeEach(() => {
+      fixture.detectChanges()
+      component.ngOnInit()
+      component.requestAutocompleteItems('hello').subscribe((v) => (items = v))
+      const req = httpController.expectOne('http://my.registries.org/list/q=*')
+      req.flush(VALUES_RESPONSE)
+    })
+
+    it('shows the available options', () => {
+      expect(items).toEqual([
+        'Addresses',
+        'Administrative units',
+        'Agricultural and aquaculture facilities',
+      ])
+    })
+
+    afterEach(() => {
+      httpController.verify()
+    })
   })
 })

--- a/libs/ui/inputs/src/lib/chips-input/chips-input.component.ts
+++ b/libs/ui/inputs/src/lib/chips-input/chips-input.component.ts
@@ -45,7 +45,7 @@ export class ChipsInputComponent implements OnInit, OnDestroy {
       }
       const url = this.url(text)
 
-      const lang = LANG_2_TO_3_MAPPER[this.translate.currentLang]
+      const lang = LANG_2_TO_3_MAPPER[this.translate.currentLang.slice(0, 2)]
       return this.http
         .get<any>(url.replace('${lang}', lang))
         .pipe(map((item) => item.map((i) => i.values[lang])))


### PR DESCRIPTION
Due to a subtle bug the keyword list was not showing up when typing, only when clicking the field. This has been fixed.

![image](https://user-images.githubusercontent.com/10629150/231539045-9ef7da65-26d5-48ec-9b0a-8e27dc10c6cd.png)

This PR also contains some small fixes taken from the georchestra fork which has been used in production for several months now.

Note that this component relies on https://github.com/Gbuomprisco/ngx-chips which is both outdated and not maintained any more, so we should move to a more recent library whenever working on new features on this part.