### PR TITLE
[Map-Viewer] Add layer from WFS service

### DIFF
--- a/libs/feature/map/src/lib/add-layer-from-wfs/add-layer-from-wfs.component.html
+++ b/libs/feature/map/src/lib/add-layer-from-wfs/add-layer-from-wfs.component.html
@@ -1,0 +1,37 @@
+<div class="flex items-center mb-5">
+  <gn-ui-text-input
+    [(value)]="wfsUrl"
+    (valueChange)="urlChange.next($event)"
+    [hint]="'map.wfs.urlInput.hint' | translate"
+    class="w-96"
+  >
+  </gn-ui-text-input>
+</div>
+
+<div *ngIf="errorMessage" class="text-red-500 mt-2">
+  {{ errorMessage }}
+</div>
+
+<div *ngIf="loading">
+  <p class="loading-message" translate>map.loading.service</p>
+</div>
+
+<div *ngIf="!loading && layers.length > 0">
+  <h2 class="font-bold" translate>map.layers.available</h2>
+  <ng-container *ngFor="let layer of layers">
+    <div class="flex items-center justify-between my-2 layer-item-tree">
+      <p class="max-w-xs overflow-hidden overflow-ellipsis whitespace-nowrap">
+        {{ layer.title }}
+      </p>
+      <gn-ui-button
+        *ngIf="layer.name"
+        class="layer-add-btn"
+        type="primary"
+        (buttonClick)="addLayer(layer)"
+        extraClass="text-sm !px-2 !py-1"
+        translate
+        ><span translate> map.layer.add </span></gn-ui-button
+      >
+    </div>
+  </ng-container>
+</div>

--- a/libs/feature/map/src/lib/add-layer-from-wfs/add-layer-from-wfs.component.spec.ts
+++ b/libs/feature/map/src/lib/add-layer-from-wfs/add-layer-from-wfs.component.spec.ts
@@ -159,7 +159,6 @@ describe('AddLayerFromWfsComponent', () => {
         title: 'Feature Type 1',
         url: 'http://my.service.org/wfs',
         type: 'wfs',
-        featureCount: 10000,
       })
     })
   })

