### PR TITLE
Fix a bug in the topic facet

### DIFF
--- a/libs/feature/search/src/lib/utils/service/fields.spec.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.spec.ts
@@ -255,10 +255,11 @@ describe('search fields implementations', () => {
           expect.any(String),
           JSON.stringify({
             aggregations: {
-              topic: {
+              'cl_topic.key': {
                 terms: {
                   size: 1000,
                   field: 'cl_topic.key',
+                  order: { _key: 'asc' },
                 },
               },
             },

--- a/libs/feature/search/src/lib/utils/service/fields.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.ts
@@ -26,7 +26,7 @@ export class SimpleSearchField implements AbstractSearchField {
   protected searchApiService = this.injector.get(SearchApiService)
 
   constructor(
-    private esFieldName: string,
+    protected esFieldName: string,
     private order: 'asc' | 'desc' = 'asc',
     protected injector: Injector
   ) {}
@@ -93,24 +93,13 @@ export class TopicSearchField extends SimpleSearchField {
     .pipe(shareReplay(1))
 
   constructor(injector: Injector) {
-    super('topic', 'asc', injector)
+    super('cl_topic.key', 'asc', injector)
   }
 
   private async getTopicTranslation(topicKey: string) {
     return firstValueFrom(
       this.allTranslations.pipe(map((translations) => translations[topicKey]))
     )
-  }
-
-  protected getAggregations() {
-    return {
-      topic: {
-        terms: {
-          size: 1000,
-          field: 'cl_topic.key',
-        },
-      },
-    }
   }
 
   protected async getBucketLabel(bucket) {


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/geonetwork/geonetwork-ui/pull/460 which meant that filtering on a topic wouldn't work anymore.