### PR TITLE
Add ability to predefine specific search in config

### DIFF
--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -184,7 +184,7 @@ export class AppModule {
     ThemeService.generateBgOpacityClasses(
       'primary',
       getThemeConfig().PRIMARY_COLOR,
-      [10, 25, 75]
+      [10, 25, 50, 75, 100]
     )
   }
 }

--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -25,7 +25,7 @@
           [toggled]="searchFacade.favoritesOnly$ | async"
           (action)="listFavorites($event)"
         ></datahub-header-badge-button>
-        <div *ngIf="displaySortBadges$ | async">
+        <div>
           <button
             type="button"
             class="badge-btn bg-primary-opacity-25 hover-bg-primary-opacity-75"
@@ -34,7 +34,7 @@
             <span translate="">datahub.header.lastRecords</span>
           </button>
         </div>
-        <div *ngIf="displaySortBadges$ | async">
+        <div>
           <button
             type="button"
             class="badge-btn bg-primary-opacity-25 hover-bg-primary-opacity-75"
@@ -42,6 +42,17 @@
           >
             <span translate="">datahub.header.popularRecords</span>
           </button>
+        </div>
+        <div *ngFor="let preset of searchConfig?.SEARCH_PRESET">
+          <div>
+            <button
+              type="button"
+              class="badge-btn bg-primary-opacity-25 hover-bg-primary-opacity-75"
+              (click)="clearSearchAndFilterAndSort(preset)"
+            >
+              <span translate="">{{ preset['name'] }}</span>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -28,7 +28,7 @@
         <div>
           <button
             type="button"
-            class="badge-btn bg-primary-opacity-25 hover-bg-primary-opacity-75"
+            class="badge-btn bg-primary-opacity-50 hover-bg-primary-opacity-100"
             (click)="clearSearchAndSort(SORT_BY_PARAMS.CREATE_DATE)"
           >
             <span translate="">datahub.header.lastRecords</span>
@@ -37,7 +37,7 @@
         <div>
           <button
             type="button"
-            class="badge-btn bg-primary-opacity-25 hover-bg-primary-opacity-75"
+            class="badge-btn bg-primary-opacity-50 hover-bg-primary-opacity-100"
             (click)="clearSearchAndSort(SORT_BY_PARAMS.POPULARITY)"
           >
             <span translate="">datahub.header.popularRecords</span>
@@ -47,7 +47,7 @@
           <div>
             <button
               type="button"
-              class="badge-btn bg-primary-opacity-25 hover-bg-primary-opacity-75"
+              class="badge-btn bg-primary-opacity-50 hover-bg-primary-opacity-100"
               (click)="clearSearchAndFilterAndSort(preset)"
             >
               <span translate="">{{ preset['name'] }}</span>

--- a/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
@@ -6,11 +6,15 @@ import {
   RouterFacade,
   ROUTER_ROUTE_SEARCH,
 } from '@geonetwork-ui/feature/router'
-import { SearchFacade, SearchService } from '@geonetwork-ui/feature/search'
+import {
+  FieldsService,
+  SearchFacade,
+  SearchService,
+} from '@geonetwork-ui/feature/search'
 import { SortByEnum } from '@geonetwork-ui/util/shared'
 import { TranslateModule } from '@ngx-translate/core'
 import { readFirst } from '@nrwl/angular/testing'
-import { BehaviorSubject } from 'rxjs'
+import { BehaviorSubject, of } from 'rxjs'
 import { ROUTER_ROUTE_NEWS } from '../../router/constants'
 import { HeaderBadgeButtonComponent } from '../header-badge-button/header-badge-button.component'
 import { HomeHeaderComponent } from './home-header.component'
