### PR TITLE
Fix: Simplify link classifier service

### DIFF
--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.ts
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.ts
@@ -62,6 +62,9 @@ export class DownloadsListComponent {
     if (format === 'all') {
       return true
     }
+    if (getFileFormat(link) === null) {
+      return format === 'others'
+    }
     if (format === 'others') {
       const knownFormats = FILTER_FORMATS.filter(
         (format) => format !== 'all' && format !== 'others'

--- a/libs/util/shared/src/lib/links/link-classifier.service.spec.ts
+++ b/libs/util/shared/src/lib/links/link-classifier.service.spec.ts
@@ -30,6 +30,17 @@ describe('LinkClassifierService', () => {
         ])
       })
     })
+    describe('for a WFS link (registered as download)', () => {
+      it('returns download, data and API usage', () => {
+        expect(
+          service.getUsagesForLink({
+            name: 'mylayer',
+            type: 'download',
+            url: new URL('https://my.ogc.server/wfs?abcd'),
+          })
+        ).toEqual([LinkUsage.DOWNLOAD, LinkUsage.GEODATA])
+      })
+    })
     describe('for a ESRI REST feature service link', () => {
       it('returns download and API usage', () => {
         expect(service.getUsagesForLink(LINK_FIXTURES.geodataRest)).toEqual([

--- a/libs/util/shared/src/lib/links/link-utils.ts
+++ b/libs/util/shared/src/lib/links/link-utils.ts
@@ -82,7 +82,9 @@ export const FORMATS = {
     color: '#d98294',
     mimeTypes: ['image/svg+xml'],
   },
-}
+} as const
+
+type FileFormat = keyof typeof FORMATS
 
 export function sortPriority(link: DatasetDistribution): number {
   const linkFormat = getFileFormat(link)
@@ -97,26 +99,26 @@ export function sortPriority(link: DatasetDistribution): number {
   return 0
 }
 
-export function extensionToFormat(extension: string): string {
+export function extensionToFormat(extension: string): FileFormat {
   for (const format in FORMATS) {
     for (const alias of FORMATS[format].extensions) {
-      if (alias === extension.toLowerCase()) return format
+      if (alias === extension.toLowerCase()) return format as FileFormat
     }
   }
   return undefined
 }
 
-export function getFileFormat(link: DatasetDistribution): string {
+export function getFileFormat(link: DatasetDistribution): FileFormat {
   if ('mimeType' in link) {
     return mimeTypeToFormat(link.mimeType)
   }
   for (const format in FORMATS) {
     for (const alias of FORMATS[format].extensions) {
-      if (checkFileFormat(link, alias)) return format
-      if (isFormatInQueryParam(link, alias)) return format
+      if (checkFileFormat(link, alias)) return format as FileFormat
+      if (isFormatInQueryParam(link, alias)) return format as FileFormat
     }
   }
-  return ''
+  return null
 }
 
 export function isFormatInQueryParam(
@@ -132,10 +134,10 @@ export function isFormatInQueryParam(
   return false
 }
 
-export function mimeTypeToFormat(mimeType: string): string {
+export function mimeTypeToFormat(mimeType: string): FileFormat {
   for (const format in FORMATS) {
     for (const mt of FORMATS[format].mimeTypes) {
-      if (mimeType === mt) return format
+      if (mimeType === mt) return format as FileFormat
     }
   }
   return undefined
@@ -143,7 +145,7 @@ export function mimeTypeToFormat(mimeType: string): string {
 
 export function checkFileFormat(
   link: DatasetDistribution,
-  format: string
+  format: FileFormat
 ): boolean {
   return (
     ('name' in link && new RegExp(`[./]${format}`, 'i').test(link.name)) ||
@@ -152,7 +154,7 @@ export function checkFileFormat(
   )
 }
 
-export function getBadgeColor(linkFormat: string): string {
+export function getBadgeColor(linkFormat: FileFormat): string {
   for (const format in FORMATS) {
     for (const alias of FORMATS[format].extensions) {
       if (new RegExp(`${alias}`, 'i').test(linkFormat))
@@ -190,6 +192,6 @@ export function getLinkLabel(link: DatasetDistribution): string {
   return format ? `${label} (${format})` : label
 }
 
-export function getMimeTypeForFormat(format: string): string | null {
+export function getMimeTypeForFormat(format: FileFormat): string | null {
   return format in FORMATS ? FORMATS[format.toLowerCase()].mimeTypes[0] : null
 }


### PR DESCRIPTION
Bug: If the format is 'csv', in some cases the format will not be recognized.

This PR fixes this bug.