### PR TITLE
[DH] Metadata-Quality widget update

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -158,7 +158,7 @@ jobs:
         run: cd tools && docker build . -f pipelines/Dockerfile -t geonetwork/geonetwork-ui-tools-pipelines:latest
 
       - name: Build the backend
-        run: sudo docker-compose -f support-services/docker-compose.yml up -d init tools-pipelines
+        run: sudo docker-compose -f support-services/docker-compose.yml up -d init
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -154,8 +154,11 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
+      - name: Create pipeline docker image
+        run: cd tools && docker build . -f pipelines/Dockerfile -t geonetwork/geonetwork-ui-tools-pipelines:latest
+
       - name: Build the backend
-        run: sudo docker-compose -f support-services/docker-compose.yml up -d init
+        run: sudo docker-compose -f support-services/docker-compose.yml up -d init tools-pipelines
 
       - name: Install dependencies
         run: |

--- a/apps/datahub-e2e/src/e2e/datasets.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasets.cy.ts
@@ -470,43 +470,24 @@ describe('datasets', () => {
 
     describe('metadata quality widget enabled', () => {
       beforeEach(() => {
-        // this will enable spatial filtering
+        // this will enable metadata quality widget
         cy.intercept('GET', '/assets/configuration/default.toml', {
           fixture: 'config-with-metadata-quality.toml',
         })
         cy.visit('/search')
       })
-      it('should not display widget', () => {
-        cy.get('@results')
-          .eq(2)
-          .get('gn-ui-metadata-quality')
-          .should('not.exist')
-      })
-
-      it('should reindex records', () => {
-        cy.login('admin', 'admin', false)
-        cy.visit(
-          `http://localhost:8080/geonetwork/srv/eng/admin.console#/tools`
-        )
-        cy.intercept({
-          method: 'PUT',
-          url: 'http://localhost:8080/geonetwork/srv/api/site/index?reset=false&asynchronous=true',
-        }).as('indexingRecordsXHR')
-        cy.get('[class=panel-body]').find('button').first().click()
-        cy.wait('@indexingRecordsXHR')
-      })
 
       it('should display quality widget', () => {
-        cy.visit('/search')
+        cy.get('@sortBy').selectDropdownOption('desc,createDate')
         cy.get('gn-ui-progress-bar')
-          .eq(2)
+          .eq(0)
           .should('have.attr', 'ng-reflect-value', 87)
       })
 
       it('should display results sorted by quality score', () => {
         cy.get('@sortBy').selectDropdownOption('desc,qualityScore')
         cy.get('gn-ui-progress-bar')
-          .eq(2)
+          .eq(0)
           .should('have.attr', 'ng-reflect-value', 100)
       })
     })

--- a/apps/datahub-e2e/src/fixtures/config-with-metadata-quality.toml
+++ b/apps/datahub-e2e/src/fixtures/config-with-metadata-quality.toml
@@ -1,0 +1,12 @@
+[global]
+geonetwork4_api_url = "/geonetwork/srv/api"
+proxy_path = ""
+
+[theme]
+primary_color = "#c82850"
+secondary_color = "#001638"
+main_color = "#212029" # All-purpose text color
+background_color = "#fdfbff"
+
+[metadata-quality]
+enabled = true

--- a/apps/datahub/src/app/home/search/search-page/search-page.component.html
+++ b/apps/datahub/src/app/home/search/search-page/search-page.component.html
@@ -1,6 +1,6 @@
 <div class="container-lg mx-auto mt-8">
   <datahub-search-filters
-    [isQualitySortable]="isQualitySortable"
+    [isQualitySortable]="metadataQualityDisplay"
   ></datahub-search-filters>
   <div class="mt-6 rounded-lg text-gray-800 p-4 bg-slate-100">
     <gn-ui-results-hits></gn-ui-results-hits>

--- a/apps/datahub/src/app/home/search/search-page/search-page.component.ts
+++ b/apps/datahub/src/app/home/search/search-page/search-page.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core'
 import { RouterFacade } from '@geonetwork-ui/feature/router'
 import { SearchFacade } from '@geonetwork-ui/feature/search'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
-import { MetadataQualityDisplay } from '@geonetwork-ui/ui/elements'
 import {
   MetadataQualityConfig,
   getMetadataQualityConfig,
@@ -15,12 +14,11 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SearchPageComponent implements OnInit {
-  isQualitySortable = false
-  metadataQualityDisplay = {} as MetadataQualityDisplay
+  metadataQualityDisplay: boolean
 
   constructor(
     private searchRouter: RouterFacade,
-    private searchFacade: SearchFacade
+    public searchFacade: SearchFacade
   ) {}
 
   ngOnInit() {
@@ -28,18 +26,7 @@ export class SearchPageComponent implements OnInit {
 
     const cfg: MetadataQualityConfig =
       getMetadataQualityConfig() || ({} as MetadataQualityConfig)
-    this.isQualitySortable = cfg.SORTABLE === true
-    this.metadataQualityDisplay = {
-      widget: cfg.ENABLED && cfg.DISPLAY_WIDGET_IN_SEARCH !== false,
-      title: cfg.DISPLAY_TITLE,
-      description: cfg.DISPLAY_DESCRIPTION,
-      contact: cfg.DISPLAY_CONTACT,
-      keywords: cfg.DISPLAY_KEYWORDS,
-      legalConstraints: cfg.DISPLAY_LEGAL_CONSTRAINTS,
-      topic: cfg.DISPLAY_TOPIC,
-      updateFrequency: cfg.DISPLAY_UPDATE_FREQUENCY,
-      organisation: cfg.DISPLAY_ORGANISATION,
-    }
+    this.metadataQualityDisplay = cfg.ENABLED
   }
 
   onMetadataSelection(metadata: CatalogRecord): void {

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
@@ -24,13 +24,12 @@
         </gn-ui-metadata-info>
       </div>
       <div>
-        <div *ngIf="hasMetadataQualityWidget">
+        <div *ngIf="metadataQualityDisplay">
           <p class="text text-gray-700 text-xs mb-3 uppercase" translate>
             record.metadata.quality
           </p>
           <gn-ui-metadata-quality
             [metadata]="facade.metadata$ | async"
-            [metadataQualityDisplay]="metadataQualityDisplay"
           ></gn-ui-metadata-quality>
         </div>
         <gn-ui-metadata-contact

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { SourcesService } from '@geonetwork-ui/feature/catalog'
 import { SearchService } from '@geonetwork-ui/feature/search'
-import { ErrorType, MetadataQualityDisplay } from '@geonetwork-ui/ui/elements'
+import { ErrorType } from '@geonetwork-ui/ui/elements'
 import { BehaviorSubject, combineLatest } from 'rxjs'
 import { filter, map, mergeMap } from 'rxjs/operators'
 import { OrganizationsServiceInterface } from '@geonetwork-ui/common/domain/organizations.service.interface'
@@ -15,7 +15,7 @@ import { MdViewFacade } from '@geonetwork-ui/feature/record'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RecordMetadataComponent {
-  @Input() metadataQualityDisplay: MetadataQualityDisplay
+  @Input() metadataQualityDisplay: boolean
 
   displayMap$ = combineLatest([
     this.facade.mapApiLinks$,
@@ -76,9 +76,5 @@ export class RecordMetadataComponent {
     this.orgsService
       .getFiltersForOrgs([org])
       .subscribe((filters) => this.searchService.updateFilters(filters))
-  }
-
-  get hasMetadataQualityWidget() {
-    return this.metadataQualityDisplay?.widget === true
   }
 }

--- a/apps/datahub/src/app/record/record-page/record-page.component.ts
+++ b/apps/datahub/src/app/record/record-page/record-page.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnDestroy } from '@angular/core'
 import { MdViewFacade } from '@geonetwork-ui/feature/record'
-import { MetadataQualityDisplay } from '@geonetwork-ui/ui/elements'
 import {
   MetadataQualityConfig,
   getMetadataQualityConfig,
@@ -13,23 +12,13 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RecordPageComponent implements OnDestroy {
-  metadataQualityDisplay: MetadataQualityDisplay = {} as MetadataQualityDisplay
+  metadataQualityDisplay: boolean
 
   constructor(public mdViewFacade: MdViewFacade) {
     document.documentElement.classList.add('record-page-active')
     const cfg: MetadataQualityConfig =
       getMetadataQualityConfig() || ({} as MetadataQualityConfig)
-    this.metadataQualityDisplay = {
-      widget: cfg.ENABLED && cfg.DISPLAY_WIDGET_IN_DETAIL !== false,
-      title: cfg.DISPLAY_TITLE,
-      description: cfg.DISPLAY_DESCRIPTION,
-      contact: cfg.DISPLAY_CONTACT,
-      keywords: cfg.DISPLAY_KEYWORDS,
-      legalConstraints: cfg.DISPLAY_LEGAL_CONSTRAINTS,
-      topic: cfg.DISPLAY_TOPIC,
-      updateFrequency: cfg.DISPLAY_UPDATE_FREQUENCY,
-      organisation: cfg.DISPLAY_ORGANISATION,
-    }
+    this.metadataQualityDisplay = cfg.ENABLED
   }
   ngOnDestroy() {
     document.documentElement.classList.remove('record-page-active')

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -109,27 +109,6 @@ background_color = "#fdfbff"
 # enabled = true
 # If u want to use metadata quality widget this configuration is required
 
-# if you add an indexed field to calculate the qualityScore, the datahub search allow you to sort on this field with this parameter
-# sortable = true
-
-# by default the widget appears in 2 locations in the search list and in the detail page
-# allow you to hide the widget in detail
-# display_widget_in_detail = false
-# allow you to hide the widget in search list
-# display_widget_in_search = false
-# If you want see the widget in the two locations, don't fill theses configurations
-
-# By default the window popup all fields to view if they are filled or not but you can hide some
-# display_title = false
-# display_description = false
-# display_topic = false
-# display_keywords = false
-# display_legal_constraints = false
-# display_contact = false
-# display_update_frequency = false
-# display_organisation = false
-# If you want see all fields, don't fill theses configurations
-
 ### MAP SETTINGS
 
 # The map section allows to customize how maps are configured.

--- a/libs/feature/search/src/lib/results-list/results-list.container.component.html
+++ b/libs/feature/search/src/lib/results-list/results-list.container.component.html
@@ -2,12 +2,13 @@
   <gn-ui-results-list
     [records]="facade.results$ | async"
     [layoutConfig]="layoutConfig$ | async"
-    [metadataQualityDisplay]="metadataQualityDisplay"
+    [metadataQualityDisplay]="
+      metadataQualityDisplay && (pipelineForQualityScoreActivated | async)
+    "
     [favoriteTemplate]="favoriteToggle"
     [recordUrlGetter]="recordUrlGetter"
     (mdSelect)="onMetadataSelection($event)"
   ></gn-ui-results-list>
-
   <ng-container
     *ngIf="
       (facade.isLoading$ | async) === false &&

--- a/libs/feature/search/src/lib/results-list/results-list.container.component.ts
+++ b/libs/feature/search/src/lib/results-list/results-list.container.component.ts
@@ -38,17 +38,7 @@ export class ResultsListContainerComponent implements OnInit {
   error$: Observable<SearchError>
   errorCode$: Observable<number>
   errorMessage$: Observable<string>
-  pipelineForQualityScoreActivated: Observable<boolean> =
-    this.facade.results$.pipe(
-      tap((records) => {
-        if (records?.length > 0 && !records[0].extras?.qualityScore) {
-          console.warn(
-            'It looks like the metadata quality indicator is not available on these records, probably due to a missing indexing pipeline'
-          )
-        }
-      }),
-      map((records) => !!records[0]?.extras.qualityScore)
-    )
+  pipelineForQualityScoreActivated: Observable<boolean>
 
   errorTypes = ErrorType
   recordUrlGetter = this.getRecordUrl.bind(this)
@@ -70,6 +60,17 @@ export class ResultsListContainerComponent implements OnInit {
     if (this.layout) {
       this.facade.setResultsLayout(this.layout)
     }
+
+    this.pipelineForQualityScoreActivated = this.facade.results$.pipe(
+      tap((records) => {
+        if (records?.length > 0 && !records[0].extras?.qualityScore) {
+          console.warn(
+            'It looks like the metadata quality indicator is not available on these records, probably due to a missing indexing pipeline'
+          )
+        }
+      }),
+      map((records) => !!records[0]?.extras.qualityScore)
+    )
 
     this.error$ = this.facade.error$
     this.errorCode$ = this.error$.pipe(

--- a/libs/feature/search/src/lib/results-list/results-list.container.component.ts
+++ b/libs/feature/search/src/lib/results-list/results-list.container.component.ts
@@ -7,11 +7,11 @@ import {
   Optional,
   Output,
 } from '@angular/core'
-import { Observable } from 'rxjs'
+import { Observable, tap } from 'rxjs'
 import { filter, map } from 'rxjs/operators'
 import { SearchFacade } from '../state/search.facade'
 import { SearchError } from '../state/reducer'
-import { ErrorType, MetadataQualityDisplay } from '@geonetwork-ui/ui/elements'
+import { ErrorType } from '@geonetwork-ui/ui/elements'
 import {
   RESULTS_LAYOUT_CONFIG,
   ResultsLayoutConfigItem,
@@ -28,7 +28,7 @@ export type ResultsListShowMoreStrategy = 'auto' | 'button' | 'none'
   styleUrls: ['./results-list.container.component.css'],
 })
 export class ResultsListContainerComponent implements OnInit {
-  @Input() metadataQualityDisplay: MetadataQualityDisplay
+  @Input() metadataQualityDisplay: boolean
   @Input() layout: string
   @Input() showMore: ResultsListShowMoreStrategy = 'auto'
   @Output() mdSelect = new EventEmitter<CatalogRecord>()
@@ -38,6 +38,17 @@ export class ResultsListContainerComponent implements OnInit {
   error$: Observable<SearchError>
   errorCode$: Observable<number>
   errorMessage$: Observable<string>
+  pipelineForQualityScoreActivated: Observable<boolean> =
+    this.facade.results$.pipe(
+      tap((records) => {
+        if (records?.length > 0 && !records[0].extras?.qualityScore) {
+          console.warn(
+            'It looks like the metadata quality indicator is not available on these records, probably due to a missing indexing pipeline'
+          )
+        }
+      }),
+      map((records) => !!records[0]?.extras.qualityScore)
+    )
 
   errorTypes = ErrorType
   recordUrlGetter = this.getRecordUrl.bind(this)

--- a/libs/ui/elements/src/lib/metadata-quality-item/metadata-quality-item.component.html
+++ b/libs/ui/elements/src/lib/metadata-quality-item/metadata-quality-item.component.html
@@ -1,4 +1,4 @@
 <div class="ml-4 flex flex-row">
-  <mat-icon>{{ icon }}</mat-icon>
+  <mat-icon class="material-symbols-outlined">{{ icon }}</mat-icon>
   <p class="ml-2 text">{{ labelKey | translate }}</p>
 </div>

--- a/libs/ui/elements/src/lib/metadata-quality-item/metadata-quality-item.component.spec.ts
+++ b/libs/ui/elements/src/lib/metadata-quality-item/metadata-quality-item.component.spec.ts
@@ -53,7 +53,7 @@ describe('MetadataQualityInfoComponent', () => {
     fixture.detectChanges()
 
     const iconElement = fixture.debugElement.query(By.css('mat-icon'))
-    expect(iconElement.nativeElement.innerHTML).toBe('warning_amber')
+    expect(iconElement.nativeElement.innerHTML).toBe('warning')
 
     const textElement = fixture.debugElement.query(By.css('.text'))
     expect(textElement.nativeElement.innerHTML).toBe(
@@ -81,7 +81,7 @@ describe('MetadataQualityInfoComponent', () => {
     fixture.detectChanges()
 
     const iconElement = fixture.debugElement.query(By.css('mat-icon'))
-    expect(iconElement.nativeElement.innerHTML).toBe('warning_amber')
+    expect(iconElement.nativeElement.innerHTML).toBe('warning')
 
     const textElement = fixture.debugElement.query(By.css('.text'))
     expect(textElement.nativeElement.innerHTML).toBe(

--- a/libs/ui/elements/src/lib/metadata-quality-item/metadata-quality-item.component.ts
+++ b/libs/ui/elements/src/lib/metadata-quality-item/metadata-quality-item.component.ts
@@ -33,7 +33,7 @@ export class MetadataQualityItemComponent implements MetadataQualityItem {
   @Input() value: boolean
 
   get icon() {
-    return this.value ? 'check' : 'warning_amber'
+    return this.value ? 'check' : 'warning'
   }
 
   get labelKey() {

--- a/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.html
+++ b/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.html
@@ -1,5 +1,5 @@
 <div
-  *ngIf="metadataQualityDisplay?.widget === true"
+  *ngIf="metadataQualityDisplay"
   class="mb-6 metadata-quality"
   (mouseenter)="showMenu()"
   (mouseleave)="hideMenu()"

--- a/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.ts
+++ b/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.ts
@@ -8,18 +8,6 @@ import {
 import { MetadataQualityItem } from '../metadata-quality-item/metadata-quality-item.component'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
 
-export interface MetadataQualityDisplay {
-  widget: boolean
-  title: boolean
-  description: boolean
-  topic: boolean
-  keywords: boolean
-  legalConstraints: boolean
-  organisation: boolean
-  contact: boolean
-  updateFrequency: boolean
-}
-
 @Component({
   selector: 'gn-ui-metadata-quality',
   templateUrl: './metadata-quality.component.html',
@@ -29,7 +17,7 @@ export interface MetadataQualityDisplay {
 export class MetadataQualityComponent implements OnChanges {
   @Input() metadata: Partial<CatalogRecord>
   @Input() smaller = false
-  @Input() metadataQualityDisplay: MetadataQualityDisplay
+  @Input() metadataQualityDisplay: boolean
 
   items: MetadataQualityItem[] = []
 

--- a/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.html
+++ b/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.html
@@ -35,9 +35,7 @@
     <div
       class="text-primary opacity-45 uppercase col-start-1 col-span-2 row-start-2 sm:truncate sm:row-start-3 sm:col-span-1"
       data-cy="recordOrg"
-      [class]="
-        hasMetadataQualityWidget ? 'limit-organisation-with-quality' : ''
-      "
+      [class]="metadataQualityDisplay ? 'limit-organisation-with-quality' : ''"
     >
       {{ organization?.name }}
     </div>
@@ -56,7 +54,7 @@
       >
     </div>
     <div
-      *ngIf="hasMetadataQualityWidget"
+      *ngIf="metadataQualityDisplay"
       class="col-start-2 row-start-4 sm:row-start-3 absolute right-[4em] sm:right-[5em]"
     >
       <gn-ui-metadata-quality

--- a/libs/ui/search/src/lib/record-preview/record-preview.component.ts
+++ b/libs/ui/search/src/lib/record-preview/record-preview.component.ts
@@ -13,7 +13,6 @@ import {
   stripHtml,
   removeWhitespace,
 } from '@geonetwork-ui/util/shared'
-import { MetadataQualityDisplay } from '@geonetwork-ui/ui/elements'
 import { fromEvent, Subscription } from 'rxjs'
 import {
   CatalogRecord,
@@ -31,7 +30,7 @@ export class RecordPreviewComponent implements OnInit, OnDestroy {
   @Input() linkTarget = '_blank'
   @Input() favoriteTemplate: TemplateRef<{ $implicit: CatalogRecord }>
   @Input() linkHref: string = null
-  @Input() metadataQualityDisplay: MetadataQualityDisplay
+  @Input() metadataQualityDisplay: boolean
   @Output() mdSelect = new EventEmitter<CatalogRecord>()
   subscription = new Subscription()
   abstract: string
@@ -50,9 +49,6 @@ export class RecordPreviewComponent implements OnInit, OnDestroy {
   }
   get organization(): Organization {
     return this.record.ownerOrganization
-  }
-  get hasMetadataQualityWidget(): boolean {
-    return this.metadataQualityDisplay?.widget === true
   }
 
   constructor(protected elementRef: ElementRef) {}

--- a/libs/ui/search/src/lib/results-list-item/results-list-item.component.ts
+++ b/libs/ui/search/src/lib/results-list-item/results-list-item.component.ts
@@ -14,7 +14,6 @@ import {
 import { RecordPreviewComponent } from '../record-preview/record-preview.component'
 import { ResultsLayoutConfigItem } from '../results-list/results-layout.config'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
-import { MetadataQualityDisplay } from '@geonetwork-ui/ui/elements'
 
 @Component({
   selector: 'gn-ui-results-list-item',
@@ -26,7 +25,7 @@ export class ResultsListItemComponent implements OnChanges, AfterViewInit {
   @Input() layoutConfig: ResultsLayoutConfigItem
   @Input() record: CatalogRecord
   @Input() favoriteTemplate: TemplateRef<{ $implicit: CatalogRecord }>
-  @Input() metadataQualityDisplay: MetadataQualityDisplay
+  @Input() metadataQualityDisplay: boolean
   @Input() linkHref: string
   @Output() mdSelect = new EventEmitter<CatalogRecord>()
   initialized = false

--- a/libs/ui/search/src/lib/results-list/results-list.component.ts
+++ b/libs/ui/search/src/lib/results-list/results-list.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   EventEmitter,
   Input,
+  OnInit,
   Output,
   TemplateRef,
 } from '@angular/core'
@@ -11,7 +12,6 @@ import {
   ResultsLayoutConfigItem,
 } from './results-layout.config'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
-import { MetadataQualityDisplay } from '@geonetwork-ui/ui/elements'
 
 @Component({
   selector: 'gn-ui-results-list',
@@ -25,6 +25,6 @@ export class ResultsListComponent {
     DEFAULT_RESULTS_LAYOUT_CONFIG['CARD']
   @Input() favoriteTemplate: TemplateRef<{ $implicit: CatalogRecord }>
   @Input() recordUrlGetter: (record: CatalogRecord) => string
-  @Input() metadataQualityDisplay: MetadataQualityDisplay
+  @Input() metadataQualityDisplay: boolean
   @Output() mdSelect = new EventEmitter<CatalogRecord>()
 }

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -11,8 +11,8 @@ import {
   GlobalConfig,
   LayerConfig,
   MapConfig,
-  SearchConfig,
   MetadataQualityConfig,
+  SearchConfig,
   ThemeConfig,
 } from './model'
 import { TranslateCompiler, TranslateLoader } from '@ngx-translate/core'
@@ -245,20 +245,7 @@ export function loadAppConfig() {
         parsed,
         'metadata-quality',
         [],
-        [
-          'enabled',
-          'sortable',
-          'display_widget_in_detail',
-          'display_widget_in_search',
-          'display_title',
-          'display_description',
-          'display_topic',
-          'display_keywords',
-          'display_legal_constraints',
-          'display_contact',
-          'display_update_frequency',
-          'display_organisation',
-        ],
+        ['enabled'],
         warnings,
         errors
       )
@@ -268,22 +255,6 @@ export function loadAppConfig() {
           : ({
               ENABLED: parsedMetadataQualitySection.enabled,
               SORTABLE: parsedMetadataQualitySection.sortable,
-              DISPLAY_WIDGET_IN_DETAIL:
-                parsedMetadataQualitySection.display_widget_in_detail,
-              DISPLAY_WIDGET_IN_SEARCH:
-                parsedMetadataQualitySection.display_widget_in_search,
-              DISPLAY_TITLE: parsedMetadataQualitySection.display_title,
-              DISPLAY_DESCRIPTION:
-                parsedMetadataQualitySection.display_description,
-              DISPLAY_TOPIC: parsedMetadataQualitySection.display_topic,
-              DISPLAY_KEYWORDS: parsedMetadataQualitySection.display_keywords,
-              DISPLAY_LEGAL_CONSTRAINTS:
-                parsedMetadataQualitySection.display_legal_constraints,
-              DISPLAY_CONTACT: parsedMetadataQualitySection.display_contact,
-              DISPLAY_UPDATE_FREQUENCY:
-                parsedMetadataQualitySection.display_update_frequency,
-              DISPLAY_ORGANISATION:
-                parsedMetadataQualitySection.display_organisation,
             } as MetadataQualityConfig)
 
       customTranslations = parseTranslationsConfigSection(

--- a/libs/util/app-config/src/lib/model.ts
+++ b/libs/util/app-config/src/lib/model.ts
@@ -54,17 +54,6 @@ export interface SearchConfig {
 
 export interface MetadataQualityConfig {
   ENABLED: boolean
-  SORTABLE: boolean
-  DISPLAY_WIDGET_IN_DETAIL: boolean
-  DISPLAY_WIDGET_IN_SEARCH: boolean
-  DISPLAY_TITLE: boolean
-  DISPLAY_DESCRIPTION: boolean
-  DISPLAY_TOPIC: boolean
-  DISPLAY_KEYWORDS: boolean
-  DISPLAY_LEGAL_CONSTRAINTS: boolean
-  DISPLAY_CONTACT: boolean
-  DISPLAY_UPDATE_FREQUENCY: boolean
-  DISPLAY_ORGANISATION: boolean
 }
 
 export type CustomTranslations = { [translationKey: string]: string }

--- a/support-services/docker-compose.yml
+++ b/support-services/docker-compose.yml
@@ -99,6 +99,17 @@ services:
     ports:
       - '8080:8080'
 
+  init-pipeline:
+    image: geonetwork/geonetwork-ui-tools-pipelines:latest
+    environment:
+      ES_HOST: http://elasticsearch:9200
+      RECORDS_INDEX: gn-records
+    depends_on:
+      geonetwork:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+
   init:
     image: alpine/curl
     # only run init if volumes were cleared
@@ -110,6 +121,8 @@ services:
         condition: service_healthy
       elasticsearch:
         condition: service_healthy
+      init-pipeline:
+        condition: service_completed_successfully
     healthcheck:
       test: ['CMD-SHELL', "sh -c '[ -f /done ]'"]
       interval: 5s
@@ -140,12 +153,3 @@ services:
         condition: service_healthy
     ports:
       - '8081:8080'
-
-  tools-pipelines:
-    image: geonetwork/geonetwork-ui-tools-pipelines:latest
-    environment:
-      ES_HOST: http://elasticsearch:9200
-      RECORDS_INDEX: gn-records
-    depends_on:
-      init:
-        condition: service_completed_successfully

--- a/support-services/docker-compose.yml
+++ b/support-services/docker-compose.yml
@@ -140,3 +140,12 @@ services:
         condition: service_healthy
     ports:
       - '8081:8080'
+
+  tools-pipelines:
+    image: geonetwork/geonetwork-ui-tools-pipelines:latest
+    environment:
+      ES_HOST: http://elasticsearch:9200
+      RECORDS_INDEX: gn-records
+    depends_on:
+      init:
+        condition: service_completed_successfully

--- a/support-services/docker-entrypoint.d/02-set-default-pipeline.sh
+++ b/support-services/docker-entrypoint.d/02-set-default-pipeline.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+indexConfigDir=/mnt/geonetwork_data/config/index/
+
+echo "Setting default pipeline to geonetwork-ui ..."
+jq '.settings.index.default_pipeline = "geonetwork-ui"' ${indexConfigDir}records.json > /tmp.json
+mv /tmp.json ${indexConfigDir}records.json

--- a/tools/README.md
+++ b/tools/README.md
@@ -18,7 +18,7 @@ offering greater control over the values returned by ElasticSearch and giving an
 A CLI is provided to let you register or clear GeoNetwork-UI-related pipelines on an ES instance. For example:
 
 ```shell
-node pipelines/regiser-es-pipelines.js register --host=http://localhost:9200 --records-index=gn-records
+node pipelines/register-es-pipelines.js register --host=http://localhost:9200 --records-index=gn-records
 ```
 
 A docker image can also be built to register the pipelines automatically in a docker environment:


### PR DESCRIPTION
# Metadata Quality widget simplifier

Removes config parameters for Metadata Quality widget.

## Changes 

- Removes `SORTABLE`,`DISPLAY_WIDGET_IN_DETAIL`,`DISPLAY_WIDGET_IN_SEARCH`,`DISPLAY_TITLE`,`DISPLAY_DESCRIPTION`,`DISPLAY_TOPIC`,`DISPLAY_KEYWORDS`,`DISPLAY_LEGAL_CONSTRAINTS`,`DISPLAY_CONTACT`,`DISPLAY_UPDATE_FREQUENCY`,`DISPLAY_ORGANISATION` from Toml configuration file
- Hide widget if pipeline is not installed and display warning in console
- Update icons

## TODO

- [ ] Documentation