### PR TITLE
Datafeeder / Show the max upload size as advertised in the config

### DIFF
--- a/apps/datafeeder/src/app/presentation/components/svg/upload-data-error-dialog/upload-data-error-dialog.component.html
+++ b/apps/datafeeder/src/app/presentation/components/svg/upload-data-error-dialog/upload-data-error-dialog.component.html
@@ -18,7 +18,9 @@
 <div class="error-dialog">
   <div class="w-1/2">
     <strong class="text-focus">{{ error && (error.title | translate) }}</strong>
-    <span class="text-help">{{ error && (error.subtitle | translate) }}</span>
+    <span class="text-help">{{
+      error && (error.subtitle | translate: { size: maxFileSizeMb.toFixed(0) })
+    }}</span>
   </div>
   <div class="illustration" *ngIf="error && error.type">
     <svg

--- a/apps/datafeeder/src/app/presentation/components/svg/upload-data-error-dialog/upload-data-error-dialog.component.ts
+++ b/apps/datafeeder/src/app/presentation/components/svg/upload-data-error-dialog/upload-data-error-dialog.component.ts
@@ -21,4 +21,5 @@ export interface UploadDataError {
 })
 export class UploadDataErrorDialogComponent {
   @Input() error: UploadDataError
+  @Input() maxFileSizeMb: number
 }

--- a/apps/datafeeder/src/app/presentation/components/upload-data-rules/upload-data-rules.component.html
+++ b/apps/datafeeder/src/app/presentation/components/upload-data-rules/upload-data-rules.component.html
@@ -6,7 +6,10 @@
       - {{ format }}
     </span>
   </div>
-  <span class="font-bold" translate [translateParams]="{ size: maxFileSize }"
+  <span
+    class="font-bold"
+    translate
+    [translateParams]="{ size: maxFileSizeMb.toFixed(0) }"
     >datafeeder.upload.maxFileSize</span
   >
   <div class="w-20 h-1 bg-orange-500 mt-4"></div>

--- a/apps/datafeeder/src/app/presentation/components/upload-data-rules/upload-data-rules.component.spec.ts
+++ b/apps/datafeeder/src/app/presentation/components/upload-data-rules/upload-data-rules.component.spec.ts
@@ -20,6 +20,7 @@ describe('UploadDataRulesComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(UploadDataRulesComponent)
     component = fixture.componentInstance
+    component.maxFileSizeMb = 12
     fixture.detectChanges()
   })
 

--- a/apps/datafeeder/src/app/presentation/components/upload-data-rules/upload-data-rules.component.ts
+++ b/apps/datafeeder/src/app/presentation/components/upload-data-rules/upload-data-rules.component.ts
@@ -6,6 +6,6 @@ import { Component, Input } from '@angular/core'
   styleUrls: ['./upload-data-rules.component.css'],
 })
 export class UploadDataRulesComponent {
-  @Input() maxFileSize = 30
+  @Input() maxFileSizeMb: number
   @Input() acceptedFileFormats = ['SHP', 'GeoJSON', 'GeoPackage', 'Spatialite']
 }

--- a/apps/datafeeder/src/app/presentation/pages/upload-data-page/size.utils.spec.ts
+++ b/apps/datafeeder/src/app/presentation/pages/upload-data-page/size.utils.spec.ts
@@ -1,0 +1,34 @@
+import { parseSizeAsMb } from './size.utils'
+
+describe('parseSizeAsMb', () => {
+  describe('size as number', () => {
+    it('converts to MB', () => {
+      expect(parseSizeAsMb('12')).toEqual(0.000011444091796875)
+    })
+  })
+  describe('size in B', () => {
+    it('converts to MB', () => {
+      expect(parseSizeAsMb('12B')).toEqual(0.000011444091796875)
+    })
+  })
+  describe('size in KB', () => {
+    it('converts to MB', () => {
+      expect(parseSizeAsMb('12KB')).toEqual(0.01171875)
+    })
+  })
+  describe('size in MB', () => {
+    it('converts to MB', () => {
+      expect(parseSizeAsMb('12MB')).toEqual(12)
+    })
+  })
+  describe('size in GB', () => {
+    it('converts to MB', () => {
+      expect(parseSizeAsMb('12GB')).toEqual(12288)
+    })
+  })
+  describe('size in TB', () => {
+    it('converts to MB', () => {
+      expect(parseSizeAsMb('12TB')).toEqual(12582912)
+    })
+  })
+})

--- a/apps/datafeeder/src/app/presentation/pages/upload-data-page/size.utils.ts
+++ b/apps/datafeeder/src/app/presentation/pages/upload-data-page/size.utils.ts
@@ -1,0 +1,25 @@
+/**
+ * @param dataSize In the format of the Spring Boot DataSize class
+ * https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/unit/DataSize.html
+ * @return size expressed in MB
+ */
+export function parseSizeAsMb(dataSize: string): number {
+  const suffix = dataSize.match(/[A-Z]*$/)[0]
+  const numericalPart = dataSize.substring(0, dataSize.length - suffix.length)
+  const parsedSize = parseFloat(numericalPart)
+  switch (suffix) {
+    case 'TB':
+      return parsedSize * 1024 * 1024
+    case 'GB':
+      return parsedSize * 1024
+    case 'KB':
+      return parsedSize / 1024
+    case '':
+    case 'B':
+      return parsedSize / 1024 / 1024
+    case 'MB':
+      return parsedSize
+    default:
+      throw new Error('Parsing size as MB failed')
+  }
+}

