### PR TITLE
[Datahub] Display record status

### DIFF
--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -1,9 +1,19 @@
-<p
-  class="text-[28px] text-title text-center mb-6 font-title sm:text-left"
-  translate
->
-  record.metadata.about
-</p>
+<div class="flex flex-row justify-between">
+  <p
+    class="text-[28px] text-title text-center mb-6 font-title sm:text-left"
+    translate
+  >
+    record.metadata.about
+  </p>
+  <div *ngIf="metadata.status" class="flex items-start pt-3 pr-4">
+    <span
+      class="inline-flex items-center justify-center px-2 py-1 text-13 uppercase font-medium leading-none bg-primary text-white rounded opacity-40"
+      translate
+    >
+      domain.record.status.{{ metadata.status }}
+    </span>
+  </div>
+</div>
 <div class="mb-6 md-description sm:mb-4 sm:pr-16">
   <gn-ui-content-ghost ghostClass="h-32" [showContent]="fieldReady('abstract')">
     <gn-ui-max-lines [maxLines]="6" *ngIf="metadata.abstract">


### PR DESCRIPTION
This PR adds a display of the record's status in the record page, but in the old UI. 

#### Therefore, this work in ON HOLD until the new UI is done for the header of the record page (a new PR might overlap this work).

This PR should also display the record's status in the catalog list, and is awaiting answers about its design in the new UI.