--- a/libs/feature/map/src/lib/add-layer-from-wfs/add-layer-from-wfs.component.spec.ts
+++ b/libs/feature/map/src/lib/add-layer-from-wfs/add-layer-from-wfs.component.spec.ts
@@ -1,0 +1,166 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { AddLayerFromWfsComponent } from './add-layer-from-wfs.component'
+import { MapFacade } from '../+state/map.facade'
+import { TranslateModule } from '@ngx-translate/core'
+import { By } from '@angular/platform-browser'
+
+jest.mock('@camptocamp/ogc-client', () => ({
+  WfsEndpoint: class {
+    constructor(private url) {}
+    isReady() {
+      if (this.url.indexOf('error') > -1) {
+        return Promise.reject(new Error('Something went wrong'))
+      }
+      if (this.url.indexOf('wait') > -1) {
+        return new Promise(() => {
+          // do nothing
+        })
+      }
+      return Promise.resolve(this)
+    }
+    getFeatureTypes() {
+      return [
+        {
+          name: 'ft1',
+          title: 'Feature Type 1',
+        },
+        {
+          name: 'ft2',
+          title: 'Feature Type 2',
+        },
+        {
+          name: 'ft3',
+          title: 'Feature Type 3',
+        },
+      ]
+    }
+  },
+}))
+
+class MapFacadeMock {
+  addLayer = jest.fn()
+}
+
+describe('AddLayerFromWfsComponent', () => {
+  let component: AddLayerFromWfsComponent
+  let fixture: ComponentFixture<AddLayerFromWfsComponent>
+  let mapFacade: MapFacade
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      declarations: [AddLayerFromWfsComponent],
+      providers: [
+        {
+          provide: MapFacade,
+          useClass: MapFacadeMock,
+        },
+      ],
+    }).compileComponents()
+
+    mapFacade = TestBed.inject(MapFacade)
+    fixture = TestBed.createComponent(AddLayerFromWfsComponent)
+    component = fixture.componentInstance
+  })
+
+  it('should create', () => {
+    fixture.detectChanges()
+    expect(component).toBeTruthy()
+    expect(component.errorMessage).toBeFalsy()
+    expect(component.loading).toBe(false)
+    expect(component.layers.length).toBe(0)
+  })
+
+  describe('loadLayers', () => {
+    describe('while layers are loading', () => {
+      beforeEach(() => {
+        component.wfsUrl = 'http://my.service.org/wait'
+        component.loadLayers()
+      })
+      it('shows only a "loading" message', () => {
+        expect(component.errorMessage).toBeFalsy()
+        expect(component.loading).toBe(true)
+        expect(component.layers).toEqual([])
+      })
+    })
+    describe('valid WFS service', () => {
+      beforeEach(() => {
+        component.wfsUrl = 'http://my.service.org/wfs'
+        component.loadLayers()
+      })
+      it('shows all layers', () => {
+        expect(component.errorMessage).toBeFalsy()
+        expect(component.loading).toBe(false)
+        expect(component.layers).toEqual([
+          {
+            name: 'ft1',
+            title: 'Feature Type 1',
+          },
+          {
+            name: 'ft2',
+            title: 'Feature Type 2',
+          },
+          {
+            name: 'ft3',
+            title: 'Feature Type 3',
+          },
+        ])
+      })
+      it('should show a Add button for each layer', () => {
+        fixture.detectChanges()
+        const layerElts = fixture.debugElement.queryAll(
+          By.css('.layer-item-tree')
+        )
+        expect(layerElts.length).toBe(3)
+        const hasButtons = layerElts.map(
+          (layerElt) => !!layerElt.query(By.css('.layer-add-btn'))
+        )
+        expect(hasButtons).toEqual([true, true, true])
+      })
+    })
+    describe('error loading layers', () => {
+      beforeEach(() => {
+        component.wfsUrl = 'http://my.service.org/error'
+        component.loadLayers()
+      })
+      it('shows an error message', () => {
+        expect(component.errorMessage).toBeTruthy()
+        expect(component.loading).toBe(false)
+        expect(component.layers.length).toBe(0)
+      })
+    })
+    describe('error and then valid service', () => {
+      beforeEach(async () => {
+        component.wfsUrl = 'http://my.service.org/error'
+        await component.loadLayers().catch(() => {
+          // do nothing
+        })
+        component.wfsUrl = 'http://my.service.org/wfs'
+        await component.loadLayers()
+      })
+      it('shows no error', () => {
+        expect(component.errorMessage).toBeFalsy()
+        expect(component.loading).toBe(false)
+        expect(component.layers).not.toEqual([])
+      })
+    })
+  })
+  describe('addLayer', () => {
+    beforeEach(() => {
+      component.wfsUrl = 'http://my.service.org/wfs'
+      component.addLayer({
+        name: 'ft1',
+        title: 'Feature Type 1',
+      })
+    })
+    it('should add the selected layer in the current map context', () => {
+      expect(mapFacade.addLayer).toHaveBeenCalledWith({
+        name: 'ft1',
+        title: 'Feature Type 1',
+        url: 'http://my.service.org/wfs',
+        type: 'wfs',
+        featureCount: 10000,
+      })
+    })
+  })
+})

