### PR TITLE
Use node 16 for QA checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,6 +33,7 @@ jobs:
         npx nx affected --target=lint --parallel=3
         npx nx affected --target=test --parallel=3 --ci --code-coverage
         npx nx affected --target=build --parallel=3
+      node-version: 16.17.0 # FIXME: use env.NODE_VERSION
 
   agents:
     if: github.event.pull_request.draft == false
@@ -40,6 +41,7 @@ jobs:
     uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.3
     with:
       number-of-agents: 3
+      node-version: 16.17.0 # FIXME: use env.NODE_VERSION
 
   affected-recap:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'


### PR DESCRIPTION
A test is failing on node 18:
```
FAIL   util-shared  libs/util/shared/src/lib/services/proxy.service.spec.ts
  ● Test suite failed to run

    TypeError: Cannot redefine property: window

      3 |
      4 | // mock window.location
    > 5 | ;(global as any).window = Object.create(window)
        |                        ^
      6 | Object.defineProperty(window, 'location', {
      7 |   value: new URL('http://myhost:1234/my/path?abc'),
      8 | })

      at Object.<anonymous> (src/lib/services/proxy.service.spec.ts:5:24)
```

Apparently due to a bug in node 18.16: https://github.com/nodejs/node/issues/47563

This change can eventually be reverted once this bug is fixed in the LTS version.
