### PR TITLE
Datahub: show the correct amount of records on the news page

### DIFF
--- a/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
@@ -38,7 +38,7 @@ class ElasticsearchServiceMock {
 class SearchApiServiceMock {
   search = jest.fn((bucket, payload) => {
     const body = JSON.parse(payload)
-    const count = body.size ?? 20
+    const count = body.size || 1234
     const result: EsSearchResponse = {
       hits: {
         hits: DATASET_RECORDS,
@@ -120,6 +120,32 @@ describe('Gn4Repository', () => {
     it('returns the given results as records', () => {
       expect(results.count).toBe(12)
       expect(results.records).toStrictEqual(DATASET_RECORDS)
+    })
+  })
+  describe('getMatchesCount', () => {
+    let count: number
+    beforeEach(async () => {
+      count = await lastValueFrom(
+        repository.getMatchesCount({
+          field1: '1234',
+          field2: {
+            abcd: true,
+          },
+        })
+      )
+    })
+    it('builds a payload with the specified uuid', () => {
+      expect(gn4Helper.getSearchRequestBody).toHaveBeenCalledWith(
+        {},
+        0,
+        0,
+        undefined,
+        undefined,
+        { field1: '1234', field2: { abcd: true } }
+      )
+    })
+    it('returns the result count', () => {
+      expect(count).toStrictEqual(1234)
     })
   })
   describe('getByUniqueIdentifier', () => {
@@ -204,7 +230,7 @@ describe('Gn4Repository', () => {
       expect(gn4Helper.buildAutocompletePayload).toHaveBeenCalledWith('blargz')
     })
     it('returns the given results as records', () => {
-      expect(results.count).toBe(20)
+      expect(results.count).toBe(1234)
       expect(results.records).toStrictEqual(DATASET_RECORDS)
     })
   })

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -10,6 +10,7 @@ import {
 import {
   Aggregations,
   AggregationsParams,
+  FieldFilters,
 } from '@geonetwork-ui/common/domain/search'
 import { map } from 'rxjs/operators'
 import {
@@ -60,6 +61,25 @@ export class Gn4Repository implements RecordsRepositoryInterface {
           }))
         )
       )
+  }
+
+  getMatchesCount(filters: FieldFilters): Observable<number> {
+    return this.gn4SearchApi
+      .search(
+        'records-count',
+        JSON.stringify({
+          ...this.gn4SearchHelper.getSearchRequestBody(
+            {},
+            0,
+            0,
+            undefined,
+            undefined,
+            filters
+          ),
+          track_total_hits: true,
+        })
+      )
+      .pipe(map((results: Gn4SearchResults) => results.hits.total?.value || 0))
   }
 
   getByUniqueIdentifier(

--- a/libs/common/domain/src/lib/records-repository.interface.ts
+++ b/libs/common/domain/src/lib/records-repository.interface.ts
@@ -2,6 +2,7 @@ import { Observable } from 'rxjs'
 import {
   Aggregations,
   AggregationsParams,
+  FieldFilters,
   SearchParams,
   SearchResults,
 } from './search'
@@ -9,6 +10,7 @@ import { CatalogRecord } from './record/metadata.model'
 
 export abstract class RecordsRepositoryInterface {
   abstract search(params: SearchParams): Observable<SearchResults>
+  abstract getMatchesCount(filters: FieldFilters): Observable<number>
   abstract getByUniqueIdentifier(
     uniqueIdentifier: string
   ): Observable<CatalogRecord | null>

--- a/libs/feature/catalog/src/lib/records/records.service.spec.ts
+++ b/libs/feature/catalog/src/lib/records/records.service.spec.ts
@@ -1,11 +1,9 @@
-import { TestBed } from '@angular/core/testing'
 import { RecordsService } from './records.service'
-import { SAMPLE_SEARCH_RESULTS } from '@geonetwork-ui/common/fixtures'
 import { of, throwError } from 'rxjs'
 import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/records-repository.interface'
 
 class RecordsRepositoryMock {
-  search = jest.fn(() => of(SAMPLE_SEARCH_RESULTS))
+  getMatchesCount = jest.fn(() => of(123))
 }
 
 describe('RecordsService', () => {
@@ -32,13 +30,13 @@ describe('RecordsService', () => {
         service.recordsCount$.subscribe()
         service.recordsCount$.subscribe()
         service.recordsCount$.subscribe()
-        expect(repository.search).toHaveBeenCalledTimes(1)
+        expect(repository.getMatchesCount).toHaveBeenCalledTimes(1)
       })
     })
 
     describe('when the request does not behave as expected', () => {
       beforeEach(() => {
-        repository.search = () => throwError(() => 'blargz')
+        repository.getMatchesCount = () => throwError(() => 'blargz')
         service = new RecordsService(repository) // create a new service to enable the changed repository behaviour
       })
       it('emits 0', () => {

--- a/libs/feature/catalog/src/lib/records/records.service.ts
+++ b/libs/feature/catalog/src/lib/records/records.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core'
 import { Observable, of } from 'rxjs'
-import { catchError, map, shareReplay } from 'rxjs/operators'
+import { catchError, shareReplay } from 'rxjs/operators'
 import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/records-repository.interface'
 
 @Injectable({
@@ -8,12 +8,8 @@ import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/records
 })
 export class RecordsService {
   recordsCount$: Observable<number> = this.recordsRepository
-    .search({
-      limit: 0,
-      offset: 0,
-    })
+    .getMatchesCount({})
     .pipe(
-      map((response) => response.count),
       shareReplay(1),
       catchError(() => of(0))
     )


### PR DESCRIPTION
A new `getMatchesCount` operation was added to the records repository, and this is used to show the total amount of records.

Before that we used to do a `search()` with a result amount of 0 to get the results count, but having a separate operation makes sense IMO since it allows finer performance tuning. A later optimization might be to not return the total results count with all search queries, so that `track_total_hits` is not used all the time for nothing.

![image](https://github.com/geonetwork/geonetwork-ui/assets/10629150/4852423f-dadc-45e0-95ad-747b2230bc51)

Followup of #458 

Fixes #627 