### PR TITLE
feat(ui): Adjust linkify directive

### DIFF
--- a/libs/ui/elements/src/lib/metadata-info/linkify.directive.stories.ts
+++ b/libs/ui/elements/src/lib/metadata-info/linkify.directive.stories.ts
@@ -1,9 +1,4 @@
-import {
-  componentWrapperDecorator,
-  Meta,
-  moduleMetadata,
-  StoryObj,
-} from '@storybook/angular'
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular'
 import { GnUiLinkifyDirective } from './linkify.directive'
 
 export default {
@@ -17,13 +12,19 @@ export default {
 
 export const Primary: StoryObj<any> = {
   args: {
-    htmlContent: `Région Hauts-de-France, Dreal, IGN BD Topo<br>
-
-    Les données produites s'appuient sur le modèle CNIG de juin 2018 relatif aux SCoT : http://cnig.gouv.fr/wp-content/uploads/2019/04/190315_Standard_CNIG_SCOT.pdf<br>
-    
-    La structure a été modifiée au 03/2023 pour prendre en compte les évolutions du modèle CNIG du 10/06/2021 :<br>
-    http://cnig.gouv.fr/IMG/pdf/210615_standard_cnig_nouveauscot.pdf<br>
-    (il coexiste donc dans le modèle des champs liés aux deux modèles, par exemple sur les PADD pour les "anciens" SCoT, ou encore sur les PAS ou les DAAC pour les "nouveaux" SCoT)`,
+    htmlContent: `<p class='my-2'>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin purus elit, tincidunt et gravida sit amet, mattis eget orci. Suspendisse dignissim magna sed neque rutrum lobortis. Aenean vitae quam sapien. Phasellus eleifend tortor ac imperdiet tristique. Curabitur aliquet mauris tristique, iaculis est sit amet, pulvinar ipsum. Maecenas lacinia varius felis sit amet tempor. Curabitur pulvinar ipsum eros, quis accumsan odio hendrerit sit amet.</p>
+This is a link without markup: http://cnig.gouv.fr/wp-content/uploads/2019/04/190315_Standard_CNIG_SCOT.pdf<br>
+Another link without markup:<br>
+http://cnig.gouv.fr/IMG/pdf/210615_standard_cnig_nouveauscot.pdf<br>
+<p class='my-2'>This is a link with markup: <a href="http://foo.com/(something)?after=before">This is the display text</a></p>
+This is a list containing links:
+<ul class='list-disc my-2 ml-3'>
+  <li>http://cnig.gouv.fr/IMG/pdf/210615_standard_cnig_nouveauscot.pdf</li>
+  <li><a href="http://foo.com/(something)?after=before">This is the display text</a></li>
+  <li><a href="http://foo.com/(something)?after=before" style='font-weight: bolder;'>
+    <span>Same link with style and <code>span</code> element inside</span>
+  </a></li>
+</ul>`,
   },
   argTypes: {
     htmlContent: {
@@ -33,8 +34,7 @@ export const Primary: StoryObj<any> = {
   render: (args) => ({
     props: args,
     template: `
-    <div
-        gnUiLinkify>
+    <div gnUiLinkify>
       ${args.htmlContent}
     </div>`,
   }),

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -11,6 +11,7 @@
         <p
           class="whitespace-pre-line break-words sm:mb-4 sm:pr-16"
           [innerHTML]="metadata.abstract"
+          gnUiLinkify
         ></p>
         <ng-container *ngIf="metadata.keywords?.length">
           <p class="mb-3 font-medium text-primary text-sm" translate>
@@ -100,11 +101,7 @@
     <p class="text-sm" translate>record.metadata.sheet</p>
     <p class="text-primary font-medium mt-1" translate>
       <a [href]="metadata.landingPage" target="_blank">
-        <mat-icon
-          class="material-symbols-outlined inline-block align-bottom pt-1.5 text-xs text-black !w-[20px]"
-          >open_in_new</mat-icon
-        >
-        <span class="break-all">{{ metadata.landingPage }}</span>
+        <span class="break-all" gnUiLinkify>{{ metadata.landingPage }}</span>
       </a>
     </p>
   </div>


### PR DESCRIPTION
Adjust linkify directive to be able to process HTML elements and Text.
Will be used additionally in the abstract and landing page.

Replaces this PR https://github.com/geonetwork/geonetwork-ui/pull/588

/dataset/a8b5e6c0-c21d-4c32-b8f9-10830215890a (landing page link):
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/27c3ef5f-8d08-4513-996b-d8a08b4ff8e0)

/dataset/n_tri_lill_inondable_s_059 (link in abstract with `<strong>`-tag):
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/ba1cbbe6-a9f9-4a82-910d-c76edc5ec4dd)

/dataset/ee965118-2416-4d48-b07e-bbc696f002c2 (multiple links in abstract):
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/3637ffa7-8919-4687-972e-24d809b01188)
