### PR TITLE
Fix CORS issues in webcomponent demo

### DIFF
--- a/apps/webcomponents/src/app/components/gn-dataset-view-chart/gn-dataset-view-chart.sample.html
+++ b/apps/webcomponents/src/app/components/gn-dataset-view-chart/gn-dataset-view-chart.sample.html
@@ -44,7 +44,7 @@
       <script src="gn-wc.js"></script>
       <gn-dataset-view-chart
         api-url="https://dev.geo2france.fr/geonetwork/srv/api"
-        dataset-id="accroche_velos"
+        dataset-id="9da51f58-15c6-4325-82b1-2cf6c8e75d0f"
         aggregation="average"
         x-property="adresse"
         chart-type="line"

--- a/apps/webcomponents/src/app/components/gn-dataset-view-table/gn-dataset-view-table.sample.html
+++ b/apps/webcomponents/src/app/components/gn-dataset-view-table/gn-dataset-view-table.sample.html
@@ -44,7 +44,7 @@
       <script src="gn-wc.js"></script>
       <gn-dataset-view-table
         api-url="https://dev.geo2france.fr/geonetwork/srv/api"
-        dataset-id="population-mel"
+        dataset-id="9da51f58-15c6-4325-82b1-2cf6c8e75d0f"
         primary-color="#0f4395"
         secondary-color="#8bc832"
         main-color="#555"

--- a/apps/webcomponents/src/app/components/gn-facets/gn-facets.sample.html
+++ b/apps/webcomponents/src/app/components/gn-facets/gn-facets.sample.html
@@ -41,14 +41,14 @@
       <div style="display: flex">
         <div style="width: 320px; shrink: 0; margin: 20px">
           <gn-facets
-            api-url="https://apps.titellus.net/geonetwork/srv/api"
+            api-url="https://dev.geo2france.fr/geonetwork/srv/api"
             facet-config='{"tag.default":{"terms":{"field":"tag.default","include":".*","size": 10}}}'
           ></gn-facets>
         </div>
         <div style="grow: 1; margin: 20px">
           <gn-results-list
-            api-url="https://sdi.eea.europa.eu/catalogue/eea/api"
-            catalog-url="https://sdi.eea.europa.eu/catalogue/eea/fre/catalog.search#/metadata/{uuid}"
+            api-url="https://dev.geo2france.fr/geonetwork/srv/api"
+            catalog-url="https://dev.geo2france.fr/geonetwork/srv/fre/catalog.search#/metadata/{uuid}"
             size="5"
             primary-color="#0f4395"
             secondary-color="#8bc832"

--- a/apps/webcomponents/src/index.html
+++ b/apps/webcomponents/src/index.html
@@ -82,9 +82,6 @@
           >
         </li>
         <li class="mt-5">
-          <a href="gn-facets.sample.html">Facets & results feed</a>
-        </li>
-        <li class="mt-5">
           <a href="gn-map-viewer.sample.html">Map viewer</a>
         </li>
       </ul>


### PR DESCRIPTION
The web components related to data visualization (table & chart) had CORS issue because of the Data API they used (wrong ODS API with CORS restriction).

So I just changed the dataset to have other API calls without CORS restriction.

I also removed the **facet** example as it is not working.