### PR TITLE
Migrate icons from Google Material Icons to Material Symbols

### DIFF
--- a/apps/datahub/src/app/home/header-badge-button/header-badge-button.component.css
+++ b/apps/datahub/src/app/home/header-badge-button/header-badge-button.component.css
@@ -1,0 +1,3 @@
+mat-icon {
+  font-variation-settings: 'FILL' 1;
+}

--- a/apps/datahub/src/app/home/header-badge-button/header-badge-button.component.html
+++ b/apps/datahub/src/app/home/header-badge-button/header-badge-button.component.html
@@ -3,6 +3,8 @@
   [class.active]="toggled"
   (click)="toggle()"
 >
-  <mat-icon *ngIf="icon" class="align-middle mr-2">{{ icon }}</mat-icon>
+  <mat-icon *ngIf="icon" class="material-symbols-outlined align-middle mr-2">{{
+    icon
+  }}</mat-icon>
   <span>{{ label | translate }}</span>
 </button>

--- a/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.html
+++ b/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.html
@@ -19,7 +19,7 @@
     type="button"
     class="h-12 inline-flex items-center justify-center align-middle pl-6 rounded-md shrink-0"
   >
-    <mat-icon class="align-middle">menu</mat-icon>
+    <mat-icon class="material-symbols-outlined align-middle">menu</mat-icon>
   </button>
   <div class="shrink truncate" [class]="displayMobileMenu ? 'block' : 'hidden'">
     <div *ngFor="let l of tabLinks">

--- a/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
+++ b/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
@@ -36,7 +36,10 @@
             (click)="close()"
           >
             <span class="text-sm" translate>search.filters.minimize</span>
-            <mat-icon class="ml-1 align-middle leading-none">remove</mat-icon>
+            <mat-icon
+              class="material-symbols-outlined ml-1 align-middle leading-none"
+              >remove</mat-icon
+            >
           </button>
         </span>
       </div>
@@ -81,7 +84,7 @@
         extraClass="!p-[8px]"
         data-cy="filters-expand"
       >
-        <mat-icon>more_horiz</mat-icon>
+        <mat-icon class="material-symbols-outlined">more_horiz</mat-icon>
       </gn-ui-button>
       <button
         type="button"
@@ -91,7 +94,10 @@
         data-cy="filters-expand"
       >
         <span class="text-sm" translate>search.filters.maximize</span>
-        <mat-icon class="ml-1 align-middle leading-none">add</mat-icon>
+        <mat-icon
+          class="material-symbols-outlined ml-1 align-middle leading-none"
+          >add</mat-icon
+        >
       </button>
       <gn-ui-sort-by
         [ngClass]="isOpen ? 'block text-white mb-1' : 'hidden sm:block'"
@@ -106,7 +112,10 @@
         data-cy="filters-collapse"
       >
         <span class="text-sm" translate>search.filters.minimize</span>
-        <mat-icon class="ml-1 align-middle leading-none">remove</mat-icon>
+        <mat-icon
+          class="material-symbols-outlined ml-1 align-middle leading-none"
+          >remove</mat-icon
+        >
       </button>
     </div>
   </div>

--- a/apps/datahub/src/app/record/navigation-bar/navigation-bar.component.html
+++ b/apps/datahub/src/app/record/navigation-bar/navigation-bar.component.html
@@ -42,7 +42,9 @@
       type="button"
       class="h-10 inline-flex items-center justify-center p-2 rounded-md shrink-0 sm:hidden"
     >
-      <mat-icon class="align-middle">expand_more</mat-icon>
+      <mat-icon class="material-symbols-outlined align-middle"
+        >expand_more</mat-icon
+      >
     </button>
   </div>
 </nav>

--- a/apps/datahub/src/index.html
+++ b/apps/datahub/src/index.html
@@ -9,8 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       rel="preload"

--- a/apps/demo/.storybook/preview-head.html
+++ b/apps/demo/.storybook/preview-head.html
@@ -1,4 +1,4 @@
 <link
-  href="https://fonts.googleapis.com/icon?family=Material+Icons"
   rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
 />

--- a/apps/demo/src/app/app.component.css
+++ b/apps/demo/src/app/app.component.css
@@ -126,7 +126,7 @@ summary {
   border-color: rgba(27, 31, 35, 0.35);
   background-position: -0.5em;
 }
