### PR TITLE
Datahub: Display link URL as fallback

### DIFF
--- a/libs/ui/elements/src/lib/link-card/link-card.component.html
+++ b/libs/ui/elements/src/lib/link-card/link-card.component.html
@@ -12,6 +12,12 @@
     <p class="font-medium text-sm break-words">
       {{ link.description }}
     </p>
+    <p
+      *ngIf="!link.name && !link.description"
+      class="font-medium text-sm break-words truncate"
+    >
+      {{ link.url }}
+    </p>
   </div>
   <div>
     <mat-icon class="material-symbols-outlined card-icon">open_in_new</mat-icon>


### PR DESCRIPTION
Add a fallback to link card for link name/description

![link_url](https://github.com/geonetwork/geonetwork-ui/assets/6329425/b0abff4a-6d91-4093-ab5e-6be523fb72a0)
