### PR TITLE
Datahub: handle filter geometry error

### DIFF
--- a/libs/feature/search/src/lib/state/effects.spec.ts
+++ b/libs/feature/search/src/lib/state/effects.spec.ts
@@ -444,6 +444,45 @@ describe('Effects', () => {
             })
           )
         })
+        describe('when geometry is broken', () => {
+          beforeEach(() => {
+            effects['filterGeometry$'] = of({
+              type: 'Polygon',
+              coordinates: [[]],
+            })
+            effects = TestBed.inject(SearchEffects)
+            actions$ = of(new RequestMoreResults('main'))
+          })
+          it('skips the geometry in the search', async () => {
+            await firstValueFrom(effects.loadResults$)
+            expect(repository.search).toHaveBeenCalledWith(
+              expect.not.objectContaining({
+                filterGeometry: { type: 'Polygon', coordinates: [[]] },
+              })
+            )
+          })
+        })
+        describe('when geometry is invalid', () => {
+          beforeEach(() => {
+            effects['filterGeometry$'] = of({
+              type: 'Polygon',
+              coordinates: [
+                [0, 1],
+                [0, 1],
+              ],
+            }) as any
+            effects = TestBed.inject(SearchEffects)
+            actions$ = of(new RequestMoreResults('main'))
+          })
+          it('skips the geometry in the search', async () => {
+            await firstValueFrom(effects.loadResults$)
+            expect(repository.search).toHaveBeenCalledWith(
+              expect.not.objectContaining({
+                filterGeometry: { type: 'Polygon', coordinates: [[]] },
+              })
+            )
+          })
+        })
       })
       describe('when useSpatialFilter is disabled', () => {
         beforeEach(() => {

--- a/libs/feature/search/src/lib/state/effects.ts
+++ b/libs/feature/search/src/lib/state/effects.ts
@@ -146,7 +146,7 @@ export class SearchEffects {
               map((geom) => [state, favorites, geom]),
               catchError((e) => {
                 return of([state, favorites, null])
-              }) // silently opt out of spatial filter if an error happens
+              })
             )
           }),
           switchMap(

--- a/libs/feature/search/src/lib/state/effects.ts
+++ b/libs/feature/search/src/lib/state/effects.ts
@@ -130,14 +130,21 @@ export class SearchEffects {
             }
             return this.filterGeometry$.pipe(
               tap((geom) => {
-                const isValid = validGeoJson(geom)
-                if (!isValid) {
-                  throw '\nFilter geometry is not a valid GeoJson'
+                try {
+                  const trace = validGeoJson(geom, true) as string[]
+                  if (trace?.length > 0) {
+                    throw new Error(trace.join('\n'))
+                  }
+                } catch (error) {
+                  console.warn(
+                    'Error while parsing the geometry filter\n',
+                    error
+                  )
+                  throw new Error()
                 }
               }),
               map((geom) => [state, favorites, geom]),
               catchError((e) => {
-                console.warn('The filter geometry cannot be used', e)
                 return of([state, favorites, null])
               }) // silently opt out of spatial filter if an error happens
             )

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "duration-relativetimeformat": "^2.0.3",
         "embla-carousel": "^8.0.0-rc14",
         "express": "^4.17.1",
+        "geojson-validation": "^1.0.2",
         "moment": "^2.29.4",
         "ng-table-virtual-scroll": "^1.4.1",
         "ngx-chips": "3.0.0",
@@ -19196,6 +19197,14 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geojson-validation": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-validation/-/geojson-validation-1.0.2.tgz",
+      "integrity": "sha512-K5jrJ4wFvORn2pRKeg181LL0QPYuEKn2KHPvfH1m2QtFlAXFLKdseqt0XwBM3ELOY7kNM1fglRQ6ZwUQZ5S00A==",
+      "bin": {
+        "gjv": "bin/gjv"
       }
     },
     "node_modules/geotiff": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "duration-relativetimeformat": "^2.0.3",
     "embla-carousel": "^8.0.0-rc14",
     "express": "^4.17.1",
+    "geojson-validation": "^1.0.2",
     "moment": "^2.29.4",
     "ng-table-virtual-scroll": "^1.4.1",
     "ngx-chips": "3.0.0",


### PR DESCRIPTION
#694

The validation can
- throw an error is the GeoJson is malformed
- return false if the GeoJson is not valid.

Both cases are supported.
This ensure the search runs even with a wrong geometry filter.

I'll provide test if you approve the approach.