### PR TITLE
Improve autocomplete input rendering

### DIFF
--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.css
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.css
@@ -1,10 +1,13 @@
+:host {
+  --input-height: 3.5em;
+}
 .clear-btn {
-  width: 3.5em;
+  width: var(--input-height);
+  right: var(--input-height);
   height: 100%;
-  right: 3.5em;
 }
 .search-btn {
-  width: 3.5em;
+  width: var(--input-height);
   height: 100%;
   border-left-width: 0.1em;
 }
@@ -15,9 +18,14 @@ mat-icon {
   font-size: 1.5em;
 }
 input {
-  height: 3.5em;
+  height: var(--input-height);
   padding: 1.05em;
+  padding-right: calc(2 * var(--input-height));
 }
+input:placeholder-shown {
+  text-overflow: ellipsis;
+}
+
 .mat-mdc-option.suggestion.mat-mdc-option-active {
   background-color: var(--color-primary-lightest);
 }


### PR DESCRIPTION
- Set an input `padding-right` so the input text does not go under the absolute buttons.
![image](https://github.com/geonetwork/geonetwork-ui/assets/1491924/48ea2884-1c8d-4bd0-8d35-16633eb6bcdc)

- Add ellipsis on placeholder, works on page load but disappear on focus on Chrome
![image](https://github.com/geonetwork/geonetwork-ui/assets/1491924/c2eb5ce9-819e-4d0b-9991-b0bb827dbf02)
