### PR TITLE
feat(metadata): Add underline on hover over email

### DIFF
--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
@@ -12,7 +12,7 @@
   </div>
   <a
     [href]="'mailto:' + shownContact.email"
-    class="text-gray-700 text-sm"
+    class="text-gray-700 text-sm hover:underline"
     target="_blank"
     >{{ shownContact.email }}</a
   >


### PR DESCRIPTION
Adds underline to the email link in the contact section on hover.
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/5753f60c-ba66-4cbb-b3c2-30d2155a20ac)
