### PR TITLE
[Storybooj][Fix] : Add accessServiceProtocol to link fixture

### DIFF
--- a/libs/common/fixtures/src/lib/link.fixtures.ts
+++ b/libs/common/fixtures/src/lib/link.fixtures.ts
@@ -157,5 +157,6 @@ export const LINK_FIXTURES: Record<string, DatasetDistribution> = deepFreeze({
     url: new URL(
       'https://mel.integration.apps.gs-fr-prod.camptocamp.com/data/ogcapi/collections/comptages_velo/items?'
     ),
+    accessServiceProtocol: 'ogcFeatures',
   },
 })


### PR DESCRIPTION
Adding missing property for `ogcApiFormat` element in link fixtures.