### PR TITLE
Data service: better detect file formats from WFS outputs

### DIFF
--- a/libs/common/domain/src/lib/model/record/metadata.model.ts
+++ b/libs/common/domain/src/lib/model/record/metadata.model.ts
@@ -122,6 +122,7 @@ export interface DatasetDownloadDistribution {
   // textEncoding?: string
   name?: string
   description?: string
+  accessServiceProtocol?: ServiceProtocol
 }
 
 export interface OnlineLinkResource {

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -160,7 +160,7 @@ describe('DataService', () => {
         ),
         type: 'service',
         accessServiceProtocol: 'wfs',
-      }
+      } as const
       describe('WFS unreachable (CORS)', () => {
         it('throws a relevant error', async () => {
           try {
@@ -233,7 +233,7 @@ describe('DataService', () => {
               url: new URL(
                 'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=csv'
               ),
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
             {
@@ -243,7 +243,7 @@ describe('DataService', () => {
               url: new URL(
                 'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=xls'
               ),
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
             {
@@ -253,7 +253,7 @@ describe('DataService', () => {
               url: new URL(
                 'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=json'
               ),
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
             {
@@ -263,7 +263,7 @@ describe('DataService', () => {
               url: new URL(
                 'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=gml'
               ),
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
           ])
@@ -286,7 +286,7 @@ describe('DataService', () => {
               url: new URL(
                 'http://local/wfs?GetFeature&FeatureType=nojson_type&format=csv'
               ),
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
             {
@@ -296,7 +296,7 @@ describe('DataService', () => {
               url: new URL(
                 'http://local/wfs?GetFeature&FeatureType=nojson_type&format=xls'
               ),
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
             {
@@ -306,7 +306,7 @@ describe('DataService', () => {
               url: new URL(
                 'http://local/wfs?GetFeature&FeatureType=nojson_type&format=gml'
               ),
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
           ])
@@ -329,7 +329,7 @@ describe('DataService', () => {
               url: new URL(
                 'http://unique-feature-type/wfs?GetFeature&FeatureType=myOnlyOne&format=csv'
               ),
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
             {
@@ -339,7 +339,7 @@ describe('DataService', () => {
               url: new URL(
                 'http://unique-feature-type/wfs?GetFeature&FeatureType=myOnlyOne&format=xls'
               ),
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
             {
@@ -350,7 +350,7 @@ describe('DataService', () => {
                 'http://unique-feature-type/wfs?GetFeature&FeatureType=myOnlyOne&format=json'
               ),
 
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
             {
@@ -360,7 +360,7 @@ describe('DataService', () => {
               url: new URL(
                 'http://unique-feature-type/wfs?GetFeature&FeatureType=myOnlyOne&format=gml'
               ),
-              type: 'service',
+              type: 'download',
               accessServiceProtocol: 'wfs',
             },
           ])

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing'
 import { DataService } from './data.service'
 import { openDataset } from '@geonetwork-ui/data-fetcher'
 import { PROXY_PATH } from '@geonetwork-ui/util/shared'
-import { firstValueFrom, lastValueFrom } from 'rxjs'
+import { lastValueFrom } from 'rxjs'
 
 const newEndpointCall = jest.fn()
 
@@ -258,7 +258,7 @@ describe('DataService', () => {
             },
             {
               description: 'Lieu de surveillance (ligne)',
-              mimeType: 'gml',
+              mimeType: 'application/gml+xml',
               name: 'surval_parametre_ligne',
               url: new URL(
                 'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=gml'
@@ -301,7 +301,7 @@ describe('DataService', () => {
             },
             {
               description: 'Lieu de surveillance (ligne)',
-              mimeType: 'gml',
+              mimeType: 'application/gml+xml',
               name: 'nojson_type',
               url: new URL(
                 'http://local/wfs?GetFeature&FeatureType=nojson_type&format=gml'
@@ -355,7 +355,7 @@ describe('DataService', () => {
             },
             {
               description: 'Lieu de surveillance (ligne)',
-              mimeType: 'gml',
+              mimeType: 'application/gml+xml',
               name: '',
               url: new URL(
                 'http://unique-feature-type/wfs?GetFeature&FeatureType=myOnlyOne&format=gml'

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -45,7 +45,7 @@ interface WfsDownloadUrls {
 export class DataService {
   constructor(private proxy: ProxyService) {}
 
-  private getDownloadUrlsFromWfs(
+  getDownloadUrlsFromWfs(
     wfsUrl: string,
     featureTypeName: string
   ): Observable<WfsDownloadUrls> {
@@ -120,7 +120,7 @@ export class DataService {
     )
   }
 
-  private getDownloadUrlFromEsriRest(apiUrl: string, format: string): string {
+  getDownloadUrlFromEsriRest(apiUrl: string, format: string): string {
     return this.proxy.getProxiedUrl(
       `${apiUrl}/query?f=${format}&where=1=1&outFields=*`
     )
@@ -138,6 +138,7 @@ export class DataService {
       map((urls) =>
         Object.keys(urls).map((format) => ({
           ...wfsLink,
+          type: 'download',
           url: new URL(urls[format]),
           mimeType: getMimeTypeForFormat(extensionToFormat(format)) || format,
         }))

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -9,8 +9,8 @@ import {
   SupportedTypes,
 } from '@geonetwork-ui/data-fetcher'
 import {
-  extensionToFormat,
   getFileFormat,
+  getFileFormatFromServiceOutput,
   getMimeTypeForFormat,
   ProxyService,
 } from '@geonetwork-ui/util/shared'
@@ -140,7 +140,9 @@ export class DataService {
           ...wfsLink,
           type: 'download',
           url: new URL(urls[format]),
-          mimeType: getMimeTypeForFormat(extensionToFormat(format)) || format,
+          mimeType: getMimeTypeForFormat(
+            getFileFormatFromServiceOutput(format)
+          ),
         }))
       )
     )
@@ -154,7 +156,7 @@ export class DataService {
       url: new URL(
         this.getDownloadUrlFromEsriRest(esriRestLink.url.toString(), format)
       ),
-      mimeType: getMimeTypeForFormat(extensionToFormat(format)) || format,
+      mimeType: getMimeTypeForFormat(getFileFormatFromServiceOutput(format)),
     }))
   }
 

--- a/libs/util/shared/src/lib/links/link-utils.spec.ts
+++ b/libs/util/shared/src/lib/links/link-utils.spec.ts
@@ -1,13 +1,13 @@
 import { LINK_FIXTURES } from '@geonetwork-ui/common/fixtures'
 import {
   checkFileFormat,
-  extensionToFormat,
   FORMATS,
   getBadgeColor,
   getFileFormat,
+  getFileFormatFromServiceOutput,
   getLinkLabel,
-  mimeTypeToFormat,
   getLinkPriority,
+  mimeTypeToFormat,
 } from './link-utils'
 import { DatasetDownloadDistribution } from '@geonetwork-ui/common/domain/model/record'
 
@@ -50,7 +50,7 @@ describe('link utils', () => {
         expect(getFileFormat(LINK_FIXTURES.geodataShp)).toEqual('shp')
       })
     })
-    describe('for a shapefile link withe MimeType', () => {
+    describe('for a shapefile link with MimeType', () => {
       it('returns shp format', () => {
         expect(getFileFormat(LINK_FIXTURES.geodataShpWithMimeType)).toEqual(
           'shp'
@@ -165,11 +165,38 @@ describe('link utils', () => {
       }
     )
   })
-  describe('#extensionToFormat for an XLS extension', () => {
-    it('returns excel format', () => {
-      expect(extensionToFormat('XLS')).toEqual('excel')
-    })
+
+  describe('#getFileFormatFromServiceOutput', () => {
+    // service output, recognized file format
+    const toTest = [
+      ['SHAPE-ZIP', 'shp'],
+      ['application/vnd.google-earth.kml xml', 'kml'],
+      ['KML', 'kml'],
+      ['excel2007', 'excel'],
+      ['XLS', 'excel'],
+      ['gml2', 'gml'],
+      ['gml3', 'gml'],
+      ['text/xml; subtype=gml/3.1.1', 'gml'],
+      ['gml32', 'gml'],
+      ['DXF', 'dxf'],
+      ['DXF-ZIP', 'zip'],
+      ['json', 'json'],
+      ['geojson', 'geojson'],
+      ['Acbd', null],
+    ]
+
+    describe.each(toTest)(
+      'service output=%s, recognized file format=%s',
+      (serviceOutput, fileFormat) => {
+        it('returns the correct file format', () => {
+          expect(getFileFormatFromServiceOutput(serviceOutput)).toEqual(
+            fileFormat
+          )
+        })
+      }
+    )
   })
+
   describe('#getBadgeColor for format', () => {
     it('returns #1e5180', () => {
       expect(getBadgeColor('json')).toEqual('#1e5180')
@@ -190,7 +217,7 @@ describe('link utils', () => {
         })
       ).toEqual(nFormats - 1)
     })
-    it(`returns ${nFormats - 5}`, () => {
+    it(`returns ${nFormats - 6}`, () => {
       expect(
         getLinkPriority({
           description: 'Data in KML format',
@@ -198,7 +225,7 @@ describe('link utils', () => {
           url: new URL('https://my.server/files/abc.kml'),
           type: 'download',
         })
-      ).toEqual(nFormats - 5)
+      ).toEqual(nFormats - 6)
     })
   })
   describe('#checkFileFormat', () => {

--- a/libs/util/shared/src/lib/links/link-utils.ts
+++ b/libs/util/shared/src/lib/links/link-utils.ts
@@ -43,9 +43,15 @@ export const FORMATS = {
     color: '#328556',
     mimeTypes: ['x-gis/x-shapefile'],
   },
+  gml: {
+    extensions: ['gml'],
+    priority: 5,
+    color: '#c92bce',
+    mimeTypes: ['application/gml+xml', 'text/xml; subtype=gml'],
+  },
   kml: {
     extensions: ['kml', 'kmz'],
-    priority: 5,
+    priority: 6,
     color: '#348009',
     mimeTypes: [
       'application/vnd.google-earth.kml+xml',
@@ -54,33 +60,39 @@ export const FORMATS = {
   },
   gpkg: {
     extensions: ['gpkg', 'geopackage'],
-    priority: 6,
+    priority: 7,
     color: '#ea79ba',
     mimeTypes: ['application/geopackage+sqlite3'],
   },
   zip: {
     extensions: ['zip', 'tar.gz'],
-    priority: 7,
+    priority: 8,
     color: '#f2bb3a',
     mimeTypes: ['application/zip', 'application/x-zip'],
   },
   pdf: {
     extensions: ['pdf'],
-    priority: 8,
+    priority: 9,
     color: '#db544a',
     mimeTypes: ['application/pdf'],
   },
   jpg: {
     extensions: ['jpg', 'jpeg', 'jfif', 'pjpeg', 'pjp'],
-    priority: 8,
+    priority: 9,
     color: '#673ab7',
     mimeTypes: ['image/jpg'],
   },
   svg: {
     extensions: ['svg'],
-    priority: 9,
+    priority: 10,
     color: '#d98294',
     mimeTypes: ['image/svg+xml'],
+  },
+  dxf: {
+    extensions: ['dxf'],
+    priority: 11,
+    color: '#de630b',
+    mimeTypes: ['application/x-dxf', 'image/x-dxf'],
   },
 } as const
 
@@ -102,13 +114,24 @@ export function getLinkPriority(link: DatasetDistribution): number {
   return getFormatPriority(getFileFormat(link))
 }
 
-export function extensionToFormat(extension: string): FileFormat {
-  for (const format in FORMATS) {
-    for (const alias of FORMATS[format].extensions) {
-      if (alias === extension.toLowerCase()) return format as FileFormat
+export function getFileFormatFromServiceOutput(
+  serviceOutput: string
+): FileFormat | null {
+  function formatMatcher(format: typeof FORMATS[FileFormat]): boolean {
+    const output = serviceOutput.toLowerCase()
+    return (
+      format.extensions.some((extension: string) =>
+        output.includes(extension)
+      ) ||
+      format.mimeTypes.some((mimeType: string) => output.includes(mimeType))
+    )
+  }
+  for (const formatName in FORMATS) {
+    if (formatMatcher(FORMATS[formatName])) {
+      return formatName as FileFormat
     }
   }
-  return undefined
+  return null
 }
 
 export function getFileFormat(link: DatasetDistribution): FileFormat {


### PR DESCRIPTION
### Description

This PR reworks the logic for inferring file formats from a list of output types provided by a WFS endpoints. WFS will typically advertise these kinds of formats:
![image](https://github.com/geonetwork/geonetwork-ui/assets/10629150/4bb6d141-411d-4cfa-aab5-28d1608077ec)

With this PR, formats such as DXF, Shapefile and GML will now be recognized and show up properly in the Datahub download list.

Note that the DXF and GML formats were added to the list of recognized formats in the process.

### Architectural changes

none

### Screenshots

![image](https://github.com/geonetwork/geonetwork-ui/assets/10629150/22acf175-53c4-416e-8786-ec33a13db2b3)


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [x] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [Géo2France](geo2france.fr)**.
