### PR TITLE
Datahub : change updatedOn labels

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -173,7 +173,6 @@
   "record.metadata.api": "API",
   "record.metadata.author": "",
   "record.metadata.catalog": "Katalog",
-  "record.metadata.completion": "",
   "record.metadata.contact": "Kontakt",
   "record.metadata.createdOn": "Erstellt am",
   "record.metadata.details": "Details",

--- a/translations/en.json
+++ b/translations/en.json
@@ -173,7 +173,6 @@
   "record.metadata.api": "API",
   "record.metadata.author": "Author",
   "record.metadata.catalog": "Catalog",
-  "record.metadata.completion": "Completion",
   "record.metadata.contact": "Contact",
   "record.metadata.createdOn": "Created on",
   "record.metadata.details": "Details",

--- a/translations/en.json
+++ b/translations/en.json
@@ -191,7 +191,7 @@
   "record.metadata.title": "Title",
   "record.metadata.updateFrequency": "Update Frequency",
   "record.metadata.updateStatus": "Update Status",
-  "record.metadata.updatedOn": "Updated On",
+  "record.metadata.updatedOn": "Last update of data information",
   "record.metadata.usage": "Usage & constraints",
   "record.more.details": "Read more",
   "record.tab.chart": "Chart",

--- a/translations/es.json
+++ b/translations/es.json
@@ -173,7 +173,6 @@
   "record.metadata.api": "",
   "record.metadata.author": "",
   "record.metadata.catalog": "",
-  "record.metadata.completion": "",
   "record.metadata.contact": "",
   "record.metadata.createdOn": "",
   "record.metadata.details": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -191,7 +191,7 @@
   "record.metadata.title": "Titre",
   "record.metadata.updateFrequency": "Fréquence de mise à jour",
   "record.metadata.updateStatus": "Statut de mise à jour",
-  "record.metadata.updatedOn": "Dernière mise à jour",
+  "record.metadata.updatedOn": "Dernière mise à jour des informations sur les données",
   "record.metadata.usage": "Conditions d'utilisation",
   "record.more.details": "Détails",
   "record.tab.chart": "Graphique",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -173,7 +173,6 @@
   "record.metadata.api": "API",
   "record.metadata.author": "Auteur",
   "record.metadata.catalog": "Catalogue",
-  "record.metadata.completion": "Mis à jour",
   "record.metadata.contact": "Contact",
   "record.metadata.createdOn": "Créé le",
   "record.metadata.details": "Détails",

--- a/translations/it.json
+++ b/translations/it.json
@@ -173,7 +173,6 @@
   "record.metadata.api": "",
   "record.metadata.author": "",
   "record.metadata.catalog": "",
-  "record.metadata.completion": "",
   "record.metadata.contact": "",
   "record.metadata.createdOn": "",
   "record.metadata.details": "",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -173,7 +173,6 @@
   "record.metadata.api": "",
   "record.metadata.author": "",
   "record.metadata.catalog": "",
-  "record.metadata.completion": "",
   "record.metadata.contact": "",
   "record.metadata.createdOn": "",
   "record.metadata.details": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -173,7 +173,6 @@
   "record.metadata.api": "",
   "record.metadata.author": "",
   "record.metadata.catalog": "",
-  "record.metadata.completion": "",
   "record.metadata.contact": "",
   "record.metadata.createdOn": "",
   "record.metadata.details": "",


### PR DESCRIPTION
In this PR the label for `updatedOn` was changed to be more specific about what was updated.

eg: 'Updated On' becomes 'Last update of data information'.