### PR TITLE
[Datahub] Fix : Improve linkify REGEX 

### DIFF
--- a/libs/ui/elements/src/lib/metadata-info/linkify.directive.spec.ts
+++ b/libs/ui/elements/src/lib/metadata-info/linkify.directive.spec.ts
@@ -51,6 +51,10 @@ const testingUrls = [
     'Thirteenth link http://foo.com/(something)?after=parens query params',
     'http://foo.com/(something)?after=parens',
   ],
+  [
+    'Fourteenth link (http://foo.com/blah) in parenthesis',
+    'http://foo.com/blah',
+  ],
 ]
 
 const testWithMultipleUrls = {

--- a/libs/ui/elements/src/lib/metadata-info/linkify.directive.ts
+++ b/libs/ui/elements/src/lib/metadata-info/linkify.directive.ts
@@ -40,7 +40,7 @@ export class GnUiLinkifyDirective implements OnInit {
     if (url) {
       displayValue = this.createLink(displayValue, url)
     } else {
-      const urlRegex = /\bhttps?:\/\/\S+\b[=)/]?/g
+      const urlRegex = /\bhttps?:\/\/\S+?(?=[\s)|]|$)/g
       const matches = displayValue.match(urlRegex)
 
       if (matches && matches.length > 0) {

--- a/libs/ui/elements/src/lib/metadata-info/linkify.directive.ts
+++ b/libs/ui/elements/src/lib/metadata-info/linkify.directive.ts
@@ -40,9 +40,9 @@ export class GnUiLinkifyDirective implements OnInit {
     if (url) {
       displayValue = this.createLink(displayValue, url)
     } else {
-      const urlRegex = /\bhttps?:\/\/\S+?(?=[\s)|]|$)/g
-      const matches = displayValue.match(urlRegex)
+      const urlRegex = /\bhttps?:\/\/(?:\([^\s()]+\)|[^\s()]+)+/g
 
+      const matches = displayValue.match(urlRegex)
       if (matches && matches.length > 0) {
         matches.forEach((match) => {
           url = match


### PR DESCRIPTION
This PR improves the Linkify directive's REGEX to avoid including end parenthesis.

--> End parenthesis used to be detected as part of the URLS, ex : 

![image-2024-01-08-12-04-25-004](https://github.com/geonetwork/geonetwork-ui/assets/132347903/37404bcd-84fa-4dfa-a67f-729de60d5781)

--> Now they're not : 

![image](https://github.com/geonetwork/geonetwork-ui/assets/132347903/f0d706c4-2968-4e93-9bde-ea709b7d2c27)
