### PR TITLE
Metadata-editor: sorting url 

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/dashboard.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/dashboard.cy.ts
@@ -53,6 +53,10 @@ describe('dashboard', () => {
             .then((list) => {
               newFirstItem = list.trim()
               expect(newFirstItem).not.to.equal(originalFirstItem)
+              cy.url().should(
+                'include',
+                'sort=resourceTitleObject.default.keyword'
+              )
             })
         })
     })

--- a/apps/metadata-editor/src/app/dashboard/dashboard-page.component.spec.ts
+++ b/apps/metadata-editor/src/app/dashboard/dashboard-page.component.spec.ts
@@ -1,25 +1,44 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { DashboardPageComponent } from './dashboard-page.component'
 import { CommonModule } from '@angular/common'
+import { SearchService } from '@geonetwork-ui/feature/search'
+
+class SearchServiceMock {
+  setSortBy = jest.fn()
+}
 
 describe('DashboardPageComponent', () => {
   let component: DashboardPageComponent
   let fixture: ComponentFixture<DashboardPageComponent>
+  let searchService: SearchService
 
   beforeEach(async () => {
-    await TestBed.overrideComponent(DashboardPageComponent, {
-      set: {
-        imports: [CommonModule],
-        providers: [],
-      },
-    }).compileComponents()
+    await TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: SearchService,
+          useClass: SearchServiceMock,
+        },
+      ],
+    })
+      .overrideComponent(DashboardPageComponent, {
+        set: {
+          imports: [CommonModule],
+          providers: [],
+        },
+      })
+      .compileComponents()
 
     fixture = TestBed.createComponent(DashboardPageComponent)
+    searchService = TestBed.inject(SearchService)
     component = fixture.componentInstance
     fixture.detectChanges()
   })
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+  it('orders the completion column', () => {
+    expect(searchService.setSortBy).toHaveBeenCalledWith(['desc', 'changeDate'])
   })
 })

--- a/apps/metadata-editor/src/app/dashboard/dashboard-page.component.ts
+++ b/apps/metadata-editor/src/app/dashboard/dashboard-page.component.ts
@@ -1,7 +1,8 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core'
 import { RouterOutlet } from '@angular/router'
 import { SidebarComponent } from './sidebar/sidebar.component'
 import { SearchHeaderComponent } from './search-header/search-header.component'
+import { SearchService } from '@geonetwork-ui/feature/search'
 
 @Component({
   selector: 'md-editor-dashboard',
@@ -11,4 +12,10 @@ import { SearchHeaderComponent } from './search-header/search-header.component'
   imports: [RouterOutlet, SidebarComponent, SearchHeaderComponent],
   standalone: true,
 })
-export class DashboardPageComponent {}
+export class DashboardPageComponent implements OnInit {
+  constructor(public searchService: SearchService) {}
+
+  ngOnInit(): void {
+    this.searchService.setSortBy(['desc', 'changeDate'])
+  }
+}

--- a/apps/metadata-editor/src/app/records/records-list.component.spec.ts
+++ b/apps/metadata-editor/src/app/records/records-list.component.spec.ts
@@ -118,12 +118,6 @@ describe('RecordsListComponent', () => {
       expect(pagination.currentPage).toEqual(currentPage)
       expect(pagination.totalPages).toEqual(totalPages)
     })
-    it('orders the completion column', () => {
-      expect(searchFacade.setSortBy).toHaveBeenCalledWith([
-        'desc',
-        'changeDate',
-      ])
-    })
     describe('when click on a record', () => {
       beforeEach(() => {
         table.recordSelect.emit({ uniqueIdentifier: 123 })

--- a/apps/metadata-editor/src/app/records/records-list.component.ts
+++ b/apps/metadata-editor/src/app/records/records-list.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common'
-import { Component, Input } from '@angular/core'
+import { Component, Input, OnInit } from '@angular/core'
 import { MatIconModule } from '@angular/material/icon'
 import { Router } from '@angular/router'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/record'
@@ -34,10 +34,7 @@ export class RecordsListComponent {
     public searchFacade: SearchFacade,
     public searchService: SearchService
   ) {
-    this.searchFacade
-      .setPageSize(15)
-      .setConfigRequestFields(includes)
-      .setSortBy(['desc', 'changeDate'])
+    this.searchFacade.setPageSize(15).setConfigRequestFields(includes)
   }
 
   paginate(page: number) {
@@ -52,6 +49,6 @@ export class RecordsListComponent {
   }
 
   setSortBy(newSortBy: SortByField) {
-    this.searchFacade.setSortBy(newSortBy)
+    this.searchService.setSortBy(newSortBy)
   }
 }

--- a/libs/feature/search/src/lib/state/search.facade.ts
+++ b/libs/feature/search/src/lib/state/search.facade.ts
@@ -213,6 +213,7 @@ export class SearchFacade {
   resetSearch() {
     this.store.dispatch(new Paginate(1, this.searchId))
     this.store.dispatch(new SetFilters({}, this.searchId))
+    this.store.dispatch(new SetSortBy([], this.searchId))
     this.store.dispatch(new SetFavoritesOnly(false, this.searchId))
   }
 }


### PR DESCRIPTION
### Issue

Adding a sorting parameter to the URL.

### Resolution

This was more of a fix than a dev, and took some investigation. Turns out the Search Facade was called instead of the Search Service in `record-list-component`, preventing the URL from being updated on sorting (including when the catalog is initialized, was not working beforehand).