### PR TITLE
Only show formats that are present in the links and make them more accessible

### DIFF
--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
@@ -9,14 +9,17 @@
     record.metadata.download
   </p>
   <div class="flex flex-wrap justify-start sm:justify-end sm:pb-4">
-    <span
+    <button
+      type="button"
       [class.opacity-100]="isFilterActive(format)"
-      class="bg-gray-200 cursor-pointer p-2 m-1 rounded opacity-50 text-sm sm:2"
-      (click)="toggleFilterFormat($event.target.value)"
-      [value]="format"
-      *ngFor="let format of filterFormats"
-      >{{ getFilterFormatTitle(format) }}</span
+      class="bg-gray-200 cursor-pointer p-2 m-1 rounded text-sm sm:2 format-filter"
+      [ngClass]="isFilterActive(format) ? 'opacity-100' : 'opacity-50'"
+      (click)="toggleFilterFormat(format)"
+      [attr.data-format]="format"
+      *ngFor="let format of visibleFormats"
     >
+      {{ getFilterFormatTitle(format) }}
+    </button>
   </div>
 </div>
 <div class="mb-2 sm:mb-3" *ngFor="let link of filteredLinks">

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
@@ -9,17 +9,18 @@
     record.metadata.download
   </p>
   <div class="flex flex-wrap justify-start sm:justify-end sm:pb-4">
-    <button
-      type="button"
-      [class.opacity-100]="isFilterActive(format)"
-      class="bg-gray-200 cursor-pointer p-2 m-1 rounded text-sm sm:2 format-filter"
-      [ngClass]="isFilterActive(format) ? 'opacity-100' : 'opacity-50'"
-      (click)="toggleFilterFormat(format)"
+    <gn-ui-button
+      class="m-1 format-filter"
+      [extraClass]="
+        '!px-[12px] !py-[8px] !text-[15px]' +
+        (isFilterActive(format) ? ' opacity-100' : ' opacity-50')
+      "
+      (buttonClick)="toggleFilterFormat(format)"
       [attr.data-format]="format"
       *ngFor="let format of visibleFormats"
     >
       {{ getFilterFormatTitle(format) }}
-    </button>
+    </gn-ui-button>
   </div>
 </div>
 <div class="mb-2 sm:mb-3" *ngFor="let link of filteredLinks">

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.spec.ts
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.spec.ts
@@ -27,7 +27,7 @@ class MockDownloadItemComponent {
 describe('DownloadsListComponent', () => {
   let component: DownloadsListComponent
   let fixture: ComponentFixture<DownloadsListComponent>
-  let de
+  let de: DebugElement
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -66,7 +66,7 @@ describe('DownloadsListComponent', () => {
       fixture.detectChanges()
       items = de.queryAll(By.directive(MockDownloadItemComponent))
     })
-    it('contains one link', () => {
+    it('contains three links', () => {
       expect(items.length).toBe(3)
     })
   })
@@ -163,6 +163,58 @@ describe('DownloadsListComponent', () => {
       })
       it('shows no link', () => {
         expect(component.filteredLinks).toEqual([])
+      })
+    })
+  })
+
+  describe('filter buttons visibility', () => {
+    let items: DebugElement[]
+    describe('csv, json, pdf', () => {
+      beforeEach(() => {
+        component.links = [
+          LINK_FIXTURES.dataCsv,
+          LINK_FIXTURES.dataJson,
+          LINK_FIXTURES.dataPdf,
+        ]
+        fixture.detectChanges()
+        items = de.queryAll(By.css('.format-filter'))
+      })
+      it('show only all, csv, json and pdf filters', () => {
+        const displayedFormats = items.map(
+          (item) => item.attributes['data-format']
+        )
+        expect(displayedFormats).toEqual(['all', 'csv', 'json', 'others'])
+      })
+    })
+    describe('geojson, shp, excel', () => {
+      beforeEach(() => {
+        component.links = [
+          LINK_FIXTURES.geodataJsonWithMimeType,
+          LINK_FIXTURES.geodataShp,
+          LINK_FIXTURES.dataXls,
+          LINK_FIXTURES.dataXlsx,
+        ]
+        fixture.detectChanges()
+        items = de.queryAll(By.css('.format-filter'))
+      })
+      it('show only all, excel, json and shp  filters', () => {
+        const displayedFormats = items.map(
+          (item) => item.attributes['data-format']
+        )
+        expect(displayedFormats).toEqual(['all', 'excel', 'json', 'shp'])
+      })
+    })
+    describe('pdf', () => {
+      beforeEach(() => {
+        component.links = [LINK_FIXTURES.dataPdf]
+        fixture.detectChanges()
+        items = de.queryAll(By.css('.format-filter'))
+      })
+      it('show only all and others filters', () => {
+        const displayedFormats = items.map(
+          (item) => item.attributes['data-format']
+        )
+        expect(displayedFormats).toEqual(['all', 'others'])
       })
     })
   })

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.ts
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.ts
@@ -1,15 +1,9 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  Input,
-  OnInit,
-} from '@angular/core'
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { TranslateService } from '@ngx-translate/core'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import {
   getBadgeColor,
   getFileFormat,
-  LinkClassifierService,
   MetadataLink,
   MetadataLinkType,
 } from '@geonetwork-ui/util/shared'
