### PR TITLE
Attempt to fix E2E flaky tests

### DIFF
--- a/support-services/docker-entrypoint.d/00-remove-es-watermark.sh
+++ b/support-services/docker-entrypoint.d/00-remove-es-watermark.sh
@@ -10,4 +10,5 @@ curl -s -X PUT "elasticsearch:9200/_cluster/settings" -H 'Content-Type: applicat
   }
 }'
 
+echo ""
 echo "Removed disk space watermark in ElasticSearch."


### PR DESCRIPTION
This PR adds a waiting time in the docker composition to make sure that records show up in GN before triggering the rest. 

Previously we were only waiting for GN to declare that indexing was finished, but it turns out there can be a few seconds between end of the indexation and the records being visible in the catalog. I suspect that was the cause of the failing tests