### PR TITLE
Fix dataviz web components 

### DIFF
--- a/apps/webcomponents/src/app/components/base.component.ts
+++ b/apps/webcomponents/src/app/components/base.component.ts
@@ -80,7 +80,7 @@ export class BaseComponent implements OnChanges, OnInit {
         JSON.stringify(this.esService.getMetadataByIdPayload(uuid))
       )
     )
-      .then((response) => this.esMapper.toRecords(response))
+      .then((response) => firstValueFrom(this.esMapper.toRecords(response)))
       .then((records) => records[0])
     const dataLinks = record.links.filter((link) =>
       usages.some((usage) => this.linkClassifier.hasUsage(link, usage))


### PR DESCRIPTION
PR fixes the `base.component` by converting a received Observable to a Promise since `ElasticsearchMapper.toRecords()` now returns Observables.