### PR TITLE
[editor]: Add formats to table

### DIFF
--- a/apps/metadata-editor/src/app/records/records-list.component.ts
+++ b/apps/metadata-editor/src/app/records/records-list.component.ts
@@ -15,6 +15,7 @@ const includes = [
   'userinfo',
   'cl_status',
   'isPublishedToAll',
+  'link',
 ]
 
 @Component({

--- a/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
+++ b/libs/feature/record/src/lib/data-downloads/data-downloads.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { DataService } from '@geonetwork-ui/feature/dataviz'
-import { getFileFormat, sortPriority } from '@geonetwork-ui/util/shared'
+import { getFileFormat, getLinkPriority } from '@geonetwork-ui/util/shared'
 import { combineLatest, of } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
 import { MdViewFacade } from '../state'
@@ -92,5 +92,5 @@ const removeDuplicateLinks = (wfsDownloadLinks) =>
 
 const sortLinks = (allLinks) =>
   allLinks.sort((a: DatasetDistribution, b: DatasetDistribution): number => {
-    return sortPriority(b) - sortPriority(a)
+    return getLinkPriority(b) - getLinkPriority(a)
   })

--- a/libs/ui/search/src/lib/record-table/record-table.component.html
+++ b/libs/ui/search/src/lib/record-table/record-table.component.html
@@ -38,10 +38,20 @@
         <div [title]="record.title" class="record-table-col text-16">
           {{ record.title }}
         </div>
-        <div class="record-table-col text-16">
-          <span class="badge-btn btn-active text-sm">{{
-            getStatus(record.extras?.isPublishedToAll)
-          }}</span>
+        <div class="flex items-center">
+          <div class="record-table-col text-16">
+            <span
+              class="badge-btn text-sm text-white"
+              [style.background-color]="getBadgeColor(firstFormat(record))"
+              *ngIf="firstFormat(record)"
+              >{{ firstFormat(record) }}</span
+            >
+          </div>
+          <div>
+            <span *ngIf="secondToLastFormat(record).length > 0" [title]=""
+              >+ ({{ secondToLastFormat(record).length }})</span
+            >
+          </div>
         </div>
         <div class="record-table-col flex items-center gap-2 text-16">
           <mat-icon class="material-icons-outlined"> person </mat-icon>

--- a/libs/ui/search/src/lib/record-table/record-table.component.html
+++ b/libs/ui/search/src/lib/record-table/record-table.component.html
@@ -38,21 +38,25 @@
         <div [title]="record.title" class="record-table-col text-16">
           {{ record.title }}
         </div>
-        <div class="flex items-center">
-          <div class="record-table-col text-16 basis-1/2">
+        <div
+          class="record-table-col flex items-center"
+          [title]="formats.join(', ')"
+          *ngIf="getRecordFormats(record) as formats"
+        >
+          <div class="text-16 basis-2/3">
             <span
-              class="flex badge-btn text-sm text-white"
-              [style.background-color]="getBadgeColor(firstFormat(record))"
-              *ngIf="firstFormat(record)"
-              >{{ firstFormat(record) }}</span
+              class="badge-btn text-sm text-white mr-2"
+              [style.background-color]="getBadgeColor(formats[0])"
+              *ngIf="formats[0]"
             >
+              {{ formats[0] }}
+            </span>
           </div>
-          <div class="record-table-col text-16 basis-1/2">
-            <span
-              *ngIf="secondToLastFormat(record).length > 0"
-              [title]="secondToLastFormat(record).join(', ')"
-              >+ ({{ secondToLastFormat(record).length }})</span
-            >
+          <div
+            class="text-16 basis-1/3 flex-shrink-0"
+            *ngIf="formats.slice(1).length > 0"
+          >
+            <span>+ {{ formats.slice(1).length }}</span>
           </div>
         </div>
         <div class="record-table-col flex items-center gap-2 text-16">

--- a/libs/ui/search/src/lib/record-table/record-table.component.html
+++ b/libs/ui/search/src/lib/record-table/record-table.component.html
@@ -39,16 +39,18 @@
           {{ record.title }}
         </div>
         <div class="flex items-center">
-          <div class="record-table-col text-16">
+          <div class="record-table-col text-16 basis-1/2">
             <span
-              class="badge-btn text-sm text-white"
+              class="flex badge-btn text-sm text-white"
               [style.background-color]="getBadgeColor(firstFormat(record))"
               *ngIf="firstFormat(record)"
               >{{ firstFormat(record) }}</span
             >
           </div>
-          <div>
-            <span *ngIf="secondToLastFormat(record).length > 0" [title]=""
+          <div class="record-table-col text-16 basis-1/2">
+            <span
+              *ngIf="secondToLastFormat(record).length > 0"
+              [title]="secondToLastFormat(record).join(', ')"
               >+ ({{ secondToLastFormat(record).length }})</span
             >
           </div>

--- a/libs/ui/search/src/lib/record-table/record-table.component.html
+++ b/libs/ui/search/src/lib/record-table/record-table.component.html
@@ -39,24 +39,26 @@
           {{ record.title }}
         </div>
         <div
-          class="record-table-col flex items-center"
+          class="record-table-col flex justify-start items-center gap-2 text-16"
           [title]="formats.join(', ')"
           *ngIf="getRecordFormats(record) as formats"
         >
-          <div class="text-16 basis-2/3">
-            <span
-              class="badge-btn text-sm text-white mr-2"
-              [style.background-color]="getBadgeColor(formats[0])"
-              *ngIf="formats[0]"
-            >
-              {{ formats[0] }}
-            </span>
-          </div>
-          <div
-            class="text-16 basis-1/3 flex-shrink-0"
-            *ngIf="formats.slice(1).length > 0"
+          <span
+            class="badge-btn min-w-[45px] text-sm text-white px-2 flex-shrink-0"
+            [style.background-color]="getBadgeColor(formats[0])"
+            *ngIf="formats[0]"
           >
-            <span>+ {{ formats.slice(1).length }}</span>
+            {{ formats[0] }}
+          </span>
+          <span
+            class="badge-btn min-w-[45px] text-sm text-white px-2 flex-shrink-0"
+            [style.background-color]="getBadgeColor(formats[1])"
+            *ngIf="formats[1]"
+          >
+            {{ formats[1] }}
+          </span>
+          <div class="flex-shrink-0" *ngIf="formats.slice(2).length > 0">
+            <span>+{{ formats.slice(2).length }}</span>
           </div>
         </div>
         <div class="record-table-col flex items-center gap-2 text-16">

--- a/libs/ui/search/src/lib/record-table/record-table.component.spec.ts
+++ b/libs/ui/search/src/lib/record-table/record-table.component.spec.ts
@@ -21,13 +21,33 @@ describe('RecordTableComponent', () => {
     expect(component).toBeTruthy()
   })
 
-  describe('get a list of formats', () => {
+  describe('get a list of formats and sorts them depending on priority', () => {
     it('returns a list of unique formats', () => {
-      expect(component.createSet(DATASET_RECORDS[0])).toEqual([
+      expect(component.getRecordFormats(DATASET_RECORDS[0])).toEqual([
+        'pdf',
         'shp',
         'geojson',
-        'pdf',
       ])
+    })
+  })
+  describe('get the first format', () => {
+    it('returns the first format of the list', () => {
+      expect(component.firstFormat(DATASET_RECORDS[0])).toEqual('pdf')
+    })
+  })
+  describe('get the remaining formats', () => {
+    it('returns the first format of the list', () => {
+      expect(component.secondToLastFormat(DATASET_RECORDS[0])).toEqual([
+        'shp',
+        'geojson',
+      ])
+    })
+  })
+  describe('get the badge color for given format', () => {
+    it('returns the color for its format', () => {
+      expect(
+        component.getBadgeColor(component.firstFormat(DATASET_RECORDS[0]))
+      ).toEqual('#db544a')
     })
   })
 })

--- a/libs/ui/search/src/lib/record-table/record-table.component.spec.ts
+++ b/libs/ui/search/src/lib/record-table/record-table.component.spec.ts
@@ -24,9 +24,9 @@ describe('RecordTableComponent', () => {
   describe('get a list of formats and sorts them depending on priority', () => {
     it('returns a list of unique formats', () => {
       expect(component.getRecordFormats(DATASET_RECORDS[0])).toEqual([
-        'pdf',
-        'shp',
         'geojson',
+        'shp',
+        'pdf',
       ])
     })
   })
@@ -36,7 +36,7 @@ describe('RecordTableComponent', () => {
         component.getBadgeColor(
           component.getRecordFormats(DATASET_RECORDS[0])[0]
         )
-      ).toEqual('#db544a')
+      ).toEqual('#1e5180') // geojson
     })
   })
 })

