### PR TITLE
fix(DH): Link detection with unknown mime type

### DIFF
--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.spec.ts
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.spec.ts
@@ -11,7 +11,10 @@ import { LinkClassifierService } from '@geonetwork-ui/util/shared'
 import { LINK_FIXTURES } from '@geonetwork-ui/common/fixtures'
 import { TranslateModule } from '@ngx-translate/core'
 import { DownloadsListComponent } from './downloads-list.component'
-import { DatasetDistribution } from '@geonetwork-ui/common/domain/record'
+import {
+  DatasetDistribution,
+  DatasetDownloadDistribution,
+} from '@geonetwork-ui/common/domain/record'
 
 @Component({
   selector: 'gn-ui-download-item',
@@ -92,8 +95,27 @@ describe('DownloadsListComponent', () => {
       fixture.detectChanges()
       items = de.queryAll(By.directive(MockDownloadItemComponent))
     })
-    it('contains one link', () => {
+    it('contains one link in "others" section', () => {
       expect(items.length).toBe(1)
+      expect(component.isLinkOfFormat(component.links[0], 'others')).toBe(true)
+    })
+  })
+  describe('when link mime type is unknown', () => {
+    let items: DebugElement[]
+
+    beforeEach(() => {
+      component.links = [
+        {
+          ...LINK_FIXTURES.geodataJsonWithMimeType,
+          mimeType: 'unknown/x-type',
+        } as DatasetDownloadDistribution,
+      ]
+      fixture.detectChanges()
+      items = de.queryAll(By.directive(MockDownloadItemComponent))
+    })
+    it('contains one link and mime type is ignored', () => {
+      expect(items.length).toBe(1)
+      expect(component.isLinkOfFormat(component.links[0], 'json')).toBe(true)
     })
   })
   describe('derives color and format from link', () => {

--- a/libs/util/shared/src/lib/links/link-utils.spec.ts
+++ b/libs/util/shared/src/lib/links/link-utils.spec.ts
@@ -9,6 +9,7 @@ import {
   mimeTypeToFormat,
   getLinkPriority,
 } from './link-utils'
+import { DatasetDownloadDistribution } from '@geonetwork-ui/common/domain/record'
 
 describe('link utils', () => {
   describe('#getFileFormat', () => {
@@ -27,6 +28,16 @@ describe('link utils', () => {
         expect(getFileFormat(LINK_FIXTURES.geodataJsonWithMimeType)).toEqual(
           'geojson'
         )
+      })
+    })
+    describe('for a geojson FILE link with unrecognized mime type', () => {
+      it('returns geojson format', () => {
+        expect(
+          getFileFormat({
+            ...LINK_FIXTURES.geodataJsonWithMimeType,
+            mimeType: 'unknown',
+          } as DatasetDownloadDistribution)
+        ).toEqual('geojson')
       })
     })
     describe('for a json FILE link', () => {

--- a/libs/util/shared/src/lib/links/link-utils.ts
+++ b/libs/util/shared/src/lib/links/link-utils.ts
@@ -59,10 +59,10 @@ export const FORMATS = {
     mimeTypes: ['application/geopackage+sqlite3'],
   },
   zip: {
-    extensions: ['zip'],
+    extensions: ['zip', 'tar.gz'],
     priority: 7,
     color: '#f2bb3a',
-    mimeTypes: ['application/zip'],
+    mimeTypes: ['application/zip', 'application/x-zip'],
   },
   pdf: {
     extensions: ['pdf'],
@@ -113,7 +113,10 @@ export function extensionToFormat(extension: string): FileFormat {
 
 export function getFileFormat(link: DatasetDistribution): FileFormat {
   if ('mimeType' in link) {
-    return mimeTypeToFormat(link.mimeType)
+    const mimeTypeFormat = mimeTypeToFormat(link.mimeType)
+    if (mimeTypeFormat !== null) {
+      return mimeTypeFormat
+    }
   }
   for (const format in FORMATS) {
     for (const alias of FORMATS[format].extensions) {
@@ -143,7 +146,7 @@ export function mimeTypeToFormat(mimeType: string): FileFormat {
       if (mimeType === mt) return format as FileFormat
     }
   }
-  return undefined
+  return null
 }
 
 export function checkFileFormat(


### PR DESCRIPTION
The link detection of a file format is now working even if the mime type is unknown

![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/2e5fb50e-fd26-4a82-ac31-43aa6b7c111c)
