### PR TITLE
Datahub: Fix organisation search with special chars

### DIFF
--- a/libs/common/fixtures/src/lib/organisations.fixture.ts
+++ b/libs/common/fixtures/src/lib/organisations.fixture.ts
@@ -74,4 +74,16 @@ export const ORGANISATIONS_FIXTURE: Organization[] = deepFreeze([
     logoUrl: new URL('https://my-geonetwork.org/logo11.png'),
     recordCount: 2,
   },
+  {
+    name: "Université de l'Ingénierie",
+    description: 'another org for testing',
+    logoUrl: new URL('https://my-geonetwork.org/logo12.png'),
+    recordCount: 2,
+  },
+  {
+    name: 'ARS / Agence régionale de santé',
+    description: 'another org for testing',
+    logoUrl: new URL('https://my-geonetwork.org/logo12.png'),
+    recordCount: 2,
+  },
 ])

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.spec.ts
@@ -121,7 +121,7 @@ describe('OrganisationsComponent', () => {
         expect(orgPreviewComponents[0].organisation.name).toEqual('A Data Org')
       })
       it('should pass 6th organisation (sorted by name-asc) on page to 6th ui preview component', () => {
-        expect(orgPreviewComponents[5].organisation.name).toEqual('é Data Org')
+        expect(orgPreviewComponents[5].organisation.name).toEqual('E Data Org')
       })
     })
     describe('pass params to ui pagination component', () => {
@@ -153,14 +153,14 @@ describe('OrganisationsComponent', () => {
         })
         it('should pass first organisation of second page (sorted by name-asc) to first ui preview component', () => {
           expect(orgPreviewComponents[0].organisation.name).toEqual(
-            'F Data Org'
+            'é Data Org'
           )
         })
         it('should pass last organisation of second page (sorted by name-asc) to last ui preview component', () => {
           expect(
             orgPreviewComponents[orgPreviewComponents.length - 1].organisation
               .name
-          ).toEqual('wizard-org')
+          ).toEqual('J Data Org')
         })
       })
     })
@@ -238,6 +238,16 @@ describe('OrganisationsComponent', () => {
           component.filterBy$.next('E Data Org')
           fixture.detectChanges()
           expect(orgResultComponent.componentInstance.hits).toEqual(2)
+        })
+        it('should ignore special caharacter without space and display 1 match for "l\'Ingénierie"', () => {
+          component.filterBy$.next("l'Ingénierie")
+          fixture.detectChanges()
+          expect(orgResultComponent.componentInstance.hits).toEqual(1)
+        })
+        it('should ignore special caharacter with space and display 1 match for "ARS / Agence"', () => {
+          component.filterBy$.next('ARS / Agence')
+          fixture.detectChanges()
+          expect(orgResultComponent.componentInstance.hits).toEqual(1)
         })
         it('should combine multiple termes with "AND" logic and display 1 match for "a data"', () => {
           component.filterBy$.next('a data')

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.spec.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.spec.ts
@@ -239,12 +239,12 @@ describe('OrganisationsComponent', () => {
           fixture.detectChanges()
           expect(orgResultComponent.componentInstance.hits).toEqual(2)
         })
-        it('should ignore special caharacter without space and display 1 match for "l\'Ingénierie"', () => {
+        it('should ignore special character without space and display 1 match for "l\'Ingénierie"', () => {
           component.filterBy$.next("l'Ingénierie")
           fixture.detectChanges()
           expect(orgResultComponent.componentInstance.hits).toEqual(1)
         })
-        it('should ignore special caharacter with space and display 1 match for "ARS / Agence"', () => {
+        it('should ignore special character with space and display 1 match for "ARS / Agence"', () => {
           component.filterBy$.next('ARS / Agence')
           fixture.detectChanges()
           expect(orgResultComponent.componentInstance.hits).toEqual(1)

--- a/libs/feature/catalog/src/lib/organisations/organisations.component.ts
+++ b/libs/feature/catalog/src/lib/organisations/organisations.component.ts
@@ -85,7 +85,7 @@ export class OrganisationsComponent {
     if (!filterBy) return organisations
     const filterRegex = new RegExp(
       this.normalizeString(filterBy) //ignore accents and case
-        .replace(/[^a-z0-9\s]/g, '') //ignore special characters
+        .replace(/[^a-z0-9\s]/g, ' ') //ignore special characters (also without spaces like l')
         .replace(/\s(?=.)/g, '.*') //replace whitespaces by "AND" separator
         .replace(/\s/g, ''), //remove potential whitespaces left
       'i'

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.html
@@ -53,7 +53,7 @@
       #choiceInputs
       type="button"
       *ngFor="let choice of choices"
-      [title]="choice.label"
+      [title]="choice.label | translate"
       class="flex px-5 py-1 w-full text-start cursor-pointer transition-colors"
       [ngClass]="
         isSelected(choice)


### PR DESCRIPTION
PR handles special characters without spacing in organisation search (like in `l'éducation`)