### PR TITLE
GSGCT-54 : Keyword and Usages sections show even when empty

### DIFF
--- a/docs/apps/datahub.md
+++ b/docs/apps/datahub.md
@@ -4,20 +4,24 @@ outline: deep
 
 # Datahub
 
-## Chapter 1
-
-## Chapter 2
-
 ## Metadata pages
 
 Each metadata has its own detailed page, made of multiple sections, described as followed.
 
+The following sections are dynamically generated from the [metadata info component](https://github.com/geonetwork/geonetwork-ui/tree/main/libs/ui/elements/src/lib/metadata-info) component.
+
+### Abstract
+
+The abstract section is based on the metadata attribute `abstract`.
+
 ### Keywords
 
-The keyword section is dynamically generated from the `metadata-info` component. The metadata comes from the harvested `record.metadata` object, which contains a `keywords` array or strings. Through a test on the array's length, if the array is empty, the section will not be displayed.
+The keywords section is based on the metadata attribute `keywords`.
+
+### Lineage
+
+The lineage section is based on the metadata attribute `lineage`.
 
 ### Usage and constraints
 
-The usage and constraints section is dynamically generated from the `metadata-info` component. The metadata comes from the harvested `record.metadata` object, which contains a `constraints` array or strings. Both the usage and constraints are stored in this array. Through a test on the array's length (`hasUsage`), if the array is empty, the section will not be displayed.
-
-A part of the section can however, in some cases, be displayed despite an empty array. In this scenario, a message will be displayed `record.metadata.noUsage` to warn the user.
+The usage and constraints section is based on the metadata attribute `constraints`.

--- a/docs/apps/datahub.md
+++ b/docs/apps/datahub.md
@@ -7,3 +7,17 @@ outline: deep
 ## Chapter 1
 
 ## Chapter 2
+
+## Metadata pages
+
+Each metadata has its own detailed page, made of multiple sections, described as followed.
+
+### Keywords
+
+The keyword section is dynamically generated from the `metadata-info` component. The metadata comes from the harvested `record.metadata` object, which contains a `keywords` array or strings. Through a test on the array's length, if the array is empty, the section will not be displayed.
+
+### Usage and constraints
+
+The usage and constraints section is dynamically generated from the `metadata-info` component. The metadata comes from the harvested `record.metadata` object, which contains a `constraints` array or strings. Both the usage and constraints are stored in this array. Through a test on the array's length (`hasUsage`), if the array is empty, the section will not be displayed.
+
+A part of the section can however, in some cases, be displayed despite an empty array. In this scenario, a message will be displayed `record.metadata.noUsage` to warn the user.

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -13,7 +13,7 @@
   </gn-ui-content-ghost>
 </div>
 
-<ng-container *ngIf="metadata.keywords">
+<ng-container *ngIf="metadata.keywords?.length">
   <p class="mb-3 font-medium text-primary text-sm" translate>
     record.metadata.keywords
   </p>
@@ -68,6 +68,9 @@
     </gn-ui-badge>
     <span *ngFor="let constraint of metadata.constraints">
       {{ constraint }}
+    </span>
+    <span class="noUsage" *ngIf="!metadata.constraints">
+      {{ 'record.metadata.noUsage' | translate }}
     </span>
   </div>
 </gn-ui-expandable-panel>

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.spec.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.spec.ts
@@ -27,4 +27,60 @@ describe('MetadataInfoComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy()
   })
