### PR TITLE
Datafeeder / fix another infinite loop when polling progress

### DIFF
--- a/apps/datafeeder/src/app/presentation/pages/publish-page/publish-page.component.spec.ts
+++ b/apps/datafeeder/src/app/presentation/pages/publish-page/publish-page.component.spec.ts
@@ -2,10 +2,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { UtilI18nModule } from '@geonetwork-ui/util/i18n'
 import { TranslateModule } from '@ngx-translate/core'
 import { DatafeederFacade } from '../../../store/datafeeder.facade'
-
 import { PublishPageComponent } from './publish-page.component'
 import { NO_ERRORS_SCHEMA } from '@angular/core'
-import { Router, ActivatedRoute } from '@angular/router'
+import { ActivatedRoute, Router } from '@angular/router'
 import {
   DataPublishingApiService,
   PublishJobStatusApiModel,
@@ -15,30 +14,34 @@ import { of } from 'rxjs'
 import { TestScheduler } from 'rxjs/testing'
 import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
 
+const JOB_ID = '1234'
+
 const jobMock: PublishJobStatusApiModel = {
-  jobId: '1234',
+  jobId: JOB_ID,
   status: PublishStatusEnumApiModel.Done,
   progress: 1,
 }
 
-const publishServiceMock = {
-  getPublishingStatus: jest.fn(() => of(jobMock)),
+class PublishServiceMock {
+  getPublishingStatus = jest.fn(() => of(jobMock))
 }
-
-const activatedRouteMock = {
-  params: of({ id: 1 }),
+class FacadeMock {
+  setUpload = jest.fn()
 }
-
-const routerMock = {
-  navigate: jest.fn(),
+class ActivatedRouteMock {
+  params = of({ id: JOB_ID })
 }
-const facadeMock = {
-  setPublication: jest.fn(),
+class RouterMock {
+  navigate = jest.fn()
 }
 
 describe('SumUpPageComponent', () => {
   let component: PublishPageComponent
   let fixture: ComponentFixture<PublishPageComponent>
+  let facade: DatafeederFacade
+  let dataPublishingService: DataPublishingApiService
+  let activatedRoute: ActivatedRoute
+  let router: Router
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -48,13 +51,17 @@ describe('SumUpPageComponent', () => {
       providers: [
         {
           provide: DatafeederFacade,
-          useValue: facadeMock,
+          useClass: FacadeMock,
         },
-        { provide: DataPublishingApiService, useValue: publishServiceMock },
-        { provide: Router, useValue: routerMock },
-        { provide: ActivatedRoute, useValue: activatedRouteMock },
+        { provide: DataPublishingApiService, useClass: PublishServiceMock },
+        { provide: Router, useClass: RouterMock },
+        { provide: ActivatedRoute, useClass: ActivatedRouteMock },
       ],
     }).compileComponents()
+    facade = TestBed.inject(DatafeederFacade)
+    dataPublishingService = TestBed.inject(DataPublishingApiService)
+    activatedRoute = TestBed.inject(ActivatedRoute)
+    router = TestBed.inject(Router)
   })
 
   beforeEach(() => {
@@ -78,8 +85,10 @@ describe('SumUpPageComponent', () => {
       }
       expectObservable(component.statusFetch$).toBe(expected, values)
     })
-    expect(publishServiceMock.getPublishingStatus).toHaveBeenCalledWith(1)
-    expect(facadeMock.setPublication).toHaveBeenCalledWith(jobMock)
+    expect(dataPublishingService.getPublishingStatus).toHaveBeenCalledWith(
+      JOB_ID
+    )
+    expect(facade.setPublication).toHaveBeenCalledWith(jobMock)
     expect(component.progress).toBe(100)
   })
 
@@ -91,8 +100,8 @@ describe('SumUpPageComponent', () => {
     })
 
     it('route to publishok page', () => {
-      expect(routerMock.navigate).toHaveBeenCalledWith(['/', 1, 'publishok'], {
-        relativeTo: activatedRouteMock,
+      expect(router.navigate).toHaveBeenCalledWith(['/', JOB_ID, 'publishok'], {
+        relativeTo: activatedRoute,
         queryParams: {},
       })
     })

--- a/apps/datafeeder/src/app/presentation/pages/publish-page/publish-page.component.spec.ts
+++ b/apps/datafeeder/src/app/presentation/pages/publish-page/publish-page.component.spec.ts
@@ -10,9 +10,9 @@ import {
   PublishJobStatusApiModel,
   PublishStatusEnumApiModel,
 } from '@geonetwork-ui/data-access/datafeeder'
-import { of } from 'rxjs'
-import { TestScheduler } from 'rxjs/testing'
+import { delay, of } from 'rxjs'
 import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
+import advanceTimersByTime = jest.advanceTimersByTime
 
 const JOB_ID = '1234'
 
@@ -23,10 +23,37 @@ const jobMock: PublishJobStatusApiModel = {
 }
 
 class PublishServiceMock {
-  getPublishingStatus = jest.fn(() => of(jobMock))
+  _startTime = null
+  _delay = 0
+  _interval
+  getPublishingStatus = jest.fn(() => {
+    // simulate passage of time
+    if (this._startTime === null) {
+      this._startTime = Date.now()
+    }
+    const duration = Date.now() - this._startTime
+    // total duration is 4s
+    const progress = Math.min(1, Math.round(duration / 40) / 100)
+    const job = {
+      ...jobMock,
+      progress,
+      status:
+        progress === 1
+          ? PublishStatusEnumApiModel.Done
+          : PublishStatusEnumApiModel.Pending,
+    }
+    if (progress === 1) {
+      clearInterval(this._interval)
+    }
+    if (this._delay) {
+      return of(job).pipe(delay(this._delay))
+    } else {
+      return of(job)
+    }
+  })
 }
 class FacadeMock {
-  setUpload = jest.fn()
+  setPublication = jest.fn()
 }
 class ActivatedRouteMock {
   params = of({ id: JOB_ID })
@@ -35,7 +62,9 @@ class RouterMock {
   navigate = jest.fn()
 }
 
-describe('SumUpPageComponent', () => {
+jest.useFakeTimers()
+
+describe('PublishPageComponent', () => {
   let component: PublishPageComponent
   let fixture: ComponentFixture<PublishPageComponent>
   let facade: DatafeederFacade
@@ -67,35 +96,77 @@ describe('SumUpPageComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(PublishPageComponent)
     component = fixture.componentInstance
-    fixture.detectChanges()
+    jest.spyOn(component, 'onJobFinish')
   })
 
   it('should create', () => {
+    fixture.detectChanges()
     expect(component).toBeTruthy()
   })
 
-  it('fetches batch status', () => {
-    const scheduler = new TestScheduler((actual, expected) => {
-      expect(actual).toEqual(expected)
+  describe('progress monitoring', () => {
+    it('calls getPublishingStatus initially', async () => {
+      await component.ngOnInit()
+      expect(dataPublishingService.getPublishingStatus).toHaveBeenCalledWith(
+        JOB_ID
+      )
     })
-    scheduler.run(({ expectObservable }) => {
-      const expected = '500ms (a-|)'
-      const values = {
-        a: jobMock,
-      }
-      expectObservable(component.statusFetch$).toBe(expected, values)
+    it('completes after 4s', async () => {
+      await component.ngOnInit()
+      advanceTimersByTime(4100)
+      expect(component.onJobFinish).toHaveBeenCalledTimes(1)
+      expect(component.onJobFinish).toHaveBeenCalledWith({
+        ...jobMock,
+        status: PublishStatusEnumApiModel.Done,
+        progress: 1,
+      })
     })
-    expect(dataPublishingService.getPublishingStatus).toHaveBeenCalledWith(
-      JOB_ID
-    )
-    expect(facade.setPublication).toHaveBeenCalledWith(jobMock)
-    expect(component.progress).toBe(100)
+    it('calls getPublishingStatus every 500ms', async () => {
+      await component.ngOnInit()
+      advanceTimersByTime(4100)
+      expect(dataPublishingService.getPublishingStatus).toHaveBeenCalledTimes(9)
+    })
+    it('updates progress along the way', async () => {
+      await component.ngOnInit()
+      expect(component.progress).toEqual(0)
+      advanceTimersByTime(1000)
+      expect(component.progress).toEqual(25)
+      advanceTimersByTime(2000)
+      expect(component.progress).toEqual(75)
+      advanceTimersByTime(1000)
+      expect(component.progress).toEqual(100)
+      advanceTimersByTime(1000)
+      expect(component.progress).toEqual(100)
+    })
+    describe('when status request takes more than 500ms', () => {
+      beforeEach(() => {
+        ;(dataPublishingService as any)._delay = 1500
+      })
+      it('completes after 4s + delay', async () => {
+        await component.ngOnInit()
+        advanceTimersByTime(5500)
+        expect(component.onJobFinish).toHaveBeenCalledTimes(1)
+        expect(component.onJobFinish).toHaveBeenCalledWith({
+          ...jobMock,
+          status: PublishStatusEnumApiModel.Done,
+          progress: 1,
+        })
+      })
+      it('calls getPublishingStatus every 2 seconds', async () => {
+        await component.ngOnInit()
+        advanceTimersByTime(4100)
+        expect(dataPublishingService.getPublishingStatus).toHaveBeenCalledTimes(
+          3
+        )
+      })
+    })
   })
 
   describe('publish DONE', () => {
     let job
-    beforeEach(() => {
+    beforeEach(async () => {
       job = jobMock
+      await component.ngOnInit()
       component.onJobFinish(job)
     })
 


### PR DESCRIPTION
Similar to https://github.com/geonetwork/geonetwork-ui/pull/450 but for the publishing step (at the end of the process).

The issue was exactly the same and so is the fix.