### PR TITLE
Datahub: Hide nav menu on scroll down

### DIFF
--- a/apps/datahub-e2e/src/e2e/header.cy.ts
+++ b/apps/datahub-e2e/src/e2e/header.cy.ts
@@ -34,7 +34,7 @@ describe('header', () => {
         .click({ force: true })
       cy.url().should('include', '/organisations')
     })
-    it.only('hide navigation buttons when scrolling down', () => {
+    it('hide navigation buttons when scrolling down', () => {
       cy.scrollTo(0, 1000)
       cy.get('datahub-navigation-menu')
         .find('button')
@@ -121,7 +121,7 @@ describe('header', () => {
     it('should sort results by latest date', () => {
       cy.get('gn-ui-fuzzy-search').next().find('button').first().click()
       cy.get('gn-ui-record-preview-row').should('not.eq', '@initialList')
-      cy.get('select#sort-by- option:selected').should(
+      cy.get('gn-ui-sort-by option:selected').should(
         'have.value',
         'desc,createDate'
       )
@@ -129,7 +129,7 @@ describe('header', () => {
     it('should filter results by popularity', () => {
       cy.get('gn-ui-fuzzy-search').next().find('button').eq(1).click()
       cy.get('gn-ui-record-preview-row').should('not.eq', '@initialList')
-      cy.get('select#sort-by- option:selected').should(
+      cy.get('gn-ui-sort-by option:selected').should(
         'have.value',
         'desc,userSavedCount'
       )

--- a/apps/datahub-e2e/src/e2e/header.cy.ts
+++ b/apps/datahub-e2e/src/e2e/header.cy.ts
@@ -34,6 +34,13 @@ describe('header', () => {
         .click({ force: true })
       cy.url().should('include', '/organisations')
     })
+    it.only('hide navigation buttons when scrolling down', () => {
+      cy.scrollTo(0, 1000)
+      cy.get('datahub-navigation-menu')
+        .find('button')
+        .eq(0)
+        .should('not.be.visible')
+    })
   })
 
   describe('search actions', () => {

--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -69,10 +69,11 @@
       ></datahub-header-badge-button>
     </div>
 -->
-    <datahub-navigation-menu
-      class="tabs flex justify-between font-medium -mx-5 sm:mx-0 sm:mt-32 inset-x-0 bottom-0 z-50"
-      [style.opacity]="-0.6 + expandRatio * 5"
-    ></datahub-navigation-menu>
+    <div [style.opacity]="-0.6 + expandRatio * 5">
+      <datahub-navigation-menu
+        class="tabs flex justify-between font-medium -mx-5 sm:mx-0 sm:mt-32 inset-x-0 bottom-0 z-50"
+      ></datahub-navigation-menu>
+    </div>
   </div>
   <gn-ui-language-switcher
     *ngIf="showLanguageSwitcher"


### PR DESCRIPTION
Small fix to hide nav menu completely and make its buttons unclickable when scrolling down.