--- a/libs/feature/map/src/lib/add-layer-from-wfs/add-layer-from-wfs.component.ts
+++ b/libs/feature/map/src/lib/add-layer-from-wfs/add-layer-from-wfs.component.ts
@@ -1,0 +1,65 @@
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core'
+import { WfsEndpoint, WfsFeatureTypeBrief } from '@camptocamp/ogc-client'
+import { Subject } from 'rxjs'
+import {
+  MapContextLayerModel,
+  MapContextLayerTypeEnum,
+} from '../map-context/map-context.model'
+import { MapFacade } from '../+state/map.facade'
+import { debounceTime } from 'rxjs/operators'
+
+@Component({
+  selector: 'gn-ui-add-layer-from-wfs',
+  templateUrl: './add-layer-from-wfs.component.html',
+  styleUrls: ['./add-layer-from-wfs.component.css'],
+})
+export class AddLayerFromWfsComponent implements OnInit {
+  wfsUrl = ''
+  loading = false
+  layers: WfsFeatureTypeBrief[] = []
+  wfsEndpoint: WfsEndpoint | null = null
+  urlChange = new Subject<string>()
+  errorMessage: string | null = null
+
+  constructor(
+    private mapFacade: MapFacade,
+    private changeDetectorRef: ChangeDetectorRef
+  ) {}
+
+  ngOnInit() {
+    this.urlChange.pipe(debounceTime(700)).subscribe(() => this.loadLayers())
+  }
+
+  async loadLayers() {
+    this.errorMessage = null
+    try {
+      this.loading = true
+
+      if (this.wfsUrl.trim() === '') {
+        this.layers = []
+        return
+      }
+
+      this.wfsEndpoint = await new WfsEndpoint(this.wfsUrl).isReady()
+      this.layers = this.wfsEndpoint.getFeatureTypes()
+      console.log(this.layers)
+    } catch (error) {
+      const err = error as Error
+      this.layers = []
+      this.errorMessage = 'Error loading layers: ' + err.message
+    } finally {
+      this.loading = false
+      this.changeDetectorRef.markForCheck()
+    }
+  }
+
+  addLayer(layer: WfsFeatureTypeBrief) {
+    const layerToAdd: MapContextLayerModel = {
+      name: layer.name,
+      url: this.wfsUrl.toString(),
+      type: MapContextLayerTypeEnum.WFS,
+      featureCount: 10000,
+    }
+    this.mapFacade.addLayer({ ...layerToAdd, title: layer.title })
+  }
+}

--- a/libs/feature/map/src/lib/add-layer-from-wfs/add-layer-from-wfs.component.ts
+++ b/libs/feature/map/src/lib/add-layer-from-wfs/add-layer-from-wfs.component.ts
@@ -58,7 +58,6 @@ export class AddLayerFromWfsComponent implements OnInit {
       name: layer.name,
       url: this.wfsUrl.toString(),
       type: MapContextLayerTypeEnum.WFS,
-      featureCount: 10000,
     }
     this.mapFacade.addLayer({ ...layerToAdd, title: layer.title })
   }

--- a/libs/feature/map/src/lib/feature-map.module.ts
+++ b/libs/feature/map/src/lib/feature-map.module.ts
@@ -21,6 +21,7 @@ import { AddLayerRecordPreviewComponent } from './add-layer-from-catalog/add-lay
 import { UiElementsModule } from '@geonetwork-ui/ui/elements'
 import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
 import { AddLayerFromWmsComponent } from './add-layer-from-wms/add-layer-from-wms.component'