--- a/apps/datafeeder/src/app/presentation/pages/upload-data-page/upload-data.page.html
+++ b/apps/datafeeder/src/app/presentation/pages/upload-data-page/upload-data.page.html
@@ -10,19 +10,20 @@
 
       <div class="pb-20 relative">
         <gn-ui-upload-data-component
-          [maxFileSizeMb]="maxFileSize"
+          [maxFileSizeMb]="maxFileSizeMb"
           (jobId$)="onJobIdGet($event)"
           (errors$)="onUploadError($event)"
         ></gn-ui-upload-data-component>
         <gn-ui-upload-data-error-dialog
           class="error-dialog"
           [error]="error"
+          [maxFileSizeMb]="maxFileSizeMb"
           *ngIf="error"
         ></gn-ui-upload-data-error-dialog>
       </div>
 
       <gn-ui-upload-data-rules
-        [maxFileSize]="maxFileSize"
+        [maxFileSizeMb]="maxFileSizeMb"
         [acceptedFileFormats]="['SHP']"
       >
       </gn-ui-upload-data-rules>

--- a/apps/datafeeder/src/app/presentation/pages/upload-data-page/upload-data.page.ts
+++ b/apps/datafeeder/src/app/presentation/pages/upload-data-page/upload-data.page.ts
@@ -5,6 +5,8 @@ import {
   UploadDataError,
   UploadDataErrorType,
 } from '../../components/svg/upload-data-error-dialog/upload-data-error-dialog.component'
+import SETTINGS from '../../../../settings'
+import { parseSizeAsMb } from './size.utils'
 
 marker('datafeeder.upload.error.title.analysis')
 marker('datafeeder.upload.error.subtitle.analysis')
@@ -16,7 +18,9 @@ marker('datafeeder.upload.error.subtitle.analysis')
 })
 export class UploadDataPageComponent implements OnInit {
   error: UploadDataError
-  maxFileSize = 30
+  get maxFileSizeMb() {
+    return parseSizeAsMb(SETTINGS.maxFileUploadSize)
+  }
 
   constructor(private router: Router, private activatedRoute: ActivatedRoute) {}
 

--- a/apps/datafeeder/src/settings.ts
+++ b/apps/datafeeder/src/settings.ts
@@ -35,7 +35,7 @@ class Settings {
     { value: '100000', label: '1:100000' },
   ]
   thesaurusUrl = `/geonetwork/srv/api/registries/vocabularies/search?type=CONTAINS&thesaurus=external.theme.inspire-theme&rows=200&q=$\{q}&uri=**&lang=$\{lang}`
-
+  maxFileUploadSize = '-1'
   init() {
     return fetch(SETTING_API)
       .then((response) => response.json())

--- a/translations/en.json
+++ b/translations/en.json
@@ -65,7 +65,7 @@
   "datafeeder.upload.error.subtitle.analysis": "Check that the file contains a valid geospatial dataset",
   "datafeeder.upload.error.subtitle.cantOpenFile": "Please check that the file is valid",
   "datafeeder.upload.error.subtitle.fileFormat": "Remember: only SHP",
-  "datafeeder.upload.error.subtitle.fileSize": "Remember: 30 MB maximum",
+  "datafeeder.upload.error.subtitle.fileSize": "Remember: {size} MB maximum",
   "datafeeder.upload.error.title.analysis": "Error during the dataset analysis",
   "datafeeder.upload.error.title.cantOpenFile": "Error while opening the file",
   "datafeeder.upload.error.title.fileFormat": "The selected file format is not supported",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -65,7 +65,7 @@
   "datafeeder.upload.error.subtitle.analysis": "Le fichier transféré contient-il des données géographiques valides ?",
   "datafeeder.upload.error.subtitle.cantOpenFile": "Vérifiez la validité du fichier sélectionné",
   "datafeeder.upload.error.subtitle.fileFormat": "Rappel : uniquement des SHP",
-  "datafeeder.upload.error.subtitle.fileSize": "Rappel : 30MB maximum",
+  "datafeeder.upload.error.subtitle.fileSize": "Rappel : {size} Mo maximum",
   "datafeeder.upload.error.title.analysis": "Erreur lors de l'analyse des données",
   "datafeeder.upload.error.title.cantOpenFile": "Erreur lors de l'ouverture du fichier",
   "datafeeder.upload.error.title.fileFormat": "Le format du fichier n'est pas supporté",


### PR DESCRIPTION
Followup of https://github.com/georchestra/georchestra/pull/3973

Max file upload size is now available in the config API so we show it in the various relevant places.

Note: absence of file size limit (i.e. maxFileUploadSize is `-1`) is not supported.