### PR TITLE
Datahub: Fix abstract display in record preview

### DIFF
--- a/libs/ui/search/src/lib/record-preview/record-preview.component.ts
+++ b/libs/ui/search/src/lib/record-preview/record-preview.component.ts
@@ -8,7 +8,11 @@ import {
   Output,
   TemplateRef,
 } from '@angular/core'
-import { propagateToDocumentOnly, stripHtml } from '@geonetwork-ui/util/shared'
+import {
+  propagateToDocumentOnly,
+  stripHtml,
+  removeWhitespace,
+} from '@geonetwork-ui/util/shared'
 import { MetadataQualityDisplay } from '@geonetwork-ui/ui/elements'
 import { fromEvent, Subscription } from 'rxjs'
 import {
@@ -54,7 +58,7 @@ export class RecordPreviewComponent implements OnInit, OnDestroy {
   constructor(protected elementRef: ElementRef) {}
 
   ngOnInit(): void {
-    this.abstract = stripHtml(this.record?.abstract)
+    this.abstract = removeWhitespace(stripHtml(this.record?.abstract))
     this.subscription.add(
       fromEvent(this.elementRef.nativeElement, 'click').subscribe(
         (event: Event) => {

--- a/libs/util/shared/src/lib/utils/index.ts
+++ b/libs/util/shared/src/lib/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './parse'
 export * from './strip-html'
+export * from './remove-whitespace'
 export * from './geojson'
 export * from './sort-by'
 export * from './url'

--- a/libs/util/shared/src/lib/utils/remove-whitespace.spec.ts
+++ b/libs/util/shared/src/lib/utils/remove-whitespace.spec.ts
@@ -1,0 +1,16 @@
+import { removeWhitespace } from './remove-whitespace'
+
+describe('#removeWhitespace', () => {
+  it('removes superfluent whitespace for a single word', () => {
+    const html = ' hello '
+    expect(removeWhitespace(html)).toBe('hello')
+  })
+  it('removes superfluent whitespace for a paragraph', () => {
+    const html = `Service WFS pour les concentrations moyennes journalières des principaux polluants.
+                                                                                                                                                                                                                                  
+    Concentrations moyennes journalières issues du réseau fixe des principaux polluants réglementés dans l’air sur la région Hauts-de-France : dioxyde de soufre SO2, monoxyde d’azote NO et dioxyde d’azote NO2, particules en suspension PM10, particules en suspension PM2.5, ozone O3, benzène C6H6, monoxyde de carbone CO. Toutes les données fournies sont en μg/m³ (microgramme par mètre cube) sauf CO (mg/m³). Généalogie au sens Inspire : Mesures de terrain automatiques. Les concentrations moyennes ont été calculées conformément au guide méthodologique pour le calcul des statistiques relative à la qualité de l’air (LCSQA 2016) à partir des données mesurées selon`
+    expect(removeWhitespace(html)).toBe(
+      `Service WFS pour les concentrations moyennes journalières des principaux polluants. Concentrations moyennes journalières issues du réseau fixe des principaux polluants réglementés dans l’air sur la région Hauts-de-France : dioxyde de soufre SO2, monoxyde d’azote NO et dioxyde d’azote NO2, particules en suspension PM10, particules en suspension PM2.5, ozone O3, benzène C6H6, monoxyde de carbone CO. Toutes les données fournies sont en μg/m³ (microgramme par mètre cube) sauf CO (mg/m³). Généalogie au sens Inspire : Mesures de terrain automatiques. Les concentrations moyennes ont été calculées conformément au guide méthodologique pour le calcul des statistiques relative à la qualité de l’air (LCSQA 2016) à partir des données mesurées selon`
+    )
+  })
+})

--- a/libs/util/shared/src/lib/utils/remove-whitespace.ts
+++ b/libs/util/shared/src/lib/utils/remove-whitespace.ts
@@ -1,0 +1,3 @@
+export const removeWhitespace = function (str: string): string {
+  return str.replace(/\s+/g, ' ').trim()
+}


### PR DESCRIPTION
Remove unnecessary whitespaces from html which can break line-clamp behaviour. [Example](https://www.geo2france.fr/geonetwork/srv/api/records/atmo-hdf::mes-hdf-journalier-poll-princ-1/formatters/xml?approved=true) abstract. Has only been reproduced on firefox.

![line-clamp](https://github.com/geonetwork/geonetwork-ui/assets/6329425/6767b95a-8223-43b9-9d06-dc8a8718daa7)
