### PR TITLE
Datahub: Fix display of news org thumbnail

### DIFF
--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
@@ -25,6 +25,7 @@
         <gn-ui-thumbnail
           *ngIf="hasLogo"
           [thumbnailUrl]="record.ownerOrganization?.logoUrl?.toString()"
+          [fit]="'contain'"
         ></gn-ui-thumbnail>
       </div>
       <div class="flex flex-col overflow-hidden items-start">


### PR DESCRIPTION
PR display news org thumbnail as contain, which should give better results here, especially with wide logos:

before:
![news_logo](https://github.com/geonetwork/geonetwork-ui/assets/6329425/2753ff8b-f29b-4b40-8b25-e4e1635cccf1)

after:
![news_logo_contain](https://github.com/geonetwork/geonetwork-ui/assets/6329425/6259e0d9-653f-4848-b9bf-5e849e7a4233)
