### PR TITLE
Fix web components which rely on API version

### DIFF
--- a/apps/webcomponents/src/app/webcomponents.module.ts
+++ b/apps/webcomponents/src/app/webcomponents.module.ts
@@ -32,6 +32,8 @@ import { FeatureMapModule } from '@geonetwork-ui/feature/map'
 import { GnDatasetViewChartComponent } from './components/gn-dataset-view-chart/gn-dataset-view-chart.component'
 import { FeatureDatavizModule } from '@geonetwork-ui/feature/dataviz'
 import { EmbeddedTranslateLoader } from '@geonetwork-ui/util/i18n'
+import { FeatureAuthModule } from '@geonetwork-ui/feature/auth'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
 const CUSTOM_ELEMENTS: [new (...args) => BaseComponent, string][] = [
   [GnFacetsComponent, 'gn-facets'],
@@ -78,6 +80,8 @@ const CUSTOM_ELEMENTS: [new (...args) => BaseComponent, string][] = [
     }),
     MatIconModule,
     FeatureDatavizModule,
+    FeatureAuthModule,
+    BrowserAnimationsModule,
   ],
   providers: [
     {

--- a/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.ts
+++ b/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.ts
@@ -53,14 +53,16 @@ interface IncompleteOrganization {
 export class OrganizationsFromMetadataService
   implements OrganizationsServiceInterface
 {
-  geonetworkVersion$ = this.siteApiService.getSiteOrPortalDescription().pipe(
+  geonetworkVersion$ = of(true).pipe(
+    switchMap(() => this.siteApiService.getSiteOrPortalDescription()),
     map((info) => info['system/platform/version']),
     shareReplay(1)
   )
 
-  private groups$: Observable<GroupApiModel[]> = this.groupsApiService
-    .getGroups()
-    .pipe(shareReplay())
+  private groups$: Observable<GroupApiModel[]> = of(true).pipe(
+    switchMap(() => this.groupsApiService.getGroups()),
+    shareReplay()
+  )
   private organisationsAggs$: Observable<OrganizationAggsBucket[]> =
     this.geonetworkVersion$.pipe(
       switchMap((version) =>


### PR DESCRIPTION
Angular Services should never call a `gn4API` function on Service initialization, because for web component, the `API_URL` is not defined yet.

One should use cold Observable instead, to be sure that the API is fetched only if subscribed.

This fixes the Web components runtime.