### PR TITLE
Datahub : Custom data toggle broken

### DIFF
--- a/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
@@ -34,7 +34,6 @@ jest.mock('@geonetwork-ui/util/app-config', () => {
           filters: { publisher: ['DREAL'] },
         },
         {
-          sort: 'title',
           name: 'filterCarto',
           filters: { q: 'Cartographie' },
         },
@@ -69,6 +68,7 @@ class searchServiceMock {
   setSearch = jest.fn()
   setSortBy = jest.fn()
   setSortAndFilters = jest.fn()
+  setFilters = jest.fn()
 }
 
 class AuthServiceMock {
@@ -234,17 +234,32 @@ describe('HeaderComponent', () => {
           const allBadges = fixture.debugElement.queryAll(By.css('.badge-btn'))
           expect(allBadges.length).toBe(4)
         })
-        beforeEach(() => {
-          const firstCustomBadge = fixture.debugElement.queryAll(
-            By.css('.badge-btn')
-          )[2]
-          firstCustomBadge.nativeElement.click()
+        describe('when sort is defined', () => {
+          beforeEach(() => {
+            const firstCustomBadge = fixture.debugElement.queryAll(
+              By.css('.badge-btn')
+            )[2]
+            firstCustomBadge.nativeElement.click()
+          })
+          it('should redirect correctly', () => {
+            expect(searchService.setSortAndFilters).toHaveBeenCalledWith(
+              { thisIs: 'a fake filter' },
+              SortByEnum.CREATE_DATE
+            )
+          })
         })
-        it('should redirect correctly', () => {
-          expect(searchService.setSortAndFilters).toHaveBeenCalledWith(
-            { thisIs: 'a fake filter' },
-            SortByEnum.CREATE_DATE
-          )
+        describe('when sort is not defined', () => {
+          beforeEach(() => {
+            const secondCustomBadge = fixture.debugElement.queryAll(
+              By.css('.badge-btn')
+            )[3]
+            secondCustomBadge.nativeElement.click()
+          })
+          it('should redirect correctly', () => {
+            expect(searchService.setFilters).toHaveBeenCalledWith({
+              thisIs: 'a fake filter',
+            })
+          })
         })
       })
 

--- a/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
@@ -61,6 +61,7 @@ class routerFacadeMock {
 class searchFacadeMock {
   setFavoritesOnly = jest.fn()
   setSortBy = jest.fn()
+  sortBy$ = new BehaviorSubject(['desc', 'createDate'])
 }
 
 class searchServiceMock {

--- a/apps/datahub/src/app/home/home-header/home-header.component.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.ts
@@ -22,7 +22,7 @@ import { map } from 'rxjs/operators'
 import { ROUTER_ROUTE_NEWS } from '../../router/constants'
 import { firstValueFrom, lastValueFrom } from 'rxjs'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/record'
-import { sortByToString } from '@geonetwork-ui/util/shared'
+import { sortByFromString } from '@geonetwork-ui/util/shared'
 
 marker('datahub.header.myfavorites')
 marker('datahub.header.lastRecords')
@@ -84,7 +84,11 @@ export class HomeHeaderComponent {
         customSearchParameters.filters
       )
     )
-    const sortBy = await firstValueFrom(this.searchFacade.sortBy$)
-    this.searchService.setSortAndFilters(searchFilters, sortBy)
+    if (customSearchParameters.sort) {
+      const sortBy = sortByFromString(customSearchParameters.sort[0])
+      this.searchService.setSortAndFilters(searchFilters, sortBy)
+    } else {
+      this.searchService.setFilters(searchFilters)
+    }
   }
 }

--- a/apps/datahub/src/app/home/home-header/home-header.component.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.ts
@@ -85,7 +85,7 @@ export class HomeHeaderComponent {
       )
     )
     if (customSearchParameters.sort) {
-      const sortBy = sortByFromString(customSearchParameters.sort[0])
+      const sortBy = sortByFromString(customSearchParameters.sort)
       this.searchService.setSortAndFilters(searchFilters, sortBy)
     } else {
       this.searchService.setFilters(searchFilters)

--- a/apps/datahub/src/app/home/home-header/home-header.component.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.ts
@@ -20,9 +20,9 @@ import {
 import { SortByEnum, SortByField } from '@geonetwork-ui/common/domain/search'
 import { map } from 'rxjs/operators'
 import { ROUTER_ROUTE_NEWS } from '../../router/constants'
-import { lastValueFrom } from 'rxjs'
+import { firstValueFrom, lastValueFrom } from 'rxjs'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/record'
-import { sortByFromString } from '@geonetwork-ui/util/shared'
+import { sortByToString } from '@geonetwork-ui/util/shared'
 
 marker('datahub.header.myfavorites')
 marker('datahub.header.lastRecords')
@@ -84,9 +84,7 @@ export class HomeHeaderComponent {
         customSearchParameters.filters
       )
     )
-    this.searchService.setSortAndFilters(
-      searchFilters,
-      sortByFromString(customSearchParameters.sort)
-    )
+    const sortBy = await firstValueFrom(this.searchFacade.sortBy$)
+    this.searchService.setSortAndFilters(searchFilters, sortBy)
   }
 }

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -75,7 +75,7 @@ background_color = "#fdfbff"
 
 # One or several search presets can be defined here; every search preset is composed of:
 # - a name (which can be a translation key)
-# - a sort criteria: either `createDate`, `userSavedCount` or `_score` (prepend with `-` for descending sort)
+# - a sort criteria: either `createDate`, `userSavedCount` or `_score` (prepend with `-` for descending sort) (optionnal)
 # - filters which can be expressed like so:
 # [[search_preset]]
 #     name = 'filterByName'
@@ -88,6 +88,7 @@ background_color = "#fdfbff"
 #     filters.publicationYear = ['2023', '2022']
 #     filters.isSpatial = ['yes']
 #     filters.license = ['unknown']
+#     sort = ['createDate']
 # [[search_preset]]
 #     name = 'otherFilterName'
 #     filters.q = 'Other Full text search'

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -88,7 +88,7 @@ background_color = "#fdfbff"
 #     filters.publicationYear = ['2023', '2022']
 #     filters.isSpatial = ['yes']
 #     filters.license = ['unknown']
-#     sort = ['createDate']
+#     sort = 'createDate'
 # [[search_preset]]
 #     name = 'otherFilterName'
 #     filters.q = 'Other Full text search'


### PR DESCRIPTION
### Issue

The custom filter buttons of the home header were broken because of a missing `sort` argument expected in their properties. However, such a property is not asked in the TOML's instructions. Fixed by getting the current sorting parameter as a `sort` argument.

### To test

Add a custom button to the TOML file, for instance : 

`[[search_preset]]
name = 'filterByLicense'
filters.q = 'Full text search'
filters.license = ['unknown']
sort = 'createDate'

