### PR TITLE
Datahub: Fix display of usage conditions

### DIFF
--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -82,7 +82,7 @@
         class="material-symbols-outlined inline-block align-bottom pt-1.5 text-xs text-black"
         >open_in_new</mat-icon
       >
-      <span class="text-primary">{{ metadata.landingPage }}</span>
+      <span class="text-primary break-all">{{ metadata.landingPage }}</span>
     </a>
   </div>
 </gn-ui-expandable-panel>

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.spec.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.spec.ts
@@ -16,36 +16,25 @@ describe('MetadataInfoComponent', () => {
     }).compileComponents()
   })
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(MetadataInfoComponent)
-    component = fixture.componentInstance
-    component.incomplete = false
-    component.metadata = DATASET_RECORDS[0]
-    fixture.detectChanges()
-  })
-
-  it('should create', () => {
-    expect(component).toBeTruthy()
-  })
-
   describe('When a section is empty', () => {
     beforeEach(() => {
+      fixture = TestBed.createComponent(MetadataInfoComponent)
+      component = fixture.componentInstance
       component.metadata = {
-        id: '',
-        uuid: '',
-        title: '',
-        metadataUrl: '',
-        keywords: [],
-        constraints: null,
+        ...DATASET_RECORDS[0],
+        useLimitations: null,
+        accessConstraints: null,
+        extras: {
+          isOpenData: false,
+        },
+        keywords: null,
       }
       fixture.detectChanges()
     })
     it('should display a message for no usage or constraints', () => {
-      const displayedElement =
-        fixture.nativeElement.getElementsByClassName('noUsage')
+      const displayedElement = fixture.nativeElement.querySelector('.noUsage')
       expect(displayedElement).toBeTruthy()
     })
-
     it('should not display the keywords section', () => {
       const displayedElement =
         fixture.nativeElement.querySelector('ng-container')
@@ -55,23 +44,14 @@ describe('MetadataInfoComponent', () => {
 
   describe('When a section is not empty', () => {
     beforeEach(() => {
-      component.metadata = {
-        id: '',
-        uuid: '',
-        title: '',
-        metadataUrl: '',
-        keywords: ['banana', 'pear'],
-        constraints: ['no usage'],
-      }
+      fixture = TestBed.createComponent(MetadataInfoComponent)
+      component = fixture.componentInstance
+      component.metadata = DATASET_RECORDS[0]
       fixture.detectChanges()
     })
     it('should not display a message for no usage or constraints', () => {
-      // Use waitForAsync to handle asynchronous changes in the DOM.
-      fixture.whenStable().then(() => {
-        const displayedElement =
-          fixture.nativeElement.getElementsByClassName('noUsage')
-        expect(displayedElement).toBeFalsy()
-      })
+      const displayedElement = fixture.nativeElement.querySelector('.noUsage')
+      expect(displayedElement).toBeFalsy()
     })
 
     it('should display the keywords section', () => {

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
@@ -23,7 +23,7 @@ export class MetadataInfoComponent {
 
   get hasUsage() {
     return (
-      ('extras' in this.metadata && 'isOpenData' in this.metadata.extras) ||
+      this.metadata.extras?.isOpenData === true ||
       this.metadata.useLimitations?.length ||
       this.metadata.accessConstraints?.length
     )


### PR DESCRIPTION
PR fixes a case where message that there are no usage conditions, was not displayed and wraps URLs in "Details" correctly.

![usage](https://github.com/geonetwork/geonetwork-ui/assets/6329425/06e06e03-a5d2-4edc-ab79-904270432416)
