### PR TITLE
Map context: fix WMTS layer extent

### DIFF
--- a/libs/feature/map/src/lib/add-layer-from-catalog/add-layer-record-preview/add-layer-record-preview.component.ts
+++ b/libs/feature/map/src/lib/add-layer-from-catalog/add-layer-record-preview/add-layer-record-preview.component.ts
@@ -59,12 +59,7 @@ export class AddLayerRecordPreviewComponent extends RecordPreviewComponent {
         name: link.name,
       })
     } else if (link.accessServiceProtocol === 'wmts') {
-      return this.mapUtils.getWmtsOptionsFromCapabilities(link).pipe(
-        map((options) => ({
-          type: MapContextLayerTypeEnum.WMTS,
-          options: options,
-        }))
-      )
+      return this.mapUtils.getWmtsLayerFromCapabilities(link)
     }
     return throwError(() => 'protocol not supported')
   }

--- a/libs/feature/map/src/lib/map-context/map-context.model.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.model.ts
@@ -25,6 +25,7 @@ export interface MapContextLayerWmsModel {
 export interface MapContextLayerWmtsModel {
   type: 'wmts'
   options: Options
+  extent?: Extent
 }
 
 interface MapContextLayerWfsModel {

--- a/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
@@ -27,6 +27,7 @@ import {
 } from 'ol/interaction'
 import { DatasetServiceDistribution } from '@geonetwork-ui/common/domain/model/record'
 import MapBrowserEvent from 'ol/MapBrowserEvent'
+import { MapContextLayerWmtsModel } from '@geonetwork-ui/feature/map'
 
 jest.mock('ol/proj/proj4', () => {
   const fromEPSGCodeMock = jest.fn()
@@ -444,7 +445,7 @@ describe('MapUtilsService', () => {
       window.fetch = originalFetch
     })
     describe('nominal', () => {
-      let wmtsOptions: Options
+      let wmtsLayer: MapContextLayerWmtsModel
       beforeEach(async () => {
         ;(window as any).fetch = jest.fn(() =>
           Promise.resolve({
@@ -453,8 +454,8 @@ describe('MapUtilsService', () => {
             text: () => Promise.resolve(SAMPLE_WMTS_CAPABILITIES),
           })
         )
-        wmtsOptions = await readFirst(
-          service.getWmtsOptionsFromCapabilities(SAMPLE_WMTS_LINK)
+        wmtsLayer = await readFirst(
+          service.getWmtsLayerFromCapabilities(SAMPLE_WMTS_LINK)
         )
       })
       it('appends query params to the URL', () => {
@@ -463,13 +464,16 @@ describe('MapUtilsService', () => {
         )
       })
       it('returns appropriate WMTS options', () => {
-        expect(wmtsOptions).toMatchObject({
-          format: 'image/jpeg',
-          layer: 'GEOGRAPHICALGRIDSYSTEMS.ETATMAJOR10',
-          matrixSet: 'PM',
-          requestEncoding: 'KVP',
-          style: 'normal',
-          urls: ['https://wxs.ign.fr/cartes/geoportail/wmts?'],
+        expect(wmtsLayer).toMatchObject({
+          type: 'wmts',
+          options: {
+            format: 'image/jpeg',
+            layer: 'GEOGRAPHICALGRIDSYSTEMS.ETATMAJOR10',
+            matrixSet: 'PM',
+            requestEncoding: 'KVP',
+            style: 'normal',
+            urls: ['https://wxs.ign.fr/cartes/geoportail/wmts?'],
+          },
         })
       })
     })
@@ -489,7 +493,7 @@ describe('MapUtilsService', () => {
         )
         try {
           await readFirst(
-            service.getWmtsOptionsFromCapabilities(SAMPLE_WMTS_LINK)
+            service.getWmtsLayerFromCapabilities(SAMPLE_WMTS_LINK)
           )
         } catch (e) {
           error = e
@@ -515,7 +519,7 @@ describe('MapUtilsService', () => {
         )
         try {
           await readFirst(
-            service.getWmtsOptionsFromCapabilities(SAMPLE_WMTS_LINK)
+            service.getWmtsLayerFromCapabilities(SAMPLE_WMTS_LINK)
           )
         } catch (e) {
           error = e

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -23,7 +23,11 @@ import {
 import WMTSCapabilities from 'ol/format/WMTSCapabilities'
 import { from, Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
-import { MapContextLayerModel } from '../map-context/map-context.model'
+import {
+  MapContextLayerModel,
+  MapContextLayerTypeEnum,
+  MapContextLayerWmtsModel,
+} from '../map-context/map-context.model'
 import { MapUtilsWMSService } from './map-utils-wms.service'
 import Collection from 'ol/Collection'
 import MapBrowserEvent from 'ol/MapBrowserEvent'
@@ -163,9 +167,9 @@ export class MapUtilsService {
     )
   }
 
-  getWmtsOptionsFromCapabilities(
+  getWmtsLayerFromCapabilities(
     link: DatasetDistribution
-  ): Observable<Options> {
+  ): Observable<MapContextLayerWmtsModel> {
     const getCapabilitiesUrl = new URL(link.url, window.location.toString())
     getCapabilitiesUrl.searchParams.set('SERVICE', 'WMTS')
     getCapabilitiesUrl.searchParams.set('REQUEST', 'GetCapabilities')
@@ -183,10 +187,14 @@ ${await response.text()}`)
         .then(function (text) {
           try {
             const result = new WMTSCapabilities().read(text)
-            return optionsFromCapabilities(result, {
+            const options = optionsFromCapabilities(result, {
               layer: link.name,
               matrixSet: 'EPSG:3857',
             })
+            return {
+              options,
+              type: MapContextLayerTypeEnum.WMTS as 'wmts',
+            }
           } catch (e: any) {
             throw new Error(`WMTS GetCapabilities parsing failed:
 ${e.stack || e.message || e}`)

--- a/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
@@ -80,9 +80,9 @@ class MapUtilsServiceMock {
       }
     })
   })
-  getWmtsOptionsFromCapabilities = jest.fn(function () {
+  getWmtsLayerFromCapabilities = jest.fn(function () {
     return new Observable((observer) => {
-      observer.next(null)
+      observer.next({ type: 'wmts', options: null })
     })
   })
   prioritizePageScroll = jest.fn()

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -173,12 +173,7 @@ export class MapViewComponent implements OnInit, OnDestroy {
       link.type === 'service' &&
       link.accessServiceProtocol === 'wmts'
     ) {
-      return this.mapUtils.getWmtsOptionsFromCapabilities(link).pipe(
-        map((options) => ({
-          type: MapContextLayerTypeEnum.WMTS,
-          options: options,
-        }))
-      )
+      return this.mapUtils.getWmtsLayerFromCapabilities(link)
     } else if (
       (link.type === 'service' &&
         (link.accessServiceProtocol === 'wfs' ||


### PR DESCRIPTION
A the moment, the extent used to zoom on a WMTS layer is the tilegrid extent, extracted by Openlayers from the `getCapabilities` informations. It's generally the projection world extent.

The idea is to get the accurate extent of the layer from the capabilities itself, and use it if any.

**Sponsored by SwissTopo geocat.ch**