### PR TITLE
ME: checkbox color options

### DIFF
--- a/libs/ui/inputs/src/lib/checkbox/checkbox.component.css
+++ b/libs/ui/inputs/src/lib/checkbox/checkbox.component.css
@@ -1,0 +1,24 @@
+.default {
+  --gn-ui-checkbox-color: var(--color-main);
+}
+
+.secondary {
+  --gn-ui-checkbox-color: var(--color-secondary);
+}
+
+.primary {
+  --gn-ui-checkbox-color: var(--color-primary);
+}
+
+mat-checkbox {
+  --mdc-checkbox-selected-icon-color: var(--gn-ui-checkbox-color);
+  --mdc-checkbox-selected-focus-icon-color: var(--gn-ui-checkbox-color);
+  --mdc-checkbox-selected-hover-icon-color: var(--gn-ui-checkbox-color);
+  --mdc-checkbox-selected-icon-color: var(--gn-ui-checkbox-color);
+  --mdc-checkbox-selected-pressed-icon-color: var(--gn-ui-checkbox-color);
+  --mdc-checkbox-selected-focus-state-layer-color: var(--gn-ui-checkbox-color);
+  --mdc-checkbox-selected-hover-state-layer-color: var(--gn-ui-checkbox-color);
+  --mdc-checkbox-selected-pressed-state-layer-color: var(
+    --gn-ui-checkbox-color
+  );
+}

--- a/libs/ui/inputs/src/lib/checkbox/checkbox.component.html
+++ b/libs/ui/inputs/src/lib/checkbox/checkbox.component.html
@@ -1,8 +1,8 @@
 <mat-checkbox
   class="cursor-pointer"
+  [class]="classList"
   type="checkbox"
   [checked]="checked"
   [indeterminate]="indeterminate"
   (click)="handleClick($event)"
-  color="primary"
 ></mat-checkbox>

--- a/libs/ui/inputs/src/lib/checkbox/checkbox.component.ts
+++ b/libs/ui/inputs/src/lib/checkbox/checkbox.component.ts
@@ -13,9 +13,14 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CheckboxComponent {
+  @Input() type: 'primary' | 'secondary' | 'default' = 'default'
   @Input() checked = false
   @Input() indeterminate? = false
   @Output() changed = new EventEmitter<boolean>()
+
+  get classList() {
+    return `${this.type}`
+  }
 
   handleClick(event: Event) {
     event.stopPropagation()

--- a/libs/ui/search/src/lib/record-table/record-table.component.html
+++ b/libs/ui/search/src/lib/record-table/record-table.component.html
@@ -53,6 +53,7 @@
             [checked]="isAllSelected()"
             [indeterminate]="isSomeSelected()"
             (changed)="selectAll()"
+            type="default"
           >
           </gn-ui-checkbox>
         </div>
@@ -153,6 +154,7 @@
           <gn-ui-checkbox
             [checked]="isChecked(record)"
             (changed)="handleRecordSelectedChange($event, record)"
+            type="default"
           ></gn-ui-checkbox>
         </div>
         <div


### PR DESCRIPTION
The 'default' color for the checkboxes looks like this (it relies on --color-main variable):
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/2c6abd9b-5a97-45d3-a60f-aeb7d4ce2b21)
