### PR TITLE
Add an ElasticSearch pipeline to make formats human-readable

### DIFF
--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -141,3 +141,45 @@ As such, **authenticated requests are not yet supported in GeoNetwork-UI in the 
 Lastly, even if authenticated requests were cleared regarding CORS rules, it would still be needed to disable the XSRF mechanism for the endpoints that GeoNetwork-UI relies on; XSRF protections works by making the client read the content of an HTTP cookie, and that is forbidden in a cross-origin context
 
 :::
+
+## Enabling improved search fields
+
+ElasticSearch offers the possibility to preprocess the records of a catalog, and this can be leveraged to **improve the search experience in GeoNetwork-UI**. This is done by registering so-called _ingest pipelines_.
+
+GeoNetwork-UI provides several pipelines:
+
+- Enable the Metadata Quality Score
+- Show better, human-readable data formats
+
+There are two options to register these pipelines:
+
+### Option A: Executing a Node script
+
+This will require having `node` installed on the device, as well as a direct HTTP access to the ElasticSearch instance (i.e. not just access to the GeoNetwork API).
+
+First clone the GeoNetwork-UI repository:
+
+```shell
+git clone git@github.com:geonetwork/geonetwork-ui.git
+cd geonetwork-ui
+```
+
+Then run the following script with the appropriate options:
+
+```shell
+node tools/pipelines/register-es-pipelines.js register --host=http://localhost:9090
+```
+
+The `--host` option is used to point to the ElasticSearch instance. Additionnally, the `--records-index` option can be used if the index containing the metadata records is not called `gn-records`.
+
+### Option B: Running a docker image
+
+A docker image called `geonetwork/geonetwork-ui-tools-pipelines` can be used to register pipelines automatically on startup.
+
+To run it:
+
+```shell
+docker run --rm --env ES_HOST=http://localhost:9200 --network host geonetwork/geonetwork-ui-tools-pipelines
+```
+
+Here the `ES_HOST` environment variable is used to point to the ElasticSearch instance. Note that this host will be used _from inside the docker container_, so to access an instance on `localhost` the `--network host` option is also required.

--- a/docs/guide/deploy.md
+++ b/docs/guide/deploy.md
@@ -144,14 +144,22 @@ Lastly, even if authenticated requests were cleared regarding CORS rules, it wou
 
 ## Enabling improved search fields
 
-ElasticSearch offers the possibility to preprocess the records of a catalog, and this can be leveraged to **improve the search experience in GeoNetwork-UI**. This is done by registering so-called _ingest pipelines_.
+ElasticSearch offers the possibility to preprocess the records of a catalog, and this can be leveraged to **improve the search experience in GeoNetwork-UI**. This is done by registering so-called [ingest pipelines](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/ingest.html).
 
-GeoNetwork-UI provides several pipelines:
+GeoNetwork-UI provides several pipelines, for instance:
 
 - Enable the Metadata Quality Score
 - Show better, human-readable data formats
 
-There are two options to register these pipelines:
+The two options for registering the pipelines are explained below.
+
+::: tip
+Once pipelines are registered, the GeoNetwork catalog should be fully reindexed again.
+:::
+
+::: warning
+**Please note that destroying and recreating the GeoNetwork index _will_ disable the pipelines!** These should simply be registered again afterward.
+:::
 
 ### Option A: Executing a Node script
 
@@ -170,7 +178,7 @@ Then run the following script with the appropriate options:
 node tools/pipelines/register-es-pipelines.js register --host=http://localhost:9090
 ```
 
-The `--host` option is used to point to the ElasticSearch instance. Additionnally, the `--records-index` option can be used if the index containing the metadata records is not called `gn-records`.
+The `--host` option is used to point to the ElasticSearch instance. Additionally, the `--records-index` option can be used if the index containing the metadata records is not called `gn-records`.
 
 ### Option B: Running a docker image
 
@@ -183,3 +191,5 @@ docker run --rm --env ES_HOST=http://localhost:9200 --network host geonetwork/ge
 ```
 
 Here the `ES_HOST` environment variable is used to point to the ElasticSearch instance. Note that this host will be used _from inside the docker container_, so to access an instance on `localhost` the `--network host` option is also required.
