### PR TITLE
feat(editor): Filter by current org

### DIFF
--- a/apps/metadata-editor/src/app/dashboard/dashboard-menu/dashboard-menu.component.html
+++ b/apps/metadata-editor/src/app/dashboard/dashboard-menu/dashboard-menu.component.html
@@ -2,26 +2,28 @@
   <a
     class="menu-item"
     routerLink="/records/my-org"
-    routerLinkActive
+    routerLinkActive="btn-active"
     #rlaMyOrg="routerLinkActive"
   >
     <mat-icon class="material-icons-outlined">home</mat-icon>
     <span translate="">dashboard.records.myOrg</span>
   </a>
+
   <a
     class="menu-item"
     routerLink="/records/all"
-    routerLinkActive
+    routerLinkActive="btn-active"
     #rlaAll="routerLinkActive"
   >
     <mat-icon class="material-icons-outlined">work_outline</mat-icon>
     <span translate="">dashboard.records.all</span>
   </a>
+
   <div class="menu-title" translate="">dashboard.labels.mySpace</div>
   <a
     class="menu-item"
     routerLink="/records/my-records"
-    routerLinkActive
+    routerLinkActive="btn-active"
     #rlaMyRecords="routerLinkActive"
   >
     <mat-icon class="material-icons-outlined">post_add</mat-icon>
@@ -30,7 +32,7 @@
   <a
     class="menu-item"
     routerLink="/records/my-draft"
-    routerLinkActive
+    routerLinkActive="btn-active"
     #rlaMyDraft="routerLinkActive"
   >
     <mat-icon class="material-icons-outlined">edit_note</mat-icon>
@@ -39,7 +41,7 @@
   <a
     class="menu-item"
     routerLink="/records/my-library"
-    routerLinkActive
+    routerLinkActive="btn-active"
     #rlaMyLibrary="routerLinkActive"
   >
     <mat-icon class="material-icons-outlined">bookmark_border</mat-icon>

--- a/apps/metadata-editor/src/app/records/my-org-records/my-org-records.component.spec.ts
+++ b/apps/metadata-editor/src/app/records/my-org-records/my-org-records.component.spec.ts
@@ -1,10 +1,35 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { MyOrgRecordsComponent } from './my-org-records.component'
-import { SearchFacade } from '@geonetwork-ui/feature/search'
+import { SearchFacade, SearchService } from '@geonetwork-ui/feature/search'
 import { Component, importProvidersFrom } from '@angular/core'
 import { TranslateModule } from '@ngx-translate/core'
 import { RecordsListComponent } from '../records-list.component'
+import { USER_FIXTURE } from '@geonetwork-ui/common/fixtures'
+import { BehaviorSubject, of } from 'rxjs'
+import { AuthService } from '@geonetwork-ui/feature/auth'
+import { OrganizationsServiceInterface } from '@geonetwork-ui/common/domain/organizations.service.interface'
+
+const user = USER_FIXTURE()
+class AuthServiceMock {
+  user$ = new BehaviorSubject(user)
+  authReady = jest.fn(() => this._authSubject$)
+  _authSubject$ = new BehaviorSubject({})
+}
+class OrganisationsServiceMock {
+  organisationsCount$ = of(456)
+}
+
+class searchServiceMock {
+  updateSearchFilters = jest.fn()
+  setSearch = jest.fn()
+  setSortBy = jest.fn()
+  setSortAndFilters = jest.fn()
+}
+
+class SearchFacadeMock {
+  resetSearch = jest.fn()
+}
 
 @Component({
   // eslint-disable-next-line
@@ -13,10 +38,6 @@ import { RecordsListComponent } from '../records-list.component'
   standalone: true,
 })
 export class MockRecordsListComponent {}