--- a/libs/ui/search/src/lib/record-table/record-table.component.spec.ts
+++ b/libs/ui/search/src/lib/record-table/record-table.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { DATASET_RECORDS } from '@geonetwork-ui/common/fixtures'
 
 import { RecordTableComponent } from './record-table.component'
 
@@ -18,5 +19,15 @@ describe('RecordTableComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  describe('get a list of formats', () => {
+    it('returns a list of unique formats', () => {
+      expect(component.createSet(DATASET_RECORDS[0])).toEqual([
+        'shp',
+        'geojson',
+        'pdf',
+      ])
+    })
   })
 })

--- a/libs/ui/search/src/lib/record-table/record-table.component.spec.ts
+++ b/libs/ui/search/src/lib/record-table/record-table.component.spec.ts
@@ -30,23 +30,12 @@ describe('RecordTableComponent', () => {
       ])
     })
   })
-  describe('get the first format', () => {
-    it('returns the first format of the list', () => {
-      expect(component.firstFormat(DATASET_RECORDS[0])).toEqual('pdf')
-    })
-  })
-  describe('get the remaining formats', () => {
-    it('returns the first format of the list', () => {
-      expect(component.secondToLastFormat(DATASET_RECORDS[0])).toEqual([
-        'shp',
-        'geojson',
-      ])
-    })
-  })
   describe('get the badge color for given format', () => {
     it('returns the color for its format', () => {
       expect(
-        component.getBadgeColor(component.firstFormat(DATASET_RECORDS[0]))
+        component.getBadgeColor(
+          component.getRecordFormats(DATASET_RECORDS[0])[0]
+        )
       ).toEqual('#db544a')
     })
   })

