### PR TITLE
add ui element markdown-parser and markdown support on metadata…

### DIFF
--- a/apps/map-viewer/project.json
+++ b/apps/map-viewer/project.json
@@ -42,7 +42,7 @@
             {
               "type": "anyComponentStyle",
               "maximumWarning": "2kb",
-              "maximumError": "4kb"
+              "maximumError": "5kb"
             }
           ],
           "fileReplacements": [

--- a/apps/metadata-editor/project.json
+++ b/apps/metadata-editor/project.json
@@ -52,7 +52,7 @@
             {
               "type": "anyComponentStyle",
               "maximumWarning": "2kb",
-              "maximumError": "4kb"
+              "maximumError": "5kb"
             }
           ],
           "outputHashing": "all"

--- a/apps/search/project.json
+++ b/apps/search/project.json
@@ -33,7 +33,7 @@
             {
               "type": "anyComponentStyle",
               "maximumWarning": "2kb",
-              "maximumError": "4kb"
+              "maximumError": "5kb"
             }
           ],
           "fileReplacements": [

--- a/libs/ui/elements/src/index.ts
+++ b/libs/ui/elements/src/index.ts
@@ -19,3 +19,5 @@ export * from './lib/related-record-card/related-record-card.component'
 export * from './lib/search-results-error/search-results-error.component'
 export * from './lib/user-preview/user-preview.component'
 export * from './lib/record-api-form/record-api-form.component'
+
+export * from './lib/markdown-parser/markdown-parser.component'

--- a/libs/ui/elements/src/index.ts
+++ b/libs/ui/elements/src/index.ts
@@ -19,5 +19,4 @@ export * from './lib/related-record-card/related-record-card.component'
 export * from './lib/search-results-error/search-results-error.component'
 export * from './lib/user-preview/user-preview.component'
 export * from './lib/record-api-form/record-api-form.component'
-
 export * from './lib/markdown-parser/markdown-parser.component'

--- a/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.css
+++ b/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.css
@@ -1,0 +1,271 @@
+/** Body **/
+.markdown-body {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0px 0px 1.5rem 0px;
+  color: var(--color-main);
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+/** Emphasis **/
+
+.markdown-body strong {
+  font-weight: 600;
+  color: var(--color-secondary-darker);
+}
+
+/** Headings **/
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.markdown-body h1 {
+  margin: 0.67em 0;
+  font-weight: 600;
+  padding-bottom: 0.3em;
+  font-size: 2em;
+  color: var(--color-primary);
+}
+
+.markdown-body h2 {
+  font-weight: 600;
+  padding-bottom: 0.3em;
+  font-size: 1.5em;
+  color: var(--color-secondary);
+}
+
+.markdown-body h3 {
+  font-weight: 600;
+  font-size: 1.25em;
+  color: var(--color-secondary);
+}
+
+.markdown-body h4 {
+  font-weight: 600;
+  font-size: 1em;
+  color: var(--color-secondary);
+}
+
+.markdown-body h5 {
+  font-weight: 600;
+  font-size: 0.875em;
+  color: var(--color-secondary);
+}
+
+.markdown-body h6 {
+  font-weight: 600;
+  font-size: 0.85em;
+  color: var(--color-secondary-lighter);
+}
+
+/** Paragraphs **/
+
+.markdown-body p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+/** Links **/
+
+.markdown-body p > a {
+  margin-top: 0;
+  margin-bottom: 10px;
+  color: var(--color-primary) !important;
+  text-decoration: none !important;
+  font-weight: 600;
+}
+
+.markdown-body p > a:hover {
+  color: var(--color-primary-darker) !important;
+}
+
+/** Blockquotes **/
+
+.markdown-body blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: var(--color-secondary-lighter);
+  border-left: 0.25em solid var(--color-primary-lighter);
+}
+
+/** Code **/
+
+.markdown-body pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 12px;
+  background-color: var(--color-gray-100);
+  word-wrap: normal;
+}
+
+.markdown-body pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  color: var(--color-secondary);
+  border-radius: 6px;
+}
+
+.markdown-body code {
+  padding: 0.2em 0.4em;
+  margin: 0;
+  font-size: 85%;
+  white-space: break-spaces;
+  border-radius: 6px;
+}
+
+.markdown-body pre code {
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  border: 0;
+}
+
+/** Horizontal rules **/
+
+.markdown-body hr {
+  box-sizing: content-box;
+  overflow: hidden;
+  background: transparent;
+  border-bottom: 1px solid var(--color-secondary);
+  height: 0.15em;
+  padding: 0;
+  margin: 24px 0;
+  background-color: var(--color-secondary);
+  border: 0;
+}
+
+.markdown-body hr::before {
+  display: table;
+  content: '';
+}
+
+.markdown-body hr::after {
+  display: table;
+  clear: both;
+  content: '';
+}
+
+/** Lists **/
+
+.markdown-body ul,
+.markdown-body ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+  list-style: revert;
+}
+
+.markdown-body ol ol,
+.markdown-body ul ol {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ul ul ol,
+.markdown-body ul ol ol,
+.markdown-body ol ul ol,
+.markdown-body ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body ol[type='a s'] {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body ol[type='A s'] {
+  list-style-type: upper-alpha;
+}
+
+.markdown-body ol[type='i s'] {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ol[type='I s'] {
+  list-style-type: upper-roman;
+}
+
+.markdown-body ol[type='1'] {
+  list-style: unset;
+  list-style-type: decimal;
+}
+
+.markdown-body div > ol:not([type]) {
+  list-style: unset;
+  list-style-type: decimal;
+}
+
+/** Table **/
+
+.markdown-body table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+}
+
+.markdown-body td,
+.markdown-body th {
+  padding: 0;
+}
+
+.markdown-body th {
+  color: var(--color-secondary);
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  padding: 6px 13px;
+  border: 1px solid var(--color-gray-500);
+}
+
+.markdown-body table td > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body table tr {
+  background-color: #ffffff;
+  border-top: 1px solid var(--color-secondary-lighter);
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background-color: var(--color-gray-100);
+}
+
+.markdown-body table img {
+  background-color: transparent;
+}
+
+/** Images **/
+
+.markdown-body img {
+  border-style: none;
+  max-width: 100%;
+  box-sizing: content-box;
+  background-color: transparent;
+}
+
+.markdown-body img[align='right'] {
+  padding-left: 20px;
+}
+
+.markdown-body img[align='left'] {
+  padding-right: 20px;
+}

--- a/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.css
+++ b/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.css
@@ -1,98 +1,90 @@
 /** Body **/
-.markdown-body {
+:host /deep/ .markdown-body {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   margin: 0px 0px 1.5rem 0px;
-  color: var(--color-main);
-  font-size: 16px;
   line-height: 1.5;
   word-wrap: break-word;
 }
 
 /** Emphasis **/
 
-.markdown-body strong {
-  font-weight: 600;
+:host /deep/ .markdown-body strong {
+  @apply font-bold;
   color: var(--color-secondary-darker);
 }
 
 /** Headings **/
 
-.markdown-body h1,
-.markdown-body h2,
-.markdown-body h3,
-.markdown-body h4,
-.markdown-body h5,
-.markdown-body h6 {
+:host /deep/ .markdown-body h1,
+:host /deep/ .markdown-body h2,
+:host /deep/ .markdown-body h3,
+:host /deep/ .markdown-body h4,
+:host /deep/ .markdown-body h5,
+:host /deep/ .markdown-body h6 {
   margin-top: 24px;
   margin-bottom: 16px;
-  font-weight: 600;
   line-height: 1.25;
+  @apply text-title font-title font-bold;
 }
 
-.markdown-body h1 {
+:host /deep/ .markdown-body h1 {
   margin: 0.67em 0;
-  font-weight: 600;
   padding-bottom: 0.3em;
   font-size: 2em;
   color: var(--color-primary);
 }
 
-.markdown-body h2 {
-  font-weight: 600;
+:host /deep/ .markdown-body h2 {
   padding-bottom: 0.3em;
   font-size: 1.5em;
   color: var(--color-secondary);
 }
 
-.markdown-body h3 {
-  font-weight: 600;
+:host /deep/ .markdown-body h3 {
   font-size: 1.25em;
   color: var(--color-secondary);
 }
 
-.markdown-body h4 {
-  font-weight: 600;
+:host /deep/ .markdown-body h4 {
   font-size: 1em;
   color: var(--color-secondary);
 }
 
-.markdown-body h5 {
-  font-weight: 600;
+:host /deep/ .markdown-body h5 {
   font-size: 0.875em;
   color: var(--color-secondary);
 }
 
-.markdown-body h6 {
-  font-weight: 600;
+:host /deep/ .markdown-body h6 {
   font-size: 0.85em;
   color: var(--color-secondary-lighter);
 }
 
 /** Paragraphs **/
 
-.markdown-body p {
+:host /deep/ .markdown-body p {
   margin-top: 0;
   margin-bottom: 10px;
 }
 
 /** Links **/
 
-.markdown-body p > a {
+:host /deep/ .markdown-body p > a {
   margin-top: 0;
   margin-bottom: 10px;
   color: var(--color-primary) !important;
   text-decoration: none !important;
-  font-weight: 600;
+  @apply font-bold;
 }
 
-.markdown-body p > a:hover {
+:host /deep/ .markdown-body p > a:hover {
   color: var(--color-primary-darker) !important;
 }
 
 /** Blockquotes **/
 
-.markdown-body blockquote {
+:host /deep/ .markdown-body blockquote {
   margin: 0;
   padding: 0 1em;
   color: var(--color-secondary-lighter);
@@ -101,7 +93,7 @@
 
 /** Code **/
 
-.markdown-body pre {
+:host /deep/ .markdown-body pre {
   margin-top: 0;
   margin-bottom: 0;
   font-size: 12px;
@@ -109,7 +101,7 @@
   word-wrap: normal;
 }
 
-.markdown-body pre {
+:host /deep/ .markdown-body pre {
   padding: 16px;
   overflow: auto;
   font-size: 85%;
@@ -118,7 +110,7 @@
   border-radius: 6px;
 }
 
-.markdown-body code {
+:host /deep/ .markdown-body code {
   padding: 0.2em 0.4em;
   margin: 0;
   font-size: 85%;
@@ -126,7 +118,7 @@
   border-radius: 6px;
 }
 
-.markdown-body pre code {
+:host /deep/ .markdown-body pre code {
   display: inline;
   max-width: auto;
   padding: 0;
@@ -139,7 +131,7 @@
 
 /** Horizontal rules **/
 
-.markdown-body hr {
+:host /deep/ .markdown-body hr {
   box-sizing: content-box;
   overflow: hidden;
   background: transparent;
@@ -151,12 +143,12 @@
   border: 0;
 }
 
-.markdown-body hr::before {
+:host /deep/ .markdown-body hr::before {
   display: table;
   content: '';
 }
 
-.markdown-body hr::after {
+:host /deep/ .markdown-body hr::after {
   display: table;
   clear: both;
   content: '';
@@ -164,108 +156,109 @@
 
 /** Lists **/
 
-.markdown-body ul,
-.markdown-body ol {
+:host /deep/ .markdown-body ul,
+:host /deep/ .markdown-body ol {
   margin-top: 0;
   margin-bottom: 0;
   padding-left: 2em;
   list-style: revert;
 }
 
-.markdown-body ol ol,
-.markdown-body ul ol {
+:host /deep/ .markdown-body ol ol,
+:host /deep/ .markdown-body ul ol {
   list-style-type: lower-roman;
 }
 
-.markdown-body ul ul ol,
-.markdown-body ul ol ol,
-.markdown-body ol ul ol,
-.markdown-body ol ol ol {
+:host /deep/ .markdown-body ul ul ol,
+:host /deep/ .markdown-body ul ol ol,
+:host /deep/ .markdown-body ol ul ol,
+:host /deep/ .markdown-body ol ol ol {
   list-style-type: lower-alpha;
 }
 
-.markdown-body ol[type='a s'] {
+:host /deep/ .markdown-body ol[type='a s'] {
   list-style-type: lower-alpha;
 }
 
-.markdown-body ol[type='A s'] {
+:host /deep/ .markdown-body ol[type='A s'] {
   list-style-type: upper-alpha;
 }
 
-.markdown-body ol[type='i s'] {
+:host /deep/ .markdown-body ol[type='i s'] {
   list-style-type: lower-roman;
 }
 
-.markdown-body ol[type='I s'] {
+:host /deep/ .markdown-body ol[type='I s'] {
   list-style-type: upper-roman;
 }
 
-.markdown-body ol[type='1'] {
+:host /deep/ .markdown-body ol[type='1'] {
   list-style: unset;
   list-style-type: decimal;
 }
 
-.markdown-body div > ol:not([type]) {
+:host /deep/ .markdown-body div > ol:not([type]) {
   list-style: unset;
   list-style-type: decimal;
 }
 
 /** Table **/
 
-.markdown-body table {
+:host /deep/ .markdown-body table {
   border-spacing: 0;
   border-collapse: collapse;
   display: block;
   width: max-content;
   max-width: 100%;
   overflow: auto;
+  padding-bottom: 15px;
 }
 
-.markdown-body td,
-.markdown-body th {
+:host /deep/ .markdown-body td,
+:host /deep/ .markdown-body th {
   padding: 0;
 }
 
-.markdown-body th {
+:host /deep/ .markdown-body th {
   color: var(--color-secondary);
 }
 
-.markdown-body table th,
-.markdown-body table td {
+:host /deep/ .markdown-body table th,
+:host /deep/ .markdown-body table td {
   padding: 6px 13px;
   border: 1px solid var(--color-gray-500);
 }
 
-.markdown-body table td > :last-child {
+:host /deep/ .markdown-body table td > :last-child {
   margin-bottom: 0;
 }
 
-.markdown-body table tr {
+:host /deep/ .markdown-body table tr {
   background-color: #ffffff;
   border-top: 1px solid var(--color-secondary-lighter);
 }
 
-.markdown-body table tr:nth-child(2n) {
+:host /deep/ .markdown-body table tr:nth-child(2n) {
   background-color: var(--color-gray-100);
 }
 
-.markdown-body table img {
+:host /deep/ .markdown-body table img {
   background-color: transparent;
 }
 
 /** Images **/
 
-.markdown-body img {
+:host /deep/ .markdown-body img {
   border-style: none;
   max-width: 100%;
   box-sizing: content-box;
   background-color: transparent;
 }
 
-.markdown-body img[align='right'] {
+:host /deep/ .markdown-body img[align='right'] {
   padding-left: 20px;
 }
 
-.markdown-body img[align='left'] {
+:host /deep/ .markdown-body img[align='left'] {
   padding-right: 20px;
 }

--- a/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.html
+++ b/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.html
@@ -1,0 +1,1 @@
+<div class="markdown-body" [innerHTML]="parsedMarkdown"></div>

--- a/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.spec.ts
+++ b/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { MarkdownParserComponent } from './markdown-parser.component'
+
+describe('MarkdownParserComponent', () => {
+  let component: MarkdownParserComponent
+  let fixture: ComponentFixture<MarkdownParserComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MarkdownParserComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(MarkdownParserComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.spec.ts
+++ b/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.spec.ts
@@ -12,10 +12,30 @@ describe('MarkdownParserComponent', () => {
 
     fixture = TestBed.createComponent(MarkdownParserComponent)
     component = fixture.componentInstance
-    fixture.detectChanges()
   })
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  it('should render markdown as HTML', () => {
+    component.textContent = '**bold markdown**'
+    fixture.detectChanges()
+    const markdown = fixture.nativeElement.innerHTML
+    expect(markdown).toContain('<p><strong>bold markdown</strong></p>')
+  })
+
+  it('should render HTML as HTML', () => {
+    component.textContent = '<p><strong>simple html</strong></p>'
+    fixture.detectChanges()
+    const html = fixture.nativeElement.innerHTML
+    expect(html).toContain('<p><strong>simple html</strong></p>')
+  })
+
+  it('should render text as HTML', () => {
+    component.textContent = 'simple text'
+    fixture.detectChanges()
+    const text = fixture.nativeElement.innerHTML
+    expect(text).toContain('<p>simple text</p>')
   })
 })

--- a/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.stories.ts
+++ b/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.stories.ts
@@ -1,0 +1,148 @@
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular'
+import { MarkdownParserComponent } from './markdown-parser.component'
+
+export default {
+  title: 'Elements/MarkdownParserComponent',
+  component: MarkdownParserComponent,
+  decorators: [
+    moduleMetadata({
+      declarations: [MarkdownParserComponent],
+    }),
+  ],
+} as Meta<MarkdownParserComponent>
+
+export const Primary: StoryObj<MarkdownParserComponent> = {
+  args: {
+    textContent: ` 
+# SUPPORTED MARKDOWN CONTENT
+
+## 1) Headings
+
++ # h1 Heading
++ ## h2 Heading
++ ### h3 Heading
++ #### h4 Heading
++ ##### h5 Heading
++ ###### h6 Heading
+
+
+## 2) Horizontal Rules
+
++ ___
+
++ ---
+
++ ***
+
+## 3) Emphasis
+
++ **This is bold text**
+
++ __This is bold text__
+
++ *This is italic text*
+
++ _This is italic text_
+
++ ~~Strikethrough~~
+
+
+## 3) Blockquotes
+
+
+> Blockquotes can also be nested...
+>> ...by using additional greater-than signs right next to each other...
+> > > ...or with spaces between arrows.
+
+
+## 4) Lists
+
+**Unordered**
+
++ Create a list by starting a line with +, -, or *
++ Sub-lists are made by indenting 2 spaces:
+  - Marker character change forces new list start:
+    * Ac tristique libero volutpat at
+    + Facilisis in pretium nisl aliquet
+    - Nulla volutpat aliquam velit
++ List continue here
+
+**Ordered**
+
+1. Lorem ipsum dolor sit amet
+2. Consectetur adipiscing elit
+3. Integer molestie lorem at massa
+
+
+1. You can use sequential numbers...
+1. ...or keep all the numbers as 1.
+
+**Start numbering with offset:**
+
+57. foo
+1. bar
+
+
+## 5) Code
+
+**Inline code**
+
+(no example)
+
+**Indented code**
+
+    // Some comments
+    line 1 of code
+    line 2 of code
+    line 3 of code
+
+
+**Block code "fences"**
+
+(no example)
+
+
+## 6) Tables
+
+**Left aligned columns**
+
+| Option | Description |
+| ------ | ----------- |
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
+| ext    | extension to be used for dest files. |
+
+**Right aligned columns**
+
+| Option | Description |
+| ------:| -----------:|
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
+| ext    | extension to be used for dest files. |
+
+
+## 7) Links
+
+[link text](https://github.com/geonetwork/geonetwork-ui)
+
+[link with title](https://github.com/geonetwork/geonetwork-ui "title text!")
+
+
+## 8) Images
+
+**With and without title**
+
+![Geonetwork](https://geonetwork-opensource.org/_static/chrome/geonetwork3-logo.png "Geonetwork title")`,
+  },
+  argTypes: {
+    textContent: {
+      control: 'text',
+    },
+  },
+  render: (args) => ({
+    props: args,
+    template: `<gn-ui-markdown-parser [textContent]="
+    textContent
+    "></gn-ui-markdown-parser>`,
+  }),
+}

--- a/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.ts
+++ b/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.ts
@@ -1,11 +1,10 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core'
+import { Component, Input } from '@angular/core'
 import { marked } from 'marked'
 
 @Component({
   selector: 'gn-ui-markdown-parser',
   templateUrl: './markdown-parser.component.html',
   styleUrls: ['./markdown-parser.component.css'],
-  encapsulation: ViewEncapsulation.None,
 })
 export class MarkdownParserComponent {
   @Input() textContent: string

--- a/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.ts
+++ b/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input, ViewEncapsulation } from '@angular/core'
+import { marked } from 'marked'
+
+@Component({
+  selector: 'gn-ui-markdown-parser',
+  templateUrl: './markdown-parser.component.html',
+  styleUrls: ['./markdown-parser.component.css'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class MarkdownParserComponent {
+  @Input() textContent: string
+
+  get parsedMarkdown() {
+    return marked.parse(this.textContent)
+  }
+}

--- a/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.ts
+++ b/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.ts
@@ -1,10 +1,11 @@
-import { Component, Input } from '@angular/core'
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core'
 import { marked } from 'marked'
 
 @Component({
   selector: 'gn-ui-markdown-parser',
   templateUrl: './markdown-parser.component.html',
   styleUrls: ['./markdown-parser.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MarkdownParserComponent {
   @Input() textContent: string

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -8,11 +8,9 @@
   <gn-ui-content-ghost ghostClass="h-32" [showContent]="fieldReady('abstract')">
     <gn-ui-max-lines [maxLines]="6" *ngIf="metadata.abstract">
       <div>
-        <p
-          class="whitespace-pre-line break-words sm:mb-4 sm:pr-16"
-          [innerHTML]="metadata.abstract"
-          gnUiLinkify
-        ></p>
+        <gn-ui-markdown-parser
+          [textContent]="metadata.abstract"
+        ></gn-ui-markdown-parser>
         <ng-container *ngIf="metadata.keywords?.length">
           <p class="mb-3 font-medium text-primary text-sm" translate>
             record.metadata.keywords

--- a/libs/ui/elements/src/lib/ui-elements.module.ts
+++ b/libs/ui/elements/src/lib/ui-elements.module.ts
@@ -29,6 +29,7 @@ import { GnUiLinkifyDirective } from './metadata-info/linkify.directive'
 import { PaginationButtonsComponent } from './pagination-buttons/pagination-buttons.component'
 import { MaxLinesComponent } from './max-lines/max-lines.component'
 import { RecordApiFormComponent } from './record-api-form/record-api-form.component'
+import { MarkdownParserComponent } from './markdown-parser/markdown-parser.component'
 
 @NgModule({
   imports: [
@@ -65,6 +66,7 @@ import { RecordApiFormComponent } from './record-api-form/record-api-form.compon
     PaginationButtonsComponent,
     MaxLinesComponent,
     RecordApiFormComponent,
+    MarkdownParserComponent,
   ],
   exports: [
     MetadataInfoComponent,
@@ -85,6 +87,7 @@ import { RecordApiFormComponent } from './record-api-form/record-api-form.compon
     UserPreviewComponent,
     PaginationButtonsComponent,
     RecordApiFormComponent,
+    MarkdownParserComponent,
   ],
 })
 export class UiElementsModule {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "embla-carousel": "^8.0.0-rc14",
         "express": "^4.17.1",
         "geojson-validation": "^1.0.2",
+        "marked": "^11.1.1",
         "moment": "^2.29.4",
         "ng-table-virtual-scroll": "^1.4.1",
         "ngx-chips": "3.0.0",
@@ -23995,6 +23996,17 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.1.1.tgz",
+      "integrity": "sha512-EgxRjgK9axsQuUa/oKMx5DEY8oXpKJfk61rT5iY3aRlgU6QJtUcxU5OAymdhCvWvhYcd9FKmO5eQoX8m9VGJXg==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "embla-carousel": "^8.0.0-rc14",
     "express": "^4.17.1",
     "geojson-validation": "^1.0.2",
+    "marked": "^11.1.1",
     "moment": "^2.29.4",
     "ng-table-virtual-scroll": "^1.4.1",
     "ngx-chips": "3.0.0",


### PR DESCRIPTION
Hi, first of all happy new year to everyone seeing this. Here is my first contribution to the project.

**This pull request makes the following changes :**
* Fixes isssue #733 

I used `marked` to parse markdown content to html and then i defined some basic style for the following elements as suggested by @jahow  :

- h1 to h6
- ul, ol and li
- p
- a
- blockquote
- pre - code
- hr
- table
- img

I tried to use tailwind base colors to make it close to the default style. 
I'm not sure how should i render links, blockquotes or table. I'll wait for your feedbacks to make some changes if needed.