### PR TITLE
Datahub: Fix thumbnail background for org logos

### DIFF
--- a/libs/ui/elements/src/lib/thumbnail/thumbnail.component.html
+++ b/libs/ui/elements/src/lib/thumbnail/thumbnail.component.html
@@ -1,9 +1,7 @@
 <div
   #containerElement
-  class="h-full w-full relative shrink-0 overflow-hidden flex items-center bg-gray-100"
-  [ngClass]="{
-    'bg-white': !isPlaceholder
-  }"
+  class="h-full w-full relative shrink-0 overflow-hidden flex items-center"
+  [ngClass]="isPlaceholder ? 'bg-gray-100' : 'bg-white'"
   [attr.data-cy-is-placeholder]="isPlaceholder.toString()"
 >
   <img

--- a/libs/ui/elements/src/lib/thumbnail/thumbnail.component.ts
+++ b/libs/ui/elements/src/lib/thumbnail/thumbnail.component.ts
@@ -77,6 +77,7 @@ export class ThumbnailComponent implements OnInit, OnChanges {
       this.setPlaceholder()
       return
     }
+    this.isPlaceholder = false
     this.setNewSrcImage(this.images[0])
   }
 


### PR DESCRIPTION
PR fixes the background color of logos, which is currently gray when loading the datahub on the organisations tab or when turning pages in the orgs tab.

![logos](https://github.com/geonetwork/geonetwork-ui/assets/6329425/503d247e-cac3-4bd5-8747-4676b8f15e27)
