### PR TITLE
feat: Make email in contact block "mailto"

### DIFF
--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
@@ -17,7 +17,7 @@
     <a
       [href]="shownContact.website"
       target="_blank"
-      class="text-primary text-sm cursor-pointer hover:underline transition-all"
+      class="contact-website text-primary text-sm cursor-pointer hover:underline transition-all"
       >{{ shownContact.website }}
       <mat-icon class="!w-[12px] !h-[12px] !text-[12px] opacity-75"
         >open_in_new</mat-icon

--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
@@ -10,7 +10,7 @@
       {{ shownContact.organisation }}
     </div>
   </div>
-  <a [href]="'mailto:' + shownContact.email" class="text-gray-700 text-sm">{{
+  <a [href]="'mailto:' + shownContact.email" class="text-gray-700 text-sm" target="_blank">{{
     shownContact.email
   }}</a>
   <div *ngIf="shownContact.website" class="mb-2">

--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
@@ -10,7 +10,9 @@
       {{ shownContact.organisation }}
     </div>
   </div>
-  <p class="text-gray-700 text-sm">{{ shownContact.email }}</p>
+  <a [href]="'mailto:' + shownContact.email" class="text-gray-700 text-sm">{{
+    shownContact.email
+  }}</a>
   <div *ngIf="shownContact.website" class="mb-2">
     <a
       [href]="shownContact.website"

--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
@@ -10,9 +10,12 @@
       {{ shownContact.organisation }}
     </div>
   </div>
-  <a [href]="'mailto:' + shownContact.email" class="text-gray-700 text-sm" target="_blank">{{
-    shownContact.email
-  }}</a>
+  <a
+    [href]="'mailto:' + shownContact.email"
+    class="text-gray-700 text-sm"
+    target="_blank"
+    >{{ shownContact.email }}</a
+  >
   <div *ngIf="shownContact.website" class="mb-2">
     <a
       [href]="shownContact.website"

--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.spec.ts
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.spec.ts
@@ -58,9 +58,9 @@ describe('MetadataContactComponent', () => {
     })
   })
   describe('content', () => {
-    let ps
+    let email
     beforeEach(() => {
-      ps = fixture.debugElement.queryAll(By.css('p'))
+      email = fixture.debugElement.query(By.css('a'))
     })
     it('displays the contact name', () => {
       const el = fixture.debugElement.query(
@@ -69,10 +69,10 @@ describe('MetadataContactComponent', () => {
       expect(el.innerHTML).toBe(' Worldcorp ')
     })
     it('displays the contact email', () => {
-      expect(ps[1].nativeElement.innerHTML).toBe('john@world.co')
+      expect(email.attributes.href).toBe('mailto:john@world.co')
     })
     it('displays a link to the contact website', () => {
-      const a = fixture.debugElement.query(By.css('a'))
+      const a = fixture.debugElement.query(By.css('.contact-website'))
       expect(a.attributes.href).toBe('https://john.world.co')
       expect(a.attributes.target).toBe('_blank')
     })


### PR DESCRIPTION
In order to make the email in the contact block clickable, this PR adds the mailto: functionality. As discussed in our weekly, we don't want to add a copy button next to the email, because this is not consistent with what we see on other websites.