### PR TITLE
GSGCT-56 : Rename the "sort by date" label

### DIFF
--- a/apps/search/src/assets/i18n/en.json
+++ b/apps/search/src/assets/i18n/en.json
@@ -19,7 +19,7 @@
   "results.layout.selectOne": "Results layout",
   "results.records.hits.found": "{hits, plural, =0{No documents match the specified search.} one{} other{{hits} records found.}}",
   "results.records.hits.empty.help.html": "Suggestions: <ul class='list-disc list-inside'><li>Try other words</li><li>Specify fewer words</li></ul>",
-  "results.sortBy.dateStamp": "Last updates",
+  "results.sortBy.dateStamp": "Most recent",
   "results.sortBy.popularity": "Popularity",
   "results.sortBy.relevancy": "Relevancy",
   "search.field.any.placeholder": "Search datasets, services and maps ...",

--- a/apps/webcomponents/src/assets/i18n/en.json
+++ b/apps/webcomponents/src/assets/i18n/en.json
@@ -19,7 +19,7 @@
   "results.layout.selectOne": "Results layout",
   "results.records.hits.found": "{hits, plural, =0{No documents match the specified search.} one{} other{{hits} records found.}}",
   "results.records.hits.empty.help.html": "Suggestions: <ul class='list-disc list-inside'><li>Try other words</li><li>Specify fewer words</li></ul>",
-  "results.sortBy.dateStamp": "Last updates",
+  "results.sortBy.dateStamp": "Most recent",
   "results.sortBy.popularity": "Popularity",
   "results.sortBy.relevancy": "Relevancy",
   "search.field.any.placeholder": "Search datasets, services and maps ...",

--- a/translations/en.json
+++ b/translations/en.json
@@ -187,7 +187,7 @@
   "results.records.hits.empty.help.html": "Suggestions: <ul class='list-disc list-inside'><li>Try other words</li><li>Specify fewer words</li></ul>",
   "results.records.hits.found": "{hits, plural, =0{No documents match the specified search.} one{1 record found.} other{{hits} records found.}}",
   "results.showMore": "Show more results...",
-  "results.sortBy.dateStamp": "Last updates",
+  "results.sortBy.dateStamp": "Most recent",
   "results.sortBy.popularity": "Popularity",
   "results.sortBy.relevancy": "Relevancy",
   "search.autocomplete.error": "Suggestions could not be fetched:",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -187,7 +187,7 @@
   "results.records.hits.empty.help.html": "Suggestions : <ul class='list-disc list-inside'><li>Essayez d'autres mots clés</li><li>Cherchez moins de mots</li></ul>",
   "results.records.hits.found": "{hits, plural, =0{Aucune correspondance.} one{1 enregistrement trouvé.} other{{hits} résultats.}}",
   "results.showMore": "Plus de résultats...",
-  "results.sortBy.dateStamp": "Date",
+  "results.sortBy.dateStamp": "Plus récent",
   "results.sortBy.popularity": "Popularité",
   "results.sortBy.relevancy": "Pertinence",
   "search.autocomplete.error": "Les suggestions ne peuvent pas être récupérées",


### PR DESCRIPTION
### JIRA Ticket

https://jira.camptocamp.com/browse/GSGCT-56

### Issue

The 'Filter' dropdown in the dataset page was unclear about the "Date" criteria.

### Resolution

Changed the French translation for `results.sortBy.dateStamp` variable. Also changed the English translation from "Last updates" to "Most recent".

### To test

Go to dataset page, and look up the "Filter" dropdown.