### PR TITLE
Fix [datahub]: Display external viewer button correctly

### DIFF
--- a/libs/feature/record/src/lib/data-view/data-view.component.html
+++ b/libs/feature/record/src/lib/data-view/data-view.component.html
@@ -2,7 +2,7 @@
   <gn-ui-dropdown-selector
     *ngIf="dropdownChoices$ | async as choices"
     [title]="'table.select.data' | translate"
-    class="mb-7 w-auto ml-auto"
+    class="truncate p-1 -mx-1"
     extraBtnClass="!text-primary font-sans font-medium"
     [choices]="choices"
     (selectValue)="selectLink($event)"

--- a/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.html
+++ b/libs/feature/record/src/lib/external-viewer-button/external-viewer-button.component.html
@@ -3,7 +3,7 @@
   (buttonClick)="openInExternalViewer()"
   type="secondary"
   [title]="'record.externalViewer.open' | translate"
-  extraClass="!p-[0.6em] !rounded-lg"
+  extraClass="ms-2 !rounded-lg"
 >
   <mat-icon class="material-symbols-outlined">open_in_new</mat-icon>
 </gn-ui-button>

--- a/libs/feature/record/src/lib/map-view/map-view.component.html
+++ b/libs/feature/record/src/lib/map-view/map-view.component.html
@@ -1,13 +1,14 @@
 <div class="w-full h-full flex flex-col p-1">
-  <div class="w-full mb-7 mt-1">
+  <div class="w-full flex justify-end mb-7 mt-1">
     <gn-ui-dropdown-selector
+      class="truncate p-1 -mx-1"
       extraBtnClass="!text-primary font-sans font-medium"
       [title]="'map.select.layer' | translate"
       [choices]="dropdownChoices$ | async"
       (selectValue)="selectLinkToDisplay($event)"
     ></gn-ui-dropdown-selector>
     <gn-ui-external-viewer-button
-      class="shrink-0"
+      class="shrink-0 py-1 place-self-end"
       [link]="selectedLink$ | async"
       [mapConfig]="mapConfig"
     >

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
@@ -1,6 +1,4 @@
-<div
-  class="flex items-start flex-col sm:flex-row sm:items-center relative w-full"
->
+<div class="flex flex-col sm:flex-row sm:items-center relative w-full">
   <span
     *ngIf="showTitle"
     class="tracking-wide text-sm mb-2 sm:mb-0 sm:mr-2 whitespace-nowrap"
@@ -56,7 +54,7 @@
       type="button"
       *ngFor="let choice of choices"
       [title]="choice.label"
-      class="flex px-5 py-1 w-full cursor-pointer transition-colors"
+      class="flex px-5 py-1 w-full text-start cursor-pointer transition-colors"
       [ngClass]="
         isSelected(choice)
           ? 'text-white bg-primary hover:text-white hover:bg-primary-darker focus:text-white focus:bg-primary-darker'


### PR DESCRIPTION
Fixes the external viewer button display while allowing truncating long values in the dropdown select.

![button](https://github.com/geonetwork/geonetwork-ui/assets/6329425/2071c773-b73c-4adb-98bb-7e5d82c33706)
![no-button](https://github.com/geonetwork/geonetwork-ui/assets/6329425/c208d276-46e3-48d3-b4d7-2756f49cf04b)