+import { AddLayerFromWfsComponent } from './add-layer-from-wfs/add-layer-from-wfs.component'
 
 @NgModule({
   declarations: [
@@ -31,6 +32,7 @@ import { AddLayerFromWmsComponent } from './add-layer-from-wms/add-layer-from-wm
     MapContainerComponent,
     AddLayerRecordPreviewComponent,
     AddLayerFromWmsComponent,
+    AddLayerFromWfsComponent,
   ],
   exports: [
     MapContextComponent,

--- a/libs/feature/map/src/lib/layers-panel/layers-panel.component.html
+++ b/libs/feature/map/src/lib/layers-panel/layers-panel.component.html
@@ -36,7 +36,9 @@
         </div>
       </mat-tab>
       <mat-tab [label]="'map.add.layer.wfs' | translate" bodyClass="h-full">
-        <div class="p-3 h-full">Add from WFS</div>
+        <div class="p-3">
+          <gn-ui-add-layer-from-wfs></gn-ui-add-layer-from-wfs>
+        </div>
       </mat-tab>
       <mat-tab [label]="'map.add.layer.file' | translate" bodyClass="h-full">
         <div class="p-3 h-full">Add from file</div>

--- a/libs/feature/map/src/lib/map-context/map-context.model.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.model.ts
@@ -32,6 +32,7 @@ interface MapContextLayerWfsModel {
   type: 'wfs'
   url: string
   name: string
+  featureCount?: number
 }
 
 interface LayerXyzModel {

--- a/libs/feature/map/src/lib/map-context/map-context.model.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.model.ts
@@ -32,7 +32,6 @@ interface MapContextLayerWfsModel {
   type: 'wfs'
   url: string
   name: string
-  featureCount?: number
 }
 
 interface LayerXyzModel {

--- a/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
@@ -137,7 +137,7 @@ describe('MapContextService', () => {
         const source = layer.getSource()
         const urlLoader = source.getUrl()
         expect(urlLoader([10, 20, 30, 40])).toBe(
-          'https://www.geograndest.fr/geoserver/region-grand-est/ows?service=WFS&version=1.1.0&request=GetFeature&outputFormat=application%2Fjson&typename=ms%3Acommune_actuelle_3857&srsname=EPSG%3A3857&bbox=10%2C20%2C30%2C40%2CEPSG%3A3857'
+          'https://www.geograndest.fr/geoserver/region-grand-est/ows?service=WFS&version=1.1.0&request=GetFeature&outputFormat=application%2Fjson&typename=ms%3Acommune_actuelle_3857&srsname=EPSG%3A3857&bbox=10%2C20%2C30%2C40%2CEPSG%3A3857&maxFeatures=10000'
         )
       })
     })

--- a/libs/feature/map/src/lib/map-context/map-context.service.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.ts
@@ -40,6 +40,8 @@ export const DEFAULT_VIEW: MapContextViewModel = {
   zoom: 2,
 }
 
+export const WFS_MAX_FEATURES = 10000
+
 @Injectable({
   providedIn: 'root',
 })
@@ -111,12 +113,10 @@ export class MapContextService {
               urlObj.searchParams.set('typename', layerModel.name)
               urlObj.searchParams.set('srsname', 'EPSG:3857')
               urlObj.searchParams.set('bbox', `${extent.join(',')},EPSG:3857`)
-              if ('featureCount' in layerModel && layerModel.featureCount) {
-                urlObj.searchParams.set(
-                  'maxFeatures',
-                  layerModel.featureCount.toString()
-                )
-              }
+              urlObj.searchParams.set(
+                'maxFeatures',
+                WFS_MAX_FEATURES.toString()
+              )
               return urlObj.toString()
             },
             strategy: bboxStrategy,

--- a/libs/feature/map/src/lib/map-context/map-context.service.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.ts
@@ -111,6 +111,12 @@ export class MapContextService {
               urlObj.searchParams.set('typename', layerModel.name)
               urlObj.searchParams.set('srsname', 'EPSG:3857')
               urlObj.searchParams.set('bbox', `${extent.join(',')},EPSG:3857`)
+              if ('featureCount' in layerModel && layerModel.featureCount) {
+                urlObj.searchParams.set(
+                  'maxFeatures',
+                  layerModel.featureCount.toString()
+                )
+              }
               return urlObj.toString()
             },
             strategy: bboxStrategy,

--- a/translations/de.json
+++ b/translations/de.json
@@ -182,6 +182,7 @@
   "map.loading.service": "",
   "map.navigation.message": "Bitte verwenden Sie STRG + Maus (oder zwei Finger auf einem Mobilgerät), um die Karte zu navigieren",
   "map.select.layer": "Datenquelle",
+  "map.wfs.urlInput.hint": "",
   "map.wms.urlInput.hint": "",
   "multiselect.filter.placeholder": "Suche",
   "nav.back": "Zurück",

--- a/translations/en.json
+++ b/translations/en.json
@@ -182,6 +182,7 @@
   "map.loading.service": "Loading service...",
   "map.navigation.message": "Please use CTRL + mouse (or two fingers on mobile) to navigate the map",
   "map.select.layer": "Data source",
+  "map.wfs.urlInput.hint": "Enter WFS service URL",
   "map.wms.urlInput.hint": "Enter WMS service URL",
   "multiselect.filter.placeholder": "Search",
   "nav.back": "Back",

--- a/translations/es.json
+++ b/translations/es.json
@@ -182,6 +182,7 @@
   "map.loading.service": "",
   "map.navigation.message": "",
   "map.select.layer": "",
+  "map.wfs.urlInput.hint": "",
   "map.wms.urlInput.hint": "",
   "multiselect.filter.placeholder": "",
   "nav.back": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -182,6 +182,7 @@
   "map.loading.service": "",
   "map.navigation.message": "Veuillez utiliser CTRL + souris (ou deux doigts sur mobile) pour naviguer sur la carte",
   "map.select.layer": "Source de données",
+  "map.wfs.urlInput.hint": "",
   "map.wms.urlInput.hint": "",
   "multiselect.filter.placeholder": "Rechercher",
   "nav.back": "Retour",

--- a/translations/it.json
+++ b/translations/it.json
@@ -182,6 +182,7 @@
   "map.loading.service": "",
   "map.navigation.message": "Si prega di utilizzare CTRL + mouse (o due dita su mobile) per navigare sulla mappa",
   "map.select.layer": "Sorgente dati",
+  "map.wfs.urlInput.hint": "",
   "map.wms.urlInput.hint": "",
   "multiselect.filter.placeholder": "Cerca",
   "nav.back": "Indietro",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -182,6 +182,7 @@
   "map.loading.service": "",
   "map.navigation.message": "",
   "map.select.layer": "",
+  "map.wfs.urlInput.hint": "",
   "map.wms.urlInput.hint": "",
   "multiselect.filter.placeholder": "",
   "nav.back": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -182,6 +182,7 @@
   "map.loading.service": "",
   "map.navigation.message": "",
   "map.select.layer": "",
+  "map.wfs.urlInput.hint": "",
   "map.wms.urlInput.hint": "",
   "multiselect.filter.placeholder": "",
   "nav.back": "",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -182,6 +182,7 @@
   "map.loading.service": "",
   "map.navigation.message": "Použite prosím CTRL + myš (alebo dva prsty na mobilnom zariadení) na navigáciu po mape",
   "map.select.layer": "Zdroj dát",
+  "map.wfs.urlInput.hint": "",
   "map.wms.urlInput.hint": "",
   "multiselect.filter.placeholder": "Hľadať",
   "nav.back": "Späť",


### PR DESCRIPTION
This pull request adds the feature that allows users to add a layer from a Web Feature Service (WFS) to their map.

- Added a new `add-layer-from-wfs` component in `src/app/components/add-layer-from-wfs/add-layer-from-wfs.component.ts`
- Updated the `map-context.service.ts` and `map-context.model.ts` to add an option which limits WFS features count

**Task List:**
- [x] Ensure the initial display includes a text input for the WFS URL entry.
- [x] Implement a loading indicator upon URL submission.
- [x] Display a list of layers post-load, with each layer featuring a title and an "Add" button.
- [x] Enable layer addition to the map while keeping the panel open.
- [x] Apply default OL styling for added layers.
- [x] Enforce a maximum of 10,000 features per layer to prevent browser overload.

**Screenshots:**

![image](https://github.com/geonetwork/geonetwork-ui/assets/9210179/74a11018-6d2c-48ed-9f55-20d22790fdef)

![image](https://github.com/geonetwork/geonetwork-ui/assets/9210179/2268c1f8-32fe-40d7-afeb-e6726b325982)

#756 