### PR TITLE
Fix favorite star tooltip translation

### DIFF
--- a/libs/feature/search/src/lib/favorites/favorite-star/favorite-star.component.spec.ts
+++ b/libs/feature/search/src/lib/favorites/favorite-star/favorite-star.component.spec.ts
@@ -25,7 +25,7 @@ class FavoritesServiceMock {
 
 class TranslateServiceMock {
   currentLang = 'fr'
-  instant = jest.fn(() => 'You can log in here')
+  get = jest.fn(() => of('You can log in here'))
 }
 
 describe('FavoriteStarComponent', () => {


### PR DESCRIPTION
Ensure that the translation is loaded when the tooltip is created.
The `i18n` service loader is aynch, keep that in mind.