-
-class SearchFacadeMock {
-  resetSearch = jest.fn()
-}
 
 describe('MyOrgRecordsComponent', () => {
   let component: MyOrgRecordsComponent
@@ -30,6 +51,19 @@ describe('MyOrgRecordsComponent', () => {
         {
           provide: SearchFacade,
           useClass: SearchFacadeMock,
+        },
+        { provide: AuthService, useClass: AuthServiceMock },
+        {
+          provide: OrganizationsServiceInterface,
+          useClass: OrganisationsServiceMock,
+        },
+        {
+          provide: SearchFacade,
+          useClass: SearchFacadeMock,
+        },
+        {
+          provide: SearchService,
+          useClass: searchServiceMock,
         },
       ],
     }).overrideComponent(MyOrgRecordsComponent, {

--- a/apps/metadata-editor/src/app/records/my-org-records/my-org-records.component.spec.ts
+++ b/apps/metadata-editor/src/app/records/my-org-records/my-org-records.component.spec.ts
@@ -5,18 +5,24 @@ import { SearchFacade, SearchService } from '@geonetwork-ui/feature/search'
 import { Component, importProvidersFrom } from '@angular/core'
 import { TranslateModule } from '@ngx-translate/core'
 import { RecordsListComponent } from '../records-list.component'
-import { USER_FIXTURE } from '@geonetwork-ui/common/fixtures'
+import {
+  FILTERS_AGGREGATION,
+  USER_FIXTURE,
+} from '@geonetwork-ui/common/fixtures'
 import { BehaviorSubject, of } from 'rxjs'
 import { AuthService } from '@geonetwork-ui/feature/auth'
 import { OrganizationsServiceInterface } from '@geonetwork-ui/common/domain/organizations.service.interface'
 
 const user = USER_FIXTURE()
+const filters = FILTERS_AGGREGATION
+
 class AuthServiceMock {
   user$ = new BehaviorSubject(user)
   authReady = jest.fn(() => this._authSubject$)
   _authSubject$ = new BehaviorSubject({})
 }
 class OrganisationsServiceMock {
+  getFiltersForOrgs = jest.fn(() => new BehaviorSubject(filters))
   organisationsCount$ = of(456)
 }
 
@@ -29,6 +35,7 @@ class searchServiceMock {
 
 class SearchFacadeMock {
   resetSearch = jest.fn()
+  setFilters = jest.fn()
 }
 
 @Component({
@@ -43,6 +50,7 @@ describe('MyOrgRecordsComponent', () => {
   let component: MyOrgRecordsComponent
   let fixture: ComponentFixture<MyOrgRecordsComponent>
   let searchFacade: SearchFacade
+  let orgService: OrganizationsServiceInterface
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -75,6 +83,7 @@ describe('MyOrgRecordsComponent', () => {
       },
     })
     searchFacade = TestBed.inject(SearchFacade)
+    orgService = TestBed.inject(OrganizationsServiceInterface)
     fixture = TestBed.createComponent(MyOrgRecordsComponent)
     component = fixture.componentInstance
     fixture.detectChanges()
@@ -87,6 +96,14 @@ describe('MyOrgRecordsComponent', () => {
   describe('filters', () => {
     it('clears filters on init', () => {
       expect(searchFacade.resetSearch).toHaveBeenCalled()
+    })
+    it('filters by user organisation on init', () => {
+      expect(orgService.getFiltersForOrgs).toHaveBeenCalledWith([
+        {
+          name: user.organisation,
+        },
+      ])
+      expect(searchFacade.setFilters).toHaveBeenCalledWith(filters)
     })
   })
 })

--- a/apps/metadata-editor/src/app/records/my-org-records/my-org-records.component.ts
+++ b/apps/metadata-editor/src/app/records/my-org-records/my-org-records.component.ts
@@ -3,6 +3,9 @@ import { CommonModule } from '@angular/common'
 import { TranslateModule } from '@ngx-translate/core'
 import { RecordsListComponent } from '../records-list.component'
 import { SearchFacade } from '@geonetwork-ui/feature/search'
+import { OrganizationsServiceInterface } from '@geonetwork-ui/common/domain/organizations.service.interface'
+import { Organization } from '@geonetwork-ui/common/domain/record'
+import { AuthService } from '@geonetwork-ui/feature/auth'
 
 @Component({
   selector: 'md-editor-my-org-records',
@@ -12,7 +15,20 @@ import { SearchFacade } from '@geonetwork-ui/feature/search'
   imports: [CommonModule, TranslateModule, RecordsListComponent],
 })
 export class MyOrgRecordsComponent {
-  constructor(public searchFacade: SearchFacade) {
+  constructor(
+    public searchFacade: SearchFacade,
+    private authService: AuthService,
+    private orgService: OrganizationsServiceInterface
+  ) {
     this.searchFacade.resetSearch()
+    this.authService.user$.subscribe((user) => {
+      this.searchByOrganisation({ name: user.organisation })
+    })
+  }
+
+  searchByOrganisation(organisation: Organization) {
+    this.orgService
+      .getFiltersForOrgs([organisation])
+      .subscribe((filters) => this.searchFacade.setFilters(filters))
   }
 }


### PR DESCRIPTION
With this PR, we will be able to filter the records by the current organisation of the authenticated user.
Additionally the highlighting of the active menu item is re-implemented here.

Right now the table is empty, because the organisation name is empty:
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/fc1f697d-89cc-4ea5-99b8-2978daba6809)

