### PR TITLE
Datahub: hide chart on mobile

### DIFF
--- a/libs/feature/record/src/lib/record-metadata/record-metadata.component.css
+++ b/libs/feature/record/src/lib/record-metadata/record-metadata.component.css
@@ -26,6 +26,10 @@
     margin-right: 24px;
     justify-content: left !important;
   }
+  /*hide chart tab on mobile*/
+  ::ng-deep .mat-mdc-tab.mdc-tab:nth-child(3) {
+    display: none;
+  }
 }
 .tracking-wider {
   letter-spacing: 0.88px;


### PR DESCRIPTION
PR hides the dataviz chart on small devices (witdh < 640px). Could not find a better way than touching on CSS for this, using the mat-tabs.