+
+The `RECORDS_INDEX` environment variable can be used to a different index name if it is not called `gn-records`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "@typescript-eslint/eslint-plugin": "5.62.0",
         "@typescript-eslint/parser": "5.62.0",
         "autoprefixer": "^10.4.13",
-        "commander": "^6.2.1",
+        "commander": "11.1.0",
         "cypress": "^12.17.1",
         "cypress-browser-permissions": "^1.1.0",
         "cypress-real-events": "^1.9.1",
@@ -10235,6 +10235,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@storybook/cli/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@storybook/cli/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -15650,12 +15659,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "devOptional": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">=16"
       }
     },
     "node_modules/comment-json": {
@@ -16706,6 +16715,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cypress/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "devOptional": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cypress/node_modules/execa": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,6 @@
         "@typescript-eslint/eslint-plugin": "5.62.0",
         "@typescript-eslint/parser": "5.62.0",
         "autoprefixer": "^10.4.13",
-        "commander": "11.1.0",
         "cypress": "^12.17.1",
         "cypress-browser-permissions": "^1.1.0",
         "cypress-real-events": "^1.9.1",
@@ -15656,15 +15655,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/comment-json": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "autoprefixer": "^10.4.13",
-    "commander": "11.1.0",
     "cypress": "^12.17.1",
     "cypress-browser-permissions": "^1.1.0",
     "cypress-real-events": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "autoprefixer": "^10.4.13",
-    "commander": "^6.2.1",
+    "commander": "11.1.0",
     "cypress": "^12.17.1",
     "cypress-browser-permissions": "^1.1.0",
     "cypress-real-events": "^1.9.1",

--- a/support-services/docker-compose.yml
+++ b/support-services/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       retries: 10
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data
+    ports:
+      - '9200:9200'
 
   kibana:
     image: kibana:7.11.1

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,40 @@
+# GeoNetwork-UI Tools
+
+This directory contains various tools used in the development and deployment phases of GeoNetwork-UI.
+
+## [`docker` folder](./docker)
+
+Contains a generic Dockerfile that can be used for any applications provided by GeoNetwork-UI, as well as the corresponding entrypoing and NGINX configuration file.
+
+## [`i18n` folder](./i18n)
+
+Contains utilities related to translation files used in GeoNetwork-UI.
+
+## [`pipelines` folder](./pipelines)
+
+Contains utilities related to [registering pipelines on ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/ingest.html). Pipelines are used to preprocess records during the indexation process, thus
+offering greater control over the values returned by ElasticSearch and giving an improved user experience when searching records.
+
+A CLI is provided to let you register or clear GeoNetwork-UI-related pipelines on an ES instance. For example:
+
+```shell
+node pipelines/regiser-es-pipelines.js register --host=http://localhost:9200 --records-index=gn-records
+```
+
+A docker image can also be built to register the pipelines automatically in a docker environment:
+
+```shell
+npm run pipelines:docker-build
+# once image is built, use it like so:
+docker run --rm --env ES_HOST=http://localhost:9200 --env RECORDS_INDEX=gn-records --network host geonetwork/geonetwork-ui-tools-pipelines
+```
+
+## [`webcomponent` folder](./webcomponent)
+
+Contains utilities related to Web Components provided by the GeoNetwork-UI project.
+
+## Other tools
+
+- `generate-api.sh`: regenerates API clients automatically from existing OpenAPI YAML files
+- `make-archive.sh`: bundles directories in `dist` and names it appropriately for releases
+- `print-docker-tag.sh`: outputs a docker tag based on the current git tag/branch

--- a/tools/i18n/cli.js
+++ b/tools/i18n/cli.js
@@ -1,5 +1,5 @@
-const { readFile, writeFile } = require('fs/promises')
-const { program } = require('commander')
+import { readFile, writeFile } from 'fs/promises'
+import { program } from 'commander'
 
 program
   .command('merge <sourcePath> <destPath>')

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "geonetwork-ui-tools",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "geonetwork-ui-tools",
+      "devDependencies": {
+        "commander": "11.1.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,3 +1,12 @@
 {
-  "type": "module"
+  "name": "geonetwork-ui-tools",
+  "description": "A series of tools used alongside GeoNetwork-UI",
+  "type": "module",
+  "devDependencies": {
+    "commander": "11.1.0"
+  },
+  "scripts": {
+    "pipelines:register": "node pipelines/register-es-pipelines.js register",
+    "pipelines:docker-build": "docker build . -f pipelines/Dockerfile -t $(./print-docker-tag.sh tools-pipelines)"
+  }
 }

--- a/tools/pipelines/Dockerfile
+++ b/tools/pipelines/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:lts-alpine
+
+RUN mkdir /app
+WORKDIR /app
+COPY ./pipelines/register-es-pipelines.js ./
+COPY ./package.json ./
+COPY ./package-lock.json ./
+
+ENV ES_HOST="http://elasticsearch:9200"
+ENV RECORDS_INDEX="gn-records"
+
+RUN npm ci
+
+#ENTRYPOINT ["node", "./register-es-pipelines.js", "register", "--host", "echo $ES_HOST", "--records-index", "echo $RECORDS_INDEX"]
+ENTRYPOINT node ./register-es-pipelines.js register --host $ES_HOST --records-index $RECORDS_INDEX

--- a/tools/pipelines/register-es-pipelines.js
+++ b/tools/pipelines/register-es-pipelines.js
@@ -8,14 +8,14 @@ program
 program
   .command('register')
   .description('Register pipelines')
-  .option('--host <value>', 'ElasticSearch host', 'http://localhost:9200/')
+  .option('--host <value>', 'ElasticSearch host', 'http://localhost:9200')
   .option(
     '--records-index <value>',
     'Name of the index used by GeoNetwork for records',
     'gn-records'
   )
   .action((options) => {
-    const esUrl = options.host
+    const esUrl = options.host.replace(/\/$/, '') // remove trailing slash if any
     const recordsIndex = options.recordsIndex
     registerPipelines(esUrl, recordsIndex)
   })
@@ -24,11 +24,11 @@ program
   .description('Clear all registered pipelines')
   .option(
     '--host <value>',
-    'ElasticSearch host, default is http://localhost:9090/',
-    'http://localhost:9200/'
+    'ElasticSearch host, default is http://localhost:9090',
+    'http://localhost:9200'
   )
   .action((options) => {
-    const esUrl = options.host || 'http://localhost:9200/'
+    const esUrl = options.host.replace(/\/$/, '') // remove trailing slash if any
     clearPipelines(esUrl)
   })
 
@@ -132,7 +132,7 @@ for(int i = ctx.format.length - 1; i >= 0; i--) {
 async function registerPipeline(esHost, name, payload) {
   console.log(`adding ${name} pipeline...`)
 
-  await fetch(`${esHost}_ingest/pipeline/${name}`, {
+  await fetch(`${esHost}/_ingest/pipeline/${name}`, {
     method: 'PUT',
     body: JSON.stringify(payload),
     headers: {
@@ -153,7 +153,7 @@ async function registerPipeline(esHost, name, payload) {
 async function clearPipeline(esHost, name) {
   console.log(`clearing ${name} pipeline...`)
 
-  await fetch(`${esHost}_ingest/pipeline/${name}`, {
+  await fetch(`${esHost}/_ingest/pipeline/${name}`, {
     method: 'DELETE',
   })
     .then((resp) => resp.json())
@@ -170,7 +170,7 @@ async function clearPipeline(esHost, name) {
 async function setDefaultPipeline(esHost, recordsIndex, name) {
   console.log(`setting ${name} as default pipeline...`)
 
-  await fetch(`${esHost}${recordsIndex}/_settings`, {
+  await fetch(`${esHost}/${recordsIndex}/_settings`, {
     method: 'PUT',
     body: JSON.stringify({ 'index.default_pipeline': name }),
     headers: {
@@ -191,7 +191,7 @@ async function setDefaultPipeline(esHost, recordsIndex, name) {
 async function registerPipelines(esHost, recordsIndex) {
   console.log('querying currently registered pipelines...')
 
-  const pipelines = await fetch(`${esHost}_ingest/pipeline`).then((resp) =>
+  const pipelines = await fetch(`${esHost}/_ingest/pipeline`).then((resp) =>
     resp.json()
   )
 
@@ -210,7 +210,7 @@ async function registerPipelines(esHost, recordsIndex) {
 }
 
 async function clearPipelines(esHost) {
-  const pipelines = await fetch(`${esHost}_ingest/pipeline`).then((resp) =>
+  const pipelines = await fetch(`${esHost}/_ingest/pipeline`).then((resp) =>
     resp.json()
   )
 

--- a/tools/register-es-pipelines.js
+++ b/tools/register-es-pipelines.js
@@ -1,0 +1,223 @@
+import { program } from 'commander'
+
+program
+  .name('register-es-pipelines')
+  .description(
+    'Lets you register ElasticSearch pipelines to improve the search experience in GeoNetwork-UI. Trigger a reindexation of the catalog after using.'
+  )
+program
+  .command('register')
+  .description('Register pipelines')
+  .option('--host <value>', 'ElasticSearch host', 'http://localhost:9200/')
+  .option(
+    '--records-index <value>',
+    'Name of the index used by GeoNetwork for records',
+    'gn-records'
+  )
+  .action((options) => {
+    const esUrl = options.host
+    const recordsIndex = options.recordsIndex
+    registerPipelines(esUrl, recordsIndex)
+  })
+program
+  .command('clear')
+  .description('Clear all registered pipelines')
+  .option(
+    '--host <value>',
+    'ElasticSearch host, default is http://localhost:9090/',
+    'http://localhost:9200/'
+  )
+  .action((options) => {
+    const esUrl = options.host || 'http://localhost:9200/'
+    clearPipelines(esUrl)
+  })
+
+program.parse(process.argv)
+
+const VERSION = 100 // increment on changes
+
+const GEONETWORK_UI_PIPELINE = {
+  description: 'GeoNetwork-UI pipeline',
+  version: VERSION,
+  processors: [
+    {
+      // compute the metadata quality score
+      script: {
+        lang: 'painless',
+        source: `
+int total=8;
+int ok=0;
+if(ctx.resourceTitleObject != null && ctx.resourceTitleObject.default != null && ctx.resourceTitleObject.default != '') {
+  ok++
+}
+if(ctx.resourceAbstractObject != null && ctx.resourceAbstractObject.default != null && ctx.resourceAbstractObject.default != '') {
+  ok++
+}
+if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisation != null && ctx.contact[0].organisation != '') {
+  ok++
+}
+if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].email != null && ctx.contact[0].email != '') {
+  ok++
+}
+if(ctx.cl_topic != null && ctx.cl_topic.length > 0) {
+  ok++
+}
+if(ctx.tag != null && ctx.tag.length > 0) {
+  ok++
+}
+if(ctx.cl_maintenanceAndUpdateFrequency != null && ctx.cl_maintenanceAndUpdateFrequency.length > 0) {
+  ok++
+}
+if(ctx.MD_LegalConstraintsUseLimitationObject != null && ctx.MD_LegalConstraintsUseLimitationObject.length > 0) {
+  ok++
+}
+ctx.qualityScore = ok * 100 / total;`,
+      },
+    },
+    {
+      // generate human-readable data formats
+      script: {
+        lang: 'painless',
+        source: `
+if (!ctx.containsKey('format')) return;
+if (ctx.format == null) return;
+ctx.originalFormat = ctx.format;
+for(int i = ctx.format.length - 1; i >= 0; i--) {
+  String format = ctx.format[i].toLowerCase();
+  if (format.contains('shp') || format.contains('shapefile')) {
+    ctx.format[i] = 'ESRI Shapefile'
+  } else if (format.contains('ogc:w') || format.contains('esri:rest') || format.contains('tms')) {
+    ctx.format[i] = 'Service'
+  } else if (format.contains('pdf')) {
+    ctx.format[i] = 'PDF'
+  } else if (format.contains('png') || format.contains('jpg') || format.contains('jpeg') || format.contains('bmp')) {
+    ctx.format[i] = 'Image'
+  } else if (format.contains('excel') || format.contains('xls') || format.contains('vnd.oasis.opendocument.spreadsheet') || format.contains('vnd.openxmlformats-officedocument.spreadsheetml.sheet')) {
+    ctx.format[i] = 'Excel'
+  } else if (format.contains('geopackage') || format.contains('gpkg')) {
+    ctx.format[i] = 'Geopackage'
+  } else if (format.contains('postgis')) {
+    ctx.format[i] = 'PostGIS'
+  } else if (format.contains('gml')) {
+    ctx.format[i] = 'GML'
+  } else if (format.contains('kml')) {
+    ctx.format[i] = 'KML'
+  } else if (format.contains('xml')) {
+    ctx.format[i] = 'XML'
+  } else if (format.contains('html')) {
+    ctx.format[i] = 'HTML'
+  } else if (format.contains('geo+json') || format.contains('geojson')) {
+    ctx.format[i] = 'GeoJSON'
+  } else if (format.contains('json')) {
+    ctx.format[i] = 'JSON'
+  } else if (format.contains('csv')) {
+    ctx.format[i] = 'CSV'
+  } else if (format.contains('rtf')) {
+    ctx.format[i] = 'RTF'
+  } else if (format.contains('text')) {
+    ctx.format[i] = 'Text'
+  } else if (format.contains('zip')) {
+    ctx.format[i] = 'ZIP'
+  } else if (format != null) {
+    ctx.format.remove(i);
+    // uncomment this to show unrecognized formats
+    // ctx.format[i] = 'unknown: ' + ctx.format[i];
+  }
+}`,
+      },
+    },
+  ],
+}
+
+async function registerPipeline(esHost, name, payload) {
+  console.log(`adding ${name} pipeline...`)
+
+  await fetch(`${esHost}_ingest/pipeline/${name}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((resp) => resp.json())
+    .then((result) => {
+      if (result.acknowledged !== true) {
+        console.error(result)
+        throw new Error('something went wrong')
+      }
+    })
+
+  console.log(`${name} pipeline was successfully registered!`)
+}
+
+async function clearPipeline(esHost, name) {
+  console.log(`clearing ${name} pipeline...`)
+
+  await fetch(`${esHost}_ingest/pipeline/${name}`, {
+    method: 'DELETE',
+  })
+    .then((resp) => resp.json())
+    .then((result) => {
+      if (result.acknowledged !== true) {
+        console.error(result)
+        throw new Error('something went wrong')
+      }
+    })
+
+  console.log(`${name} pipeline was successfully cleaned!`)
+}
+
+async function setDefaultPipeline(esHost, recordsIndex, name) {
+  console.log(`setting ${name} as default pipeline...`)
+
+  await fetch(`${esHost}${recordsIndex}/_settings`, {
+    method: 'PUT',
+    body: JSON.stringify({ 'index.default_pipeline': name }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((resp) => resp.json())
+    .then((result) => {
+      if (result.acknowledged !== true) {
+        console.error(result)
+        throw new Error('something went wrong')
+      }
+    })
+
+  console.log(`${name} pipeline was successfully set as default!`)
+}
+
+async function registerPipelines(esHost, recordsIndex) {
+  console.log('querying currently registered pipelines...')
+
+  const pipelines = await fetch(`${esHost}_ingest/pipeline`).then((resp) =>
+    resp.json()
+  )
+
+  const names = Object.keys(pipelines)
+  names.forEach((name) => {
+    console.log(`
+ > ${name}`)
+    console.log(`   ${pipelines[name].description}`)
+  })
+
+  console.log('')
+  await registerPipeline(esHost, 'geonetwork-ui', GEONETWORK_UI_PIPELINE)
+
+  console.log('')
+  await setDefaultPipeline(esHost, recordsIndex, 'geonetwork-ui')
+}
+
+async function clearPipelines(esHost) {
+  const pipelines = await fetch(`${esHost}_ingest/pipeline`).then((resp) =>
+    resp.json()
+  )
+
+  if (!('geonetwork-ui' in pipelines)) {
+    console.log('No geonetwork-ui pipelines found, exiting')
+    return
+  }
+
+  await clearPipeline(esHost, 'geonetwork-ui')
+}


### PR DESCRIPTION
This PR adds a script that will register a pipeline specific to GeoNetwork-UI on the ES index. This pipeline does:
- compute the quality score (taken from https://github.com/geonetwork/geonetwork-ui/discussions/446#discussioncomment-6035489)
- process the formats to make them more consistent & easier to read

The script needs to be run against the desired ES instance, and then a reindexation should be started.

![image](https://github.com/geonetwork/geonetwork-ui/assets/10629150/beb14b38-73ad-433c-a290-ac408058fa18)

Addresses #531 


To do:
- [x] make the ES host and index name configurable in the script
- [x] put the script somewhere else
- [x] document
- [x] make it easy to use in a docker context