### PR TITLE
Multilingual search

### DIFF
--- a/conf/default.toml
+++ b/conf/default.toml
@@ -12,8 +12,9 @@ geonetwork4_api_url = "/geonetwork/srv/api"
 proxy_path = ""
 # This optional parameter defines, in which language metadata should be queried in elasticsearch.
 # Use ISO 639-2/B (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format to indicate the language of the metadata.
+# Setting to "current" will use the current language of the Datahub, the UI langage.
 # If not indicated, a wildcard is used and no language preference is applied for the search.
-# metadata_language = "fre"
+# metadata_language = "fre" or "current"
 # This optional URL should point to the login page that allows authentication to the datahub.
 # If not indicated, the default geonetwork login page is used.
 # The following three placeholders can be part of this URL:

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -12,9 +12,9 @@ geonetwork4_api_url = "/geonetwork/srv/api"
 proxy_path = ""
 # This optional parameter defines, in which language metadata should be queried in elasticsearch.
 # Use ISO 639-2/B (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format to indicate the language of the metadata.
-# Setting to "current" will use the current language of the Datahub, the UI langage.
+# Setting to "current" will use the current language of the User Interface.
 # If not indicated, a wildcard is used and no language preference is applied for the search.
-# metadata_language = "fre" or "current"
+# metadata_language = "current"
 # This optional URL should point to the login page that allows authentication to the datahub.
 # If not indicated, the default geonetwork login page is used.
 # The following three placeholders can be part of this URL:

--- a/libs/api/repository/src/lib/gn4/elasticsearch/constant.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/constant.ts
@@ -14,11 +14,12 @@ export const ES_SOURCE_SUMMARY = [
   'userSavedCount',
 ]
 
-export const ES_QUERY_STRING_FIELDS = [
-  'resourceTitleObject.${searchLang}^5',
-  'tag.${searchLang}^4',
-  'resourceAbstractObject.${searchLang}^3',
-  'lineageObject.${searchLang}^2',
-  'any.${searchLang}',
-  'uuid',
-]
+export type EsQueryFieldsPriorityType = Record<string, number>
+export const ES_QUERY_FIELDS_PRIORITY = {
+  'resourceTitleObject.${searchLang}': 5,
+  'tag.${searchLang}': 4,
+  'resourceAbstractObject.${searchLang}': 3,
+  'lineageObject.${searchLang}': 2,
+  'any.${searchLang}': 1,
+  uuid: 1,
+}

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -362,7 +362,7 @@ describe('ElasticsearchService', () => {
   })
 
   describe('#injectLangInQueryStringFields - Search language', () => {
-    const queryStringFields = ['resourceTitleObject.${searchLang}']
+    let queryStringFields = ['resourceTitleObject.${searchLang}']
     describe('When no lang from config', () => {
       beforeEach(() => {
         service['metadataLang'] = undefined
@@ -398,6 +398,31 @@ describe('ElasticsearchService', () => {
             '.'
           )[1]
         ).toEqual('langeng')
+      })
+      it('add * fallback with low priority', () => {
+        queryStringFields = [
+          'resourceTitleObject.${searchLang}^5',
+          'tag.${searchLang}^4',
+          'resourceAbstractObject.${searchLang}^3',
+          'lineageObject.${searchLang}^2',
+          'any.${searchLang}',
+          'uuid',
+        ]
+        expect(
+          service['injectLangInQueryStringFields'](queryStringFields)
+        ).toEqual([
+          'resourceTitleObject.langeng^5',
+          'tag.langeng^4',
+          'resourceAbstractObject.langeng^3',
+          'lineageObject.langeng^2',
+          'any.langeng',
+          'uuid',
+          'resourceTitleObject.*',
+          'tag.*',
+          'resourceAbstractObject.*',
+          'lineageObject.*',
+          'any.*',
+        ])
       })
     })
   })

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -2,17 +2,31 @@ import { ElasticsearchService } from './elasticsearch.service'
 import { ES_FIXTURE_AGGS_RESPONSE } from '@geonetwork-ui/common/fixtures'
 import { LangService } from '@geonetwork-ui/util/i18n'
 import { EsSearchParams } from '@geonetwork-ui/api/metadata-converter'
+import { TestBed } from '@angular/core/testing'
+import { METADATA_LANGUAGE } from '../../metadata-language'
 
