### PR TITLE
fix(feed): strip html in abstract

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,10 +47,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout branch
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
           persist-credentials: false
           fetch-depth: 0
 
@@ -61,9 +60,7 @@ jobs:
           cache: 'npm'
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v2
-        with:
-          main-branch-name: 'main'
+        uses: nrwl/nx-set-shas@v3
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,7 +42,7 @@ jobs:
       number-of-agents: 3
 
   affected-recap:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     name: Print affected libs and apps
     runs-on: ubuntu-latest
 
@@ -76,7 +76,7 @@ jobs:
           { print "`"$1"`" }')" >> $GITHUB_ENV
 
       - name: add PR comment
-        uses: thollander/actions-comment-pull-request@v1
+        uses: thollander/actions-comment-pull-request@v2
         with:
           message: 'Affected libs: ${{ env.AFFECTED_LIBS }}
 

--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
@@ -61,7 +61,7 @@
       <h1 class="font-title text-[21px] font-medium mb-3 pr-8">
         {{ record.title }}
       </h1>
-      <p class="text-gray-900 line-clamp-3">{{ record.abstract }}</p>
+      <p class="text-gray-900 line-clamp-3">{{ abstract }}</p>
       <gn-ui-thumbnail
         *ngIf="record.thumbnailUrl"
         class="block mt-3 w-full h-[136px] border border-gray-100 rounded-lg overflow-hidden"

--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.spec.ts
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.spec.ts
@@ -20,7 +20,7 @@ describe('RecordPreviewFeedComponent', () => {
       id: '139',
       uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
       title: 'abcd',
-      abstract: 'Abcd',
+      abstract: '<b>abstract</b>',
       metadataUrl: '/abcd.html',
       thumbnailUrl: '/abcd.jpg',
     }
@@ -29,5 +29,8 @@ describe('RecordPreviewFeedComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+  it('abstract is stripped', () => {
+    expect(component.abstract).toBe('abstract')
   })
 })

--- a/libs/ui/search/src/lib/record-preview-list/record-preview-list.component.spec.ts
+++ b/libs/ui/search/src/lib/record-preview-list/record-preview-list.component.spec.ts
@@ -21,7 +21,7 @@ describe('RecordPreviewListComponent', () => {
       id: '139',
       uuid: 'd2f30aa4-867e-40b9-9c37-3cb21f541008',
       title: 'abcd',
-      abstract: 'Abcd',
+      abstract: '<b>abstract</b>',
       metadataUrl: '/abcd.html',
       thumbnailUrl: '/abcd.jpg',
     }
@@ -30,5 +30,8 @@ describe('RecordPreviewListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+  it('abstract is stripped', () => {
+    expect(component.abstract).toBe('abstract')
   })
 })

--- a/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.ts
+++ b/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.ts
@@ -1,6 +1,5 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core'
+import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { RecordPreviewComponent } from '../record-preview/record-preview.component'
-import { stripHtml } from '@geonetwork-ui/util/shared'
 
 @Component({
   selector: 'gn-ui-record-preview-row',
@@ -8,13 +7,4 @@ import { stripHtml } from '@geonetwork-ui/util/shared'
   styleUrls: ['./record-preview-row.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RecordPreviewRowComponent
-  extends RecordPreviewComponent
-  implements OnInit
-{
-  abstract: string
-  ngOnInit() {
-    super.ngOnInit()
-    this.abstract = stripHtml(this.record.abstract)
-  }
-}
+export class RecordPreviewRowComponent extends RecordPreviewComponent {}

--- a/libs/ui/search/src/lib/record-preview/record-preview.component.ts
+++ b/libs/ui/search/src/lib/record-preview/record-preview.component.ts
@@ -8,7 +8,11 @@ import {
   ElementRef,
   TemplateRef,
 } from '@angular/core'
-import { MetadataContact, MetadataRecord } from '@geonetwork-ui/util/shared'
+import {
+  MetadataContact,
+  MetadataRecord,
+  stripHtml,
+} from '@geonetwork-ui/util/shared'
 import { fromEvent, Subscription } from 'rxjs'
 
 @Component({
@@ -21,6 +25,7 @@ export class RecordPreviewComponent implements OnInit, OnDestroy {
   @Input() favoriteTemplate: TemplateRef<{ $implicit: MetadataRecord }>
   @Output() mdSelect = new EventEmitter<MetadataRecord>()
   subscription = new Subscription()
+  abstract: string
 
   get isViewable() {
     return this.record.hasMaps
@@ -35,6 +40,7 @@ export class RecordPreviewComponent implements OnInit, OnDestroy {
   constructor(protected elementRef: ElementRef) {}
 
   ngOnInit(): void {
+    this.abstract = stripHtml(this.record?.abstract)
     this.subscription.add(
       fromEvent(this.elementRef.nativeElement, 'click').subscribe(
         (event: Event) => {


### PR DESCRIPTION
Refactor so stripped abstract is available for every preview

Also test PR from fork

- [x] Works good with `nx-cloud` 
- [x] Skip the `print-affected` task (only READ mode for forks).