@@ -23,14 +27,14 @@ jest.mock('@geonetwork-ui/util/app-config', () => ({
   getOptionalSearchConfig: () => ({
     SEARCH_PRESET: [
       {
-        _sort: '-createDate',
+        sort: '-createDate',
         name: 'sortCeatedDateAndOrg',
-        OrgForResource: ['DREAL'],
+        filters: { publisher: ['DREAL'] },
       },
       {
-        _sort: '-createDate',
+        sort: '-createDate',
         name: 'filterCarto',
-        any: 'Cartographie',
+        filters: { q: 'Cartographie' },
       },
     ],
   }),
@@ -57,6 +61,10 @@ class searchServiceMock {
 class AuthServiceMock {
   authReady = jest.fn(() => this._authSubject$)
   _authSubject$ = new BehaviorSubject({})
+}
+
+class FieldsServiceMock {
+  buildFiltersFromFieldValues = jest.fn(() => of({ thisIs: 'a fake filter' }))
 }
 
 describe('HeaderComponent', () => {
@@ -88,6 +96,10 @@ describe('HeaderComponent', () => {
         {
           provide: AuthService,
           useClass: AuthServiceMock,
+        },
+        {
+          provide: FieldsService,
+          useClass: FieldsServiceMock,
         },
       ],
     }).compileComponents()
@@ -208,7 +220,7 @@ describe('HeaderComponent', () => {
         })
         it('should redirect correctly', () => {
           expect(searchService.setSortAndFilters).toHaveBeenCalledWith(
-            { OrgForResource: { DREAL: true } },
+            { thisIs: 'a fake filter' },
             SortByEnum.CREATE_DATE
           )
         })

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -21,7 +21,7 @@ proxy_path = ""
 #  - ${lang2}, ${lang3}: indicates if and where the current language should be part of the login URL in language 2 or 3 letter code
 # Example to use the georchestra login page:
 # login_url = "/cas/login?service=${current_url}"
-# This optional URL should point to the static html page wc-embedder.html which allows to display a web component (like chart and table) via a permalink. 
+# This optional URL should point to the static html page wc-embedder.html which allows to display a web component (like chart and table) via a permalink.
 # URLs can be indicated from the root of the same server starting with a "/" or as an external URL. Be conscious of potential CORS issues when using an external URL.
 # The default location in the dockerized datahub app for example is "/datahub/wc-embedder.html".
 # If the URL is not indicated, no permalinks will show up in the UI.
@@ -63,6 +63,21 @@ background_color = "#fdfbff"
 # Note: if the GeoJSON object contains multiple features, only the geometry of the first one will be kept!
 # filter_geometry_url = "https://my.domain.org/assets/boundary.geojson"
 # filter_geometry_data = '{ "coordinates": [...], "type": "Polygon" }'
+# [[search_preset]]
+# _sort = "-createDate"
+# name = 'filterByOrgs'
+# any = 'Carto'
+# organisation = ['DREAL', 'atmo Hauts-de-France']
+# format = ['ESRI Shapefile']
+# standard = ['iso19115-3.2018']
+# #inspireKeyword = []
+# topic = ['boundaries']
+# publicationYear = ['2023', '2022']
+# spatial = ['yes']
+# license = ['unknown']
+# [[search_preset]]
+# name = 'Wind turbines'
+# any = 'wind'
 
 ### MAP SETTINGS
 

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -63,21 +63,31 @@ background_color = "#fdfbff"
 # Note: if the GeoJSON object contains multiple features, only the geometry of the first one will be kept!
 # filter_geometry_url = "https://my.domain.org/assets/boundary.geojson"
 # filter_geometry_data = '{ "coordinates": [...], "type": "Polygon" }'
+
+# One or several search presets can be defined here; every search preset is composed of:
+# - a name (which can be a translation key)
+# - a sort criteria: either `createDate`, `userSavedCount` or `_score` (prepend with `-` for descending sort)
+# - filters which can be expressed like so:
 # [[search_preset]]
-# _sort = "-createDate"
+#     filters.q = 'Full text search
+#     filters.publisher = ['Org 1', 'Org 2']
+#     filters.format = ['format 1', 'format 2']
+#     filters.documentStandard = ['iso19115-3.2018']
+#     filters.inspireKeyword = ['keyword 1', 'keyword 2']
+#     filters.topic = ['boundaries']
+#     filters.publicationYear = ['2023', '2022']
+#     filters.isSpatial = ['yes']
+#     filters.license = ['unknown']
+#
+# Search presets will be advertised to the user along the main search field.
+
+# [[search_preset]]
+# sort = "-createDate"
 # name = 'filterByOrgs'
-# any = 'Carto'
-# organisation = ['DREAL', 'atmo Hauts-de-France']
-# format = ['ESRI Shapefile']
-# standard = ['iso19115-3.2018']
-# #inspireKeyword = []
-# topic = ['boundaries']
-# publicationYear = ['2023', '2022']
-# spatial = ['yes']
-# license = ['unknown']
+# filters.publisher = ['DREAL', 'atmo Hauts-de-France', 'blargz']
 # [[search_preset]]
 # name = 'Wind turbines'
-# any = 'wind'
+# filters.q = 'wind'
 
 ### MAP SETTINGS
 

--- a/libs/feature/search/src/lib/utils/service/fields.service.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.ts
@@ -10,8 +10,8 @@ import {
   SimpleSearchField,
   TopicSearchField,
 } from './fields'
-import { combineLatest, forkJoin, Observable, of, takeLast } from 'rxjs'
-import { map, mergeScan } from 'rxjs/operators'
+import { forkJoin, Observable, of } from 'rxjs'
+import { map } from 'rxjs/operators'
 
 // key is the field name
 export type FieldValues = Record<string, FieldValue[] | FieldValue>

--- a/libs/feature/search/src/lib/utils/service/fields.spec.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.spec.ts
@@ -528,6 +528,7 @@ describe('search fields implementations', () => {
           searchField.getFiltersForValues([
             'Municipalité de Köniz',
             'Office fédéral de la communication OFCOM',
+            'Non existent org',
           ])
         )
       })

--- a/libs/feature/search/src/lib/utils/service/fields.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.ts
@@ -279,7 +279,9 @@ export class OrganizationSearchField implements AbstractSearchField {
   getFiltersForValues(values: FieldValue[]): Observable<SearchFilters> {
     return this.orgsService.organisations$.pipe(
       map((orgs) =>
-        values.map((name) => orgs.find((org) => org.name === name))
+        values
+          .map((name) => orgs.find((org) => org.name === name))
+          .filter((org) => org !== undefined)
       ),
       switchMap((selectedOrgs) =>
         this.orgsService.getFiltersForOrgs(selectedOrgs)

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -161,13 +161,15 @@ describe('app config utils', () => {
           SEARCH_PRESET: [
             {
               name: 'filterByOrgs',
-              _sort: '-createDate',
-              any: 'Carto',
-              OrgForResource: ['Org1', 'Org2'],
-              'cl_topic.key': ['boundaries'],
-              format: ['ESRI Shapefile'],
-              isSpatial: ['yes'],
-              publicationYearForResource: ['2023', '2022'],
+              sort: '-createDate',
+              filters: {
+                q: 'Carto',
+                organisation: ['Org1', 'Org2'],
+                topic: ['boundaries'],
+                format: ['ESRI Shapefile'],
+                spatial: ['yes'],
+                publicationYear: ['2023', '2022'],
+              },
             },
           ],
         })

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -158,6 +158,18 @@ describe('app config utils', () => {
       it('returns the search config', () => {
         expect(getOptionalSearchConfig()).toEqual({
           FILTER_GEOMETRY_URL: 'https://my.domain.org/geom.json',
+          SEARCH_PRESET: [
+            {
+              name: 'filterByOrgs',
+              _sort: '-createDate',
+              any: 'Carto',
+              OrgForResource: ['Org1', 'Org2'],
+              'cl_topic.key': ['boundaries'],
+              format: ['ESRI Shapefile'],
+              isSpatial: ['yes'],
+              publicationYearForResource: ['2023', '2022'],
+            },
+          ],
         })
       })
     })

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -212,16 +212,6 @@ export function loadAppConfig() {
                 sort: param.sort,
                 name: param.name,
                 filters: param.filters,
-                // any: param.any,
-                // OrgForResource: param.organisation,
-                // format: param.format,
-                // documentStandard: param.standard,
-                // 'th_httpinspireeceuropaeutheme-theme_tree.default':
-                //   param.inspireKeyword,
-                // 'cl_topic.key': param.topic,
-                // publicationYearForResource: param.publicationYear,
-                // isSpatial: param.spatial,
-                // license: param.license,
               })),
             } as any)
 

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -14,7 +14,6 @@ import {
   SearchConfig,
   ThemeConfig,
 } from './model'
-import { RawCustomSearchFilters } from '@geonetwork-ui/util/shared'
 
 const MISSING_CONFIG_ERROR = `Application configuration was not initialized correctly.
 This error might show up in case of an invalid/malformed configuration file.
@@ -199,18 +198,7 @@ export function loadAppConfig() {
         parsed,
         'search_preset',
         ['name'],
-        [
-          '_sort',
-          'any',
-          'organisation',
-          'format',
-          'standard',
-          'inspireKeyword',
-          'topic',
-          'publicationYear',
-          'spatial',
-          'license',
-        ],
+        ['sort', 'filters'],
         warnings,
         errors
       )
@@ -220,23 +208,21 @@ export function loadAppConfig() {
           : ({
               FILTER_GEOMETRY_DATA: parsedSearchSection.filter_geometry_data,
               FILTER_GEOMETRY_URL: parsedSearchSection.filter_geometry_url,
-              SEARCH_PRESET: parsedSearchParams.map(
-                (param) =>
-                  ({
-                    _sort: param._sort,
-                    name: param.name,
-                    any: param.any,
-                    OrgForResource: param.organisation,
-                    format: param.format,
-                    documentStandard: param.standard,
-                    'th_httpinspireeceuropaeutheme-theme_tree.default':
-                      param.inspireKeyword,
-                    'cl_topic.key': param.topic,
-                    publicationYearForResource: param.publicationYear,
-                    isSpatial: param.spatial,
-                    license: param.license,
-                  } as RawCustomSearchFilters)
-              ),
+              SEARCH_PRESET: parsedSearchParams.map((param) => ({
+                sort: param.sort,
+                name: param.name,
+                filters: param.filters,
+                // any: param.any,
+                // OrgForResource: param.organisation,
+                // format: param.format,
+                // documentStandard: param.standard,
+                // 'th_httpinspireeceuropaeutheme-theme_tree.default':
+                //   param.inspireKeyword,
+                // 'cl_topic.key': param.topic,
+                // publicationYearForResource: param.publicationYear,
+                // isSpatial: param.spatial,
+                // license: param.license,
+              })),
             } as any)
 
       customTranslations = parseTranslationsConfigSection(

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -109,26 +109,6 @@ export function loadAppConfig() {
                 parsedGlobalSection.web_component_embedder_url,
             } as GlobalConfig)
 
-      const parsedSearchParams = parseMultiConfigSection(
-        parsed,
-        'search_preset',
-        ['name'],
-        [
-          '_sort',
-          'any',
-          'organisation',
-          'format',
-          'standard',
-          'inspireKeyword',
-          'topic',
-          'publicationYear',
-          'spatial',
-          'license',
-        ],
-        warnings,
-        errors
-      )
-
       const parsedLayersSections = parseMultiConfigSection(
         parsed,
         'map_layer',
@@ -212,6 +192,25 @@ export function loadAppConfig() {
         'search',
         [],
         ['filter_geometry_data', 'filter_geometry_url', 'search_preset'],
+        warnings,
+        errors
+      )
+      const parsedSearchParams = parseMultiConfigSection(
+        parsed,
+        'search_preset',
+        ['name'],
+        [
+          '_sort',
+          'any',
+          'organisation',
+          'format',
+          'standard',
+          'inspireKeyword',
+          'topic',
+          'publicationYear',
+          'spatial',
+          'license',
+        ],
         warnings,
         errors
       )

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -38,6 +38,16 @@ fonts_stylesheet_url = "https://fonts.googleapis.com/css2?family=Open+Sans"
 [search]
 filter_geometry_url = 'https://my.domain.org/geom.json'
 
+[[search_preset]]
+_sort = "-createDate"
+name = 'filterByOrgs'
+any = 'Carto'
+organisation = ['Org1', 'Org2']
+format = ['ESRI Shapefile']
+topic = ['boundaries']
+publicationYear = ['2023', '2022']
+spatial = ['yes']
+
 [translations.en]
 "my.first.key" = 'First label.'
 "my.second.key" = """

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -39,14 +39,14 @@ fonts_stylesheet_url = "https://fonts.googleapis.com/css2?family=Open+Sans"
 filter_geometry_url = 'https://my.domain.org/geom.json'
 
 [[search_preset]]
-_sort = "-createDate"
+sort = "-createDate"
 name = 'filterByOrgs'
-any = 'Carto'
-organisation = ['Org1', 'Org2']
-format = ['ESRI Shapefile']
-topic = ['boundaries']
-publicationYear = ['2023', '2022']
-spatial = ['yes']
+filters.q = 'Carto'
+filters.organisation = ['Org1', 'Org2']
+filters.format = ['ESRI Shapefile']
+filters.topic = ['boundaries']
+filters.publicationYear = ['2023', '2022']
+filters.spatial = ['yes']
 
 [translations.en]
 "my.first.key" = 'First label.'

--- a/libs/util/app-config/src/lib/model.ts
+++ b/libs/util/app-config/src/lib/model.ts
@@ -37,14 +37,16 @@ export interface ThemeConfig {
   FONTS_STYLESHEET_URL?: string
 }
 
+export interface SearchPreset {
+  sort: string
+  name: string
+  filters: Record<string, string[] | string>
+}
+
 export interface SearchConfig {
   FILTER_GEOMETRY_URL?: string
   FILTER_GEOMETRY_DATA?: string
-  SEARCH_PRESET?: {
-    _sort: string
-    _filters: unknown
-    name: string
-  }[]
+  SEARCH_PRESET?: SearchPreset[]
 }
 
 export type CustomTranslations = { [translationKey: string]: string }

--- a/libs/util/app-config/src/lib/model.ts
+++ b/libs/util/app-config/src/lib/model.ts
@@ -40,6 +40,11 @@ export interface ThemeConfig {
 export interface SearchConfig {
   FILTER_GEOMETRY_URL?: string
   FILTER_GEOMETRY_DATA?: string
+  SEARCH_PRESET?: {
+    _sort: string
+    _filters: unknown
+    name: string
+  }[]
 }
 
 export type CustomTranslations = { [translationKey: string]: string }

--- a/libs/util/app-config/src/lib/parse-utils.spec.ts
+++ b/libs/util/app-config/src/lib/parse-utils.spec.ts
@@ -129,16 +129,20 @@ describe('parse utils', () => {
             },
           },
           'test',
-          ['mandatory1.path.local'],
-          ['mandatory1.path.global'],
+          ['mandatory1'],
+          [],
           warnings,
           errors
         )
       })
-      it('returns an object with flattened properties', () => {
+      it('returns the nested object as is', () => {
         expect(result).toEqual({
-          ['mandatory1.path.local']: '/aaa/bbb',
-          ['mandatory1.path.global']: 'https://hello',
+          mandatory1: {
+            path: {
+              local: '/aaa/bbb',
+              global: 'https://hello',
+            },
+          },
         })
       })
     })

--- a/libs/util/app-config/src/lib/parse-utils.ts
+++ b/libs/util/app-config/src/lib/parse-utils.ts
@@ -54,7 +54,7 @@ export function parseConfigSection(
     return null
   }
 
-  const sectionConf = flatten('', fullConfigObj[sectionName])
+  const sectionConf = fullConfigObj[sectionName] as Record<string, string>
   const keysCheck = checkKeys(sectionConf, mandatoryKeys, optionalKeys)
 
   if (keysCheck.missing.length) {

--- a/libs/util/shared/src/lib/models/search.model.ts
+++ b/libs/util/shared/src/lib/models/search.model.ts
@@ -3,6 +3,11 @@ export interface SearchFilters {
   [x: string]: any
 }
 
+export interface RawCustomSearchFilters {
+  any?: string
+  [x: string]: any
+}
+
 type SearchFiltersFields = {
   [key: string]: SearchFiltersFields | SearchFiltersFieldsLeaf
 }

--- a/libs/util/shared/src/lib/services/proxy.service.spec.ts
+++ b/libs/util/shared/src/lib/services/proxy.service.spec.ts
@@ -2,7 +2,7 @@ import { PROXY_PATH, ProxyService } from './proxy.service'
 import { TestBed } from '@angular/core/testing'
 
 // mock window.location
-;(global as any).window = Object.create(window)
+;(global as any).window ??= Object.create(window)
 Object.defineProperty(window, 'location', {
   value: new URL('http://myhost:1234/my/path?abc'),
 })


### PR DESCRIPTION
Proposal: (Admin) users will now be able to add predefined searches through the `default.toml` file that will appear under the main search field as a button.
One or several search presets can be defined; every search preset is composed of:
- a name (which can be a translation key)
- a sort criteria: either `createDate`, `userSavedCount` or `_score` (prepend with `-` for descending sort)
- filters which can be expressed like (see `default.toml`)


Screenshot:
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/267ab5aa-f9e3-46c4-b095-acd7f85f6f01)


Todo:

- [x] Add screenshot
- [x] Add a proposal for the configuration schema changes