-const langServiceMock = {
-  iso3: 'eng',
-} as LangService
+class LangServiceMock {
+  iso3 = 'eng'
+}
 
 describe('ElasticsearchService', () => {
   let service: ElasticsearchService
   let searchFilters
 
   beforeEach(() => {
-    service = new ElasticsearchService(langServiceMock, 'fre')
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: LangService,
+          useClass: LangServiceMock,
+        },
+        {
+          provide: METADATA_LANGUAGE,
+          useValue: 'fre',
+        },
+      ],
+    })
+    service = TestBed.inject(ElasticsearchService)
   })
 
   it('should be created', () => {

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -362,7 +362,7 @@ describe('ElasticsearchService', () => {
   })
 
   describe('#injectLangInQueryStringFields - Search language', () => {
-    let queryStringFields = ['resourceTitleObject.${searchLang}']
+    let queryStringFields = { 'resourceTitleObject.${searchLang}': 1 }
     describe('When no lang from config', () => {
       beforeEach(() => {
         service['metadataLang'] = undefined
@@ -397,31 +397,31 @@ describe('ElasticsearchService', () => {
           service['injectLangInQueryStringFields'](queryStringFields)[0].split(
             '.'
           )[1]
-        ).toEqual('langeng')
+        ).toEqual('langeng^11')
       })
       it('add * fallback with low priority', () => {
-        queryStringFields = [
-          'resourceTitleObject.${searchLang}^5',
-          'tag.${searchLang}^4',
-          'resourceAbstractObject.${searchLang}^3',
-          'lineageObject.${searchLang}^2',
-          'any.${searchLang}',
-          'uuid',
-        ]
+        queryStringFields = {
+          'resourceTitleObject.${searchLang}': 5,
+          'tag.${searchLang}': 4,
+          'resourceAbstractObject.${searchLang}': 3,
+          'lineageObject.${searchLang}': 2,
+          'any.${searchLang}': 1,
+          uuid: 1,
+        }
         expect(
           service['injectLangInQueryStringFields'](queryStringFields)
         ).toEqual([
-          'resourceTitleObject.langeng^5',
-          'tag.langeng^4',
-          'resourceAbstractObject.langeng^3',
-          'lineageObject.langeng^2',
-          'any.langeng',
-          'uuid',
-          'resourceTitleObject.*',
-          'tag.*',
-          'resourceAbstractObject.*',
-          'lineageObject.*',
+          'resourceTitleObject.langeng^15',
+          'resourceTitleObject.*^5',
+          'tag.langeng^14',
+          'tag.*^4',
+          'resourceAbstractObject.langeng^13',
+          'resourceAbstractObject.*^3',
+          'lineageObject.langeng^12',
+          'lineageObject.*^2',
+          'any.langeng^11',
           'any.*',
+          'uuid',
         ])
       })
     })
@@ -444,9 +444,9 @@ describe('ElasticsearchService', () => {
                 {
                   multi_match: {
                     fields: [
-                      'resourceTitleObject.langfre',
-                      'resourceAbstractObject.langfre',
-                      'tag',
+                      'resourceTitleObject.langfre^4',
+                      'resourceAbstractObject.langfre^3',
+                      'tag^2',
                       'resourceIdentifier',
                     ],
                     query: 'blarg',

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -1,13 +1,18 @@
 import { ElasticsearchService } from './elasticsearch.service'
 import { ES_FIXTURE_AGGS_RESPONSE } from '@geonetwork-ui/common/fixtures'
-import { EsSearchParams } from '../types/elasticsearch.model'
+import { LangService } from '@geonetwork-ui/util/i18n'
+import { EsSearchParams } from '@geonetwork-ui/api/metadata-converter'
+
+const langServiceMock = {
+  iso3: 'eng',
+} as LangService
 
 describe('ElasticsearchService', () => {
   let service: ElasticsearchService
   let searchFilters
 
   beforeEach(() => {
-    service = new ElasticsearchService('fre')
+    service = new ElasticsearchService(langServiceMock, 'fre')
   })
 
   it('should be created', () => {
@@ -352,6 +357,47 @@ describe('ElasticsearchService', () => {
             ],
           },
         })
+      })
+    })
+  })
+
+  describe('#injectLangInQueryStringFields - Search language', () => {
+    const queryStringFields = ['resourceTitleObject.${searchLang}']
+    describe('When no lang from config', () => {
+      beforeEach(() => {
+        service['metadataLang'] = undefined
+      })
+      it('use * wildcard', () => {
+        expect(
+          service['injectLangInQueryStringFields'](queryStringFields)[0].split(
+            '.'
+          )[1]
+        ).toEqual('*')
+      })
+    })
+    describe('When one lang in config', () => {
+      beforeEach(() => {
+        service['metadataLang'] = 'fre'
+      })
+      it('search in the config language', () => {
+        expect(
+          service['injectLangInQueryStringFields'](queryStringFields)[0].split(
+            '.'
+          )[1]
+        ).toEqual('langfre')
+      })
+    })
+    describe('When "current" language from config"', () => {
+      beforeEach(() => {
+        service['metadataLang'] = 'current'
+        service['lang3'] = 'eng'
+      })
+      it('search in the UI language', () => {
+        expect(
+          service['injectLangInQueryStringFields'](queryStringFields)[0].split(
+            '.'
+          )[1]
+        ).toEqual('langeng')
       })
     })
   })

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -201,11 +201,11 @@ export class ElasticsearchService {
   }
 
   private getQueryLang(): string {
-    return this.metadataLang
-      ? this.isCurrentSearchLang()
+    if (this.metadataLang) {
+      return this.isCurrentSearchLang()
         ? `lang${this.lang3}`
         : `lang${this.metadataLang}`
-      : `*`
+    } else return '*'
   }
   private isCurrentSearchLang() {
     return this.metadataLang === 'current'


### PR DESCRIPTION
Introduces a new option for the `metadata_language` configuration property: `current`.
This is mostly useful for **multilingual catalogs**.

If `metadata_language == current`, then the Elasticsearch search is queried in the current language of the application (the UI language).

The other rules remains
- `metadata_language` is `undefined`: we use the `.*` wildcard
- `metadata_language` is set to one language: we use the that language for the search eg. `.langeng`

Here what the search looks like with the UI in english and the property set to `current`
```json
{
  "query_string": {
    "query": "carte établie",
    "default_operator": "AND",
    "fields": [
      "resourceTitleObject.langeng^5",
      "tag.langeng^4",
      "resourceAbstractObject.langeng^3",
      "lineageObject.langeng^2",
      "any.langeng",
      "uuid"
    ]
  }
} 
```