### PR TITLE
feat(orgs): Two lines for org name and fading out description

### DIFF
--- a/libs/feature/catalog/src/lib/organisations/organisations.component.html
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.html
@@ -5,7 +5,8 @@
   class="grid grid-cols-1 mt-6 gap-x-6 gap-y-8 sm:grid-cols-2 lg:grid-cols-3"
 >
   <gn-ui-content-ghost
-    ghostClass="h-36 mb-36"
+    class="h-[300px]"
+    ghostClass="h-full mb-36"
     *ngFor="let organisation of organisations$ | async; trackBy: trackByIndex"
     [showContent]="organisation.description !== null"
   >

--- a/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.css
+++ b/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.css
@@ -1,0 +1,13 @@
+.abstract {
+  position: relative;
+}
+
+.abstract::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: linear-gradient(0deg, white, transparent);
+  height: 10px;
+}

--- a/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.html
+++ b/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.html
@@ -1,22 +1,26 @@
 <a href (click)="clickOrganisation($event)">
-  <div class="group cursor-pointer rounded-lg" [title]="organisation.name">
+  <div
+    class="group cursor-pointer rounded-lg h-full flex flex-col"
+    [title]="organisation.name"
+  >
     <div
-      class="overflow-hidden bg-gray-100 rounded-lg w-full border border-gray-300 h-36 group-hover:shadow-xl group-hover:border-0"
+      class="flex-shrink-0 bg-gray-100 rounded-lg w-full border border-gray-300 h-36 group-hover:shadow-xl group-hover:border-0"
     >
       <gn-ui-thumbnail
         class="relative h-full w-full"
         [thumbnailUrl]="organisation.logoUrl"
         fit="contain"
-      ></gn-ui-thumbnail>
+      >
+      </gn-ui-thumbnail>
     </div>
-    <div class="px-3 pb-2 capitalize">
+    <div class="px-3 pb-2 capitalize flex flex-col flex-grow overflow-hidden">
       <span
-        class="mb-3 mt-5 font-title text-21 text-title group-hover:text-primary line-clamp-2 sm:line-clamp-1 sm:mt-2"
+        class="flex-shrink-0 mb-3 mt-5 font-title text-21 text-title group-hover:text-primary line-clamp-2 sm:mt-2"
       >
         {{ organisation.name }}</span
       >
       <p
-        class="abstract mt-4 mb-5 h-36 sm:mb-2 sm:h-[4.5rem] line-clamp-6 sm:line-clamp-3 sm:mt-0"
+        class="abstract mt-4 mb-5 sm:mb-2 sm:mt-0 flex-grow flex-shrink-1 overflow-hidden"
       >
         {{ organisation.description }}
       </p>
@@ -29,7 +33,7 @@
       <span>suivre</span>
     </button>
 -->
-      <div class="text-primary opacity-50 flex leading-6">
+      <div class="flex-shrink-0 text-primary opacity-50 flex leading-6">
         <mat-icon class="text-primary opacity-50 mr-1">folder_open </mat-icon>
         <span class="mx-1">{{ organisation.recordCount }}</span>
         <span translate>record.metadata.publications</span>

--- a/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.stories.ts
+++ b/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.stories.ts
@@ -32,7 +32,8 @@ export default {
       ],
     }),
     componentWrapperDecorator(
-      (story) => `<div style="max-width: 700px">${story}</div>`
+      (story) =>
+        `<div class="border border-gray-300 h-[350px] w-[250px] p-[10px]" style="resize: both; overflow: auto">${story}</div>`
     ),
   ],
 } as Meta<OrganisationPreviewComponent>


### PR DESCRIPTION
![Screenshot from 2023-05-15 14-24-00](https://github.com/geonetwork/geonetwork-ui/assets/133115263/9af06361-a18c-4717-a079-73be4dea8f04)

- We are using the line-clamp after two lines of org name
- Since we cannot know if the org name is one or two lines, we are using a fading out gradient for the description, if it's too long
