### PR TITLE
Datahub: Add generic "keyword" filter with translated values

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasets.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasets.cy.ts
@@ -157,6 +157,12 @@ describe('datasets', () => {
     }
 
     beforeEach(() => {
+      // this will enable all available filters
+      cy.intercept('GET', '/assets/configuration/default.toml', {
+        fixture: 'config-with-all-filters.toml',
+      })
+      cy.visit('/search')
+
       // expand filters
       cy.get('datahub-search-filters')
         .find('[data-cy=filters-expand]')
@@ -164,7 +170,7 @@ describe('datasets', () => {
         .click()
     })
     it('should display all filters', () => {
-      cy.get('@filters').filter(':visible').should('have.length', 6)
+      cy.get('@filters').filter(':visible').should('have.length', 10)
       cy.get('@filters')
         .children()
         .then(($dropdowns) =>
@@ -179,6 +185,10 @@ describe('datasets', () => {
           'topic',
           'isSpatial',
           'license',
+          'inspireKeyword',
+          'keyword',
+          'resourceType',
+          'representationType',
         ])
     })
 
@@ -342,6 +352,72 @@ describe('datasets', () => {
     describe('licence filter', () => {
       beforeEach(() => {
         cy.get('@filters').eq(5).click()
+        getFilterOptions()
+      })
+      it('should have options', () => {
+        cy.get('@options').should('have.length.above', 0)
+      })
+      it('should not have duplicates', () => {
+        cy.get<string[]>('@optionsLabelWithoutCount').then(checkHasDuplicates)
+      })
+    })
+
+    describe('inspire keyword filter', () => {
+      beforeEach(() => {
+        cy.get('@filters').eq(6).click()
+        getFilterOptions()
+      })
+      it('should have options', () => {
+        cy.get('@options').should('have.length.above', 0)
+        cy.get('@optionsLabel')
+          .invoke('slice', 0, 3)
+          .should('eql', [
+            'Environmental monitoring facilities (2)',
+            'Land use (1)',
+            'Production and industrial facilities (1)',
+          ])
+      })
+      it('should not have duplicates', () => {
+        cy.get<string[]>('@optionsLabelWithoutCount').then(checkHasDuplicates)
+      })
+    })
+
+    describe('keyword filter', () => {
+      beforeEach(() => {
+        cy.get('@filters').eq(7).click()
+        getFilterOptions()
+      })
+      it('should have options', () => {
+        cy.get('@options').should('have.length.above', 0)
+        cy.get('@optionsLabel')
+          .invoke('slice', 0, 3)
+          .should('eql', [
+            'DONNEE OUVERTE (3)',
+            'HAUTS-DE-FRANCE (3)',
+            'Open Data (3)',
+          ])
+      })
+      it('should not have duplicates', () => {
+        cy.get<string[]>('@optionsLabelWithoutCount').then(checkHasDuplicates)
+      })
+    })
+
+    describe('resource type filter', () => {
+      beforeEach(() => {
+        cy.get('@filters').eq(8).click()
+        getFilterOptions()
+      })
+      it('should have options', () => {
+        cy.get('@options').should('have.length.above', 0)
+      })
+      it('should not have duplicates', () => {
+        cy.get<string[]>('@optionsLabelWithoutCount').then(checkHasDuplicates)
+      })
+    })
+
+    describe('representation type filter', () => {
+      beforeEach(() => {
+        cy.get('@filters').eq(9).click()
         getFilterOptions()
       })
       it('should have options', () => {

--- a/apps/datahub-e2e/src/fixtures/config-with-all-filters.toml
+++ b/apps/datahub-e2e/src/fixtures/config-with-all-filters.toml
@@ -1,0 +1,12 @@
+[global]
+geonetwork4_api_url = "/geonetwork/srv/api"
+proxy_path = ""
+
+[theme]
+primary_color = "#c82850"
+secondary_color = "#001638"
+main_color = "#212029" # All-purpose text color
+background_color = "#fdfbff"
+
+[search]
+advanced_filters = ['publisher', 'format', 'publicationYear', 'topic', 'isSpatial', 'license', 'inspireKeyword', 'keyword', 'resourceType', 'representationType']

--- a/apps/metadata-editor-e2e/src/e2e/dashboard.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/dashboard.cy.ts
@@ -50,14 +50,16 @@ describe('dashboard', () => {
       cy.url().should('include', 'sort=resourceTitleObject.default.keyword')
       cy.get('.table-header-cell').eq(1).click()
       cy.url().should('include', 'sort=-resourceTitleObject.default.keyword')
-      cy.get('gn-ui-results-table')
-        .find('.table-row-cell')
-        .eq(1)
-        .invoke('text')
-        .invoke('trim')
-        .then(function (newFirstItem) {
-          expect(newFirstItem).not.to.equal(this.originalFirstItem)
-        })
+
+      // this is wrapped in a then call because we want to have access to `this.originalFirstItem`
+      cy.get('gn-ui-results-table').then(function (table) {
+        cy.wrap(table)
+          .find('.table-row-cell')
+          .eq(1)
+          .invoke('text')
+          .invoke('trim')
+          .should('not.equal', this.originalFirstItem)
+      })
     })
   })
 

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -79,7 +79,7 @@ background_color = "#fdfbff"
 # filter_geometry_data = '{ "coordinates": [...], "type": "Polygon" }'
 
 # The advanced search filters available to the user can be customized with this setting.
-# The following fields can be used for filtering: 'publisher', 'format', 'publicationYear', 'standard', 'inspireKeyword', 'topic', 'isSpatial', 'license', 'resourceType', 'representationType'
+# The following fields can be used for filtering: 'publisher', 'format', 'publicationYear', 'standard', 'inspireKeyword', 'keyword', 'topic', 'isSpatial', 'license', 'resourceType', 'representationType'
 # any other field will be ignored
 # advanced_filters = ['publisher', 'format', 'publicationYear', 'topic', 'isSpatial', 'license']
 

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -2,8 +2,303 @@
 outline: deep
 ---
 
-# Configure
+# Configuration of a GeoNetwork-UI application
 
-## Chapter 1
+Each application can rely on its own system for configuration. This page lists the main ones.
 
-## Chapter 2
+## TOML file
+
+### Introduction
+
+Most applications such as the [Datahub](../apps/datahub.md) rely on a file called `default.toml` which is part of its available assets. **This file is loaded and read before anything else is done**, e.g. bootstrapping the application.
+
+This file uses the [TOML format](https://toml.io/en/), which is an easy-to-read format composed of sections, each of them containing key-value pairs. Comments are also present in the default file to help customizing it.
+
+Some additional notes:
+
+- Languages in the configuration are specified using [two-letters ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) unless noted otherwise
+- Tokens in URL templates are specified using the `${token_name}` syntax
+
+### Sections
+
+#### `[global]`
+
+- `geonetwork4_api_url`
+
+  This URL (relative or absolute) must point to the API endpoint of a GeoNetwork 4.x instance, such as "/geonetwork/srv/api".
+
+- `proxy_path` (optional)
+
+  This should point to a proxy to avoid CORS errors on some requests (data preview, OGC capabilities etc.). The actual URL will be appended after this path, e.g. : https://my.proxy/?url=http%3A%2F%2Fencoded.url%2Fservice.
+
+  This is an optional parameter: leave empty to disable proxy usage.
+
+- `languages` (optional)
+
+  This optional parameter defines the languages that will be provided in the UI language switcher. Available languages are listed [in this file](https://github.com/geonetwork/geonetwork-ui/blob/1533e02e24258814ef19f21e991a45e01fd06f36/libs/util/i18n/src/lib/i18n.constants.ts#L25).
+
+  Languages should be provided as an array, for instance:
+
+  ```toml
+  languages = ['en', 'fr', 'de']
+  ```
+
+  More information about the translation can be found in the [relevant documentation](../reference/i18n.md)
+
+- `metadata_language` (optional)
+
+  This optional parameter lets you specify which language to use when searching in the catalog connected to GeoNetwork-UI. This might improve the search experience by showing results relevant to your users' language.
+
+  Use [ISO three-letter codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) to indicate the language used in the search (e.g. "fre" or "ger"). Alternatively, setting to "current" will use the current language of the User Interface.
+
+  If not indicated, the search will be done across all localized values for each record, potentially showing more results that expected or unrelated results.
+
+- `login_url` (optional)
+
+  This optional URL should point to the login page that allows authentication to the GeoNetwork-UI backend (e.g. GeoNetwork).
+
+  If not indicated, a default GeoNetwork login link is used.
+
+  The following three placeholders can be part of this URL:
+
+  - `${current_url}`: indicates where the current location should be injected in the constructed login URL
+
+  - `${lang2}`, `${lang3}`: indicates if and where the current language should be part of the login URL in 2- or 3-letters ISO format
+
+  Example for a platform relying on CAS:
+
+  ```toml
+  login_url = "/cas/login?service=${current_url}"
+  ```
+
+- `web_component_embedder_url` (optional)
+
+  This optional URL should point to the static html page [`wc-embedder.html`](https://github.com/geonetwork/geonetwork-ui/blob/1533e02e24258814ef19f21e991a45e01fd06f36/tools/webcomponent/wc-embedder.html) which allows displaying any GeoNetwork-UI web component (e.g. chart or table) via a permalink.
+
+  URLs can be indicated from the root of the same server starting with a "/" or as an external URL. Be conscious of potential CORS issues when using an external URL.
+
+  The default location in the dockerized Datahub app is for example "/datahub/wc-embedder.html".
+
+  If the URL is not indicated, no permalinks will show up in the UI.
+
+- `contact_email` (optional)
+
+  Enables displaying a "contact block" wherever relevant in applications.
+
+- `datahub_url` (optional)
+
+  (WIP)
+
+#### `[theme]`
+
+::: tip
+All parameters in this section are expressed using CSS formats; references:
+
+- for color: https://developer.mozilla.org/en-US/docs/Web/CSS/color
+- for font families: https://developer.mozilla.org/en-US/docs/Web/CSS/font-family
+- for background: https://developer.mozilla.org/en-US/docs/Web/CSS/background
+  :::
+
+* `primary_color`, `secondary_color`, `main_color` and `background_color`
+
+  These colors constitute the building blocks of the visual theme of an application. Color scales will be derived from them automatically to offer relevant contrasts and engaging visuals.
+
+  Note that `main_color` is the all-purpose text color, usually very close to black. `background_color` is the general page background, usually very cloe to white.
+
+* `header_background` and `header_foreground_color` (optional)
+
+  These optional parameters indicate which background should be used for the main header and the text color used on top of the background. The color should be chosen to contrast well with the background (defaults to white).
+
+* `thumbnail_placeholder` (optional)
+
+  This optional parameter allows overriding the fallback image that should be used for thumbnails in case the metadata record has no thumbnail image URL or it fails to load.
+
+* `main_font` and `title_font` (optional)
+
+  These optional parameters allow changing fonts used in the app.
+
+* `fonts_stylesheet_url` (optional)
+
+  If using custom fonts, specify a URL pointing to a stylesheet defining these fonts. This could typically be a Google Fonts URL, for instance:
+
+  ```toml
+  fonts_stylesheet_url = "https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Permanent+Marker&display=swap"
+  ```
+
+- `favicon` (optional)
+
+  Use this setting to set a custom URL for the favicon; by default, "/favicon.ico" will be used.
+
+#### `[search]`
+
+- `filter_geometry_url` or `filter_geometry_data` (optional)
+
+Specify a GeoJSON object to be used as filter: all records contained inside the geometry will be **boosted on top**, all records which do not intersect with the geometry will be **shown with lower priority**.
+
+The GeoJSON geometry can be specified either as URL or inline data.
+
+Note: if the GeoJSON object contains multiple features, only the geometry of the first one will be kept!
+
+- `advanced_filters` (optional)
+
+The advanced search filters available to the user can be customized with this setting.
+For a list of supported search fields, see [this documentation page](../reference/search-fields.md). Any unknown field will be ignored.
+
+The filters should be provided as an array, for instance:
+
+```toml
+advanced_filters = ['publisher', 'inspireKeyword', 'keyword', 'topic']
+```
+
+- `[[search_preset]]` (multiple, optional)
+
+  Search presets are shown in a prominent way to the user and can be used to showcase certain records in the catalog or offer shortcuts to frequent search criteria.
+
+  Every search preset is composed of:
+
+  - a name for the preset, which can be a translation key (mandatory)
+  - a sort criteria: either `createDate`, `userSavedCount` or `_score` (prepend with `-` for descending sort) (optional)
+  - a set of filters, each of them being a key-value pair where the key is a [known search field](../reference/search-fields.md) and the value is an array of strings (optional)
+  - additionally, `filters.q` can be used to specify a full text search query
+
+  Multiple search presets can be defined like so:
+
+  ```toml
+  [[search_preset]]
+  name = 'filterByName'
+  filters.q = 'full text search'
+  filters.publisher = ['Org 1', 'Org 2']
+  filters.format = ['format 1', 'format 2']
+  filters.documentStandard = ['iso19115-3.2018']
+  filters.inspireKeyword = ['keyword 1', 'keyword 2']
+  filters.topic = ['boundaries']
+  filters.publicationYear = ['2023', '2022']
+  filters.isSpatial = ['yes']
+  filters.license = ['unknown']
+  sort = 'createDate'
+
+  [[search_preset]]
+  name = 'otherFilter'
+  filters.q = 'full text search'
+  ```
+
+#### `[metadata-quality]`
+
+This section contains settings related to the Metadata Quality system.
+
+::: info How to enable the Metadata Quality system
+To show Metadata Quality scores on records and allow sorting, enabling the setting below is not enough. An ElasticSearch pipeline also has to be registered; please refer to [this section](../guide/deploy.md#enabling-improved-search-fields) for more information.
+:::
+
+- `enabled` (optional)
+
+  By default, the widget is not activated; to enable it, just set this parameter to "true".
+
+#### `[map]`
+
+The map section lets you customize how maps appear and behave across GeoNetwork-UI applications.
+
+- `max_zoom` (optional)
+
+  Will limit the possibility to zoom in past a certain zoom level.
+
+- `max_extent` (optional)
+
+  Will limit the possibility to pan or zoom outside of an extent. Expressed as an array of _minX_, _minY_, _maxX_ and _maxY_ numerical components in the map view projection (EPSG:3857 by default), e.g.:
+
+  ```toml
+  max_extent = [-418263.418776, 5251529.591305, 961272.067714, 6706890.609855]
+  ```
+
+- `do_not_use_default_basemap` (optional)
+
+  If set to `true`, the default basemap will not be added to the map. Defaults to `false` (base map is shown).
+  Use `[[map_layer]]` sections to define your own custom layers (see below)
+
+- `[[map_layer]]` (multiple, optional)
+
+  One or several layers (as background or overlay) can be added to the map with the following properties:
+
+  - `type` (mandatory): Indicates the layer type. Possible values are "xyz", "wms", "wfs", "geojson".
+  - `url` (mandatory for "xyz", "wms" and "wfs" types): Layer endpoint URL.
+  - `name` (mandatory for "wms" and "wfs" types): indicates the layer name or feature type.
+  - `data` (for "geojson" type only): inline GeoJSON data as string.
+
+  Layer order in the config is the same as in the map, the foreground layer being the last defined one.
+
+  Each layer is defined in its own `[[map_layer]]` section. For instance:
+
+  ```toml
+  [[map_layer]]
+  type = "xyz"
+  url = "https://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+
+  [[map_layer]]
+  type = "wfs"
+  url = "https://www.geo2france.fr/geoserver/cr_hdf/ows"
+  name = "masque_hdf_ign_carto_latin1"
+
+  [[map_layer]]
+  type = "geojson"
+  data = """
+  {
+  "type": "FeatureCollection",
+  "features": [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [125.6, 10.1]}}]
+  }
+  """
+  ```
+
+- `external_viewer_url_template` (optional)
+
+  URL template allowing opening map layers in an external viewer; if set, applications such as the Datahub will offer a button next to the map viewer tp open the currently-viewed layers in an external viewer.
+
+  The template must include the following placeholders, which allow applications to inject the correct values when generating the final URL:
+
+  - `${service_url}`: URL of the data file or web service providing the layer
+  - `${service_type}`: Type of layer; currently supported types are WMS, WFS, GEOJSON
+  - `${layer_name}`: Name of the layer
+
+  Example for an integration with MapStore viewer:
+
+  ```toml
+  external_viewer_url_template = 'https://my.sdi.org/mapstore/#/?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["${layer_name}"],"sources":[{"url":"${service_url}","type":"${service_type}"}]}]'
+  ```
+
+- `external_viewer_open_new_tab` (optional)
+
+  If set to "true", the external viewer will open in a new tab when adding layers to it; if set to "false" (default), the external viewer will open in the same tab. Requires `external_viewer_url_template` to have any effect.
+
+#### `[translations.xy]`
+
+To override translations in a specific language, use a "translations.xy" section where "xy" is a two-letter language code.
+
+Example:
+
+```toml
+[translations.en]
+results.sortBy.dateStamp = "Last time someone changed something"
+[translations.fr]
+results.sortBy.dateStamp = "Dernière fois que quelqu'un a modifié quelque chose"
+```
+
+::: tip Using HTML in translations
+Translation keys ending with ".html" _can_ contain HTML markup, including inline CSS:
+
+```toml
+[translations.en]
+catalog.welcome.html = """
+Welcome to <span class="text-primary">Organization</span>'s<br>
+wonderful <span style="font-size: 1.2em;">data catalogue</span>
+"""
+```
+
+:::
+
+### Backwards compatibility
+
+A `default.toml` file authored for a previous release of GeoNetwork-UI _should_ always work when using a more recent version. There are two caveats:
+
+- if upgrading to a higher major version (e.g. from 1.2.0 to 2.0.0), some breaking changes might occur; these changes and how to migrate the file will be documented in the release notes
+- if some settings of the file become obsolete, a warning will be printed in the browser console when loading the app; this _should not_ break functionalities, but fixing those warnings by the administrator is recommended
+
+As for translation keys, these are subject to change outside of major version bumps, so any overridden translation key in the configuration file might become obsolete between versions. Please refer to the release notes to get a list of obsolete translation keys and their replacements.

--- a/docs/reference/search-fields.md
+++ b/docs/reference/search-fields.md
@@ -2,8 +2,98 @@
 outline: deep
 ---
 
-# Search fields
+# Supported search fields
 
-## Chapter 1
+GeoNetwork-UI has built-in logic for several search fields, each of them relying on specific parts of the GeoNetwork search index. This page lists them all and their specificities.
 
-## Chapter 2
+## Usage
+
+These fields are used in the following context:
+
+- when building a URL or permalink from several search criteria; these fields will appear as query parameters in the URL, for instance:  
+  `/search?publisher=MyOrg&format=csv&format=excel`
+- when specifying advanced filters [in a configuration file](../guide/configure.md#search)
+
+## Fields
+
+### Publisher
+
+> Field id: `publisher`
+
+This field targets the owner organization of a record. The exact meaning of a record's organization is defined by the "organization strategy" used; see [this documentation page](./organizations.md) for more details.
+
+### Format
+
+> Field id: `format`
+
+This field targets the formats of the distributions present in a record. To have human-readable formats with a GeoNetwork 4 backend, see [this section of the documentation](../guide/deploy.md#enabling-improved-search-fields).
+
+### Publication year
+
+> Field id: `publicationYear`
+
+This field targets the "year" part of the publication date of a record.
+
+### Topic
+
+> Field id: `topic`
+
+This field targets the "topic" field of a record, sometimes also known as "theme". Topics are used for a general first-level classification and categorization of records.
+
+### Keyword
+
+> Field id: `keyword`
+
+This field targets the keywords present in a record. These are treated as simple strings.
+
+::: info Note for multilingual catalogs
+GeoNetwork 4 supports multilingual keywords.
+
+The keywords will show up in the correct language when viewing a record in applications such as the Datahub, but for the search fields **only the "default" labels are used** (i.e. the labels in the main language of the record).
+
+This means that a "keyword" search filter will show values in potentially many different languages.
+:::
+
+### INSPIRE keyword
+
+> Field id: `inspireKeyword`
+
+This field target keywords that are part of the following INSPIRE-specific thesaurus: https://inspire.ec.europa.eu/theme.
+
+Because such keywords are part of a controlled list, they can be shown in the correct language according to the user's preferences.
+
+### Has spatial component
+
+> Field id: `isSpatial`
+
+This field offers the only two values "yes" and "no" according to whether a record contains data with a (geo-)spatial component.
+
+### License
+
+> Field id: `license`
+
+This field targets the license(s) that are mentioned in a record. Note that this only works for a few well-known licenses, such as:
+
+- Creative Commons licenses
+- Open Data Commons licenses
+- [Etalab Open licenses](https://www.etalab.gouv.fr/licence-ouverte-open-licence/)
+
+Other kind of licenses will appear under the label "Unknown or absent".
+
+### Resource type
+
+> Field id: `resourceType`
+
+Type of record, such as "dataset" or "service".
+
+### Representation type
+
+> Field id: `representationType`
+
+Representation type of a record, such as "vector" or "raster".
+
+### Metadata standard
+
+> Field id: `standard`
+
+This field targets the name of the metadata standard used to describe a record. This can for instance be "ISO 19115-3" or "ISO 19139".

--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.mapper.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.mapper.ts
@@ -45,12 +45,23 @@ export class Gn4PlatformMapper {
     return { ...apiUser, id: id.toString() } as UserModel
   }
 
-  thesaurusFromApi(thesaurus: any[]): ThesaurusModel {
+  thesaurusFromApi(thesaurus: any[], lang3?: string): ThesaurusModel {
     return thesaurus.map((keyword) => {
-      const { uri, value } = keyword
+      let key = keyword.uri
+      // sometines GN can prefix an URI with an "all thesaurus" URI; only keep the last one
+      if (key.indexOf('@@@') > -1) {
+        key = key.split('@@@')[1]
+      }
+      const label =
+        lang3 && lang3 in keyword.values ? keyword.values[lang3] : keyword.value
+      const description =
+        lang3 && lang3 in keyword.definitions
+          ? keyword.definitions[lang3]
+          : keyword.definition
       return {
-        key: uri,
-        label: value,
+        key,
+        label,
+        description,
       }
     })
   }

--- a/libs/common/domain/src/lib/model/thesaurus/thesaurus.model.ts
+++ b/libs/common/domain/src/lib/model/thesaurus/thesaurus.model.ts
@@ -1,6 +1,7 @@
 export interface ThesaurusItemModel {
   key: string
   label: string
+  description?: string
 }
 
 export type ThesaurusModel = ThesaurusItemModel[]

--- a/libs/common/domain/src/lib/platform.service.interface.ts
+++ b/libs/common/domain/src/lib/platform.service.interface.ts
@@ -15,8 +15,5 @@ export abstract class PlatformServiceInterface {
   ): Observable<UserModel[]>
   abstract getOrganizations(): Observable<Organization[]>
   abstract translateKey(key: string): Observable<string>
-  abstract getThesaurusByLang(
-    thesaurusName: string,
-    lang: string
-  ): Observable<ThesaurusModel>
+  abstract getThesaurusByUri(uri: string): Observable<ThesaurusModel>
 }

--- a/libs/feature/search/src/lib/utils/service/fields.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.spec.ts
@@ -41,13 +41,6 @@ class PlatformServiceInterfaceMock {
         return of(null)
     }
   })
-  getThesaurusByLang = jest.fn((thesaurusName: string, lang: string) =>
-    of([
-      { key: 'First value', label: 'Rivière' },
-      { key: 'Second value', label: 'Forêt' },
-      { key: 'Third value', label: 'Planète' },
-    ])
-  )
 }
 
 describe('FieldsService', () => {
@@ -100,6 +93,7 @@ describe('FieldsService', () => {
           'publicationYear',
           'topic',
           'inspireKeyword',
+          'keyword',
           'documentStandard',
           'isSpatial',
           'q',
@@ -176,6 +170,7 @@ describe('FieldsService', () => {
           documentStandard: [],
           format: ['ascii', 'png'],
           inspireKeyword: [],
+          keyword: [],
           isSpatial: [],
           license: [],
           publicationYear: [],

--- a/libs/feature/search/src/lib/utils/service/fields.service.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.ts
@@ -5,6 +5,7 @@ import {
   FullTextSearchField,
   IsSpatialSearchField,
   LicenseSearchField,
+  MultilingualSearchField,
   OrganizationSearchField,
   OwnerSearchField,
   SimpleSearchField,
@@ -59,7 +60,7 @@ export class FieldsService {
       this.injector,
       'asc'
     ),
-    keyword: new TranslatedSearchField('tag', this.injector, 'desc', 'count'),
+    keyword: new MultilingualSearchField('tag', this.injector, 'desc', 'count'),
     documentStandard: new SimpleSearchField(
       'documentStandard',
       this.injector,

--- a/libs/feature/search/src/lib/utils/service/fields.service.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.ts
@@ -4,12 +4,11 @@ import {
   FieldValue,
   FullTextSearchField,
   IsSpatialSearchField,
-  KeySearchField,
   LicenseSearchField,
   OrganizationSearchField,
   OwnerSearchField,
   SimpleSearchField,
-  ThesaurusField,
+  TranslatedSearchField,
 } from './fields'
 import { forkJoin, Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
@@ -21,6 +20,7 @@ export type FieldValues = Record<string, FieldValue[] | FieldValue>
 
 marker('search.filters.format')
 marker('search.filters.inspireKeyword')
+marker('search.filters.keyword')
 marker('search.filters.isSpatial')
 marker('search.filters.license')
 marker('search.filters.publicationYear')
@@ -37,29 +37,33 @@ marker('search.filters.contact')
 export class FieldsService {
   private fields = {
     publisher: new OrganizationSearchField(this.injector),
-    format: new SimpleSearchField('format', 'asc', this.injector),
-    resourceType: new KeySearchField('resourceType', 'asc', this.injector),
-    representationType: new KeySearchField(
+    format: new SimpleSearchField('format', this.injector, 'asc'),
+    resourceType: new TranslatedSearchField(
+      'resourceType',
+      this.injector,
+      'asc'
+    ),
+    representationType: new TranslatedSearchField(
       'cl_spatialRepresentationType.key',
-      'asc',
-      this.injector
+      this.injector,
+      'asc'
     ),
     publicationYear: new SimpleSearchField(
       'publicationYearForResource',
-      'desc',
-      this.injector
+      this.injector,
+      'desc'
     ),
-    topic: new KeySearchField('cl_topic.key', 'asc', this.injector),
-    inspireKeyword: new ThesaurusField(
-      'th_httpinspireeceuropaeutheme-theme.link',
-      'external.theme.httpinspireeceuropaeutheme-theme',
-      'asc',
-      this.injector
+    topic: new TranslatedSearchField('cl_topic.key', this.injector, 'asc'),
+    inspireKeyword: new TranslatedSearchField(
+      'th_httpinspireeceuropaeutheme-theme',
+      this.injector,
+      'asc'
     ),
+    keyword: new TranslatedSearchField('tag', this.injector, 'desc', 'count'),
     documentStandard: new SimpleSearchField(
       'documentStandard',
-      'asc',
-      this.injector
+      this.injector,
+      'asc'
     ),
     isSpatial: new IsSpatialSearchField(this.injector),
     q: new FullTextSearchField(),

--- a/libs/feature/search/src/lib/utils/service/fields.service.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.ts
@@ -56,7 +56,7 @@ export class FieldsService {
     ),
     topic: new TranslatedSearchField('cl_topic.key', this.injector, 'asc'),
     inspireKeyword: new TranslatedSearchField(
-      'th_httpinspireeceuropaeutheme-theme',
+      'th_httpinspireeceuropaeutheme-theme.link',
       this.injector,
       'asc'
     ),

--- a/libs/feature/search/src/lib/utils/service/fields.spec.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.spec.ts
@@ -137,13 +137,6 @@ class PlatformInterfaceMock {
         return of(null)
     }
   })
-  getThesaurusByLang = jest.fn((thesaurusName: string, lang: string) =>
-    of([
-      { key: 'First value', label: 'Rivière' },
-      { key: 'Second value', label: 'Forêt' },
-      { key: 'Third value', label: 'Planète' },
-    ])
-  )
 }
 
 const sampleOrgs: Organization[] = [

--- a/libs/feature/search/src/lib/utils/service/fields.spec.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.spec.ts
@@ -3,11 +3,10 @@ import {
   AbstractSearchField,
   FullTextSearchField,
   IsSpatialSearchField,
-  KeySearchField,
+  TranslatedSearchField,
   LicenseSearchField,
   OrganizationSearchField,
   SimpleSearchField,
-  ThesaurusField,
 } from './fields'
 import { TestBed } from '@angular/core/testing'
 import { Injector } from '@angular/core'
@@ -301,10 +300,10 @@ describe('search fields implementations', () => {
     })
   })
 
-  describe('KeySearchField', () => {
+  describe('TranslatedSearchField', () => {
     describe('sort by key', () => {
       beforeEach(() => {
-        searchField = new KeySearchField('cl_topic.key', injector, 'asc')
+        searchField = new TranslatedSearchField('cl_topic.key', injector, 'asc')
       })
       describe('#getAvailableValues', () => {
         let values
@@ -336,7 +335,7 @@ describe('search fields implementations', () => {
     })
     describe('sort by count', () => {
       beforeEach(() => {
-        searchField = new KeySearchField(
+        searchField = new TranslatedSearchField(
           'tag.default',
           injector,
           'desc',
@@ -366,36 +365,6 @@ describe('search fields implementations', () => {
             { label: 'Fourth value (1)', value: 'Fourth value' },
           ])
         })
-      })
-    })
-  })
-  describe('ThesaurusField', () => {
-    beforeEach(() => {
-      searchField = new ThesaurusField(
-        'th_inspire.link',
-        'inspire',
-        injector,
-        'asc'
-      )
-    })
-    describe('#getAvailableValues', () => {
-      let values
-      beforeEach(async () => {
-        values = await lastValueFrom(searchField.getAvailableValues())
-      })
-      it('calls search with a simple unsorted terms', () => {
-        expect(platformService.getThesaurusByLang).toHaveBeenCalledWith(
-          'inspire',
-          'fre'
-        )
-      })
-      it('returns a list of values sorted by translated labels', () => {
-        expect(values).toEqual([
-          { label: 'Forêt (3)', value: 'Second value' },
-          { label: 'Fourth value (1)', value: 'Fourth value' },
-          { label: 'Planète (12)', value: 'Third value' },
-          { label: 'Rivière (5)', value: 'First value' },
-        ])
       })
     })
   })

--- a/libs/feature/search/src/lib/utils/service/fields.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.ts
@@ -36,8 +36,9 @@ export class SimpleSearchField implements AbstractSearchField {
 
   constructor(
     protected esFieldName: string,
+    protected injector: Injector,
     protected order: 'asc' | 'desc' = 'asc',
-    protected injector: Injector
+    protected orderType: 'key' | 'count' = 'key'
   ) {}
 
   protected getAggregations(): AggregationsParams {
@@ -46,7 +47,7 @@ export class SimpleSearchField implements AbstractSearchField {
         type: 'terms',
         field: this.esFieldName,
         limit: 1000,
-        sort: [this.order, 'key'],
+        sort: [this.order, this.orderType],
       },
     }
   }
@@ -100,6 +101,7 @@ export class KeySearchField extends SimpleSearchField {
   }
 
   getAvailableValues(): Observable<FieldAvailableValue[]> {
+    if (this.orderType === 'count') return super.getAvailableValues()
     // sort values by alphabetical order
     return super
       .getAvailableValues()
@@ -126,10 +128,10 @@ export class ThesaurusField extends KeySearchField {
   constructor(
     esFieldName: string,
     protected thesaurusName: string,
-    order: 'asc' | 'desc' = 'asc',
-    injector: Injector
+    injector: Injector,
+    order: 'asc' | 'desc' = 'asc'
   ) {
-    super(esFieldName, order, injector)
+    super(esFieldName, injector, order)
   }
   protected async getTranslation(key: string) {
     return firstValueFrom(
@@ -163,7 +165,7 @@ export class IsSpatialSearchField extends SimpleSearchField {
   private translateService = this.injector.get(TranslateService)
 
   constructor(injector: Injector) {
-    super('isSpatial', 'asc', injector)
+    super('isSpatial', injector, 'asc')
     this.esService.registerRuntimeField(
       'isSpatial',
       `String result = 'no';
@@ -223,7 +225,7 @@ export class LicenseSearchField extends SimpleSearchField {
   private translateService = this.injector.get(TranslateService)
 
   constructor(injector: Injector) {
-    super('license', 'asc', injector)
+    super('license', injector, 'asc')
     this.esService.registerRuntimeField(
       'license',
       `String raw = '';
@@ -330,7 +332,7 @@ export class OrganizationSearchField implements AbstractSearchField {
 }
 export class OwnerSearchField extends SimpleSearchField {
   constructor(injector: Injector) {
-    super('owner', 'asc', injector)
+    super('owner', injector, 'asc')
   }
 
   getAvailableValues(): Observable<FieldAvailableValue[]> {

--- a/translations/de.json
+++ b/translations/de.json
@@ -292,6 +292,7 @@
   "search.filters.isSpatial": "Ist räumliche Daten",
   "search.filters.isSpatial.no": "nicht räumlich",
   "search.filters.isSpatial.yes": "räumlich",
+  "search.filters.keyword": "Schlüsselwort",
   "search.filters.license": "Lizenz",
   "search.filters.license.cc-by": "Creative Commons CC-BY",
   "search.filters.license.cc-by-sa": "Creative Commons CC-BY-SA",

--- a/translations/en.json
+++ b/translations/en.json
@@ -292,6 +292,7 @@
   "search.filters.isSpatial": "Is spatial data",
   "search.filters.isSpatial.no": "non spatial",
   "search.filters.isSpatial.yes": "spatial",
+  "search.filters.keyword": "Keyword",
   "search.filters.license": "License",
   "search.filters.license.cc-by": "Creative Commons CC-BY",
   "search.filters.license.cc-by-sa": "Creative Commons CC-BY-SA",

--- a/translations/es.json
+++ b/translations/es.json
@@ -292,6 +292,7 @@
   "search.filters.isSpatial": "",
   "search.filters.isSpatial.no": "",
   "search.filters.isSpatial.yes": "",
+  "search.filters.keyword": "",
   "search.filters.license": "",
   "search.filters.license.cc-by": "",
   "search.filters.license.cc-by-sa": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -292,6 +292,7 @@
   "search.filters.isSpatial": "Données spatiales",
   "search.filters.isSpatial.no": "non-géolocalisées",
   "search.filters.isSpatial.yes": "géolocalisées",
+  "search.filters.keyword": "Mot-clé",
   "search.filters.license": "Licence",
   "search.filters.license.cc-by": "cc-by",
   "search.filters.license.cc-by-sa": "cc-by-sa",

--- a/translations/it.json
+++ b/translations/it.json
@@ -292,6 +292,7 @@
   "search.filters.isSpatial": "Dati spaziali",
   "search.filters.isSpatial.no": "Non geolocalizzati",
   "search.filters.isSpatial.yes": "Geolocalizzati",
+  "search.filters.keyword": "Parola chiave",
   "search.filters.license": "Licenza",
   "search.filters.license.cc-by": "cc-by",
   "search.filters.license.cc-by-sa": "cc-by-sa",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -292,6 +292,7 @@
   "search.filters.isSpatial": "",
   "search.filters.isSpatial.no": "",
   "search.filters.isSpatial.yes": "",
+  "search.filters.keyword": "",
   "search.filters.license": "",
   "search.filters.license.cc-by": "",
   "search.filters.license.cc-by-sa": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -292,6 +292,7 @@
   "search.filters.isSpatial": "",
   "search.filters.isSpatial.no": "",
   "search.filters.isSpatial.yes": "",
+  "search.filters.keyword": "",
   "search.filters.license": "",
   "search.filters.license.cc-by": "",
   "search.filters.license.cc-by-sa": "",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -292,6 +292,7 @@
   "search.filters.isSpatial": "Je priestorový údaj",
   "search.filters.isSpatial.no": "nepravdivé",
   "search.filters.isSpatial.yes": "pravdivé",
+  "search.filters.keyword": "Kľúčové slová",
   "search.filters.license": "Licencia",
   "search.filters.license.cc-by": "Creative Commons CC-BY",
   "search.filters.license.cc-by-sa": "Creative Commons CC-BY-SA",


### PR DESCRIPTION
### Description

This PR introduces a generic `keyword` filter. Unlike the INSPIRE keyword filter which fetches translation dynamically from the GeoNetwork API, the `keyword` filter simply looks at either `tag.default` or `tag.langxyz` fields depending on whether a hardcoded metadata language is defined in the configuration.

This PR also simplifies the implementation of both topics and INSPIRE keyword filters by introducing a `TranslatedSearchField` class which relies on the platform service to show a label in the correct language.

### Architectural changes

No significant changes.


### Screenshots

![image](https://github.com/geonetwork/geonetwork-ui/assets/10629150/a601aa58-e48b-41c2-a8c8-f90857f7dd95)


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [x] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by Swisstopo / [Geocat.ch](geocat.ch)**.
