### PR TITLE
feat: update select dropdown to match multiselect one

### DIFF
--- a/apps/datafeeder/src/app/app.module.ts
+++ b/apps/datafeeder/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { SummarizeIllustrationComponent } from './presentation/components/svg/su
 import { SummarizeBackgroundComponent } from './presentation/components/svg/summarize-background/summarize-background.component'
 import { DATAFEEDER_STATE_KEY, reducer } from './store/datafeeder.reducer'
 import { FeatureAuthModule } from '@geonetwork-ui/feature/auth'
+import { MatIconModule } from '@angular/material/icon'
 
 export function apiConfigurationFactory() {
   return new Configuration({
@@ -72,6 +73,7 @@ export function apiConfigurationFactory() {
     UiInputsModule,
     UiWidgetsModule,
     HttpClientModule,
+    MatIconModule,
     UtilI18nModule,
     FeatureEditorModule,
     ApiModule.forRoot(apiConfigurationFactory),

--- a/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.html
+++ b/apps/datafeeder/src/app/presentation/components/data-import-validation-map-panel/data-import-validation-map-panel.component.html
@@ -23,6 +23,7 @@
         [choices]="footerList"
         (selectValue)="selectValue($event)"
         [selected]="selectedValue"
+        [extraBtnClass]="'secondary min-w-full'"
         ariaName="search-sort-by"
         *ngIf="footerList.length > 0"
       >

--- a/apps/datafeeder/src/index.html
+++ b/apps/datafeeder/src/index.html
@@ -11,6 +11,10 @@
       href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Permanent+Marker&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
+      rel="stylesheet"
+    />
 
     <script src="assets/env.js"></script>
   </head>

--- a/apps/datafeeder/src/styles.css
+++ b/apps/datafeeder/src/styles.css
@@ -43,6 +43,11 @@ gn-ui-button button[type='button'].secondary {
   border-color: var(--color-primary);
   border-width: 1px;
 }
+
+gn-ui-dropdown-selector gn-ui-button button[type='button'].secondary {
+  border-width: 2px;
+}
+
 gn-ui-button button[type='button'].secondary:hover {
   background: var(--color-primary-darker);
   color: white;

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.html
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.html
@@ -5,6 +5,7 @@
     <gn-ui-dropdown-selector
       class="basis-1/4"
       [choices]="typeChoices"
+      [extraBtnClass]="'secondary min-w-full'"
       (selectValue)="chartType$.next($event)"
       [selected]="chartType$.value"
       [title]="'chart.dropdown.type' | translate"
@@ -12,6 +13,7 @@
     <gn-ui-dropdown-selector
       class="basis-1/4"
       [choices]="xChoices$ | async"
+      [extraBtnClass]="'secondary min-w-full'"
       (selectValue)="xProperty$.next($event)"
       [selected]="xProperty$.value"
       [title]="'chart.dropdown.xProperty' | translate"

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.spec.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.spec.ts
@@ -39,6 +39,7 @@ export class MockChartComponent {
   template: '<div></div>',
 })
 export class MockDropdownSelectorComponent {
+  @Input() selected: any
   @Input() choices: unknown[]
   @Output() selectValue = new EventEmitter<any>()
 }

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.stories.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.stories.ts
@@ -13,22 +13,23 @@ import { ChartViewComponent } from './chart-view.component'
 import { ChartComponent, UiDatavizModule } from '@geonetwork-ui/ui/dataviz'
 import { LoadingMaskComponent } from '@geonetwork-ui/ui/widgets'
 import { importProvidersFrom } from '@angular/core'
-import { DropdownSelectorComponent } from '@geonetwork-ui/ui/inputs'
+import {
+  DropdownSelectorComponent,
+  UiInputsModule,
+} from '@geonetwork-ui/ui/inputs'
 import { MatProgressSpinner } from '@angular/material/progress-spinner'
+import { OverlayModule } from '@angular/cdk/overlay'
 
 export default {
   title: 'Smart/Dataviz/ChartView',
   component: ChartViewComponent,
   decorators: [
     moduleMetadata({
-      declarations: [
-        DropdownSelectorComponent,
-        LoadingMaskComponent,
-        MatProgressSpinner,
-      ],
       imports: [
         ChartComponent,
+        OverlayModule,
         TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
+        UiInputsModule,
       ],
     }),
     applicationConfig({

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.ts
@@ -12,7 +12,7 @@ import {
   FieldAggregation,
   getJsonDataItemsProxy,
 } from '@geonetwork-ui/data-fetcher'
-import { DDChoices } from '@geonetwork-ui/ui/inputs'
+import { DropdownChoice } from '@geonetwork-ui/ui/inputs'
 import { BehaviorSubject, combineLatest, EMPTY, Observable } from 'rxjs'
 import {
   catchError,
@@ -24,10 +24,7 @@ import {
   tap,
 } from 'rxjs/operators'
 import { DataService } from '../service/data.service'
-import {
-  AggregationTypes,
-  InputChartType,
-} from '@geonetwork-ui/common/domain/dataviz-configuration.model'
+import { InputChartType } from '@geonetwork-ui/common/domain/dataviz-configuration.model'
 import { DatasetDistribution } from '@geonetwork-ui/common/domain/record'
 import { TranslateService } from '@ngx-translate/core'
 
@@ -93,7 +90,7 @@ export class ChartViewComponent {
   error = null
   errorInfo = null
 
-  typeChoices: DDChoices = [
+  typeChoices: DropdownChoice[] = [
     { label: 'chart.type.bar', value: 'bar' },
     { label: 'chart.type.barHorizontal', value: 'bar-horizontal' },
     { label: 'chart.type.line', value: 'line' },
@@ -111,7 +108,7 @@ export class ChartViewComponent {
       { label: 'chart.aggregation.min', value: 'min' },
       { label: 'chart.aggregation.average', value: 'average' },
       { label: 'chart.aggregation.count', value: 'count' },
-    ] as DDChoices
+    ] as DropdownChoice[]
   }
 
   dataset$: Observable<BaseReader> = this.currentLink$.pipe(

--- a/libs/feature/editor/src/lib/components/wizard-field/wizard-field.component.html
+++ b/libs/feature/editor/src/lib/components/wizard-field/wizard-field.component.html
@@ -64,6 +64,7 @@
         #dropdown
         [id]="wizardFieldConfig.id"
         [title]="''"
+        [extraBtnClass]="'secondary min-w-full'"
         [showTitle]="false"
         [choices]="dropdownChoices"
         [selected]="wizardFieldData"

--- a/libs/feature/editor/src/lib/components/wizard-field/wizard-field.component.ts
+++ b/libs/feature/editor/src/lib/components/wizard-field/wizard-field.component.ts
@@ -103,7 +103,7 @@ export class WizardFieldComponent implements AfterViewInit, OnDestroy {
         return data ? new Date(Number(data)) : new Date()
       }
       case WizardFieldType.DROPDOWN: {
-        return data ? JSON.parse(data) : this.dropdownChoices[1]
+        return data ? JSON.parse(data) : this.dropdownChoices[0]?.value
       }
     }
   }

--- a/libs/feature/record/src/lib/data-view/data-view.component.html
+++ b/libs/feature/record/src/lib/data-view/data-view.component.html
@@ -3,7 +3,7 @@
     *ngIf="dropdownChoices$ | async as choices"
     [title]="'table.select.data' | translate"
     class="mb-7 w-auto ml-auto"
-    extraClass="!text-primary font-sans font-medium"
+    extraBtnClass="!text-primary font-sans font-medium"
     [choices]="choices"
     (selectValue)="selectLink($event)"
   ></gn-ui-dropdown-selector>

--- a/libs/feature/record/src/lib/map-view/map-view.component.html
+++ b/libs/feature/record/src/lib/map-view/map-view.component.html
@@ -1,7 +1,7 @@
 <div class="w-full h-full flex flex-col p-1">
-  <div class="flex w-full justify-end mb-7 mt-1">
+  <div class="w-full mb-7 mt-1">
     <gn-ui-dropdown-selector
-      extraClass="!text-primary font-sans font-medium"
+      extraBtnClass="!text-primary font-sans font-medium"
       [title]="'map.select.layer' | translate"
       [choices]="dropdownChoices$ | async"
       (selectValue)="selectLinkToDisplay($event)"

--- a/libs/ui/catalog/src/lib/organisations-sort/organisations-sort.component.html
+++ b/libs/ui/catalog/src/lib/organisations-sort/organisations-sort.component.html
@@ -5,14 +5,12 @@
     <p translate>organisation.sort.intro</p>
   </span>
   <span class="flex flex-wrap sm:flex-nowrap sm:shrink-0">
-    <span class="mt-2 mr-2 opacity-75" translate>
-      organisation.sort.sortBy
-    </span>
     <gn-ui-dropdown-selector
-      [title]="''"
+      [title]="'organisation.sort.sortBy' | translate"
       class="shrink"
       [choices]="choices"
-      [showTitle]="false"
+      [minWidth]="'180px'"
+      [showTitle]="true"
       (selectValue)="selectOrderToDisplay($event)"
     ></gn-ui-dropdown-selector>
   </span>

--- a/libs/ui/catalog/src/lib/organisations-sort/organisations-sort.component.spec.ts
+++ b/libs/ui/catalog/src/lib/organisations-sort/organisations-sort.component.spec.ts
@@ -1,5 +1,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { OrganisationsSortComponent } from './organisations-sort.component'
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { TranslateModule } from '@ngx-translate/core'
+
+@Component({
+  selector: 'gn-ui-dropdown-selector',
+  template: '',
+})
+class DropdownSelectorMockComponent {
+  @Input() showTitle: unknown
+  @Input() choices: {
+    value: unknown
+    label: string
+  }[]
+  @Input() selected: unknown
+  @Output() selectValue = new EventEmitter<unknown>()
+}
 
 describe('OrganisationsOrderComponent', () => {
   let component: OrganisationsSortComponent
@@ -7,7 +23,8 @@ describe('OrganisationsOrderComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [OrganisationsSortComponent],
+      declarations: [OrganisationsSortComponent, DropdownSelectorMockComponent],
+      imports: [TranslateModule.forRoot()],
     }).compileComponents()
 
     fixture = TestBed.createComponent(OrganisationsSortComponent)

--- a/libs/ui/inputs/src/index.ts
+++ b/libs/ui/inputs/src/index.ts
@@ -1,4 +1,6 @@
 export * from './lib/dropdown-selector/dropdown-selector.component'
+export * from './lib/dropdown-selector/dropdown-selector.model'
+export * from './lib/dropdown-multiselect/dropdown-multiselect.component'
 export * from './lib/dropdown-multiselect/dropdown-multiselect.model'
 export * from './lib/text-input/text-input.component'
 export * from './lib/chips-input/chips-input.component'

--- a/libs/ui/inputs/src/lib/button/button.component.ts
+++ b/libs/ui/inputs/src/lib/button/button.component.ts
@@ -55,15 +55,15 @@ export class ButtonComponent {
   get borderColor() {
     switch (this.type) {
       case 'default':
-        return 'focus:ring-4 focus:ring-gray-200'
+        return 'border border-gray-700 focus:ring-4 focus:ring-gray-200'
       case 'secondary':
-        return 'focus:ring-4 focus:ring-secondary-lightest'
+        return 'border border-secondary focus:ring-4 focus:ring-secondary-lightest'
       case 'primary':
-        return 'focus:ring-4 focus:ring-primary-lightest'
+        return 'border border-primary focus:ring-4 focus:ring-primary-lightest'
       case 'outline':
-        return 'border border-gray-300 -m-[1px] hover:border-primary-lighter focus:border-primary-lighter focus:ring-4 focus:ring-primary-lightest active:border-primary-darker'
+        return 'border border-gray-300 hover:border-primary-lighter focus:border-primary-lighter focus:ring-4 focus:ring-primary-lightest active:border-primary-darker'
       case 'light':
-        return 'focus:ring-4 focus:ring-gray-300'
+        return 'border border-white focus:ring-4 focus:ring-gray-300'
     }
   }
 

--- a/libs/ui/inputs/src/lib/dropdown-multiselect/dropdown-multiselect.component.stories.ts
+++ b/libs/ui/inputs/src/lib/dropdown-multiselect/dropdown-multiselect.component.stories.ts
@@ -9,13 +9,14 @@ import { OverlayModule } from '@angular/cdk/overlay'
 import { MatCheckboxModule } from '@angular/material/checkbox'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatIcon } from '@angular/material/icon'
+import { ButtonComponent } from '../button/button.component'
 
 export default {
   title: 'Inputs/DropdownMultiselectComponent',
   component: DropdownMultiselectComponent,
   decorators: [
     moduleMetadata({
-      declarations: [MatIcon],
+      declarations: [MatIcon, ButtonComponent],
       imports: [OverlayModule, MatCheckboxModule, TranslateModule.forRoot()],
     }),
     componentWrapperDecorator(

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
@@ -1,27 +1,71 @@
-<div class="flex flex-col items-start sm:flex-row sm:items-center relative">
-  <label
+<div
+  class="flex items-start flex-col sm:flex-row sm:items-center relative w-full"
+>
+  <span
     *ngIf="showTitle"
     class="tracking-wide text-sm mb-2 sm:mb-0 sm:mr-2 whitespace-nowrap"
     [attr.for]="id"
   >
     {{ title }}
-  </label>
-  <select
-    [id]="id"
-    (change)="this.selectValue.emit($event.target.value)"
-    class="w-full min-w-[66px] truncate text-main bg-white border border-gray-300 py-[10px] px-2 rounded-[0.25em] cursor-pointer leading-tight focus:outline-none hover:text-primary-darker hover:border-primary-lighter focus:ring-primary-lightest focus:ring-4"
-    [ngClass]="extraClass"
-    [class.w-full]="!showTitle"
+  </span>
+  <gn-ui-button
+    type="outline"
+    class="grow min-w-0"
+    style="min-width: {{ minWidth }}"
+    extraClass="w-full !p-[8px] !pl-[16px] {{ extraBtnClass }}"
+    [title]="title"
+    [attr.aria-owns]="id"
+    (buttonClick)="openOverlay()"
+    cdkOverlayOrigin
+    #overlayOrigin="cdkOverlayOrigin"
   >
-    <option
-      *ngFor="let choice of choices"
-      [value]="choice.value"
-      [selected]="isSelected(choice)"
-    >
-      {{ choice.label | translate }}
-    </option>
-  </select>
-  <div
-    class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800"
-  ></div>
+    <div class="grow flex items-center mr-2 gap-2 overflow-hidden">
+      <div class="text-left font-medium truncate py-1">
+        {{ getChoiceLabel() | translate }}
+      </div>
+    </div>
+    <mat-icon class="shrink-0 opacity-40">
+      <ng-container *ngIf="overlayOpen">expand_less</ng-container>
+      <ng-container *ngIf="!overlayOpen">expand_more</ng-container>
+    </mat-icon>
+  </gn-ui-button>
 </div>
+
+<ng-template
+  cdkConnectedOverlay
+  cdkConnectedOverlayHasBackdrop
+  cdkConnectedOverlayBackdropClass="cdk-overlay-transparent-backdrop"
+  [cdkConnectedOverlayOrigin]="overlayOrigin"
+  [cdkConnectedOverlayOpen]="overlayOpen"
+  [cdkConnectedOverlayPositions]="overlayPositions"
+  [cdkConnectedOverlayFlexibleDimensions]="true"
+  (backdropClick)="closeOverlay()"
+  (detach)="closeOverlay()"
+>
+  <div
+    class="bg-white border border-gray-300 rounded shadow-lg py-2 w-full overflow-x-hidden overflow-y-auto overlay-container"
+    [style.max-height]="overlayMaxHeight"
+    [style.width]="overlayWidth"
+    role="listbox"
+    tabindex="-1"
+    [attr.id]="id"
+    [attr.aria-multiselectable]="true"
+    [attr.aria-label]="title"
+  >
+    <label
+      *ngFor="let choice of choices"
+      [title]="choice.label"
+      class="flex px-5 py-1 w-full text-gray-900 cursor-pointer hover:text-primary-darkest hover:bg-gray-50 focus-within:text-primary-darkest focus-within:bg-gray-50 transition-colors"
+    >
+      <input
+        class="w-[0px] h-[18px] align-text-top shrink-0"
+        type="text"
+        [checked]="isSelected(choice)"
+        (click)="onSelectValue(choice)"
+      />
+      <span class="text-[14px]">
+        {{ choice.label | translate }}
+      </span>
+    </label>
+  </div>
+</ng-template>

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
@@ -18,6 +18,7 @@
     (buttonClick)="openOverlay()"
     cdkOverlayOrigin
     #overlayOrigin="cdkOverlayOrigin"
+    (keydown)="handleTriggerKeydown($event)"
   >
     <div class="grow flex items-center mr-2 gap-2 overflow-hidden">
       <div class="text-left font-medium truncate py-1">
@@ -51,6 +52,7 @@
     [attr.id]="id"
     [attr.aria-multiselectable]="true"
     [attr.aria-label]="title"
+    (keydown)="handleOverlayKeydown($event)"
   >
     <label
       *ngFor="let choice of choices"
@@ -58,10 +60,12 @@
       class="flex px-5 py-1 w-full text-gray-900 cursor-pointer hover:text-primary-darkest hover:bg-gray-50 focus-within:text-primary-darkest focus-within:bg-gray-50 transition-colors"
     >
       <input
+        #choiceInputs
         class="w-[0px] h-[18px] align-text-top shrink-0"
         type="text"
         [checked]="isSelected(choice)"
         (click)="onSelectValue(choice)"
+        (keydown)="selectIfEnter($event, choice)"
       />
       <span class="text-[14px]">
         {{ choice.label | translate }}

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
@@ -11,8 +11,7 @@
   <gn-ui-button
     type="outline"
     class="grow min-w-0"
-    style="min-width: {{ minWidth }}"
-    extraClass="w-full !p-[8px] !pl-[16px] {{ extraBtnClass }}"
+    extraClass="!p-[8px] !pl-[16px] flex flex-row w-full {{ extraBtnClass }}"
     [title]="title"
     [attr.aria-owns]="id"
     (buttonClick)="openOverlay()"
@@ -20,12 +19,10 @@
     #overlayOrigin="cdkOverlayOrigin"
     (keydown)="handleTriggerKeydown($event)"
   >
-    <div class="grow flex items-center mr-2 gap-2 overflow-hidden">
-      <div class="text-left font-medium truncate py-1">
-        {{ getChoiceLabel() | translate }}
-      </div>
+    <div class="grow font-medium truncate py-1 mr-2 text-left">
+      {{ getChoiceLabel() | translate }}
     </div>
-    <mat-icon class="shrink-0 opacity-40">
+    <mat-icon class="material-symbols-outlined shrink-0 opacity-40">
       <ng-container *ngIf="overlayOpen">expand_less</ng-container>
       <ng-container *ngIf="!overlayOpen">expand_more</ng-container>
     </mat-icon>
@@ -46,7 +43,7 @@
   <div
     class="bg-white border border-gray-300 rounded shadow-lg py-2 w-full overflow-x-hidden overflow-y-auto overlay-container"
     [style.max-height]="overlayMaxHeight"
-    [style.width]="overlayWidth"
+    [style.min-width]="overlayWidth"
     role="listbox"
     tabindex="-1"
     [attr.id]="id"
@@ -54,22 +51,23 @@
     [attr.aria-label]="title"
     (keydown)="handleOverlayKeydown($event)"
   >
-    <label
+    <button
+      #choiceInputs
+      type="button"
       *ngFor="let choice of choices"
       [title]="choice.label"
-      class="flex px-5 py-1 w-full text-gray-900 cursor-pointer hover:text-primary-darkest hover:bg-gray-50 focus-within:text-primary-darkest focus-within:bg-gray-50 transition-colors"
+      class="flex px-5 py-1 w-full cursor-pointer transition-colors"
+      [ngClass]="
+        isSelected(choice)
+          ? 'text-white bg-primary hover:text-white hover:bg-primary-darker focus:text-white focus:bg-primary-darker'
+          : 'text-gray-900 hover:text-primary-darkest hover:bg-gray-50 focus:text-primary-darkest focus:bg-gray-50'
+      "
+      (click)="onSelectValue(choice)"
+      (keydown)="selectIfEnter($event, choice)"
     >
-      <input
-        #choiceInputs
-        class="w-[0px] h-[18px] align-text-top shrink-0"
-        type="text"
-        [checked]="isSelected(choice)"
-        (click)="onSelectValue(choice)"
-        (keydown)="selectIfEnter($event, choice)"
-      />
       <span class="text-[14px]">
         {{ choice.label | translate }}
       </span>
-    </label>
+    </button>
   </div>
 </ng-template>

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.stories.ts
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.stories.ts
@@ -5,11 +5,13 @@ import {
   StoryObj,
 } from '@storybook/angular'
 import { DropdownSelectorComponent } from './dropdown-selector.component'
+import { OverlayModule } from '@angular/cdk/overlay'
 import { TranslateModule } from '@ngx-translate/core'
 import {
   TRANSLATE_DEFAULT_CONFIG,
   UtilI18nModule,
 } from '@geonetwork-ui/util/i18n'
+import { MatCheckboxModule } from '@angular/material/checkbox'
 
 export default {
   title: 'Inputs/DropdownSelectorComponent',
@@ -19,6 +21,8 @@ export default {
       declarations: [],
       imports: [
         UtilI18nModule,
+        OverlayModule,
+        MatCheckboxModule,
         TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
       ],
     }),

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.stories.ts
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.stories.ts
@@ -1,5 +1,6 @@
 import {
   applicationConfig,
+  componentWrapperDecorator,
   Meta,
   moduleMetadata,
   StoryObj,
@@ -11,24 +12,27 @@ import {
   TRANSLATE_DEFAULT_CONFIG,
   UtilI18nModule,
 } from '@geonetwork-ui/util/i18n'
-import { MatCheckboxModule } from '@angular/material/checkbox'
+import { MatIcon } from '@angular/material/icon'
+import { ButtonComponent } from '../button/button.component'
+import { importProvidersFrom } from '@angular/core'
 
 export default {
   title: 'Inputs/DropdownSelectorComponent',
   component: DropdownSelectorComponent,
   decorators: [
     moduleMetadata({
-      declarations: [],
-      imports: [
-        UtilI18nModule,
-        OverlayModule,
-        MatCheckboxModule,
-        TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
-      ],
+      declarations: [MatIcon, ButtonComponent],
+      imports: [UtilI18nModule, OverlayModule, TranslateModule],
     }),
     applicationConfig({
-      providers: [],
+      providers: [
+        importProvidersFrom(TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG)),
+      ],
     }),
+    componentWrapperDecorator(
+      (story) =>
+        `<div class="border border-gray-300 h-[250px] w-[600px] p-[10px]" style="resize: both; overflow: auto">${story}</div>`
+    ),
   ],
 } as Meta<DropdownSelectorComponent>
 
@@ -42,11 +46,11 @@ export const Primary: StoryObj<DropdownSelectorComponent> = {
         value: 'choice1',
       },
       {
-        label: 'My Choice 2',
+        label: 'My Choice 2, second choice',
         value: 'choice2',
       },
       {
-        label: 'My Choice 3',
+        label: 'My Choice 3, very very very very very very long text',
         value: 'choice3',
       },
     ],

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.ts
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.ts
@@ -1,16 +1,25 @@
 import {
-  AfterViewInit,
+  CdkConnectedOverlay,
+  CdkOverlayOrigin,
+  ConnectedPosition,
+} from '@angular/cdk/overlay'
+import {
   ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
+  OnInit,
   Output,
+  ViewChild,
 } from '@angular/core'
+import { Choice } from '../dropdown-multiselect/dropdown-multiselect.model'
 
 export type DDChoices = Array<{
   label: string
   value: string
 }>
+
+const DEFAULT_ROW_NUMBERS = 6
 
 @Component({
   selector: 'gn-ui-dropdown-selector',
@@ -18,20 +27,80 @@ export type DDChoices = Array<{
   styleUrls: ['./dropdown-selector.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class DropdownSelectorComponent {
+export class DropdownSelectorComponent implements OnInit {
   @Input() title: string
   @Input() showTitle = true
   @Input() ariaName: string
   @Input() choices: DDChoices
   @Input() selected: any
-  @Input() extraClass = ''
+  @Input() maxRows: number
+  @Input() extraBtnClass = ''
+  @Input() minWidth = ''
   @Output() selectValue = new EventEmitter<any>()
+  @ViewChild('overlayOrigin') overlayOrigin: CdkOverlayOrigin
+  @ViewChild(CdkConnectedOverlay) overlay: CdkConnectedOverlay
+  overlayOpen = false
+  overlayWidth = 'auto'
+  overlayMaxHeight = 'none'
+  overlayPositions: ConnectedPosition[] = [
+    {
+      originX: 'start',
+      originY: 'bottom',
+      overlayX: 'start',
+      overlayY: 'top',
+      offsetY: 8,
+    },
+    {
+      originX: 'start',
+      originY: 'top',
+      overlayX: 'start',
+      overlayY: 'bottom',
+      offsetY: -8,
+    },
+  ]
+  get selectedChoice(): Choice {
+    return (
+      this.choices.find((choice) => choice.value === this.selected) ??
+      this.choices[0]
+    )
+  }
 
   get id() {
     return this.title.toLowerCase().replace(/[^a-z]+/g, '-')
   }
 
+  getChoiceLabel(): string {
+    return this.selectedChoice?.label
+  }
+
+  ngOnInit(): void {
+    if (!this.maxRows) this.maxRows = DEFAULT_ROW_NUMBERS
+    if (!this.choices || this.choices.length === 0) {
+      this.choices = []
+    }
+  }
+
   isSelected(choice) {
-    return choice.value === this.selected
+    return choice === this.selectedChoice
+  }
+
+  onSelectValue(choice: Choice): void {
+    this.closeOverlay()
+    this.selected = choice.value
+    this.selectValue.emit(this.selected)
+  }
+
+  openOverlay() {
+    this.overlayWidth =
+      this.overlayOrigin.elementRef.nativeElement.getBoundingClientRect()
+        .width + 'px'
+    this.overlayMaxHeight = this.maxRows
+      ? `${this.maxRows * 29 + 60}px`
+      : 'none'
+    this.overlayOpen = true
+  }
+
+  closeOverlay() {
+    this.overlayOpen = false
   }
 }

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.ts
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.ts
@@ -15,13 +15,8 @@ import {
   ViewChild,
   ViewChildren,
 } from '@angular/core'
-import { Choice } from '../dropdown-multiselect/dropdown-multiselect.model'
-import { take } from 'rxjs/operators'
-
-export type DDChoices = Array<{
-  label: string
-  value: string
-}>
+import { firstValueFrom } from 'rxjs'
+import { DropdownChoice } from './dropdown-selector.model'
 
 const DEFAULT_ROW_NUMBERS = 6
 
@@ -35,12 +30,12 @@ export class DropdownSelectorComponent implements OnInit {
   @Input() title: string
   @Input() showTitle = true
   @Input() ariaName: string
-  @Input() choices: DDChoices
-  @Input() selected: any
+  @Input() choices: Array<DropdownChoice>
+  @Input() selected: DropdownChoice['value']
   @Input() maxRows: number
   @Input() extraBtnClass = ''
   @Input() minWidth = ''
-  @Output() selectValue = new EventEmitter<any>()
+  @Output() selectValue = new EventEmitter<DropdownChoice['value']>()
   @ViewChild('overlayOrigin') overlayOrigin: CdkOverlayOrigin
   @ViewChild(CdkConnectedOverlay) overlay: CdkConnectedOverlay
   overlayOpen = false
@@ -65,7 +60,7 @@ export class DropdownSelectorComponent implements OnInit {
   @ViewChildren('choiceInputs', { read: ElementRef })
   choiceInputs: QueryList<ElementRef>
 
-  get selectedChoice(): Choice {
+  get selectedChoice(): DropdownChoice {
     return (
       this.choices.find((choice) => choice.value === this.selected) ??
       this.choices[0]
@@ -87,11 +82,11 @@ export class DropdownSelectorComponent implements OnInit {
     }
   }
 
-  isSelected(choice) {
+  isSelected(choice: DropdownChoice) {
     return choice === this.selectedChoice
   }
 
-  onSelectValue(choice: Choice): void {
+  onSelectValue(choice: DropdownChoice) {
     this.closeOverlay()
     this.selected = choice.value
     this.selectValue.emit(this.selected)
@@ -106,8 +101,8 @@ export class DropdownSelectorComponent implements OnInit {
       : 'none'
     this.overlayOpen = true
     return Promise.all([
-      this.overlay.attach.pipe(take(1)).toPromise(),
-      this.choiceInputs.changes.pipe(take(1)).toPromise(),
+      firstValueFrom(this.overlay.attach),
+      firstValueFrom(this.choiceInputs.changes),
     ])
   }
 
@@ -177,7 +172,7 @@ export class DropdownSelectorComponent implements OnInit {
     )
   }
 
-  selectIfEnter(event: KeyboardEvent, choice: Choice) {
+  selectIfEnter(event: KeyboardEvent, choice: DropdownChoice) {
     if (event.code === 'Enter') {
       event.preventDefault()
       this.onSelectValue(choice)

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.model.ts
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.model.ts
@@ -1,0 +1,5 @@
+// FIXME: this should support more than string values, and match the multiselect choice model
+export interface DropdownChoice {
+  value: unknown
+  label: string
+}


### PR DESCRIPTION
An overlay has been set to be as closed as the multiselect dropdown. 

Sometimes the selected value is a string or an object. I made the majority of the changes in the dropdown component in order to keep the original behavior of each parent component. 