### PR TITLE
fix: observable too long

### DIFF
--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -317,22 +317,17 @@ describe('OrganisationsFromMetadataService', () => {
         title: 'Surval - Données par paramètre',
         uuid: 'cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
         contact: {
-          name: 'Ifremer',
-          email: 'ifremer.ifremer@ifremer.admin.ch',
+          name: "Cellule d'administration Quadrige",
+          organisation: 'Ifremer',
+          email: 'q2suppor@ifremer.fr',
+          website: 'https://www.ifremer.fr/',
           logoUrl: 'http://localhost/geonetwork/images/harvesting/ifremer.png',
         },
         resourceContacts: [
           {
-            email: 'ifremer.ifremer@ifremer.admin.ch',
-            logoUrl:
-              'http://localhost/geonetwork/images/harvesting/ifremer.png',
-            name: 'Ifremer',
-            organisation: 'Ifremer',
-          },
-          {
             email: 'q2_support@ifremer.fr',
             logoUrl:
-              'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
+              'http://localhost/geonetwork/images/harvesting/ifremer.png',
             name: "Cellule d'Administration Quadrige",
             organisation: 'Ifremer',
           },


### PR DESCRIPTION
PR is intended to reduce loading time of records search and display. 

It's also covering the issue, that contact and resourcecontact should not be set with org, because it breaks normal behaviour within the app.