+
+  describe('When a section is empty', () => {
+    beforeEach(() => {
+      component.metadata = {
+        id: '',
+        uuid: '',
+        title: '',
+        metadataUrl: '',
+        keywords: [],
+        constraints: null,
+      }
+      fixture.detectChanges()
+    })
+    it('should display a message for no usage or constraints', () => {
+      const displayedElement =
+        fixture.nativeElement.getElementsByClassName('noUsage')
+      expect(displayedElement).toBeTruthy()
+    })
+
+    it('should not display the keywords section', () => {
+      const displayedElement =
+        fixture.nativeElement.querySelector('ng-container')
+      expect(displayedElement).toBeFalsy()
+    })
+  })
+
+  describe('When a section is not empty', () => {
+    beforeEach(() => {
+      component.metadata = {
+        id: '',
+        uuid: '',
+        title: '',
+        metadataUrl: '',
+        keywords: ['banana', 'pear'],
+        constraints: ['no usage'],
+      }
+      fixture.detectChanges()
+    })
+    it('should not display a message for no usage or constraints', () => {
+      // Use waitForAsync to handle asynchronous changes in the DOM.
+      fixture.whenStable().then(() => {
+        const displayedElement =
+          fixture.nativeElement.getElementsByClassName('noUsage')
+        expect(displayedElement).toBeFalsy()
+      })
+    })
+
+    it('should display the keywords section', () => {
+      // Use waitForAsync to handle asynchronous changes in the DOM.
+      fixture.whenStable().then(() => {
+        const displayedElement =
+          fixture.nativeElement.querySelector('ng-container')
+        expect(displayedElement).toBeTruthy()
+      })
+    })
+  })
 })

--- a/translations/de.json
+++ b/translations/de.json
@@ -191,6 +191,7 @@
   "record.metadata.updateStatus": "Aktualisierungsstatus",
   "record.metadata.updatedOn": "Zuletzt aktualisiert am",
   "record.metadata.usage": "Nutzung und Einschränkungen",
+  "record.metadata.noUsage": "Für diesen Datensatz sind keine Verwendungsbedingungen angegeben.",
   "record.more.details": "Weitere Details",
   "record.tab.chart": "Diagramm",
   "record.tab.data": "Tabelle",

--- a/translations/en.json
+++ b/translations/en.json
@@ -191,6 +191,7 @@
   "record.metadata.updateStatus": "Update Status",
   "record.metadata.updatedOn": "Updated On",
   "record.metadata.usage": "Usage & constraints",
+  "record.metadata.noUsage": "No usage conditions specified for this record.",
   "record.more.details": "Read more",
   "record.tab.chart": "Chart",
   "record.tab.data": "Table",

--- a/translations/es.json
+++ b/translations/es.json
@@ -191,6 +191,7 @@
   "record.metadata.updateStatus": "",
   "record.metadata.updatedOn": "",
   "record.metadata.usage": "",
+  "record.metadata.noUsage": "",
   "record.more.details": "",
   "record.tab.chart": "",
   "record.tab.data": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -191,6 +191,7 @@
   "record.metadata.updateStatus": "Statut de mise à jour",
   "record.metadata.updatedOn": "Dernière mise à jour",
   "record.metadata.usage": "Conditions d'utilisation",
+  "record.metadata.noUsage": "Aucune condition d'utilisation spécifiée pour ces données",
   "record.more.details": "Détails",
   "record.tab.chart": "Graphique",
   "record.tab.data": "Tableau",

--- a/translations/it.json
+++ b/translations/it.json
@@ -191,6 +191,7 @@
   "record.metadata.updateStatus": "",
   "record.metadata.updatedOn": "",
   "record.metadata.usage": "",
+  "record.metadata.noUsage": "",
   "record.more.details": "",
   "record.tab.chart": "",
   "record.tab.data": "",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -191,6 +191,7 @@
   "record.metadata.updateStatus": "",
   "record.metadata.updatedOn": "",
   "record.metadata.usage": "",
+  "record.metadata.noUsage": "",
   "record.more.details": "",
   "record.tab.chart": "",
   "record.tab.data": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -191,6 +191,7 @@
   "record.metadata.updateStatus": "",
   "record.metadata.updatedOn": "",
   "record.metadata.usage": "",
+  "record.metadata.noUsage": "",
   "record.more.details": "",
   "record.tab.chart": "",
   "record.tab.data": "",


### PR DESCRIPTION
### JIRA Ticket

https://jira.camptocamp.com/browse/GSGCT-54

### Issue

The "keywords" and "usage conditions" sections on the dataset page show even when empty

### Resolution

- [x] If no keyword is present in the metadata, hide the keywords section altogether
- [x] If no usage conditions were specified in the metadata, keep the "usage conditions" expansible block but simply show "No usage conditions specified for this record." in the block

### To test

- [x] Add doc

### To test

Go to a metadata that doesn't have keywords or usage conditions.
ex : `5d04741e-441e-4cff-84f8-deb819c8a263` or `7bad4fdb-af8f-427a-8f62-5f321d47445f-6571`