### PR TITLE
Adding i18n to records

### DIFF
--- a/libs/api/metadata-converter/src/lib/gn4/atomic-operations.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/atomic-operations.ts
@@ -24,7 +24,8 @@ export const selectFallback = <T, U>(field: T, fallback: U): T | U =>
 export const selectTranslatedValue = <T>(
   source: SourceWithUnknownProps,
   lang3: string
-): T | null => selectField(source, lang3) || selectField(source, 'default')
+): T | null =>
+  selectFallback(selectField(source, lang3), selectField(source, 'default'))
 
 export const selectTranslatedField = <T>(
   source: SourceWithUnknownProps,
@@ -61,13 +62,14 @@ export const mapLogo = (source: SourceWithUnknownProps) => {
 }
 
 export const mapOrganization = (
-  sourceContact: SourceWithUnknownProps
+  sourceContact: SourceWithUnknownProps,
+  lang3: string
 ): Organization => {
   const website = getAsUrl(selectField<string>(sourceContact, 'website'))
   const logoUrl = getAsUrl(selectField<string>(sourceContact, 'logo'))
   return {
     name: selectFallback(
-      selectTranslatedField<string>(sourceContact, 'organisationObject'),
+      selectTranslatedField<string>(sourceContact, 'organisationObject', lang3),
       selectField<string>(sourceContact, 'organisation')
     ),
     ...(logoUrl && { logoUrl }),
@@ -76,13 +78,14 @@ export const mapOrganization = (
 }
 
 export const mapContact = (
-  sourceContact: SourceWithUnknownProps
+  sourceContact: SourceWithUnknownProps,
+  lang3: string
 ): Individual => {
   const address = selectField<string>(sourceContact, 'address')
   const phone = selectField<string>(sourceContact, 'phone')
   return {
     lastName: selectField<string>(sourceContact, 'individual'),
-    organization: mapOrganization(sourceContact),
+    organization: mapOrganization(sourceContact, lang3),
     email: selectField<string>(sourceContact, 'email'),
     role: getRoleFromRoleCode(selectField<string>(sourceContact, 'role')),
     ...(address && { address }),

--- a/libs/api/metadata-converter/src/lib/gn4/atomic-operations.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/atomic-operations.ts
@@ -22,13 +22,15 @@ export const selectFallback = <T, U>(field: T, fallback: U): T | U =>
   field === null ? fallback : field
 
 export const selectTranslatedValue = <T>(
-  source: SourceWithUnknownProps
-): T | null => selectField(source, 'default')
+  source: SourceWithUnknownProps,
+  lang3: string
+): T | null => selectField(source, lang3) || selectField(source, 'default')
 
 export const selectTranslatedField = <T>(
   source: SourceWithUnknownProps,
-  fieldName: string
-): T | null => selectTranslatedValue(selectField(source, fieldName))
+  fieldName: string,
+  lang3: string
+): T | null => selectTranslatedValue(selectField(source, fieldName), lang3)
 
 export const toDate = (field) => new Date(field)
 

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.spec.ts
@@ -3,10 +3,15 @@ import { TestBed } from '@angular/core/testing'
 import { ES_LINK_FIXTURES } from '@geonetwork-ui/common/fixtures'
 import { Gn4FieldMapper } from './gn4.field.mapper'
 import { MetadataUrlService } from './metadata-url.service'
+import { TranslateService } from '@ngx-translate/core'
 
 class MetadataUrlServiceMock {
   translate = undefined
   getUrl = () => 'url'
+}
+
+const translateServiceMock = {
+  currentLang: 'de',
 }
 
 describe('Gn4FieldMapper', () => {
@@ -16,6 +21,10 @@ describe('Gn4FieldMapper', () => {
     TestBed.configureTestingModule({
       providers: [
         { provide: MetadataUrlService, useClass: MetadataUrlServiceMock },
+        {
+          provide: TranslateService,
+          useValue: translateServiceMock,
+        },
       ],
     })
     service = TestBed.inject(Gn4FieldMapper)

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -25,8 +25,7 @@ import {
   OnlineLinkResource,
 } from '@geonetwork-ui/common/domain/record'
 import { matchProtocol } from '../common/distribution.mapper'
-import { TranslateService } from '@ngx-translate/core'
-import { LANG_2_TO_3_MAPPER } from '@geonetwork-ui/util/i18n'
+import { LangService } from '@geonetwork-ui/util/i18n'
 
 type ESResponseSource = SourceWithUnknownProps
 
@@ -41,12 +40,10 @@ type EsFieldMapperFn = (
 export class Gn4FieldMapper {
   constructor(
     private metadataUrlService: MetadataUrlService,
-    private translateService: TranslateService
+    private langService: LangService
   ) {}
 
-  private lang3 = LANG_2_TO_3_MAPPER[this.translateService.currentLang]
-    ? 'lang' + LANG_2_TO_3_MAPPER[this.translateService.currentLang]
-    : null
+  private lang3 = this.langService.gnLang
 
   protected fields: Record<string, EsFieldMapperFn> = {
     id: (output, source) =>
@@ -131,7 +128,9 @@ export class Gn4FieldMapper {
     },
     contact: (output, source) => ({
       ...output,
-      contacts: [mapContact(getFirstValue(selectField(source, 'contact')))],
+      contacts: [
+        mapContact(getFirstValue(selectField(source, 'contact')), this.lang3),
+      ],
     }),
     contactForResource: (output, source) => ({
       ...output,
@@ -141,7 +140,7 @@ export class Gn4FieldMapper {
           ? output.contactsForResource
           : []),
         ...getAsArray(selectField(source, 'contactForResource')).map(
-          (contact) => mapContact(contact)
+          (contact) => mapContact(contact, this.lang3)
         ),
       ],
     }),

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -25,6 +25,8 @@ import {
   OnlineLinkResource,
 } from '@geonetwork-ui/common/domain/record'
 import { matchProtocol } from '../common/distribution.mapper'
+import { TranslateService } from '@ngx-translate/core'
+import { LANG_2_TO_3_MAPPER } from '@geonetwork-ui/util/i18n'
 
 type ESResponseSource = SourceWithUnknownProps
 
@@ -37,7 +39,14 @@ type EsFieldMapperFn = (
   providedIn: 'root',
 })
 export class Gn4FieldMapper {
-  constructor(private metadataUrlService: MetadataUrlService) {}
+  constructor(
+    private metadataUrlService: MetadataUrlService,
+    private translateService: TranslateService
+  ) {}
+
+  private lang3 = LANG_2_TO_3_MAPPER[this.translateService.currentLang]
+    ? 'lang' + LANG_2_TO_3_MAPPER[this.translateService.currentLang]
+    : null
 
   protected fields: Record<string, EsFieldMapperFn> = {
     id: (output, source) =>
@@ -50,21 +59,22 @@ export class Gn4FieldMapper {
     resourceTitleObject: (output, source) => ({
       ...output,
       title: selectFallback(
-        selectTranslatedField(source, 'resourceTitleObject'),
+        selectTranslatedField(source, 'resourceTitleObject', this.lang3),
         'no title'
       ),
     }),
     resourceAbstractObject: (output, source) => ({
       ...output,
       abstract: selectFallback(
-        selectTranslatedField(source, 'resourceAbstractObject'),
+        selectTranslatedField(source, 'resourceAbstractObject', this.lang3),
         'no title'
       ),
     }),
     overview: (output, source) => {
       const firstOverview = getFirstValue(selectField(source, 'overview'))
       const description = selectTranslatedValue<string>(
-        selectField(firstOverview, 'text')
+        selectField(firstOverview, 'text'),
+        this.lang3
       )
       return {
         ...output,
@@ -150,7 +160,7 @@ export class Gn4FieldMapper {
       ...output,
       keywords: getAsArray(
         selectField<SourceWithUnknownProps[]>(source, 'tag')
-      ).map((tag) => selectTranslatedValue<string>(tag)),
+      ).map((tag) => selectTranslatedValue<string>(tag, this.lang3)),
     }),
     inspireTheme: (output, source) => ({
       ...output,
@@ -183,14 +193,14 @@ export class Gn4FieldMapper {
       ).map((license) => {
         const link = getAsUrl(selectField(license, 'link'))
         return {
-          text: selectTranslatedValue<string>(license),
+          text: selectTranslatedValue<string>(license, this.lang3),
           ...(link ? { link } : {}),
         }
       }),
     }),
     lineageObject: (output, source) => ({
       ...output,
-      lineage: selectTranslatedField(source, 'lineageObject'),
+      lineage: selectTranslatedField(source, 'lineageObject', this.lang3),
     }),
     mainLanguage: (output) => output,
     userSavedCount: (output, source) =>
@@ -243,7 +253,8 @@ export class Gn4FieldMapper {
           useLimitations: [
             ...(output.useLimitations || []),
             ...selectField<SourceWithUnknownProps[]>(source, fieldName).map(
-              selectTranslatedValue
+              (source: SourceWithUnknownProps) =>
+                selectTranslatedValue(source, this.lang3)
             ),
           ],
         }
@@ -252,7 +263,7 @@ export class Gn4FieldMapper {
             ...(output.accessConstraints || []),
             ...selectField<SourceWithUnknownProps[]>(source, fieldName).map(
               (field) => ({
-                text: selectTranslatedValue(field),
+                text: selectTranslatedValue(field, this.lang3),
                 type: this.getConstraintsType(fieldName),
               })
             ),
@@ -299,16 +310,20 @@ export class Gn4FieldMapper {
   ): DatasetDistribution | null => {
     const url = getAsUrl(
       selectFallback(
-        selectTranslatedField<string>(sourceLink, 'urlObject'),
+        selectTranslatedField<string>(sourceLink, 'urlObject', this.lang3),
         selectField<string>(sourceLink, 'url')
       )
     )
     const name = selectFallback(
-      selectTranslatedField<string>(sourceLink, 'nameObject'),
+      selectTranslatedField<string>(sourceLink, 'nameObject', this.lang3),
       selectField<string>(sourceLink, 'name')
     )
     const description = selectFallback(
-      selectTranslatedField<string>(sourceLink, 'descriptionObject'),
+      selectTranslatedField<string>(
+        sourceLink,
+        'descriptionObject',
+        this.lang3
+      ),
       selectField<string>(sourceLink, 'description')
     )
     // no url: fail early

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.metadata.mapper.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.metadata.mapper.spec.ts
@@ -12,6 +12,7 @@ import {
   CatalogRecord,
   DatasetRecord,
 } from '@geonetwork-ui/common/domain/record'
+import { TranslateService } from '@ngx-translate/core'
 
 class MetadataUrlServiceMock {
   translate = undefined
@@ -31,6 +32,10 @@ class OrganisationsServiceMock {
   )
 }
 
+const translateServiceMock = {
+  currentLang: 'de',
+}
+
 describe('Gn4MetadataMapper', () => {
   let service: Gn4MetadataMapper
 
@@ -45,6 +50,10 @@ describe('Gn4MetadataMapper', () => {
         {
           provide: OrganizationsServiceInterface,
           useClass: OrganisationsServiceMock,
+        },
+        {
+          provide: TranslateService,
+          useValue: translateServiceMock,
         },
       ],
     })
@@ -634,7 +643,7 @@ describe('Gn4MetadataMapper', () => {
               updatedTimes: 1,
             },
             useLimitations: [
-              'Restriction lié à l’exercice du droit moral',
+              'Einschränkung im Zusammenhang mit der Ausübung moralischer Rechte',
               "Restriction légale d'utilisation à préciser",
             ],
             spatialExtents: [],

--- a/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.spec.ts
@@ -15,6 +15,7 @@ import {
   ES_FIXTURE_FULL_RESPONSE,
   GROUPS_FIXTURE,
 } from '@geonetwork-ui/common/fixtures'
+import { LangService } from '@geonetwork-ui/util/i18n'
 
 const sampleOrgA: Organization = {
   description: 'A description for ARE',
@@ -152,6 +153,10 @@ class SiteApiServiceMock {
   )
 }
 
+class LangServiceMock {
+  gnLang = jest.fn(() => 'langger')
+}
+
 describe.each(['4.2.2-00', '4.2.3-xx', '4.2.5-xx'])(
   'OrganizationsFromMetadataService (gn v%s)',
   (gnVersion) => {
@@ -177,6 +182,10 @@ describe.each(['4.2.2-00', '4.2.3-xx', '4.2.5-xx'])(
           {
             provide: SiteApiService,
             useClass: SiteApiServiceMock,
+          },
+          {
+            provide: LangService,
+            useClass: LangServiceMock,
           },
         ],
       })

--- a/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.ts
+++ b/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.ts
@@ -27,6 +27,7 @@ import {
 } from '@geonetwork-ui/api/metadata-converter'
 import { combineLatest, Observable, of, switchMap, takeLast } from 'rxjs'
 import { filter, map, shareReplay, startWith, tap } from 'rxjs/operators'
+import { LangService } from '@geonetwork-ui/util/i18n'
 
 const IMAGE_URL = '/geonetwork/images/harvesting/'
 
@@ -114,8 +115,11 @@ export class OrganizationsFromMetadataService
     private esService: ElasticsearchService,
     private searchApiService: SearchApiService,
     private groupsApiService: GroupsApiService,
-    private siteApiService: SiteApiService
+    private siteApiService: SiteApiService,
+    private langService: LangService
   ) {}
+
+  private lang3 = this.langService.gnLang
 
   equalsNormalizedStrings(
     str1: string,
@@ -276,19 +280,19 @@ export class OrganizationsFromMetadataService
   ): Observable<CatalogRecord> {
     const contacts: SourceWithUnknownProps[] = getAsArray(
       selectFallback(
-        selectTranslatedField(source, 'contactObject'),
+        selectTranslatedField(source, 'contactObject', this.lang3),
         selectField(source, 'contact')
       )
     )
     const resourceContacts: SourceWithUnknownProps[] = getAsArray(
       selectFallback(
-        selectTranslatedField(source, 'contactForResourceObject'),
+        selectTranslatedField(source, 'contactForResourceObject', this.lang3),
         selectField(source, 'contactForResource')
       )
     )
     const allContactOrgs = resourceContacts
       .concat(contacts)
-      .map((contact) => mapOrganization(contact))
+      .map((contact) => mapOrganization(contact, this.lang3))
 
     if (!allContactOrgs.length) return of(record)
 

--- a/libs/common/fixtures/src/lib/elasticsearch/full-response.ts
+++ b/libs/common/fixtures/src/lib/elasticsearch/full-response.ts
@@ -1269,6 +1269,8 @@ export const ES_FIXTURE_FULL_RESPONSE = deepFreeze({
             {
               default: 'Restriction lié à l’exercice du droit moral',
               langfre: 'Restriction lié à l’exercice du droit moral',
+              langger:
+                'Einschränkung im Zusammenhang mit der Ausübung moralischer Rechte',
             },
           ],
           geom: {

--- a/libs/feature/catalog/src/lib/feature-catalog.module.ts
+++ b/libs/feature/catalog/src/lib/feature-catalog.module.ts
@@ -9,18 +9,18 @@ import {
 } from '@geonetwork-ui/data-access/gn4'
 import { CommonModule } from '@angular/common'
 import { SourceLabelComponent } from './source-label/source-label.component'
-import { UtilI18nModule } from '@geonetwork-ui/util/i18n'
+import { LangService, UtilI18nModule } from '@geonetwork-ui/util/i18n'
 import { OrganisationsComponent } from './organisations/organisations.component'
 import { UiLayoutModule } from '@geonetwork-ui/ui/layout'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { UiElementsModule } from '@geonetwork-ui/ui/elements'
 import { OrganizationsServiceInterface } from '@geonetwork-ui/common/domain/organizations.service.interface'
 import {
-  OrganizationsFromMetadataService,
+  ElasticsearchService,
   ORGANIZATIONS_STRATEGY,
   OrganizationsFromGroupsService,
+  OrganizationsFromMetadataService,
   OrganizationsStrategy,
-  ElasticsearchService,
 } from '@geonetwork-ui/api/repository/gn4'
 
 // expects the replacement key ${name}
@@ -34,7 +34,8 @@ const organizationsServiceFactory = (
   searchApiService: SearchApiService,
   groupsApiService: GroupsApiService,
   translateService: TranslateService,
-  siteApiService: SiteApiService
+  siteApiService: SiteApiService,
+  langService: LangService
 ) =>
   strategy === 'groups'
     ? new OrganizationsFromGroupsService(
@@ -47,7 +48,8 @@ const organizationsServiceFactory = (
         esService,
         searchApiService,
         groupsApiService,
-        siteApiService
+        siteApiService,
+        langService
       )
 
 @NgModule({
@@ -77,6 +79,7 @@ const organizationsServiceFactory = (
         GroupsApiService,
         TranslateService,
         SiteApiService,
+        LangService,
       ],
     },
   ],

--- a/libs/feature/search/src/lib/results-hits-number/results-hits.container.component.spec.ts
+++ b/libs/feature/search/src/lib/results-hits-number/results-hits.container.component.spec.ts
@@ -2,7 +2,7 @@ import { Component, DebugElement, Input, NO_ERRORS_SCHEMA } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
 import { SearchFacade } from '../state/search.facade'
-import { TranslateModule } from '@ngx-translate/core'
+import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { of } from 'rxjs'
 
 import { ResultsHitsContainerComponent } from './results-hits.container.component'
@@ -19,6 +19,10 @@ class MockResultsHitsNumberComponent {
 const searchFacadeMock = {
   isLoading$: of(false),
   resultsHits$: of(null),
+}
+
+const translateServiceMock = {
+  currentLang: 'de',
 }
 
 describe('ResultsHitsContainerComponent', () => {
@@ -38,6 +42,10 @@ describe('ResultsHitsContainerComponent', () => {
         {
           provide: SearchFacade,
           useValue: searchFacadeMock,
+        },
+        {
+          provide: TranslateService,
+          useValue: translateServiceMock,
         },
       ],
       schemas: [NO_ERRORS_SCHEMA],

--- a/libs/util/i18n/src/lib/lang.service.ts
+++ b/libs/util/i18n/src/lib/lang.service.ts
@@ -17,4 +17,7 @@ export class LangService {
   get index(): string {
     return `lang${this.iso3}`
   }
+  get gnLang() {
+    return this.iso3 ? 'lang' + this.iso3 : null
+  }
 }


### PR DESCRIPTION
This PR is intended to get user current locale in records instead of the default one.

If a translation is available in the record for his language, it uses this one.

Issue #556 