@@ -17,27 +11,37 @@ import {
 marker('datahub.search.filter.all')
 marker('datahub.search.filter.others')
 
+const FILTER_FORMATS = ['all', 'csv', 'excel', 'json', 'shp', 'others'] as const
+type FilterFormat = typeof FILTER_FORMATS[number]
+
 @Component({
   selector: 'gn-ui-downloads-list',
   templateUrl: './downloads-list.component.html',
   styleUrls: ['./downloads-list.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DownloadsListComponent implements OnInit {
-  constructor(
-    private linkClassifier: LinkClassifierService,
-    private translateService: TranslateService
-  ) {}
+export class DownloadsListComponent {
+  constructor(private translateService: TranslateService) {}
 
   @Input() links: MetadataLink[]
 
-  filterFormats: string[] = ['all', 'csv', 'excel', 'json', 'shp', 'others']
-  activeFilterFormats: string[] = ['all']
+  activeFilterFormats: FilterFormat[] = ['all']
 
-  filteredLinks: MetadataLink[] = []
-  filterButtons: FilterButton[]
+  get filteredLinks(): MetadataLink[] {
+    return this.links.filter((link) => {
+      return this.activeFilterFormats.some((format) =>
+        this.isLinkOfFormat(link, format)
+      )
+    })
+  }
 
-  toggleFilterFormat(format: string): void {
+  get visibleFormats(): FilterFormat[] {
+    return FILTER_FORMATS.filter((format) =>
+      this.links.some((link) => this.isLinkOfFormat(link, format))
+    )
+  }
+
+  toggleFilterFormat(format: FilterFormat): void {
     if (format === 'all') {
       this.activeFilterFormats = ['all']
     } else {
@@ -45,54 +49,32 @@ export class DownloadsListComponent implements OnInit {
         ? this.activeFilterFormats.filter((f: string) => format !== f)
         : [...this.activeFilterFormats.filter((f) => f !== 'all'), format]
     }
-    this.filteredLinks = this.filterLinks(this.links)
   }
 
-  isFilterActive(filter: string): boolean {
+  isFilterActive(filter: FilterFormat): boolean {
     return this.activeFilterFormats.includes(filter)
   }
 
-  getFilterFormatTitle(format: string) {
+  getFilterFormatTitle(format: FilterFormat) {
     if (format === 'all' || format === 'others') {
       return this.translateService.instant(`datahub.search.filter.${format}`)
     }
     return format
   }
 
-  ngOnInit(): void {
-    this.filteredLinks = this.filterLinks(this.links)
-
-    this.filterButtons = this.filterFormats.map((format) => {
-      return {
-        format,
-        color: getBadgeColor(format),
-      }
-    })
-  }
-
-  filterLinks(links: MetadataLink[]) {
-    if (
-      this.activeFilterFormats.length === 0 ||
-      this.activeFilterFormats.includes('all')
-    ) {
-      return links
+  isLinkOfFormat(link: MetadataLink, format: FilterFormat): boolean {
+    if (format === 'all') {
+      return true
     }
-    let others: MetadataLink[] = []
-    if (this.activeFilterFormats.includes('others')) {
-      others = links.filter((link) => {
-        let isOther = true
-        for (const format of this.filterFormats) {
-          if (format === getFileFormat(link)) isOther = false
-        }
-        return isOther
-      })
-    }
-    const filteredLinks = links.filter((link: MetadataLink) => {
-      return this.activeFilterFormats.some(
-        (filter) => getFileFormat(link).indexOf(filter) > -1
+    if (format === 'others') {
+      const knownFormats = FILTER_FORMATS.filter(
+        (format) => format !== 'all' && format !== 'others'
       )
-    })
-    return [...filteredLinks, ...others]
+      return knownFormats.every(
+        (knownFormat) => !getFileFormat(link).includes(knownFormat)
+      )
+    }
+    return getFileFormat(link).includes(format)
   }
 
   getLinkFormat(link: MetadataLink) {
@@ -106,9 +88,4 @@ export class DownloadsListComponent implements OnInit {
   isFromWfs(link: MetadataLink) {
     return link.type === MetadataLinkType.WFS
   }
-}
-
-export type FilterButton = {
-  format: string
-  color: string | void
 }

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.ts
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.ts
@@ -28,11 +28,11 @@ export class DownloadsListComponent {
   activeFilterFormats: FilterFormat[] = ['all']
 
   get filteredLinks(): MetadataLink[] {
-    return this.links.filter((link) => {
-      return this.activeFilterFormats.some((format) =>
+    return this.links.filter((link) =>
+      this.activeFilterFormats.some((format) =>
         this.isLinkOfFormat(link, format)
       )
-    })
+    )
   }
 
   get visibleFormats(): FilterFormat[] {


### PR DESCRIPTION
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/7318e73e-1ec3-4daa-8fe7-f6c4f2e41783)

- change each download format to be a button instead of a span to make it more accessible
- refactor the filtering of the links and filtering of the formats
- add tests to test that only the formats that are present are being displayed as a filter
- change style of filter buttons