### PR TITLE
Fix scale value to avoid nullity

### DIFF
--- a/apps/datafeeder/src/app/app.module.ts
+++ b/apps/datafeeder/src/app/app.module.ts
@@ -37,6 +37,7 @@ import { SummarizeBackgroundComponent } from './presentation/components/svg/summ
 import { DATAFEEDER_STATE_KEY, reducer } from './store/datafeeder.reducer'
 import { FeatureAuthModule } from '@geonetwork-ui/feature/auth'
 import { MatIconModule } from '@angular/material/icon'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
 export function apiConfigurationFactory() {
   return new Configuration({
@@ -76,6 +77,7 @@ export function apiConfigurationFactory() {
     MatIconModule,
     UtilI18nModule,
     FeatureEditorModule,
+    BrowserAnimationsModule,
     ApiModule.forRoot(apiConfigurationFactory),
     TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG),
     StoreModule.forRoot({

--- a/libs/feature/editor/src/lib/components/wizard-field/wizard-field.component.ts
+++ b/libs/feature/editor/src/lib/components/wizard-field/wizard-field.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   Input,
@@ -67,6 +68,7 @@ export const MY_FORMATS = {
     },
     { provide: MAT_DATE_FORMATS, useValue: MY_FORMATS },
   ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WizardFieldComponent implements AfterViewInit, OnDestroy {
   @Input() wizardFieldConfig: WizardFieldModel
@@ -104,7 +106,6 @@ export class WizardFieldComponent implements AfterViewInit, OnDestroy {
         return data ? new Date(Number(data)) : new Date()
       }
       case WizardFieldType.DROPDOWN: {
-        //TODO called continuously
         return data ? JSON.parse(data) : this.dropdownChoices[0]?.value
       }
     }

--- a/libs/feature/editor/src/lib/components/wizard-field/wizard-field.component.ts
+++ b/libs/feature/editor/src/lib/components/wizard-field/wizard-field.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectorRef,
   Component,
   Input,
   OnDestroy,
@@ -103,15 +104,20 @@ export class WizardFieldComponent implements AfterViewInit, OnDestroy {
         return data ? new Date(Number(data)) : new Date()
       }
       case WizardFieldType.DROPDOWN: {
+        //TODO called continuously
         return data ? JSON.parse(data) : this.dropdownChoices[0]?.value
       }
     }
   }
 
-  constructor(private wizardService: WizardService) {}
+  constructor(
+    private wizardService: WizardService,
+    private cdr: ChangeDetectorRef
+  ) {}
 
   ngAfterViewInit() {
     this.initializeListeners()
+    this.cdr.detectChanges()
   }
 
   ngOnDestroy() {
@@ -196,6 +202,17 @@ export class WizardFieldComponent implements AfterViewInit, OnDestroy {
   }
 
   private initializeDropdownListener() {
+    if (
+      this.wizardService.getWizardFieldData(this.wizardFieldConfig.id) ===
+        undefined &&
+      !!this.dropdown.selected
+    ) {
+      this.wizardService.setWizardFieldData(
+        this.wizardFieldConfig.id,
+        this.dropdown.selected
+      )
+    }
+
     this.subs.add(
       this.dropdown.selectValue.subscribe((value) => {
         this.wizardService.onWizardWizardFieldDataChanged(


### PR DESCRIPTION
# Datafeeder Scale fix

In order to avoid a `null` value sent to the server while a default value is the present in the UI. 

This PR fixes the next issue :
- #685

❗  Also fix an error in the console mentioning  that 'BrowserAnimationsModule' wasn't present.