### PR TITLE
Update default.toml to correct default.toml for filtering on metadata standard field

### DIFF
--- a/conf/default.toml
+++ b/conf/default.toml
@@ -71,7 +71,7 @@ background_color = "#fdfbff"
 # filter_geometry_data = '{ "coordinates": [...], "type": "Polygon" }'
 
 # The advanced search filters available to the user can be customized with this setting.
-# The following fields can be used for filtering: 'publisher', 'format', 'publicationYear', 'standard', 'inspireKeyword', 'topic', 'isSpatial', 'license'
+# The following fields can be used for filtering: 'publisher', 'format', 'publicationYear', 'documentStandard', 'inspireKeyword', 'topic', 'isSpatial', 'license'
 # any other field will be ignored
 # advanced_filters = ['publisher', 'format', 'publicationYear', 'topic', 'isSpatial', 'license']
 


### PR DESCRIPTION
The correct filter to use seems to be `documentStandard`, not just `standard` for filtering based on metadata standard.