### PR TITLE
Fix [DH]: Display record's update status correctly

### DIFF
--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.spec.ts
@@ -75,5 +75,120 @@ describe('Gn4FieldMapper', () => {
         ])
       })
     })
+
+    describe('#getMappingFn', () => {
+      it('should return a function when given a valid field name', () => {
+        const fieldName = 'id'
+        const mappingFn = service.getMappingFn(fieldName)
+        expect(typeof mappingFn).toBe('function')
+      })
+      it('should return a generic field when given an invalid field name', () => {
+        const fieldName = 'invalidField'
+        const mappingFn = service.getMappingFn(fieldName)
+        expect(mappingFn).toBe(service.genericField)
+      })
+      it('should return a function that maps the correct field even if the source object has additional unknown properties', () => {
+        const fieldName = 'id'
+        const mappingFn = service.getMappingFn(fieldName)
+        const output = {}
+        const source = { id: '12345', unknownProp: 'value' }
+        const result = mappingFn(output, source)
+        expect(result).toEqual({ extras: { id: '12345' } })
+      })
+      describe('field mappings', () => {
+        it('id - should return a function that correctly maps the field', () => {
+          const fieldName = 'id'
+          const mappingFn = service.getMappingFn(fieldName)
+          const output = {}
+          const source = { id: '12345' }
+          const result = mappingFn(output, source)
+          expect(result).toEqual({ extras: { id: '12345' } })
+        })
+        it('uuid - should return a function that correctly maps the field', () => {
+          const fieldName = 'uuid'
+          const mappingFn = service.getMappingFn(fieldName)
+          const output = {}
+          const source = { uuid: '12345' }
+          const result = mappingFn(output, source)
+          expect(result).toEqual({
+            landingPage: new URL('http://localhost/url'),
+            uniqueIdentifier: '12345',
+          })
+        })
+        it('resourceTitleObject - should return a function that correctly maps the field to default lang', () => {
+          service.lang3 = 'langeng'
+          const fieldName = 'resourceTitleObject'
+          const mappingFn = service.getMappingFn(fieldName)
+          const output = {}
+          const source = {
+            resourceTitleObject: {
+              default: 'Default title',
+              langfre: 'French title',
+            },
+          }
+          const result = mappingFn(output, source)
+          expect(result).toEqual({
+            title: 'Default title',
+          })
+        })
+        it('resourceAbstractObject - should return a function that correctly maps the field to fre lang', () => {
+          service.lang3 = 'langfre'
+          const fieldName = 'resourceAbstractObject'
+          const mappingFn = service.getMappingFn(fieldName)
+          const output = {}
+          const source = {
+            resourceAbstractObject: {
+              default: 'Default abstract',
+              langfre: 'French abstract',
+            },
+          }
+          const result = mappingFn(output, source)
+          expect(result).toEqual({
+            abstract: 'French abstract',
+          })
+        })
+        it('overview - should return a function that correctly maps the field', () => {
+          service.lang3 = 'langfre'
+          const fieldName = 'overview'
+          const mappingFn = service.getMappingFn(fieldName)
+          const output = {}
+          const source = {
+            overview: [
+              {
+                url: 'https://mygeodata/map.png',
+                text: {
+                  default: 'Default overview description',
+                  langfre: 'French overview description',
+                },
+              },
+            ],
+          }
+          const result = mappingFn(output, source)
+          expect(result).toEqual({
+            overviews: [
+              {
+                url: new URL('https://mygeodata/map.png'),
+                description: 'French overview description',
+              },
+            ],
+          })
+        })
+        it('cl_status - should return a function that correctly maps the field', () => {
+          const fieldName = 'cl_status'
+          const mappingFn = service.getMappingFn(fieldName)
+          const output = {}
+          const source = {
+            cl_status: {
+              key: 'completed',
+              default: 'Finalisé',
+              langfre: 'Finalisé',
+              link: 'http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ProgressCode',
+            },
+          }
+          const result = mappingFn(output, source)
+          expect(result).toEqual({ status: 'completed' })
+        })
+      })
+    })
   })
 })

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -100,7 +100,7 @@ export class Gn4FieldMapper {
     cl_status: (output, source) => ({
       ...output,
       status: getStatusFromStatusCode(
-        getFirstValue(selectField(source, 'cl_status'))
+        selectField(getFirstValue(selectField(source, 'cl_status')), 'key')
       ),
     }),
     cl_maintenanceAndUpdateFrequency: (output, source) => ({

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.metadata.mapper.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.metadata.mapper.spec.ts
@@ -635,7 +635,7 @@ describe('Gn4MetadataMapper', () => {
             ],
             recordCreated: new Date('2021-10-05T12:48:57.678Z'),
             recordUpdated: new Date('2021-10-05T12:48:57.678Z'),
-            status: 'under_development',
+            status: 'ongoing',
             themes: ['Installations de suivi environnemental', 'Océans'],
             title: 'Surval - Données par paramètre',
             uniqueIdentifier: 'cf5048f6-5bbf-4e44-ba74-e6f429af51ea',


### PR DESCRIPTION
Currently, the update status coming from `cl_status` always displays the (translated) fallback value of `under_development`, because the mapper uses the `cl_status` object instead of its key.

![under_dev](https://github.com/geonetwork/geonetwork-ui/assets/6329425/86a71ff8-9aba-42fd-a31d-1c5315b5f23e)
