### PR TITLE
Fix(expandable-panel): Prevent truncating content

### DIFF
--- a/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.html
+++ b/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.html
@@ -14,7 +14,11 @@
 </div>
 <div
   class="content duration-500 overflow-hidden transition-[max-height]"
-  [ngClass]="collapsed ? 'max-h-0 ease-out' : 'ease-in max-h-[300px]'"
+  [ngClass]="collapsed ? 'ease-out' : 'ease-in'"
+  [ngStyle]="{
+    'max-height': collapsed ? '0px' : contentDiv?.scrollHeight + 'px'
+  }"
+  #contentDiv
 >
   <ng-content></ng-content>
 </div>

--- a/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.html
+++ b/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.html
@@ -15,9 +15,7 @@
 <div
   class="content duration-500 overflow-hidden transition-[max-height]"
   [ngClass]="collapsed ? 'ease-out' : 'ease-in'"
-  [ngStyle]="{
-    'max-height': collapsed ? '0px' : contentDiv?.scrollHeight + 'px'
-  }"
+  [style.maxHeight]="maxHeight"
   #contentDiv
 >
   <ng-content></ng-content>

--- a/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.spec.ts
+++ b/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.spec.ts
@@ -47,7 +47,12 @@ describe('ExpandablePanelComponent', () => {
       })
       it('hides content', () => {
         const el = fixture.debugElement.query(By.css('.content'))
-        expect(el.classes['max-h-0']).toBeTruthy()
+        expect(el.styles.getPropertyValue('max-height')).toEqual('0px')
+      })
+      it('should have ease-out transition', () => {
+        const el = fixture.debugElement.query(By.css('.content'))
+        expect(el.classes['ease-out']).toBeTruthy()
+        expect(el.classes['ease-in']).toBeFalsy()
       })
     })
     describe('when not collapsed', () => {
@@ -55,9 +60,10 @@ describe('ExpandablePanelComponent', () => {
         component.collapsed = false
         fixture.detectChanges()
       })
-      it('shows content', () => {
+      it('should have ease-in transition', () => {
         const el = fixture.debugElement.query(By.css('.content'))
-        expect(el.classes['max-h-[300px]']).toBeTruthy()
+        expect(el.classes['ease-in']).toBeTruthy()
+        expect(el.classes['ease-out']).toBeFalsy()
       })
     })
   })

--- a/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.ts
+++ b/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.ts
@@ -1,4 +1,10 @@
-import { Component, ChangeDetectionStrategy, Input } from '@angular/core'
+import {
+  Component,
+  ChangeDetectionStrategy,
+  Input,
+  ViewChild,
+  ElementRef,
+} from '@angular/core'
 
 @Component({
   selector: 'gn-ui-expandable-panel',
@@ -9,6 +15,7 @@ import { Component, ChangeDetectionStrategy, Input } from '@angular/core'
 export class ExpandablePanelComponent {
   @Input() title: string
   @Input() collapsed = true
+  @ViewChild('contentDiv') contentDiv: ElementRef
 
   toggle(): void {
     this.collapsed = !this.collapsed

--- a/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.ts
+++ b/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.ts
@@ -16,8 +16,16 @@ export class ExpandablePanelComponent {
   @Input() title: string
   @Input() collapsed = true
   @ViewChild('contentDiv') contentDiv: ElementRef
+  maxHeight = this.setMaxHeight()
 
   toggle(): void {
     this.collapsed = !this.collapsed
+    this.maxHeight = this.setMaxHeight()
+  }
+
+  setMaxHeight() {
+    return `${
+      this.collapsed ? '0' : this.contentDiv.nativeElement.scrollHeight
+    }px`
   }
 }


### PR DESCRIPTION
PR prevents not displaying all content in expanded panel (as it is the case in https://www.geo2france.fr/datahub/dataset/0e864105-6bb9-4c59-aae6-2ccc2e6cdd45 = "D'où viennent ces données ?").

`contentDiv?.scrollHeight` is used to maintain the transition effect, which does not work with other dynamic properties such as `fit-content`. Couldn't get a test running to check the expanded height, though. An easy alternative would be to just raise the value of `max-h-[300px]`, but then again there will still be a limit.