### PR TITLE
fix(story): change hovering from opacity to underline

### DIFF
--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
@@ -4,19 +4,22 @@
   </p>
   <div class="flex mb-1">
     <div
-      class="text-primary font-title text-21 mr-2 cursor-pointer hover:opacity-50"
+      class="text-primary font-title text-21 mr-2 cursor-pointer hover:underline"
       (click)="onContactClick()"
     >
       {{ shownContact.organisation }}
     </div>
-    <div *ngIf="shownContact.website">
-      <a [href]="shownContact.website" target="_blank"
-        ><mat-icon
-          class="text-primary opacity-25 cursor-pointer hover:opacity-75 transition-all"
-          >open_in_new</mat-icon
-        ></a
-      >
-    </div>
   </div>
-  <p class="text-gray-700 text-sm mb-2">{{ shownContact.email }}</p>
+  <p class="text-gray-700 text-sm">{{ shownContact.email }}</p>
+  <div *ngIf="shownContact.website" class="mb-2">
+    <a
+      [href]="shownContact.website"
+      target="_blank"
+      class="text-primary text-sm cursor-pointer hover:underline transition-all"
+      >{{ shownContact.website }}
+      <mat-icon class="!w-[12px] !h-[12px] !text-[12px] opacity-75"
+        >open_in_new</mat-icon
+      >
+    </a>
+  </div>
 </div>


### PR DESCRIPTION
Set underline instead of opacity change when hovering and move website under email with full link and not only icon.

![image](https://github.com/geonetwork/geonetwork-ui/assets/39771412/085dd648-61c1-4baa-bbac-55f45d6723c3)

![contact](https://github.com/geonetwork/geonetwork-ui/assets/39771412/48821917-420c-4bd3-99ac-784b52014812)
