### PR TITLE
Fix [Datahub]: Do not point to future web component version

### DIFF
--- a/apps/datahub/src/environments/environment.prod.ts
+++ b/apps/datahub/src/environments/environment.prod.ts
@@ -1,5 +1,8 @@
 import packageJson from '../../../../package.json'
 export const environment = {
   production: true,
-  version: `v${packageJson.version.split('-')[0]}`,
+  version:
+    packageJson.version.split('-')[1] === 'dev'
+      ? 'main'
+      : `v${packageJson.version}`,
 }


### PR DESCRIPTION
PR sets same `env.version` for prod as for dev as prod env is also used for latest builds (and not only local dev). This should fix the datahub latest build to point to the main web component dist branch instead of a version that does not exist yet.