--- a/libs/ui/search/src/lib/record-table/record-table.component.ts
+++ b/libs/ui/search/src/lib/record-table/record-table.component.ts
@@ -65,13 +65,4 @@ export class RecordTableComponent {
   getBadgeColor(format: FileFormat): string {
     return getBadgeColor(format)
   }
-
-  firstFormat(record: CatalogRecord): FileFormat {
-    return this.getRecordFormats(record)[0]
-  }
-
-  secondToLastFormat(record: CatalogRecord): FileFormat[] {
-    const formats = this.getRecordFormats(record)
-    return formats.slice(formats.length - 2)
-  }
 }

--- a/libs/ui/search/src/lib/record-table/record-table.component.ts
+++ b/libs/ui/search/src/lib/record-table/record-table.component.ts
@@ -1,13 +1,10 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core'
-import {
-  CatalogRecord,
-  DatasetDistribution,
-} from '@geonetwork-ui/common/domain/record'
+import { CatalogRecord } from '@geonetwork-ui/common/domain/record'
 import {
   FileFormat,
   getBadgeColor,
   getFileFormat,
-  sortPriority,
+  getFormatPriority,
 } from '@geonetwork-ui/util/shared'
 
 @Component({
@@ -42,24 +39,16 @@ export class RecordTableComponent {
   }
 
   getRecordFormats(record: CatalogRecord): FileFormat[] {
-    if (record.kind === 'service') {
+    if (record.kind === 'service' || !('distributions' in record)) {
       return []
     }
-    const formatsAndPrio = record.distributions.map(
-      (distribution: DatasetDistribution) => {
-        return {
-          format: getFileFormat(distribution),
-          priority: sortPriority(distribution),
-        }
-      }
-    )
-
-    const sortedFormats = formatsAndPrio
-      .sort((a, b) => a.priority - b.priority)
-      .map((element) => element.format)
-
-    const types = new Set(sortedFormats)
-    return Array.from(types).filter((elm) => elm)
+    const formats = Array.from(
+      new Set(
+        record.distributions.map((distribution) => getFileFormat(distribution))
+      )
+    ).filter((format) => !!format)
+    formats.sort((a, b) => getFormatPriority(b) - getFormatPriority(a))
+    return formats
   }
 
   getBadgeColor(format: FileFormat): string {

--- a/libs/ui/search/src/lib/record-table/record-table.component.ts
+++ b/libs/ui/search/src/lib/record-table/record-table.component.ts
@@ -2,9 +2,13 @@ import { Component, EventEmitter, Input, Output } from '@angular/core'
 import {
   CatalogRecord,
   DatasetDistribution,
-  DatasetRecord,
 } from '@geonetwork-ui/common/domain/record'
-import { FileFormat, getFileFormat } from '@geonetwork-ui/util/shared'
+import {
+  FileFormat,
+  getBadgeColor,
+  getFileFormat,
+  sortPriority,
+} from '@geonetwork-ui/util/shared'
 
 @Component({
   selector: 'gn-ui-record-table',
@@ -41,9 +45,33 @@ export class RecordTableComponent {
     if (record.kind === 'service') {
       return []
     }
-    const types = new Set(
-      record.distributions.map((distribution) => getFileFormat(distribution))
+    const formatsAndPrio = record.distributions.map(
+      (distribution: DatasetDistribution) => {
+        return {
+          format: getFileFormat(distribution),
+          priority: sortPriority(distribution),
+        }
+      }
     )
+
+    const sortedFormats = formatsAndPrio
+      .sort((a, b) => a.priority - b.priority)
+      .map((element) => element.format)
+
+    const types = new Set(sortedFormats)
     return Array.from(types).filter((elm) => elm)
+  }
+
+  getBadgeColor(format: FileFormat): string {
+    return getBadgeColor(format)
+  }
+
+  firstFormat(record: CatalogRecord): FileFormat {
+    return this.getRecordFormats(record)[0]
+  }
+
+  secondToLastFormat(record: CatalogRecord): FileFormat[] {
+    const formats = this.getRecordFormats(record)
+    return formats.slice(formats.length - 2)
   }
 }

--- a/libs/ui/search/src/lib/record-table/record-table.component.ts
+++ b/libs/ui/search/src/lib/record-table/record-table.component.ts
@@ -1,6 +1,10 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core'
-import { DATASET_RECORDS } from '@geonetwork-ui/common/fixtures'
-import { CatalogRecord } from '@geonetwork-ui/common/domain/record'
+import { Component, EventEmitter, Input, Output } from '@angular/core'
+import {
+  CatalogRecord,
+  DatasetDistribution,
+  DatasetRecord,
+} from '@geonetwork-ui/common/domain/record'
+import { FileFormat, getFileFormat } from '@geonetwork-ui/util/shared'
 
 @Component({
   selector: 'gn-ui-record-table',
@@ -8,7 +12,7 @@ import { CatalogRecord } from '@geonetwork-ui/common/domain/record'
   styleUrls: ['./record-table.component.css'],
 })
 export class RecordTableComponent {
-  @Input() records: CatalogRecord[] = DATASET_RECORDS
+  @Input() records: CatalogRecord[] = []
   @Input() totalHits?: number
   @Output() recordSelect = new EventEmitter<CatalogRecord>()
 
@@ -31,5 +35,15 @@ export class RecordTableComponent {
       return `${infos[2]} ${infos[1]}`
     }
     return undefined
+  }
+
+  getRecordFormats(record: CatalogRecord): FileFormat[] {
+    if (record.kind === 'service') {
+      return []
+    }
+    const types = new Set(
+      record.distributions.map((distribution) => getFileFormat(distribution))
+    )
+    return Array.from(types).filter((elm) => elm)
   }
 }

--- a/libs/util/shared/src/lib/links/link-utils.spec.ts
+++ b/libs/util/shared/src/lib/links/link-utils.spec.ts
@@ -7,7 +7,7 @@ import {
   getFileFormat,
   getLinkLabel,
   mimeTypeToFormat,
-  sortPriority,
+  getLinkPriority,
 } from './link-utils'
 
 describe('link utils', () => {
@@ -171,7 +171,7 @@ describe('link utils', () => {
     const nFormats = Object.keys(FORMATS).length
     it(`returns ${nFormats - 1}`, () => {
       expect(
-        sortPriority({
+        getLinkPriority({
           description: 'Data in CSV format',
           name: 'abc.csv',
           url: new URL('https://my.server/files/abc.csv'),
@@ -181,7 +181,7 @@ describe('link utils', () => {
     })
     it(`returns ${nFormats - 5}`, () => {
       expect(
-        sortPriority({
+        getLinkPriority({
           description: 'Data in KML format',
           name: 'abc.kml',
           url: new URL('https://my.server/files/abc.kml'),

--- a/libs/util/shared/src/lib/links/link-utils.ts
+++ b/libs/util/shared/src/lib/links/link-utils.ts
@@ -86,8 +86,7 @@ export const FORMATS = {
 
 export type FileFormat = keyof typeof FORMATS
 
-export function sortPriority(link: DatasetDistribution): number {
-  const linkFormat = getFileFormat(link)
+export function getFormatPriority(linkFormat: FileFormat): number {
   for (const format in FORMATS) {
     for (const ext of FORMATS[format].extensions) {
       if (new RegExp(`${ext}`, 'i').test(linkFormat)) {
@@ -97,6 +96,10 @@ export function sortPriority(link: DatasetDistribution): number {
     }
   }
   return 0
+}
+
+export function getLinkPriority(link: DatasetDistribution): number {
+  return getFormatPriority(getFileFormat(link))
 }
 
 export function extensionToFormat(extension: string): FileFormat {

--- a/libs/util/shared/src/lib/links/link-utils.ts
+++ b/libs/util/shared/src/lib/links/link-utils.ts
@@ -84,7 +84,7 @@ export const FORMATS = {
   },
 } as const
 
-type FileFormat = keyof typeof FORMATS
+export type FileFormat = keyof typeof FORMATS
 
 export function sortPriority(link: DatasetDistribution): number {
   const linkFormat = getFileFormat(link)


### PR DESCRIPTION
This PR adds the formats with its corresponding color badges to the table and sorts them by priority. On hover over the number you can see the remaining formats.

![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/ffd5d0d8-d526-411a-a00d-1cae29631dfe)

TODO:
- Styling for colum (make badges same size)
