### PR TITLE
Datahub: Fix home page figures

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -35,6 +35,7 @@ jobs:
         npx nx affected --target=build --parallel=3
 
   agents:
+    if: github.event.pull_request.draft == false
     name: Nx Cloud - Agents
     uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.3
     with:

--- a/libs/feature/catalog/src/lib/organisations/organisations.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.service.spec.ts
@@ -110,6 +110,57 @@ describe('OrganisationsService', () => {
           .pipe(take(1))
           .subscribe((orgs) => (organisations = orgs))
       })
+      it('call search service', () => {
+        expect(searchApiServiceMock.search).toHaveBeenCalledWith(
+          'bucket',
+          JSON.stringify({
+            aggregations: {
+              contact: {
+                nested: { path: 'contactForResource' },
+                aggs: {
+                  org: {
+                    terms: {
+                      field: 'contactForResource.organisation',
+                      exclude: '',
+                      size: 5000,
+                      order: { _key: 'asc' },
+                    },
+                    aggs: {
+                      mail: {
+                        terms: {
+                          size: 50,
+                          exclude: '',
+                          field: 'contactForResource.email.keyword',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            from: 0,
+            size: 0,
+            query: {
+              bool: {
+                must: [{ terms: { isTemplate: ['n'] } }],
+                must_not: {
+                  terms: {
+                    resourceType: [
+                      'service',
+                      'map',
+                      'map/static',
+                      'mapDigital',
+                    ],
+                  },
+                },
+                should: [],
+                filter: [],
+              },
+            },
+            _source: [],
+          })
+        )
+      })
       it('get rough organisations', () => {
         expect(organisations).toEqual([
           {

--- a/libs/feature/catalog/src/lib/organisations/organisations.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.service.ts
@@ -97,13 +97,13 @@ export class OrganisationsService {
                   terms: {
                     field: 'contactForResource.organisation',
                     exclude: '',
-                    size: 1000,
+                    size: 5000,
                     order: { _key: 'asc' },
                   },
                   aggs: {
                     mail: {
                       terms: {
-                        size: 1000,
+                        size: 50,
                         exclude: '',
                         field: 'contactForResource.email.keyword',
                       },

--- a/libs/feature/catalog/src/lib/records/records.service.ts
+++ b/libs/feature/catalog/src/lib/records/records.service.ts
@@ -11,7 +11,10 @@ export class RecordsService {
   recordsCount$: Observable<number> = this.searchApiService
     .search(
       'records-count',
-      JSON.stringify(this.esService.getSearchRequestBody())
+      JSON.stringify({
+        ...this.esService.getSearchRequestBody(),
+        track_total_hits: true,
+      })
     )
     .pipe(
       map((response) => response.hits.total.value),


### PR DESCRIPTION
Datahub home page figures are both limited
- records to 10K
- orgs to 1K

The PR removes this limit.

It also fixes an issue with nx-agent if the PR is on draft.
