### PR TITLE
feat: get logo if available from index

### DIFF
--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.spec.ts
@@ -60,6 +60,11 @@ const organisationsAggregationMock = {
                 },
               ],
             },
+            logoUrl: {
+              doc_count_error_upper_bound: 0,
+              sum_other_doc_count: 0,
+              buckets: [],
+            },
           },
           {
             key: 'BAKOM',
@@ -70,6 +75,16 @@ const organisationsAggregationMock = {
               buckets: [
                 {
                   key: 'christian.meier@bakom.admin.ch',
+                  doc_count: 1,
+                },
+              ],
+            },
+            logoUrl: {
+              doc_count_error_upper_bound: 0,
+              sum_other_doc_count: 0,
+              buckets: [
+                {
+                  key: 'https://ids.fr/geonetwork/images/harvesting/logo_min.png',
                   doc_count: 1,
                 },
               ],
@@ -87,6 +102,11 @@ const organisationsAggregationMock = {
                   doc_count: 1,
                 },
               ],
+            },
+            logoUrl: {
+              doc_count_error_upper_bound: 0,
+              sum_other_doc_count: 0,
+              buckets: [],
             },
           },
         ],
@@ -159,6 +179,13 @@ describe('OrganisationsFromMetadataService', () => {
                           field: 'contactForResource.email.keyword',
                         },
                       },
+                      logoUrl: {
+                        terms: {
+                          size: 1,
+                          exclude: '',
+                          field: 'contactForResource.logo.keyword',
+                        },
+                      },
                     },
                   },
                 },
@@ -192,21 +219,21 @@ describe('OrganisationsFromMetadataService', () => {
           {
             description: null,
             emails: ['rolf.giezendanner@are.admin.ch', 'john.doe@are.admin.ch'],
-            logoUrl: null,
+            logoUrl: undefined,
             name: 'ARE',
             recordCount: 5,
           },
           {
             description: null,
             emails: ['christian.meier@bakom.admin.ch'],
-            logoUrl: null,
+            logoUrl: 'https://ids.fr/geonetwork/images/harvesting/logo_min.png',
             name: 'BAKOM',
             recordCount: 1,
           },
           {
             description: null,
             emails: ['ifremer.ifremer@ifremer.admin.ch'],
-            logoUrl: null,
+            logoUrl: undefined,
             name: 'Ifremer',
             recordCount: 1,
           },

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
@@ -63,9 +63,7 @@ export class OrganisationsFromMetadataService
             .filter((mail) => !!mail),
           recordCount: bucket.doc_count,
           description: null,
-          logoUrl: bucket.logoUrl.buckets
-            .map((bucket) => bucket.key)
-            .filter((logo) => !!logo)[0],
+          logoUrl: bucket.logoUrl.buckets[0]?.key,
         }))
       )
     )

--- a/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
+++ b/libs/feature/catalog/src/lib/organisations/service/organisations-from-metadata.service.ts
@@ -18,8 +18,9 @@ import {
   selectField,
   SourceWithUnknownProps,
 } from '@geonetwork-ui/util/shared'
+
 import { combineLatest, Observable, of, takeLast } from 'rxjs'
-import { filter, map, shareReplay, startWith } from 'rxjs/operators'
+import { filter, map, shareReplay, startWith, tap } from 'rxjs/operators'
 import { OrganisationsServiceInterface } from './organisations.service.interface'
 
 const IMAGE_URL = '/geonetwork/images/harvesting/'
@@ -30,6 +31,9 @@ type ESBucket = {
 }
 interface OrganisationAggsBucket extends ESBucket {
   mail: {
+    buckets: ESBucket[]
+  }
+  logoUrl: {
     buckets: ESBucket[]
   }
 }
@@ -46,6 +50,7 @@ export class OrganisationsFromMetadataService
       .pipe(
         filter((response) => !!response.aggregations.contact.org),
         map((response) => response.aggregations.contact.org.buckets),
+        tap((res) => console.log(res)),
         shareReplay()
       )
   private organisationsWithoutGroups$: Observable<Organisation[]> =
@@ -58,7 +63,9 @@ export class OrganisationsFromMetadataService
             .filter((mail) => !!mail),
           recordCount: bucket.doc_count,
           description: null,
-          logoUrl: null,
+          logoUrl: bucket.logoUrl.buckets
+            .map((bucket) => bucket.key)
+            .filter((logo) => !!logo)[0],
         }))
       )
     )
@@ -127,6 +134,13 @@ export class OrganisationsFromMetadataService
                   size: 50,
                   exclude: '',
                   field: 'contactForResource.email.keyword',
+                },
+              },
+              logoUrl: {
+                terms: {
+                  size: 1,
+                  exclude: '',
+                  field: 'contactForResource.logo.keyword',
                 },
               },
             },


### PR DESCRIPTION
In organisations tab, retrieve the resourceContact logo. This results in a better filled organisations tab (less placholders) 