### PR TITLE
feat: adding organisations thumbnails to records

### DIFF
--- a/libs/feature/catalog/src/lib/feature-catalog.module.ts
+++ b/libs/feature/catalog/src/lib/feature-catalog.module.ts
@@ -46,7 +46,8 @@ const organizationsServiceFactory = (
     : new OrganisationsFromMetadataService(
         esService,
         searchApiService,
-        groupsApiService
+        groupsApiService,
+        translateService
       )
 
 @NgModule({

--- a/libs/feature/catalog/src/lib/feature-catalog.module.ts
+++ b/libs/feature/catalog/src/lib/feature-catalog.module.ts
@@ -46,8 +46,7 @@ const organizationsServiceFactory = (
     : new OrganisationsFromMetadataService(
         esService,
         searchApiService,
-        groupsApiService,
-        translateService
+        groupsApiService
       )
 
 @NgModule({

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.ts
@@ -90,7 +90,7 @@ export class OrganisationsComponent {
     return index
   }
 
-  getOrganisationUrl(organisation: Organisation) {
+  getOrganisationUrl(organisation: Organisation): string {
     if (!this.urlTemplate) return null
     return this.urlTemplate.replace('${name}', organisation.name)
   }

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
@@ -132,7 +132,7 @@ export class OrganisationsFromGroupsService
     const groupId = parseInt(selectField(source, 'groupOwner'))
     const resourceContacts = getAsArray(
       selectField(source, 'contactForResource')
-    ).map((contact) => mapContact(contact, source))
+    ).map((contact) => mapContact(contact))
     return this.groups$.pipe(
       map((groups) => {
         const group = groups.find((g) => g.id === groupId)

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
@@ -114,7 +114,7 @@ export class OrganisationsFromGroupsService
     lang3: string
   ): MetadataContact {
     const website = getAsUrl(group.website)
-    const logoUrl = getAsUrl(`/geonetwork/images/harvesting/${group.logo}`)
+    const logoUrl = getAsUrl(`${IMAGE_URL}${group.logo}`)
     return {
       name: group.label[lang3],
       organisation: group.label[lang3],

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
@@ -16,7 +16,7 @@ import {
   selectField,
   SourceWithUnknownProps,
 } from '@geonetwork-ui/util/shared'
-import { combineLatest, forkJoin, Observable, of } from 'rxjs'
+import { forkJoin, Observable, of } from 'rxjs'
 import { map, shareReplay } from 'rxjs/operators'
 import { OrganisationsServiceInterface } from './organisations.service.interface'
 import { TranslateService } from '@ngx-translate/core'
@@ -132,7 +132,7 @@ export class OrganisationsFromGroupsService
     const groupId = parseInt(selectField(source, 'groupOwner'))
     const resourceContacts = getAsArray(
       selectField(source, 'contactForResource')
-    ).map((contact) => mapContact(contact))
+    ).map((contact) => mapContact(contact, source))
     return this.groups$.pipe(
       map((groups) => {
         const group = groups.find((g) => g.id === groupId)

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -29,6 +29,14 @@ const sampleOrgB: Organisation = {
   recordCount: 1,
   description: null,
 }
+const sampleOrgC: Organisation = {
+  emails: ['ifremer.ifremer@ifremer.admin.ch'],
+  email: 'ifremer.ifremer@ifremer.admin.ch',
+  logoUrl: '/geonetwork/images/harvesting/ifremer.png',
+  name: 'Ifremer',
+  recordCount: 1,
+  description: null,
+}
 
 const organisationsAggregationMock = {
   aggregations: {
@@ -62,6 +70,20 @@ const organisationsAggregationMock = {
               buckets: [
                 {
                   key: 'christian.meier@bakom.admin.ch',
+                  doc_count: 1,
+                },
+              ],
+            },
+          },
+          {
+            key: 'Ifremer',
+            doc_count: 1,
+            mail: {
+              doc_count_error_upper_bound: 0,
+              sum_other_doc_count: 0,
+              buckets: [
+                {
+                  key: 'ifremer.ifremer@ifremer.admin.ch',
                   doc_count: 1,
                 },
               ],
@@ -181,6 +203,13 @@ describe('OrganisationsFromMetadataService', () => {
             name: 'BAKOM',
             recordCount: 1,
           },
+          {
+            description: null,
+            emails: ['ifremer.ifremer@ifremer.admin.ch'],
+            logoUrl: null,
+            name: 'Ifremer',
+            recordCount: 1,
+          },
         ])
       })
     })
@@ -192,7 +221,7 @@ describe('OrganisationsFromMetadataService', () => {
           .subscribe((orgs) => (organisations = orgs))
       })
       it('get organisations hydrated from groups via name or email mapping', () => {
-        expect(organisations).toEqual([sampleOrgA, sampleOrgB])
+        expect(organisations).toEqual([sampleOrgA, sampleOrgB, sampleOrgC])
       })
     })
   })
@@ -245,12 +274,12 @@ describe('OrganisationsFromMetadataService', () => {
     let filters
     beforeEach(async () => {
       filters = await firstValueFrom(
-        service.getFiltersForOrgs([sampleOrgA, sampleOrgB])
+        service.getFiltersForOrgs([sampleOrgA, sampleOrgB, sampleOrgC])
       )
     })
     it('generates filters', () => {
       expect(filters).toEqual({
-        OrgForResource: { ARE: true, BAKOM: true },
+        OrgForResource: { ARE: true, BAKOM: true, Ifremer: true },
       })
     })
   })
@@ -288,14 +317,18 @@ describe('OrganisationsFromMetadataService', () => {
         title: 'Surval - Données par paramètre',
         uuid: 'cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
         contact: {
-          name: "Cellule d'administration Quadrige",
-          organisation: 'Ifremer',
-          email: 'q2suppor@ifremer.fr',
-          website: 'https://www.ifremer.fr/',
-          logoUrl:
-            'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
+          name: 'Ifremer',
+          email: 'ifremer.ifremer@ifremer.admin.ch',
+          logoUrl: 'http://localhost/geonetwork/images/harvesting/ifremer.png',
         },
         resourceContacts: [
+          {
+            email: 'ifremer.ifremer@ifremer.admin.ch',
+            logoUrl:
+              'http://localhost/geonetwork/images/harvesting/ifremer.png',
+            name: 'Ifremer',
+            organisation: 'Ifremer',
+          },
           {
             email: 'q2_support@ifremer.fr',
             logoUrl:

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -11,7 +11,6 @@ import {
   GROUPS_FIXTURE,
 } from '@geonetwork-ui/util/shared/fixtures'
 import { MetadataRecord, Organisation } from '@geonetwork-ui/util/shared'
-import { TranslateService } from '@ngx-translate/core'
 
 const sampleOrgA: Organisation = {
   description: 'A description for ARE',
@@ -82,11 +81,6 @@ class GoupsApiServiceMock {
   getGroups = jest.fn(() => of(GROUPS_FIXTURE))
 }
 
-class TranslateServiceMock {
-  currentLang = 'fr'
-  get = jest.fn((key) => of(key))
-}
-
 describe('OrganisationsFromMetadataService', () => {
   let service: OrganisationsFromMetadataService
   let searchService: SearchApiService
@@ -102,10 +96,6 @@ describe('OrganisationsFromMetadataService', () => {
         {
           provide: SearchApiService,
           useClass: SearchApiServiceMock,
-        },
-        {
-          provide: TranslateService,
-          useClass: TranslateServiceMock,
         },
       ],
     })

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -11,6 +11,7 @@ import {
   GROUPS_FIXTURE,
 } from '@geonetwork-ui/util/shared/fixtures'
 import { MetadataRecord, Organisation } from '@geonetwork-ui/util/shared'
+import { TranslateService } from '@ngx-translate/core'
 
 const sampleOrgA: Organisation = {
   description: 'A description for ARE',
@@ -81,6 +82,11 @@ class GoupsApiServiceMock {
   getGroups = jest.fn(() => of(GROUPS_FIXTURE))
 }
 
+class TranslateServiceMock {
+  currentLang = 'fr'
+  get = jest.fn((key) => of(key))
+}
+
 describe('OrganisationsFromMetadataService', () => {
   let service: OrganisationsFromMetadataService
   let searchService: SearchApiService
@@ -96,6 +102,10 @@ describe('OrganisationsFromMetadataService', () => {
         {
           provide: SearchApiService,
           useClass: SearchApiServiceMock,
+        },
+        {
+          provide: TranslateService,
+          useClass: TranslateServiceMock,
         },
       ],
     })

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
@@ -164,14 +164,17 @@ export class OrganisationsFromMetadataService
   }
 
   private mapContactFromOrganisation(
-    organisation: Organisation
+    organisation: Organisation,
+    contact: MetadataContact
   ): MetadataContact {
-    const logoUrl = getAsUrl(`${organisation.logoUrl}`)
+    const logoUrl = organisation.logoUrl
+      ? getAsUrl(`${organisation.logoUrl}`)
+      : contact.logoUrl
     return {
       name: organisation.name,
       organisation: organisation.name,
       email: organisation.email,
-      ...(organisation.logoUrl && logoUrl && { logoUrl }),
+      logoUrl: logoUrl,
     } as MetadataContact
   }
 
@@ -202,11 +205,11 @@ export class OrganisationsFromMetadataService
       ...record,
       resourceContacts: [
         ...getAsArray(selectField(source, 'contactForResource')).map(
-          (contact) => mapContact(contact)
+          (contact) => mapContact(contact, source)
         ),
       ],
       contact: {
-        ...mapContact(getFirstValue(selectField(source, 'contact'))),
+        ...mapContact(getFirstValue(selectField(source, 'contact')), source),
       },
     }
 
@@ -218,10 +221,13 @@ export class OrganisationsFromMetadataService
         )[0]
 
         if (org) {
-          const contactFromOrg = this.mapContactFromOrganisation(org)
+          const contactFromOrg = this.mapContactFromOrganisation(
+            org,
+            metadataRecord.contact
+          )
           metadataRecord.contact = contactFromOrg
           metadataRecord.resourceContacts = [
-            contactFromOrg,
+            contactFromOrg, // FIXME: this should go into an organization field
             ...metadataRecord.resourceContacts,
           ]
         }

--- a/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.html
+++ b/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.html
@@ -9,7 +9,7 @@
     >
       <gn-ui-thumbnail
         class="relative h-full w-full object-cover object-left-top"
-        [thumbnailUrl]="record.thumbnailUrl"
+        [thumbnailUrl]="record.thumbnailUrl || contact.logoUrl"
       ></gn-ui-thumbnail>
     </div>
   </div>

--- a/libs/util/shared/src/lib/fixtures/groups.fixtures.ts
+++ b/libs/util/shared/src/lib/fixtures/groups.fixtures.ts
@@ -58,4 +58,23 @@ export const GROUPS_FIXTURE = deepFreeze([
       eng: 'Municipality of Köniz',
     },
   },
+  {
+    logo: 'ifremer.png',
+    website: 'www.ifremer.ch',
+    defaultCategory: null,
+    allowedCategories: [],
+    enableAllowedCategories: false,
+    id: 348385324,
+    email: 'ifremer.ifremer@ifremer.admin.ch',
+    referrer: null,
+    description: '',
+    name: 'Ifremer',
+    label: {
+      ger: 'Ifremer',
+      ita: 'Ifremer',
+      fre: 'Ifremer',
+      roh: 'Ifremer',
+      eng: 'Ifremer',
+    },
+  },
 ])

--- a/libs/util/shared/src/lib/utils/atomic-operations.ts
+++ b/libs/util/shared/src/lib/utils/atomic-operations.ts
@@ -50,15 +50,16 @@ export const getAsUrl = (field) => {
 }
 
 export const mapLogo = (source: SourceWithUnknownProps) => {
-  const logo = selectField(source, 'logoUrl')
+  const logo = selectFallbackFields(source, 'logoUrl', 'logo')
   return logo ? getAsUrl(`/geonetwork${logo}`) : null
 }
 
 export const mapContact = (
-  sourceContact: SourceWithUnknownProps
+  sourceContact: SourceWithUnknownProps,
+  sourceRecord: SourceWithUnknownProps
 ): MetadataContact => {
   const website = getAsUrl(selectField<string>(sourceContact, 'website'))
-  const logoUrl = mapLogo(sourceContact)
+  const logoUrl = mapLogo(sourceContact) || mapLogo(sourceRecord)
   const address = selectField<string>(sourceContact, 'address')
   const phone = selectField<string>(sourceContact, 'phone')
   return {

--- a/libs/util/shared/src/lib/utils/atomic-operations.ts
+++ b/libs/util/shared/src/lib/utils/atomic-operations.ts
@@ -50,16 +50,15 @@ export const getAsUrl = (field) => {
 }
 
 export const mapLogo = (source: SourceWithUnknownProps) => {
-  const logo = selectField(source, 'logo')
+  const logo = selectField(source, 'logoUrl')
   return logo ? getAsUrl(`/geonetwork${logo}`) : null
 }
 
 export const mapContact = (
-  sourceContact: SourceWithUnknownProps,
-  sourceRecord: SourceWithUnknownProps
+  sourceContact: SourceWithUnknownProps
 ): MetadataContact => {
   const website = getAsUrl(selectField<string>(sourceContact, 'website'))
-  const logoUrl = mapLogo(sourceRecord)
+  const logoUrl = mapLogo(sourceContact)
   const address = selectField<string>(sourceContact, 'address')
   const phone = selectField<string>(sourceContact, 'phone')
   return {


### PR DESCRIPTION
Organisations thumbnails are now visible in feed and datasets tabs. 

If the organization strategy is set to metadata (default behaviour), matching is done on the organization name set in the contact property of the record.

Maybe the IMAGE_URL constant could be common in `organisations-from-groups.service.ts` and `organisations-from-metadata.service.ts`.

@fgravin @jahow @tkohr Tell me if this solution would be suitable. 
Thanks :) 