### PR TITLE
DH/Improve navigation button style

### DIFF
--- a/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
+++ b/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
@@ -1,12 +1,6 @@
 <button
-  type="button"
-  class="group flex items-center justify-center p-1 bg-white rounded opacity-80 box-shadow-xl shadow-[4.0px_8.0px_8.0px_rgba(0,0,0,0.38)] mix-blend-luminosity text-black rounded hover:opacity-100"
+  class="group flex items-center justify-center backdrop-blur p-1 bg-primary-opacity-50 text-white rounded"
 >
-  <div
-    class="absolute -z-0 inset-0 bg-white opacity-80 group-hover:opacity-100 rounded transition duration-[20ms]"
-  ></div>
-  <mat-icon class="z-0 material-symbols-outlined align-middle">{{
-    icon
-  }}</mat-icon>
-  <span class="z-0 mx-2 hidden group-hover:inline">{{ label }}</span>
+  <mat-icon class="material-symbols-outlined align-middle">{{ icon }}</mat-icon>
+  <span class="mx-2 hidden group-hover:inline">{{ label }}</span>
 </button>

--- a/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
+++ b/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
@@ -1,9 +1,9 @@
 <button
   type="button"
-  class="relative backdrop-blur group flex items-center justify-center p-1 text-main rounded overflow-hidden shadow-2xl"
+  class="group flex items-center justify-center p-1 bg-white rounded opacity-80 box-shadow-xl shadow-[4.0px_8.0px_8.0px_rgba(0,0,0,0.38)] mix-blend-luminosity text-black rounded hover:opacity-100"
 >
   <div
-    class="absolute -z-0 inset-0 bg-white opacity-60 group-hover:opacity-100 transition duration-[20ms]"
+    class="absolute -z-0 inset-0 bg-white opacity-80 group-hover:opacity-100 rounded transition duration-[20ms]"
   ></div>
   <mat-icon class="z-0 material-symbols-outlined align-middle">{{
     icon

--- a/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
+++ b/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
@@ -1,6 +1,12 @@
 <button
-  class="group flex items-center justify-center p-1 bg-white opacity-80 box-shadow-xl shadow-[4.0px_8.0px_8.0px_rgba(0,0,0,0.38)] mix-blend-luminosity text-black rounded hover:opacity-100"
+  type="button"
+  class="relative backdrop-blur group flex items-center justify-center p-1 text-main rounded overflow-hidden shadow-2xl"
 >
-  <mat-icon class="material-symbols-outlined align-middle">{{ icon }}</mat-icon>
-  <span class="mx-2 hidden group-hover:inline">{{ label }}</span>
+  <div
+    class="absolute -z-0 inset-0 bg-white opacity-60 group-hover:opacity-100 transition duration-[20ms]"
+  ></div>
+  <mat-icon class="z-0 material-symbols-outlined align-middle">{{
+    icon
+  }}</mat-icon>
+  <span class="z-0 mx-2 hidden group-hover:inline">{{ label }}</span>
 </button>

--- a/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
+++ b/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
@@ -1,5 +1,5 @@
 <button
-  class="group flex items-center justify-center p-1 bg-white opacity-80 shadow-xl text-black rounded hover:opacity-100"
+  class="group flex items-center justify-center p-1 bg-white opacity-80 box-shadow-xl shadow-[4.0px_8.0px_8.0px_rgba(0,0,0,0.38)] mix-blend-luminosity text-black rounded hover:opacity-100"
 >
   <mat-icon class="material-symbols-outlined align-middle">{{ icon }}</mat-icon>
   <span class="mx-2 hidden group-hover:inline">{{ label }}</span>

--- a/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
+++ b/libs/ui/inputs/src/lib/navigation-button/navigation-button.component.html
@@ -1,5 +1,5 @@
 <button
-  class="group flex items-center justify-center p-1 bg-primary-opacity-25 text-white rounded"
+  class="group flex items-center justify-center p-1 bg-white opacity-80 shadow-xl text-black rounded hover:opacity-100"
 >
   <mat-icon class="material-symbols-outlined align-middle">{{ icon }}</mat-icon>
   <span class="mx-2 hidden group-hover:inline">{{ label }}</span>

--- a/tailwind.base.css
+++ b/tailwind.base.css
@@ -12,7 +12,7 @@
   }
 
   .badge-btn {
-    @apply flex items-center justify-center px-4 py-1 text-white rounded;
+    @apply flex items-center justify-center px-4 py-1 text-white rounded backdrop-blur;
   }
 
   .card-icon {


### PR DESCRIPTION
### Description

This PR addresses the request to have a return button (in record page) that is easier to find. Some users struggle to find the current return button with a complex background image : 

![image(1)](https://github.com/geonetwork/geonetwork-ui/assets/132347903/ffc01a88-56c8-4b67-af9f-0cc3584f01f4)

After consulting Lucile it was decided to invert the button style, and have a white and transparent background and the text in back + a shadow.

![image](https://github.com/geonetwork/geonetwork-ui/assets/132347903/4a00bf48-d2ef-44c7-a459-716f7ca16688)
