### PR TITLE
[Map-Viewer] Added a geocoding text field

### DIFF
--- a/apps/map-viewer/src/app/app.component.html
+++ b/apps/map-viewer/src/app/app.component.html
@@ -4,4 +4,5 @@
     class="absolute"
     style="top: 20px; left: 20px; bottom: 20px"
   ></gn-ui-layers-panel>
+  <gn-ui-geocoding class="absolute w-72 top-4 right-4"></gn-ui-geocoding>
 </div>

--- a/jest.preset.js
+++ b/jest.preset.js
@@ -4,7 +4,9 @@ module.exports = {
   ...nxPreset,
   coverageReporters: ['text'],
   setupFiles: ['jest-canvas-mock'],
-  transformIgnorePatterns: ['node_modules/(?!(color-*|ol|@mapbox|.*.mjs$))'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(color-*|ol|@mapbox|@geospatial-sdk|.*.mjs$))',
+  ],
   transform: {
     '^.+\\.(ts|mjs|js|html)$': [
       'jest-preset-angular',

--- a/libs/feature/map/src/lib/feature-map.module.ts
+++ b/libs/feature/map/src/lib/feature-map.module.ts
@@ -23,6 +23,7 @@ import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
 import { AddLayerFromWmsComponent } from './add-layer-from-wms/add-layer-from-wms.component'
 import { AddLayerFromFileComponent } from './add-layer-from-file/add-layer-from-file.component'
 import { AddLayerFromWfsComponent } from './add-layer-from-wfs/add-layer-from-wfs.component'
+import { GeocodingComponent } from './geocoding/geocoding.component'
 
 @NgModule({
   declarations: [
@@ -35,6 +36,7 @@ import { AddLayerFromWfsComponent } from './add-layer-from-wfs/add-layer-from-wf
     AddLayerFromWmsComponent,
     AddLayerFromFileComponent,
     AddLayerFromWfsComponent,
+    GeocodingComponent,
   ],
   exports: [
     MapContextComponent,
@@ -42,6 +44,7 @@ import { AddLayerFromWfsComponent } from './add-layer-from-wfs/add-layer-from-wf
     LayersPanelComponent,
     AddLayerFromCatalogComponent,
     MapContainerComponent,
+    GeocodingComponent,
   ],
   imports: [
     CommonModule,

--- a/libs/feature/map/src/lib/geocoding/geocoding.component.html
+++ b/libs/feature/map/src/lib/geocoding/geocoding.component.html
@@ -1,0 +1,39 @@
+<gn-ui-search-input
+  [(value)]="searchText"
+  (valueChange)="onSearchChange($event)"
+  (keyup.enter)="onEnterPress()"
+  [placeholder]="'map.geocoding.placeholder' | translate"
+>
+</gn-ui-search-input>
+<ul
+  class="bg-gray-50 border border-gray-200 w-full mt-2 shadow-sm rounded-lg"
+  *ngIf="results && results.length"
+>
+  <li
+    *ngFor="let result of results"
+    (click)="zoomToLocation(result)"
+    class="flex items-center pl-8 pr-4 py-2 border-b border-gray-200 relative cursor-pointer hover:bg-blue-100 hover:text-gray-800 transition duration-300 ease-in-out"
+  >
+    <svg
+      class="stroke-current text-blue-500 absolute w-5 h-5 left-3 top-3"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+      />
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+      />
+    </svg>
+    <span class="font-sans font-semibold ml-4">{{ result.label }}</span>
+  </li>
+</ul>

--- a/libs/feature/map/src/lib/geocoding/geocoding.component.spec.ts
+++ b/libs/feature/map/src/lib/geocoding/geocoding.component.spec.ts
@@ -1,0 +1,115 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { GeocodingComponent } from './geocoding.component'
+import { MapManagerService } from '../manager/map-manager.service'
+import { NO_ERRORS_SCHEMA } from '@angular/core'
+import Map from 'ol/Map'
+import TileLayer from 'ol/layer/Tile'
+import XYZ from 'ol/source/XYZ'
+import VectorLayer from 'ol/layer/Vector'
+import VectorSource from 'ol/source/Vector'
+import GeoJSON from 'ol/format/GeoJSON'
+import { FEATURE_COLLECTION_POINT_FIXTURE_4326 } from '@geonetwork-ui/common/fixtures'
+import Feature from 'ol/Feature'
+import { Geometry } from 'ol/geom'
+import { TranslateModule } from '@ngx-translate/core'
+
+const vectorLayer = new VectorLayer({
+  source: new VectorSource({
+    features: new GeoJSON().readFeatures(
+      FEATURE_COLLECTION_POINT_FIXTURE_4326,
+      {
+        featureProjection: 'EPSG:3857',
+        dataProjection: 'EPSG:4326',
+      }
+    ),
+  }) as VectorSource<Feature<Geometry>>,
+})
+
+const mapMock = new Map({
+  layers: [
+    new TileLayer({
+      source: new XYZ({
+        url: 'http://test',
+      }),
+    }),
+    vectorLayer,
+  ],
+})
+
+const mapManagerMock = {
+  map: mapMock,
+}
+
+describe('GeocodingComponent', () => {
+  let component: GeocodingComponent
+  let fixture: ComponentFixture<GeocodingComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      declarations: [GeocodingComponent],
+      providers: [{ provide: MapManagerService, useValue: mapManagerMock }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(GeocodingComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+    expect(component.searchText).toBe('')
+    expect(component.results).toEqual([])
+  })
+
+  describe('On Search Change', () => {
+    describe('when search text is empty', () => {
+      beforeEach(() => {
+        component.onSearchChange('')
+      })
+      it('should not show any results', () => {
+        expect(component.searchText).toEqual('')
+        expect(component.results).toEqual([])
+      })
+    })
+    describe('when search text is not empty', () => {
+      beforeEach(() => {
+        component.searchText = 'test'
+      })
+      it('should show results', () => {
+        expect(component.searchText).toEqual('test')
+        expect(component.results).toEqual([])
+      })
+    })
+  })
+
+  describe('zoomToLocation', () => {
+    it('should zoom to the location of the result', () => {
+      const result = {
+        geom: {
+          coordinates: [[0, 0]],
+        },
+      }
+      const viewMock = {
+        fit: jest.fn(),
+      }
+      mapMock.getView = jest.fn().mockReturnValue(viewMock)
+      component.zoomToLocation(result)
+      expect(viewMock.fit).toHaveBeenCalled()
+    })
+  })
+  describe('onEnterPress', () => {
+    it('should zoom to the location of the first result', () => {
+      const result = {
+        geom: {
+          coordinates: [[0, 0]],
+        },
+      }
+      component.results = [result]
+      const zoomToLocationSpy = jest.spyOn(component, 'zoomToLocation')
+      component.onEnterPress()
+      expect(zoomToLocationSpy).toHaveBeenCalledWith(result)
+    })
+  })
+})

--- a/libs/feature/map/src/lib/geocoding/geocoding.component.ts
+++ b/libs/feature/map/src/lib/geocoding/geocoding.component.ts
@@ -1,0 +1,83 @@
+import { Component, OnDestroy } from '@angular/core'
+import { queryGeoadmin, GeoadminOptions } from '@geospatial-sdk/geocoding'
+import { catchError, from, Subject, takeUntil } from 'rxjs'
+import { debounceTime, switchMap } from 'rxjs/operators'
+import { MapManagerService } from '../manager/map-manager.service'
+import { fromLonLat } from 'ol/proj'
+import { Polygon } from 'ol/geom'
+
+@Component({
+  selector: 'gn-ui-geocoding',
+  templateUrl: './geocoding.component.html',
+  styleUrls: ['./geocoding.component.css'],
+})
+export class GeocodingComponent implements OnDestroy {
+  searchText = ''
+  results: any[] = []
+  searchTextChanged = new Subject<string>()
+  destroy$ = new Subject<void>()
+
+  constructor(private mapManager: MapManagerService) {
+    this.searchTextChanged
+      .pipe(
+        debounceTime(300),
+        switchMap((searchText) => {
+          const options: GeoadminOptions = {
+            origins: ['zipcode', 'gg25', 'address'],
+            limit: 6,
+          }
+          return from(queryGeoadmin(searchText, options)).pipe(
+            catchError((error) => {
+              console.error(error)
+              return []
+            })
+          )
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe((results) => {
+        this.results = results
+      })
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next()
+    this.destroy$.complete()
+  }
+
+  onSearchChange(searchText: string) {
+    if (!searchText) {
+      this.clearSearch()
+      return
+    } else {
+      this.searchTextChanged.next(searchText)
+    }
+  }
+
+  clearSearch() {
+    this.searchText = ''
+    this.results = []
+  }
+
+  zoomToLocation(result) {
+    const map = this.mapManager.map
+    const view = map.getView()
+    const geometry = result.geom
+
+    const polygonCoords = geometry.coordinates
+    const transformedCoords = polygonCoords[0].map((coord) => fromLonLat(coord))
+
+    const polygon = new Polygon([transformedCoords])
+
+    view.fit(polygon, {
+      duration: 100,
+      maxZoom: 12,
+    })
+  }
+
+  onEnterPress() {
+    if (this.results && this.results.length > 0) {
+      this.zoomToLocation(this.results[0])
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@bartholomej/ngx-translate-extract": "^8.0.2",
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "^0.4.0",
+        "@geospatial-sdk/geocoding": "^0.0.5-alpha.1",
         "@ltd/j-toml": "~1.35.2",
         "@messageformat/core": "^3.0.1",
         "@nestjs/common": "10.1.3",
@@ -4309,6 +4310,11 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
       "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==",
       "dev": true
+    },
+    "node_modules/@geospatial-sdk/geocoding": {
+      "version": "0.0.5-alpha.1",
+      "resolved": "https://registry.npmjs.org/@geospatial-sdk/geocoding/-/geocoding-0.0.5-alpha.1.tgz",
+      "integrity": "sha512-LM1aKG1hl2hnJFLouyjUpCwwT2ToQXeUlExHUvGi/cq1vy2z4AeygLL9etPkEnCPz70B6713gN4mKsmDWdaDiQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@bartholomej/ngx-translate-extract": "^8.0.2",
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
     "@camptocamp/ogc-client": "^0.4.0",
+    "@geospatial-sdk/geocoding": "^0.0.5-alpha.1",
     "@ltd/j-toml": "~1.35.2",
     "@messageformat/core": "^3.0.1",
     "@nestjs/common": "10.1.3",

--- a/translations/de.json
+++ b/translations/de.json
@@ -177,6 +177,7 @@
   "map.add.layer.wfs": "Aus WFS",
   "map.add.layer.wms": "Aus WMS",
   "map.addFromFile.placeholder": "Klicke hier oder ziehe eine Datei herein",
+  "map.geocoding.placeholder": "",
   "map.help.addFromFile": "Klicke oder ziehe eine Datei herein um eine Karte hinzuzufügen (momentan wird nur das GeoJSON-Format unterstützt).",
   "map.layer.add": "Hinzufügen",
   "map.layers.available": "Verfügbare Layer",

--- a/translations/en.json
+++ b/translations/en.json
@@ -177,6 +177,7 @@
   "map.add.layer.wfs": "From WFS",
   "map.add.layer.wms": "From WMS",
   "map.addFromFile.placeholder": "Click or drop a file here",
+  "map.geocoding.placeholder": "Search for a place",
   "map.help.addFromFile": "Click or drag and drop a file to add to the map (currently supports GeoJSON format only).",
   "map.layer.add": "Add",
   "map.layers.available": "Available Layers",

--- a/translations/es.json
+++ b/translations/es.json
@@ -177,6 +177,7 @@
   "map.add.layer.wfs": "",
   "map.add.layer.wms": "",
   "map.addFromFile.placeholder": "",
+  "map.geocoding.placeholder": "",
   "map.help.addFromFile": "",
   "map.layer.add": "",
   "map.layers.available": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -177,6 +177,7 @@
   "map.add.layer.wfs": "",
   "map.add.layer.wms": "",
   "map.addFromFile.placeholder": "",
+  "map.geocoding.placeholder": "",
   "map.help.addFromFile": "",
   "map.layer.add": "",
   "map.layers.available": "",

--- a/translations/it.json
+++ b/translations/it.json
@@ -177,6 +177,7 @@
   "map.add.layer.wfs": "Da un WFS",
   "map.add.layer.wms": "Da un WMS",
   "map.addFromFile.placeholder": "",
+  "map.geocoding.placeholder": "",
   "map.help.addFromFile": "",
   "map.layer.add": "",
   "map.layers.available": "",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -177,6 +177,7 @@
   "map.add.layer.wfs": "",
   "map.add.layer.wms": "",
   "map.addFromFile.placeholder": "",
+  "map.geocoding.placeholder": "",
   "map.help.addFromFile": "",
   "map.layer.add": "",
   "map.layers.available": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -177,6 +177,7 @@
   "map.add.layer.wfs": "",
   "map.add.layer.wms": "",
   "map.addFromFile.placeholder": "",
+  "map.geocoding.placeholder": "",
   "map.help.addFromFile": "",
   "map.layer.add": "",
   "map.layers.available": "",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -177,6 +177,7 @@
   "map.add.layer.wfs": "Z WFS",
   "map.add.layer.wms": "Z WMS",
   "map.addFromFile.placeholder": "",
+  "map.geocoding.placeholder": "",
   "map.help.addFromFile": "",
   "map.layer.add": "",
   "map.layers.available": "",


### PR DESCRIPTION
### Description

This PR introduces a geocoding text field to the Map Viewer application. It functions as a search input, complete with a search icon, debounce functionality, and a clear button that appears when text is entered.

- [x] Added a geocoding text field to the Map Viewer interface.
- [x] Implemented a search icon within the text field.
- [x] Added debounce functionality to handle rapid input of text.
- [x] Introduced a clear button that appears when text is entered into the field.
- [x] Implemented a dropdown list of suggestions that appears when 3 or more characters are entered into the text field.
- [x] Populated the suggestion list with matching addresses and place names from the geoadmin search API.
- [x] Added functionality to zoom into the map at the selected address or place name from the suggestion list, with a maximum zoom level of 12.
- [x] Implemented a quick animation for the zoom functionality, with a duration of approximately 100ms.
- [x] Ensured that the suggestion list disappears when the search input is cleared.


### Technical Details:
This functionality relies on the geoadmin provider from the geospatial-sdk, specifically the queryGeoadmin function.
https://github.com/camptocamp/geospatial-sdk

### Screenshots

![image](https://github.com/geonetwork/geonetwork-ui/assets/9210179/4faba59b-b2ca-4d78-8336-29ee2029ff8a)

![image](https://github.com/geonetwork/geonetwork-ui/assets/9210179/cc277a4d-d0ed-4ca2-b801-15ec40d5cb08)

![image](https://github.com/geonetwork/geonetwork-ui/assets/9210179/e272a622-f7e2-4960-9948-8bcd2988873f)

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added

#756 


