### PR TITLE
Datahub: Fix display of ESRI data on map

### DIFF
--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -593,11 +593,22 @@ describe('DataService', () => {
       it('builds a proxied url', () => {
         expect(
           service.getDownloadUrlFromEsriRest(
-            'http://esri.rest/local/',
+            'http://esri.rest/local',
             'geojson'
           )
         ).toBe(
-          'http://proxy.local/?url=http%3A%2F%2Fesri.rest%2Flocal%2F%2Fquery%3Ff%3Dgeojson%26where%3D1%3D1%26outFields%3D*'
+          'http://proxy.local/?url=http%3A%2F%2Fesri.rest%2Flocal%2Fquery%3Ff%3Dgeojson%26where%3D1%3D1%26outFields%3D*'
+        )
+      })
+      it('calls DataFetcher.openDataset with a proxied url', () => {
+        service.getDataset({
+          url: new URL('http://esri.rest/local'),
+          accessServiceProtocol: 'esriRest',
+          type: 'service',
+        })
+        expect(openDataset).toHaveBeenCalledWith(
+          'http://proxy.local/?url=http%3A%2F%2Fesri.rest%2Flocal%2Fquery%3Ff%3Dgeojson%26where%3D1%3D1%26outFields%3D*',
+          'geojson'
         )
       })
     })

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -168,9 +168,8 @@ export class DataService {
   }
 
   getDataset(link: DatasetDistribution): Observable<BaseReader> {
-    const linkUrl = this.proxy.getProxiedUrl(link.url.toString())
     if (link.type === 'service' && link.accessServiceProtocol === 'wfs') {
-      return this.getDownloadUrlsFromWfs(linkUrl, link.name).pipe(
+      return this.getDownloadUrlsFromWfs(link.url.toString(), link.name).pipe(
         switchMap((urls) => {
           if (urls.geojson) return openDataset(urls.geojson, 'geojson')
           if (urls.gml)
@@ -187,17 +186,21 @@ export class DataService {
         })
       )
     } else if (link.type === 'download') {
+      const linkProxifiedUrl = this.proxy.getProxiedUrl(link.url.toString())
       const format = getFileFormat(link)
       const supportedType =
         SupportedTypes.indexOf(format as any) > -1
           ? (format as SupportedType)
           : undefined
-      return from(openDataset(linkUrl, supportedType)).pipe()
+      return from(openDataset(linkProxifiedUrl, supportedType)).pipe()
     } else if (
       link.type === 'service' &&
       link.accessServiceProtocol === 'esriRest'
     ) {
-      const url = this.getDownloadUrlFromEsriRest(linkUrl, 'geojson')
+      const url = this.getDownloadUrlFromEsriRest(
+        link.url.toString(),
+        'geojson'
+      )
       return from(openDataset(url, 'geojson')).pipe()
     }
     return throwError(() => 'protocol not supported')

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -4,7 +4,7 @@
 >
   record.metadata.about
 </p>
-<div class="mb-6 md-description sm:mb-4 sm:pr-16">
+<div class="mb-6 md-description sm:mb-4 sm:pr-16" *ngIf="metadata.abstract">
   <gn-ui-content-ghost ghostClass="h-32" [showContent]="fieldReady('abstract')">
     <p
       class="whitespace-pre-line break-words"

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.spec.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.spec.ts
@@ -22,6 +22,7 @@ describe('MetadataInfoComponent', () => {
       component = fixture.componentInstance
       component.metadata = {
         ...DATASET_RECORDS[0],
+        abstract: null,
         useLimitations: null,
         accessConstraints: null,
         extras: {
@@ -40,6 +41,11 @@ describe('MetadataInfoComponent', () => {
         fixture.nativeElement.querySelector('ng-container')
       expect(displayedElement).toBeFalsy()
     })
+    it('should not display the abstract section', () => {
+      const displayedElement =
+        fixture.nativeElement.querySelector('.md-description')
+      expect(displayedElement).toBeFalsy()
+    })
   })
 
   describe('When a section is not empty', () => {
@@ -53,7 +59,6 @@ describe('MetadataInfoComponent', () => {
       const displayedElement = fixture.nativeElement.querySelector('.noUsage')
       expect(displayedElement).toBeFalsy()
     })
-
     it('should display the keywords section', () => {
       // Use waitForAsync to handle asynchronous changes in the DOM.
       fixture.whenStable().then(() => {
@@ -61,6 +66,11 @@ describe('MetadataInfoComponent', () => {
           fixture.nativeElement.querySelector('ng-container')
         expect(displayedElement).toBeTruthy()
       })
+    })
+    it('should display the abstract section', () => {
+      const displayedElement =
+        fixture.nativeElement.querySelector('.md-description')
+      expect(displayedElement).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
PR 

- should fix display of ESRI data on map by correctly encoding the attached query params (currently broken in https://www.geo2france.fr/datahub/dataset/atmo-hdf::emissions-de-polluants-atmosph%C3%A9riques-par-epci-dans-les-hauts-de-france-ann%C3%A9e-2010-1)
- only displays md abstract, if it is defined (see: https://www.geo2france.fr/datahub/dataset/atmo-hdf::mod%C3%A9lisation-r%C3%A9gionale-des-concentrations-en-no2-en-2019-%C2%B5g-m%C2%B3)