### PR TITLE
fix: org thumbnail loading time and contacts overrides

### DIFF
--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
@@ -132,7 +132,7 @@ export class OrganisationsFromGroupsService
     const groupId = parseInt(selectField(source, 'groupOwner'))
     const resourceContacts = getAsArray(
       selectField(source, 'contactForResource')
-    ).map((contact) => mapContact(contact, source))
+    ).map((contact) => mapContact(contact))
     return this.groups$.pipe(
       map((groups) => {
         const group = groups.find((g) => g.id === groupId)

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
@@ -8,7 +8,7 @@ import {
   ElasticsearchService,
   getAsArray,
   getAsUrl,
-  hydrateWithRecordLogo,
+  hydrateContactsWithRecordLogo,
   mapContact,
   MetadataContact,
   MetadataRecord,
@@ -137,9 +137,9 @@ export class OrganisationsFromGroupsService
     return this.groups$.pipe(
       map((groups) => {
         const group = groups.find((g) => g.id === groupId)
-        if (!group) return hydrateWithRecordLogo(record, source)
+        if (!group) return hydrateContactsWithRecordLogo(record, source)
         const contact = this.mapContactFromGroup(group, lang3)
-        return hydrateWithRecordLogo(
+        return hydrateContactsWithRecordLogo(
           {
             ...record,
             contact,

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-groups.service.ts
@@ -8,6 +8,7 @@ import {
   ElasticsearchService,
   getAsArray,
   getAsUrl,
+  hydrateWithRecordLogo,
   mapContact,
   MetadataContact,
   MetadataRecord,
@@ -136,13 +137,16 @@ export class OrganisationsFromGroupsService
     return this.groups$.pipe(
       map((groups) => {
         const group = groups.find((g) => g.id === groupId)
-        if (!group) return record
+        if (!group) return hydrateWithRecordLogo(record, source)
         const contact = this.mapContactFromGroup(group, lang3)
-        return {
-          ...record,
-          contact,
-          resourceContacts: [contact, ...resourceContacts],
-        }
+        return hydrateWithRecordLogo(
+          {
+            ...record,
+            contact,
+            resourceContacts: [contact, ...resourceContacts],
+          },
+          source
+        )
       })
     )
   }

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -317,22 +317,18 @@ describe('OrganisationsFromMetadataService', () => {
         title: 'Surval - Données par paramètre',
         uuid: 'cf5048f6-5bbf-4e44-ba74-e6f429af51ea',
         contact: {
-          name: 'Ifremer',
-          email: 'ifremer.ifremer@ifremer.admin.ch',
-          logoUrl: 'http://localhost/geonetwork/images/harvesting/ifremer.png',
+          name: "Cellule d'administration Quadrige",
+          organisation: 'Ifremer',
+          email: 'q2suppor@ifremer.fr',
+          website: 'https://www.ifremer.fr/',
+          logoUrl:
+            'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
         },
         resourceContacts: [
           {
-            email: 'ifremer.ifremer@ifremer.admin.ch',
-            logoUrl:
-              'http://localhost/geonetwork/images/harvesting/ifremer.png',
-            name: 'Ifremer',
-            organisation: 'Ifremer',
-          },
-          {
             email: 'q2_support@ifremer.fr',
             logoUrl:
-              'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
+              'http://localhost/geonetwork/images/harvesting/ifremer.png',
             name: "Cellule d'Administration Quadrige",
             organisation: 'Ifremer',
           },

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -326,9 +326,16 @@ describe('OrganisationsFromMetadataService', () => {
         },
         resourceContacts: [
           {
+            email: 'ifremer.ifremer@ifremer.admin.ch',
+            logoUrl:
+              'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
+            name: 'Ifremer',
+            organisation: 'Ifremer',
+          },
+          {
             email: 'q2_support@ifremer.fr',
             logoUrl:
-              'http://localhost/geonetwork/images/harvesting/ifremer.png',
+              'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
             name: "Cellule d'Administration Quadrige",
             organisation: 'Ifremer',
           },

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -336,13 +336,6 @@ describe('OrganisationsFromMetadataService', () => {
             email: 'q2_support@ifremer.fr',
             logoUrl:
               'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
-            name: "Cellule d'Administration Quadrige",
-            organisation: 'Ifremer',
-          },
-          {
-            email: 'q2_support@ifremer.fr',
-            logoUrl:
-              'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
             name: 'Quadrige',
             organisation: 'Ifremer',
           },

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -328,7 +328,7 @@ describe('OrganisationsFromMetadataService', () => {
           {
             email: 'ifremer.ifremer@ifremer.admin.ch',
             logoUrl:
-              'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
+              'http://localhost/geonetwork/images/harvesting/ifremer.png',
             name: 'Ifremer',
             organisation: 'Ifremer',
           },

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -321,14 +321,15 @@ describe('OrganisationsFromMetadataService', () => {
           organisation: 'Ifremer',
           email: 'q2suppor@ifremer.fr',
           website: 'https://www.ifremer.fr/',
-          logoUrl: 'http://localhost/geonetwork/images/harvesting/ifremer.png',
+          logoUrl:
+            'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
         },
         resourceContacts: [
           {
-            email: 'q2suppor@ifremer.fr',
+            email: 'q2_support@ifremer.fr',
             logoUrl:
               'http://localhost/geonetwork/images/harvesting/ifremer.png',
-            name: "Cellule d'administration Quadrige",
+            name: "Cellule d'Administration Quadrige",
             organisation: 'Ifremer',
           },
           {

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -321,15 +321,14 @@ describe('OrganisationsFromMetadataService', () => {
           organisation: 'Ifremer',
           email: 'q2suppor@ifremer.fr',
           website: 'https://www.ifremer.fr/',
-          logoUrl:
-            'http://localhost/geonetwork/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',
+          logoUrl: 'http://localhost/geonetwork/images/harvesting/ifremer.png',
         },
         resourceContacts: [
           {
-            email: 'ifremer.ifremer@ifremer.admin.ch',
+            email: 'q2suppor@ifremer.fr',
             logoUrl:
               'http://localhost/geonetwork/images/harvesting/ifremer.png',
-            name: 'Ifremer',
+            name: "Cellule d'administration Quadrige",
             organisation: 'Ifremer',
           },
           {

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
@@ -165,22 +165,32 @@ export class OrganisationsFromMetadataService
     })
   }
 
-  private hydrateResourceContactWithOrg(
+  private hydrateContactsWithRecordLogo(
     metadataRecord: MetadataRecord,
     organisation: Organisation
   ): MetadataRecord {
     const firstResourceContact = metadataRecord.resourceContacts[0]
     const logoUrl =
+      metadataRecord.contact.logoUrl ||
       firstResourceContact.logoUrl ||
       (organisation.logoUrl ? getAsUrl(`${organisation.logoUrl}`) : null)
     const mappedOrg = {
-      name: organisation.name,
+      name:
+        metadataRecord.contact?.name ||
+        firstResourceContact.name ||
+        organisation.name,
       organisation: organisation.name,
-      email: organisation.email || firstResourceContact.email,
+      email:
+        metadataRecord.contact?.email ||
+        firstResourceContact.email ||
+        organisation.email,
       logoUrl: logoUrl,
-      website: metadataRecord.resourceContacts[0].website,
+      website:
+        metadataRecord.contact?.website ||
+        metadataRecord.resourceContacts[0].website,
     } as MetadataContact
 
+    metadataRecord.contact = mappedOrg
     metadataRecord.resourceContacts[0] = mappedOrg
 
     return metadataRecord
@@ -230,7 +240,7 @@ export class OrganisationsFromMetadataService
 
         return hydrateWithRecordLogo(
           org
-            ? this.hydrateResourceContactWithOrg(metadataRecord, org)
+            ? this.hydrateContactsWithRecordLogo(metadataRecord, org)
             : metadataRecord,
           source
         )

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
@@ -9,8 +9,8 @@ import {
   getAsArray,
   getAsUrl,
   getFirstValue,
+  hydrateWithRecordLogo,
   mapContact,
-  mapLogo,
   MetadataContact,
   MetadataRecord,
   Organisation,
@@ -186,19 +186,6 @@ export class OrganisationsFromMetadataService
     return metadataRecord
   }
 
-  private hydrateWithRecordLogo(
-    record: MetadataRecord,
-    source: SourceWithUnknownProps
-  ) {
-    const recordLogo = mapLogo(source)
-    if (recordLogo) {
-      record.contact.logoUrl ??= recordLogo
-      record.resourceContacts?.map((r) => {
-        r.logoUrl ??= recordLogo
-      })
-    }
-    return record
-  }
   getFiltersForOrgs(organisations: Organisation[]): Observable<SearchFilters> {
     return of({
       OrgForResource: organisations.reduce(
@@ -241,7 +228,7 @@ export class OrganisationsFromMetadataService
           (o) => o.name === metadataRecord.resourceContacts[0]?.organisation
         )[0]
 
-        return this.hydrateWithRecordLogo(
+        return hydrateWithRecordLogo(
           org
             ? this.hydrateResourceContactWithOrg(metadataRecord, org)
             : metadataRecord,

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
@@ -205,9 +205,15 @@ export class OrganisationsFromMetadataService
           (o) => o.name === metadataRecord.resourceContacts[0]?.organisation
         )[0]
 
-        if (org && !record.resourceContacts?.[0].logoUrl && org.logoUrl) {
+        if (
+          org &&
+          !metadataRecord.resourceContacts?.[0].logoUrl &&
+          org.logoUrl
+        ) {
           const logoUrl = getAsUrl(`${org.logoUrl}`)
           metadataRecord.resourceContacts[0].logoUrl = logoUrl // FIXME: this should go into an organization field
+          metadataRecord.resourceContacts[0].email ??= org.email
+          metadataRecord.contact.email ??= org.email
         }
 
         return metadataRecord

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
@@ -180,10 +180,7 @@ export class OrganisationsFromMetadataService
       website: metadataRecord.resourceContacts[0].website,
     } as MetadataContact
 
-    metadataRecord.resourceContacts = [
-      mappedOrg,
-      ...metadataRecord.resourceContacts,
-    ]
+    metadataRecord.resourceContacts[0] = mappedOrg
 
     return metadataRecord
   }

--- a/libs/util/shared/src/lib/utils/atomic-operations.ts
+++ b/libs/util/shared/src/lib/utils/atomic-operations.ts
@@ -55,11 +55,10 @@ export const mapLogo = (source: SourceWithUnknownProps) => {
 }
 
 export const mapContact = (
-  sourceContact: SourceWithUnknownProps,
-  sourceRecord: SourceWithUnknownProps
+  sourceContact: SourceWithUnknownProps
 ): MetadataContact => {
   const website = getAsUrl(selectField<string>(sourceContact, 'website'))
-  const logoUrl = mapLogo(sourceContact) || mapLogo(sourceRecord)
+  const logoUrl = mapLogo(sourceContact)
   const address = selectField<string>(sourceContact, 'address')
   const phone = selectField<string>(sourceContact, 'phone')
   return {

--- a/libs/util/shared/src/lib/utils/atomic-operations.ts
+++ b/libs/util/shared/src/lib/utils/atomic-operations.ts
@@ -1,4 +1,4 @@
-import { MetadataContact } from '../models'
+import { MetadataContact, MetadataRecord } from '../models'
 
 export type SourceWithUnknownProps = { [key: string]: unknown }
 
@@ -52,6 +52,20 @@ export const getAsUrl = (field) => {
 export const mapLogo = (source: SourceWithUnknownProps) => {
   const logo = selectFallbackFields(source, 'logoUrl', 'logo')
   return logo ? getAsUrl(`/geonetwork${logo}`) : null
+}
+
+export const hydrateWithRecordLogo = (
+  record: MetadataRecord,
+  source: SourceWithUnknownProps
+): MetadataRecord => {
+  const recordLogo = mapLogo(source)
+  if (recordLogo) {
+    if (record.contact) record.contact.logoUrl ??= recordLogo
+    record.resourceContacts?.map((r) => {
+      r.logoUrl ??= recordLogo
+    })
+  }
+  return record
 }
 
 export const mapContact = (

--- a/libs/util/shared/src/lib/utils/atomic-operations.ts
+++ b/libs/util/shared/src/lib/utils/atomic-operations.ts
@@ -54,7 +54,7 @@ export const mapLogo = (source: SourceWithUnknownProps) => {
   return logo ? getAsUrl(`/geonetwork${logo}`) : null
 }
 
-export const hydrateWithRecordLogo = (
+export const hydrateContactsWithRecordLogo = (
   record: MetadataRecord,
   source: SourceWithUnknownProps
 ): MetadataRecord => {


### PR DESCRIPTION
Organisations observables now use shareReplay to avoid multiple call from toRecord method.

Contact is not overrided anymore to prevent wrong display in metadata view. 

Only first resourceContact logoUrl is overrided.