### PR TITLE
[Datahub] Fix : add missing tooltip

### DIFF
--- a/apps/datahub/src/app/record/record-apis/record-apis.component.html
+++ b/apps/datahub/src/app/record/record-apis/record-apis.component.html
@@ -15,6 +15,7 @@
         let first = first;
         let last = last
       "
+      [title]="link.name"
       [link]="link"
       [currentLink]="selectedApiLink"
       class="w-80"

--- a/apps/datahub/src/app/record/record-otherlinks/record-otherlinks.component.html
+++ b/apps/datahub/src/app/record/record-otherlinks/record-otherlinks.component.html
@@ -14,6 +14,7 @@
       let first = first;
       let last = last
     "
+    [title]="link.name"
     [link]="link"
     class="w-80"
     [ngClass]="{


### PR DESCRIPTION
This PR adds a tooltip for the `gn-ui-link-cards` and `gn-ui-api-cards`, to display titles that are too long for the cards.

![image](https://github.com/geonetwork/geonetwork-ui/assets/132347903/2c7d9cdd-88b3-4281-8a71-5aac43fd238c)
