### PR TITLE
fix(datahub): Console warn when filter fails to load the geometry

### DIFF
--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -176,6 +176,11 @@ export const metaReducers: MetaReducer[] = !environment.production ? [] : []
           return fetch(getOptionalSearchConfig().FILTER_GEOMETRY_URL)
             .then((resp) => resp.json())
             .then(getGeometryFromGeoJSON)
+            .catch(() =>
+              console.log(
+                'No spatial filter was applied since a valid geometry could not be found'
+              )
+            )
         }
         return null
       },


### PR DESCRIPTION
There is an error displayed in the console when the geometry filter fails to load its geometry. This will be changed now to be a console warning with a message.

![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/94b24ca3-8b75-4e7b-b4c6-c70504df4542)