-.github-star-badge .material-icons {
+.github-star-badge .material-symbols {
   height: 16px;
   width: 16px;
   margin-right: 4px;

--- a/apps/map-viewer/src/index.html
+++ b/apps/map-viewer/src/index.html
@@ -9,8 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
   </head>
   <body>

--- a/apps/metadata-converter/src/app/components/record-field-array/record-field-array.component.html
+++ b/apps/metadata-converter/src/app/components/record-field-array/record-field-array.component.html
@@ -19,7 +19,8 @@
         extraClass="!p-[0.5em]"
         title="Delete this item"
       >
-        <mat-icon class="material-icons-outlined text-[1.6em] !w-[1em] !h-[1em]"
+        <mat-icon
+          class="material-symbols-outlined text-[1.6em] !w-[1em] !h-[1em]"
           >delete_forever</mat-icon
         >
       </gn-ui-button>

--- a/apps/metadata-converter/src/index.html
+++ b/apps/metadata-converter/src/index.html
@@ -7,8 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       rel="stylesheet"

--- a/apps/metadata-editor/src/app/dashboard/dashboard-menu/dashboard-menu.component.html
+++ b/apps/metadata-editor/src/app/dashboard/dashboard-menu/dashboard-menu.component.html
@@ -5,7 +5,7 @@
     routerLinkActive
     #rlaMyOrg="routerLinkActive"
   >
-    <mat-icon class="material-icons-outlined">home</mat-icon>
+    <mat-icon class="material-symbols-outlined">home</mat-icon>
     <span translate="">dashboard.records.myOrg</span>
   </a>
   <a
@@ -14,7 +14,7 @@
     routerLinkActive
     #rlaAll="routerLinkActive"
   >
-    <mat-icon class="material-icons-outlined">work_outline</mat-icon>
+    <mat-icon class="material-symbols-outlined">work_outline</mat-icon>
     <span translate="">dashboard.records.all</span>
   </a>
   <div class="menu-title" translate="">dashboard.labels.mySpace</div>
@@ -24,7 +24,7 @@
     routerLinkActive
     #rlaMyRecords="routerLinkActive"
   >
-    <mat-icon class="material-icons-outlined">post_add</mat-icon>
+    <mat-icon class="material-symbols-outlined">post_add</mat-icon>
     <span translate="">dashboard.records.myRecords</span>
   </a>
   <a
@@ -33,7 +33,7 @@
     routerLinkActive
     #rlaMyDraft="routerLinkActive"
   >
-    <mat-icon class="material-icons-outlined">edit_note</mat-icon>
+    <mat-icon class="material-symbols-outlined">edit_note</mat-icon>
     <span translate="">dashboard.records.myDraft</span>
   </a>
   <a
@@ -42,7 +42,7 @@
     routerLinkActive
     #rlaMyLibrary="routerLinkActive"
   >
-    <mat-icon class="material-icons-outlined">bookmark_border</mat-icon>
+    <mat-icon class="material-symbols-outlined">bookmark_border</mat-icon>
     <span translate="">dashboard.records.myLibrary</span>
   </a>
 </div>

--- a/apps/metadata-editor/src/app/dashboard/search-header/search-header.component.html
+++ b/apps/metadata-editor/src/app/dashboard/search-header/search-header.component.html
@@ -4,17 +4,17 @@
   </div>
   <div class="flex gap-5 items-center">
     <button>
-      <mat-icon class="icon-btn material-icons-outlined"
+      <mat-icon class="icon-btn material-symbols-outlined"
         >notifications</mat-icon
       >
     </button>
     <button>
-      <mat-icon class="icon-btn material-icons-outlined"
+      <mat-icon class="icon-btn material-symbols-outlined"
         >speaker_notes</mat-icon
       >
     </button>
     <button>
-      <mat-icon class="icon-btn material-icons-outlined">settings</mat-icon>
+      <mat-icon class="icon-btn material-symbols-outlined">settings</mat-icon>
     </button>
     <ng-container *ngrxLet="authService.user$ as user">
       <gn-ui-user-preview

--- a/apps/metadata-editor/src/index.html
+++ b/apps/metadata-editor/src/index.html
@@ -9,8 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       rel="preload"

--- a/apps/search/src/index.html
+++ b/apps/search/src/index.html
@@ -12,8 +12,8 @@
       rel="stylesheet"
     />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
   </head>
   <body>

--- a/apps/webcomponents/src/app/components/gn-dataset-view-chart/gn-dataset-view-chart.sample.html
+++ b/apps/webcomponents/src/app/components/gn-dataset-view-chart/gn-dataset-view-chart.sample.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=Inter:wght@200;300;400;500;600;700&amp;display=swap"

--- a/apps/webcomponents/src/app/components/gn-dataset-view-table/gn-dataset-view-table.sample.html
+++ b/apps/webcomponents/src/app/components/gn-dataset-view-table/gn-dataset-view-table.sample.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=Inter:wght@200;300;400;500;600;700&amp;display=swap"

--- a/apps/webcomponents/src/app/components/gn-facets/gn-facets.sample.html
+++ b/apps/webcomponents/src/app/components/gn-facets/gn-facets.sample.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=Inter:wght@200;300;400;500;600;700&amp;display=swap"

--- a/apps/webcomponents/src/app/components/gn-map-viewer/gn-map-viewer.sample.html
+++ b/apps/webcomponents/src/app/components/gn-map-viewer/gn-map-viewer.sample.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=Inter:wght@200;300;400;500;600;700&amp;display=swap"

--- a/apps/webcomponents/src/app/components/gn-results-list/gn-results-list-multiple.sample.html
+++ b/apps/webcomponents/src/app/components/gn-results-list/gn-results-list-multiple.sample.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@200;300;400;500;600;700&amp;display=swap"

--- a/apps/webcomponents/src/app/components/gn-results-list/gn-results-list.sample.html
+++ b/apps/webcomponents/src/app/components/gn-results-list/gn-results-list.sample.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=Inter:wght@200;300;400;500;600;700&amp;display=swap"

--- a/apps/webcomponents/src/app/components/gn-search-input/gn-search-input-and-results.sample.html
+++ b/apps/webcomponents/src/app/components/gn-search-input/gn-search-input-and-results.sample.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=Inter:wght@200;300;400;500;600;700&amp;display=swap"

--- a/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.sample.html
+++ b/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.sample.html
@@ -8,8 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=Inter:wght@200;300;400;500;600;700&amp;display=swap"

--- a/apps/webcomponents/src/styles.css
+++ b/apps/webcomponents/src/styles.css
@@ -10,37 +10,14 @@
 
 /* CSS coming from host goog:material import, must be injected in shadowDOM styles */
 @font-face {
-  font-family: 'Material Icons';
-  font-style: normal;
-  font-weight: 400;
-  src: url(https://fonts.gstatic.com/s/materialicons/v139/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2)
-    format('woff2');
-}
-@font-face {
-  font-family: 'Material Icons Outlined';
+  font-family: 'Material Symbols Outlined';
   font-style: normal;
   font-weight: 400;
   src: url(https://fonts.gstatic.com/s/materialiconsoutlined/v108/gok-H7zzDkdnRel8-DQ6KAXJ69wP1tGnf4ZGhUce.woff2)
     format('woff2');
 }
-.material-icons {
-  font-family: 'Material Icons';
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  -webkit-font-feature-settings: 'liga';
-  -webkit-font-smoothing: antialiased;
-}
-
-.material-icons-outlined {
-  font-family: 'Material Icons Outlined';
+.material-symbols-outlined {
+  font-family: 'Material Symbols Outlined';
   font-weight: normal;
   font-style: normal;
   font-size: 24px;

--- a/demo/eea/datacatalogue.html
+++ b/demo/eea/datacatalogue.html
@@ -52,8 +52,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=Roboto&amp;family=Inter:wght@200;300;400;500;600;700&amp;display=swap"

--- a/libs/feature/map/src/lib/layers-panel/layers-panel.component.html
+++ b/libs/feature/map/src/lib/layers-panel/layers-panel.component.html
@@ -2,7 +2,7 @@
   class="bg-white rounded shadow shadow-lg relative h-full w-[400px] overflow-hidden"
 >
   <div class="p-3 border-b border-gray-300 flex items-center">
-    <mat-icon class="mr-2">layers</mat-icon>
+    <mat-icon class="material-symbols-outlined mr-2">layers</mat-icon>
     <span translate>map.layers.list</span>
   </div>
   <div class="flex flex-col px-4 divide-y divide-y-gray-50">
@@ -10,7 +10,9 @@
       *ngFor="let layer of layers$ | async; let index = index"
       class="flex flex-row py-3"
     >
-      <mat-icon class="-ml-2 mr-2 shrink-0">chevron_right</mat-icon>
+      <mat-icon class="material-symbols-outlined -ml-2 mr-2 shrink-0"
+        >chevron_right</mat-icon
+      >
       <span class="mr-2 grow">{{ layer.title }}</span>
       <a
         href
@@ -42,6 +44,6 @@
 </div>
 
 <ng-template #addLayerTitle>
-  <mat-icon class="mr-4">add_circle</mat-icon>
+  <mat-icon class="material-symbols-outlined mr-4">add_circle</mat-icon>
   <span translate>map.add.layer</span>
 </ng-template>

--- a/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.html
+++ b/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.html
@@ -5,5 +5,5 @@
   [title]="'record.externalViewer.open' | translate"
   extraClass="!p-[0.6em] !rounded-lg"
 >
-  <mat-icon>open_in_new</mat-icon>
+  <mat-icon class="material-symbols-outlined">open_in_new</mat-icon>
 </gn-ui-button>

--- a/libs/feature/record/src/lib/map-view/map-view.component.html
+++ b/libs/feature/record/src/lib/map-view/map-view.component.html
@@ -28,7 +28,9 @@
         (click)="resetSelection()"
         class="rounded bg-primary-opacity-25 text-white absolute right-[0.5em]"
       >
-        <mat-icon class="align-middle text-sm" style="height: 21px"
+        <mat-icon
+          class="material-symbols-outlined align-middle text-sm"
+          style="height: 21px"
           >close</mat-icon
         >
       </button>

--- a/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.html
+++ b/libs/ui/catalog/src/lib/organisation-preview/organisation-preview.component.html
@@ -27,7 +27,9 @@
         {{ organisation.description }}
       </p>
       <div class="flex-shrink-0 text-primary opacity-50 flex leading-6">
-        <mat-icon class="text-primary opacity-50 mr-1">folder_open </mat-icon>
+        <mat-icon class="material-symbols-outlined text-primary opacity-50 mr-1"
+          >folder_open
+        </mat-icon>
         <span class="mx-1" data-cy="organizationRecordsCount">{{
           organisation.recordCount
         }}</span>

--- a/libs/ui/dataviz/src/lib/figure/figure.component.html
+++ b/libs/ui/dataviz/src/lib/figure/figure.component.html
@@ -3,7 +3,7 @@
   [title]="hoverTitle"
 >
   <mat-icon
-    class="{{ bgClass }} {{
+    class="material-symbols-outlined {{ bgClass }} {{
       textClass
     }} text-[1.875em] rounded-full mr-[0.55em] p-[0.6em] w-[2.2em] h-[2.2em] shrink-0"
     style="width: 2.2em; height: 2.2em"

--- a/libs/ui/elements/src/lib/download-item/download-item.component.html
+++ b/libs/ui/elements/src/lib/download-item/download-item.component.html
@@ -27,7 +27,7 @@
     </div>
   </div>
   <div class="shrink-1 w-14 flex flex-col justify-center items-center">
-    <mat-icon class="!w-8 !h-8 card-icon text-3xl material-icons-outlined">
+    <mat-icon class="!w-8 !h-8 card-icon text-3xl material-symbols-outlined">
       cloud_download
     </mat-icon>
   </div>

--- a/libs/ui/elements/src/lib/link-card/link-card.component.html
+++ b/libs/ui/elements/src/lib/link-card/link-card.component.html
@@ -14,6 +14,6 @@
     </p>
   </div>
   <div>
-    <mat-icon class="card-icon">open_in_new</mat-icon>
+    <mat-icon class="material-symbols-outlined card-icon">open_in_new</mat-icon>
   </div>
 </a>

--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
@@ -23,7 +23,8 @@
       target="_blank"
       class="contact-website text-primary text-sm cursor-pointer hover:underline transition-all"
       >{{ shownOrganization.website }}
-      <mat-icon class="!w-[12px] !h-[12px] !text-[12px] opacity-75"
+      <mat-icon
+        class="material-symbols-outlined !w-[12px] !h-[12px] !text-[12px] opacity-75"
         >open_in_new</mat-icon
       >
     </a>

--- a/libs/ui/elements/src/lib/metadata-info/linkify.directive.ts
+++ b/libs/ui/elements/src/lib/metadata-info/linkify.directive.ts
@@ -32,7 +32,7 @@ export class GnUiLinkifyDirective implements OnInit {
   private linkifyText(text: string): string {
     return text.replace(/(\bhttps?:\/\/\S+\b)/g, (match) => {
       return `<a href="${match}" target="_blank"
-                  class="text-primary cursor-pointer hover:underline">${match} <mat-icon class="mat-icon !w-[12px] !h-[14px] !text-[14px] opacity-75 material-icons">open_in_new</mat-icon></a>`
+                  class="text-primary cursor-pointer hover:underline">${match} <mat-icon class="material-symbols-outlined !w-[12px] !h-[14px] !text-[14px] opacity-75">open_in_new</mat-icon></a>`
     })
   }
 }

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -78,7 +78,8 @@
   <div class="py-5 px-5 rounded bg-gray-100 text-gray-700">
     <p class="text-sm" translate>record.metadata.sheet</p>
     <a [href]="metadata.landingPage" target="_blank">
-      <mat-icon class="inline-block align-bottom pt-1.5 text-xs text-black"
+      <mat-icon
+        class="material-symbols-outlined inline-block align-bottom pt-1.5 text-xs text-black"
         >open_in_new</mat-icon
       >
       <span class="text-primary">{{ metadata.landingPage }}</span>

--- a/libs/ui/elements/src/lib/pagination-buttons/pagination-buttons.component.html
+++ b/libs/ui/elements/src/lib/pagination-buttons/pagination-buttons.component.html
@@ -5,7 +5,7 @@
       [disabled]="currentPage === 1"
       (buttonClick)="previousPage()"
     >
-      <mat-icon>chevron_left</mat-icon>
+      <mat-icon class="material-symbols-outlined">chevron_left</mat-icon>
     </gn-ui-button>
     <ng-container *ngFor="let page of visiblePages">
       <ng-container *ngIf="page === '...'">
@@ -25,7 +25,7 @@
       [disabled]="currentPage === totalPages"
       (buttonClick)="nextPage()"
     >
-      <mat-icon>chevron_right</mat-icon>
+      <mat-icon class="material-symbols-outlined">chevron_right</mat-icon>
     </gn-ui-button>
   </div>
 </div>

--- a/libs/ui/elements/src/lib/pagination/pagination.component.html
+++ b/libs/ui/elements/src/lib/pagination/pagination.component.html
@@ -38,7 +38,7 @@
         extraClass="!p-[3px]"
         data-cy="prev-page"
       >
-        <mat-icon>navigate_before</mat-icon>
+        <mat-icon class="material-symbols-outlined">navigate_before</mat-icon>
       </gn-ui-button>
       <gn-ui-button
         (buttonClick)="nextPage()"
@@ -48,7 +48,7 @@
         extraClass="!p-[3px]"
         data-cy="next-page"
       >
-        <mat-icon>navigate_next</mat-icon>
+        <mat-icon class="material-symbols-outlined">navigate_next</mat-icon>
       </gn-ui-button>
     </div>
   </div>

--- a/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
+++ b/libs/ui/elements/src/lib/related-record-card/related-record-card.component.html
@@ -21,7 +21,9 @@
         [matTooltip]="'tooltip.url.open' | translate"
         matTooltipPosition="above"
       >
-        <mat-icon class="align-middle text-secondary">open_in_new</mat-icon>
+        <mat-icon class="material-symbols-outlined align-middle text-secondary"
+          >open_in_new</mat-icon
+        >
       </button>
     </div>
   </div>

--- a/libs/ui/elements/src/lib/search-results-error/search-results-error.component.html
+++ b/libs/ui/elements/src/lib/search-results-error/search-results-error.component.html
@@ -3,23 +3,29 @@
 >
   <div *ngIf="type === types.COULD_NOT_REACH_API">
     <div class="relative opacity-40">
-      <mat-icon class="face">face</mat-icon>
-      <mat-icon class="question-mark1">question_mark</mat-icon>
-      <mat-icon class="question-mark2">question_mark</mat-icon>
+      <mat-icon class="material-symbols-outlined face">face</mat-icon>
+      <mat-icon class="material-symbols-outlined question-mark1"
+        >question_mark</mat-icon
+      >
+      <mat-icon class="material-symbols-outlined question-mark2"
+        >question_mark</mat-icon
+      >
     </div>
     <div translate>search.error.couldNotReachApi</div>
   </div>
   <div *ngIf="type === types.RECEIVED_ERROR">
     <div class="relative opacity-40">
-      <mat-icon class="face">mood_bad</mat-icon>
+      <mat-icon class="material-symbols-outlined face">mood_bad</mat-icon>
     </div>
     <div translate>search.error.receivedError</div>
     <div *ngIf="error">{{ error }}</div>
   </div>
   <div *ngIf="type === types.RECORD_NOT_FOUND">
     <div class="relative opacity-40">
-      <mat-icon class="computer">computer</mat-icon>
-      <mat-icon class="computer-question-mark">question_mark</mat-icon>
+      <mat-icon class="material-symbols-outlined computer">computer</mat-icon>
+      <mat-icon class="material-symbols-outlined computer-question-mark"
+        >question_mark</mat-icon
+      >
     </div>
     <div translate [translateParams]="{ id: recordId }">
       search.error.recordNotFound

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
@@ -15,7 +15,7 @@
     aria-label="Clear"
     (click)="clear()"
   >
-    <mat-icon>close</mat-icon>
+    <mat-icon class="material-symbols-outlined">close</mat-icon>
   </button>
   <button
     type="button"
@@ -23,7 +23,7 @@
     aria-label="Trigger search"
     (click)="handleClickSearch()"
   >
-    <mat-icon>search</mat-icon>
+    <mat-icon class="material-symbols-outlined">search</mat-icon>
   </button>
   <gn-ui-popup-alert
     *ngIf="error"

--- a/libs/ui/inputs/src/lib/copy-text-button/copy-text-button.component.html
+++ b/libs/ui/inputs/src/lib/copy-text-button/copy-text-button.component.html
@@ -24,7 +24,8 @@
     [matTooltip]="tooltipText"
     matTooltipPosition="above"
   >
-    <mat-icon class="pointer-events-none align-middle card-icon"
+    <mat-icon
+      class="material-symbols-outlined pointer-events-none align-middle card-icon"
       >content_copy</mat-icon
     >
   </button>

--- a/libs/ui/inputs/src/lib/dropdown-multiselect/dropdown-multiselect.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-multiselect/dropdown-multiselect.component.html
@@ -21,14 +21,14 @@
   </div>
   <button class="h-6 w-6" data-cy="clearSelection">
     <mat-icon
-      class="shrink-0 opacity-40 mr-1.5 hover:opacity-80 transition-colors clear-btn"
+      class="material-symbols-outlined shrink-0 opacity-40 mr-1.5 hover:opacity-80 transition-colors clear-btn"
       *ngIf="hasSelectedChoices && !overlayOpen"
       (click)="clearSelection($event)"
     >
       close
     </mat-icon>
   </button>
-  <mat-icon class="shrink-0 opacity-40">
+  <mat-icon class="material-symbols-outlined shrink-0 opacity-40">
     <ng-container *ngIf="overlayOpen">expand_less</ng-container>
     <ng-container *ngIf="!overlayOpen">expand_more</ng-container>
   </mat-icon>
@@ -74,7 +74,11 @@
         <div
           class="flex items-center justify-center rounded-full bg-white text-main h-[13px] w-[13px] pt-px -mt-px shrink-0"
         >
-          <mat-icon class="!h-[12px] !w-[12px] text-[12px]"> close</mat-icon>
+          <mat-icon
+            class="material-symbols-outlined !h-[12px] !w-[12px] text-[12px]"
+          >
+            close</mat-icon
+          >
         </div>
       </button>
 
@@ -90,7 +94,11 @@
           class="absolute top-1/2 -translate-y-1/2 right-0 px-[7px] leading-tight clear-search-input mr-2"
           (click)="clearSearchInputValue($event)"
         >
-          <mat-icon class="!h-[10px] !w-[12px] text-[12px]"> close </mat-icon>
+          <mat-icon
+            class="material-symbols-outlined !h-[10px] !w-[12px] text-[12px]"
+          >
+            close
+          </mat-icon>
         </button>
       </div>
     </div>

--- a/libs/ui/inputs/src/lib/form-field/form-field.component.html
+++ b/libs/ui/inputs/src/lib/form-field/form-field.component.html
@@ -8,15 +8,19 @@
         - {{ config.hintKey | translate }}
       </span>
     </label>
-    <mat-icon *ngIf="isFieldOk" class="text-[#c6d950] icon-ok"
+    <mat-icon
+      *ngIf="isFieldOk"
+      class="material-symbols-outlined text-[#c6d950] icon-ok"
       >check_circle</mat-icon
     >
     <mat-icon
       *ngIf="isFieldLocked"
-      class="material-icons-outlined text-blue-400 icon-locked"
+      class="material-symbols-outlined text-blue-400 icon-locked"
       >lock</mat-icon
     >
-    <mat-icon *ngIf="isFieldInvalid" class="text-pink-500 icon-invalid"
+    <mat-icon
+      *ngIf="isFieldInvalid"
+      class="material-symbols-outlined text-pink-500 icon-invalid"
       >cancel</mat-icon
     >
   </div>

--- a/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
+++ b/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
@@ -1,6 +1,6 @@
 <button
   class="group flex items-center justify-center p-1 bg-primary-opacity-25 text-white rounded"
 >
-  <mat-icon class="align-middle">{{ icon }}</mat-icon>
+  <mat-icon class="material-symbols-outlined align-middle">{{ icon }}</mat-icon>
   <span class="mx-2 hidden group-hover:inline">{{ label }}</span>
 </button>

--- a/libs/ui/inputs/src/lib/star-toggle/star-toggle.component.css
+++ b/libs/ui/inputs/src/lib/star-toggle/star-toggle.component.css
@@ -9,6 +9,12 @@ mat-icon {
   width: 1em;
   height: 1em;
   font-size: 1.5em;
+  margin-top: -0.1em;
+  font-variation-settings: 'opsz' 40;
+}
+
+.star-filled {
+  font-variation-settings: 'FILL' 1;
 }
 
 .star-toggle-overlay {

--- a/libs/ui/inputs/src/lib/star-toggle/star-toggle.component.html
+++ b/libs/ui/inputs/src/lib/star-toggle/star-toggle.component.html
@@ -9,7 +9,11 @@
       'cursor-default': disabled
     }"
   >
-    <mat-icon>{{ toggled ? 'star' : 'star_outline' }}</mat-icon>
+    <mat-icon
+      class="material-symbols-outlined"
+      [ngClass]="{ 'star-filled': toggled }"
+      >star</mat-icon
+    >
   </button>
   <svg
     #starOverlay

--- a/libs/ui/layout/src/lib/expandable-panel-button/expandable-panel-button.component.html
+++ b/libs/ui/layout/src/lib/expandable-panel-button/expandable-panel-button.component.html
@@ -6,8 +6,12 @@
 >
   <ng-container [ngTemplateOutlet]="titleTemplate"></ng-container>
   <div class="ml-3 grow"></div>
-  <mat-icon *ngIf="collapsed">expand_more</mat-icon>
-  <mat-icon *ngIf="!collapsed">expand_less</mat-icon>
+  <mat-icon class="material-symbols-outlined" *ngIf="collapsed"
+    >expand_more</mat-icon
+  >
+  <mat-icon class="material-symbols-outlined" *ngIf="!collapsed"
+    >expand_less</mat-icon
+  >
 </button>
 <div
   class="content transition-all pointer-events-auto bg-white"

--- a/libs/ui/layout/src/lib/expandable-panel-button/expandable-panel-button.component.stories.ts
+++ b/libs/ui/layout/src/lib/expandable-panel-button/expandable-panel-button.component.stories.ts
@@ -38,7 +38,7 @@ type ExpandablePanelButtonTemplate = ExpandablePanelButtonComponent & {
 export const Primary: StoryObj<ExpandablePanelButtonTemplate> = {
   args: {
     titleTemplateString:
-      "<mat-icon class='mr-4'>key</mat-icon> Open this menu to find out more",
+      "<mat-icon class='material-symbols-outlined mr-4'>key</mat-icon> Open this menu to find out more",
   },
   render: (args) => ({
     props: args,

--- a/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.html
+++ b/libs/ui/layout/src/lib/expandable-panel/expandable-panel.component.html
@@ -8,8 +8,10 @@
   <div
     class="w-8 opacity-25 text-primary group-hover:opacity-100 transition-opacity"
   >
-    <mat-icon *ngIf="collapsed">add</mat-icon>
-    <mat-icon *ngIf="!collapsed">remove</mat-icon>
+    <mat-icon class="material-symbols-outlined" *ngIf="collapsed">add</mat-icon>
+    <mat-icon class="material-symbols-outlined" *ngIf="!collapsed"
+      >remove</mat-icon
+    >
   </div>
 </div>
 <div

--- a/libs/ui/map/src/lib/components/map/map.component.html
+++ b/libs/ui/map/src/lib/components/map/map.component.html
@@ -8,6 +8,8 @@
   <div
     class="absolute z-[-1] inset-0 bg-gradient-to-b from-white to-primary-lightest opacity-60"
   ></div>
-  <mat-icon class="!w-16 !h-16 text-[64px] mb-4">swipe</mat-icon>
+  <mat-icon class="material-symbols-outlined !w-16 !h-16 text-[64px] mb-4"
+    >swipe</mat-icon
+  >
   <p translate>map.navigation.message</p>
 </div>

--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
@@ -18,7 +18,7 @@
       >
         <mat-icon
           *ngIf="!hasLogo"
-          class="text-gray-200"
+          class="material-symbols-outlined text-gray-200"
           style="width: 42px; height: 42px; font-size: 42px; margin: 10px"
           >{{ hasOnlyPerson ? 'face' : 'home_work' }}</mat-icon
         >
@@ -66,12 +66,12 @@
       <div class="flex flex-row mt-3" *ngIf="isDownloadable || isViewable">
         <mat-icon
           *ngIf="isDownloadable"
-          class="material-icons-outlined text-primary opacity-45 mr-3"
+          class="material-symbols-outlined text-primary opacity-45 mr-3"
           >cloud_download
         </mat-icon>
         <mat-icon
           *ngIf="isViewable"
-          class="material-icons-outlined text-primary opacity-45 mr-3"
+          class="material-symbols-outlined text-primary opacity-45 mr-3"
           >map
         </mat-icon>
       </div>

--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.stories.ts
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.stories.ts
@@ -47,7 +47,7 @@ export const Primary: StoryObj<RecordPreviewFeedTemplate> = {
     record: DATASET_RECORDS[0],
     linkTarget: '_blank',
     favoriteTemplateString: `<a href title="Mark '{{record.title}}' as favorite">
-    1234 <mat-icon class="align-middle">star</mat-icon>
+    1234 <mat-icon class="material-symbols-outlined align-middle">star</mat-icon>
   </a>`,
   },
   render: (args) => ({

--- a/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.html
+++ b/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.html
@@ -43,12 +43,12 @@
     >
       <mat-icon
         *ngIf="isDownloadable"
-        class="material-icons-outlined text-primary opacity-45 mx-1"
+        class="material-symbols-outlined text-primary opacity-45 mx-1"
         >cloud_download</mat-icon
       >
       <mat-icon
         *ngIf="isViewable"
-        class="material-icons-outlined text-primary opacity-45 mx-1"
+        class="material-symbols-outlined text-primary opacity-45 mx-1"
         >map</mat-icon
       >
     </div>

--- a/libs/ui/search/src/lib/record-table/record-table.component.html
+++ b/libs/ui/search/src/lib/record-table/record-table.component.html
@@ -62,7 +62,7 @@
           </div>
         </div>
         <div class="record-table-col flex items-center gap-2 text-16">
-          <mat-icon class="material-icons-outlined"> person </mat-icon>
+          <mat-icon class="material-symbols-outlined"> person </mat-icon>
           <span class="">{{ formatUserInfo(record.extras?.ownerInfo) }}</span>
         </div>
         <div class="record-table-col text-16">

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.html
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.html
@@ -13,7 +13,9 @@
     (mouseenter)="expand()"
     (mouseleave)="expandAndClose()"
   >
-    <mat-icon class="mr-2 shrink-0 select-none">{{ icon }}</mat-icon>
+    <mat-icon class="material-symbols-outlined mr-2 shrink-0 select-none">{{
+      icon
+    }}</mat-icon>
     <div class="grow" #content [ngClass]="{ invisible: !expanded }">
       <ng-content></ng-content>
     </div>


### PR DESCRIPTION
Material Symbols offers more icons as well as variation settings for each icon. This means that a single font is used for all icons, and the style (filled or outlined, thick or thin etc.) can be changed using the `font-variation-settings` CSS property.

See https://developers.google.com/fonts/docs/material_symbols?hl=fr

The imported CSS files were changed everywhere. Note that the `material-symbols-outlined` class is now required for all mat-icon components.

Note: this should probably be factorized in a `gn-ui-icon` component later on.