### PR TITLE
[Map-Viewer] Added Geocoding service for Multiple Providers

### DIFF
--- a/libs/feature/map/src/lib/feature-map.module.ts
+++ b/libs/feature/map/src/lib/feature-map.module.ts
@@ -24,6 +24,7 @@ import { AddLayerFromWmsComponent } from './add-layer-from-wms/add-layer-from-wm
 import { AddLayerFromFileComponent } from './add-layer-from-file/add-layer-from-file.component'
 import { AddLayerFromWfsComponent } from './add-layer-from-wfs/add-layer-from-wfs.component'
 import { GeocodingComponent } from './geocoding/geocoding.component'
+import { GEOCODING_PROVIDER } from './geocoding.service'
 
 @NgModule({
   declarations: [
@@ -65,6 +66,15 @@ import { GeocodingComponent } from './geocoding/geocoding.component'
       useValue: defaultMapOptions,
     },
     MapFacade,
+    {
+      provide: GEOCODING_PROVIDER,
+      useValue: {
+        id: 'geonames',
+        options: {
+          maxRows: 5,
+        },
+      },
+    },
   ],
 })
 export class FeatureMapModule {}

--- a/libs/feature/map/src/lib/feature-map.module.ts
+++ b/libs/feature/map/src/lib/feature-map.module.ts
@@ -24,7 +24,7 @@ import { AddLayerFromWmsComponent } from './add-layer-from-wms/add-layer-from-wm
 import { AddLayerFromFileComponent } from './add-layer-from-file/add-layer-from-file.component'
 import { AddLayerFromWfsComponent } from './add-layer-from-wfs/add-layer-from-wfs.component'
 import { GeocodingComponent } from './geocoding/geocoding.component'
-import { GEOCODING_PROVIDER } from './geocoding.service'
+import { GEOCODING_PROVIDER, GeocodingProvider } from './geocoding.service'
 
 @NgModule({
   declarations: [
@@ -68,12 +68,7 @@ import { GEOCODING_PROVIDER } from './geocoding.service'
     MapFacade,
     {
       provide: GEOCODING_PROVIDER,
-      useValue: {
-        id: 'geonames',
-        options: {
-          maxRows: 5,
-        },
-      },
+      useValue: ['geonames', { maxRows: 5 }] as GeocodingProvider,
     },
   ],
 })

--- a/libs/feature/map/src/lib/geocoding.service.ts
+++ b/libs/feature/map/src/lib/geocoding.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Inject, InjectionToken } from '@angular/core'
+import {
+  queryGeoadmin,
+  GeoadminOptions,
+  GeocodingResult,
+  queryGeonames,
+  GeonamesOptions,
+  DataGouvFrOptions,
+  queryDataGouvFr,
+} from '@geospatial-sdk/geocoding'
+import { from, Observable, throwError } from 'rxjs'
+import { catchError } from 'rxjs/operators'
+
+export const GEOCODING_PROVIDER = new InjectionToken('geocoding-provider')
+
+export interface GeocodingProvider {
+  id: 'geoadmin' | 'geonames' | 'data-gouv-fr'
+  options: GeoadminOptions | GeonamesOptions | DataGouvFrOptions
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GeocodingService {
+  constructor(
+    @Inject(GEOCODING_PROVIDER) private provider: GeocodingProvider
+  ) {}
+
+  query(text: string): Observable<GeocodingResult[]> {
+    let queryObservable: Observable<GeocodingResult[]>
+    switch (this.provider.id) {
+      case 'geoadmin':
+        queryObservable = from(
+          queryGeoadmin(text, this.provider.options as GeoadminOptions)
+        )
+        break
+      case 'geonames':
+        queryObservable = from(
+          queryGeonames(text, this.provider.options as GeonamesOptions)
+        )
+        break
+      case 'data-gouv-fr':
+        queryObservable = from(
+          queryDataGouvFr(text, this.provider.options as DataGouvFrOptions)
+        )
+        break
+      default:
+        return throwError(
+          () => new Error(`Unsupported geocoding provider: ${this.provider.id}`)
+        )
+    }
+    return queryObservable.pipe(catchError((error) => throwError(error)))
+  }
+}

--- a/libs/feature/map/src/lib/geocoding.service.ts
+++ b/libs/feature/map/src/lib/geocoding.service.ts
@@ -11,12 +11,17 @@ import {
 import { from, Observable, throwError } from 'rxjs'
 import { catchError } from 'rxjs/operators'
 
-export const GEOCODING_PROVIDER = new InjectionToken('geocoding-provider')
+type GeoadminGeocodingProvider = ['geoadmin', GeoadminOptions]
+type GeonamesGeocodingProvider = ['geonames', GeonamesOptions]
+type DataGouvFrGeocodingProvider = ['data-gouv-fr', DataGouvFrOptions]
+export type GeocodingProvider =
+  | GeoadminGeocodingProvider
+  | GeonamesGeocodingProvider
+  | DataGouvFrGeocodingProvider
 
-export interface GeocodingProvider {
-  id: 'geoadmin' | 'geonames' | 'data-gouv-fr'
-  options: GeoadminOptions | GeonamesOptions | DataGouvFrOptions
-}
+export const GEOCODING_PROVIDER = new InjectionToken<GeocodingProvider>(
+  'geocoding-provider'
+)
 
 @Injectable({
   providedIn: 'root',
@@ -28,25 +33,25 @@ export class GeocodingService {
 
   query(text: string): Observable<GeocodingResult[]> {
     let queryObservable: Observable<GeocodingResult[]>
-    switch (this.provider.id) {
+    switch (this.provider[0]) {
       case 'geoadmin':
         queryObservable = from(
-          queryGeoadmin(text, this.provider.options as GeoadminOptions)
+          queryGeoadmin(text, this.provider[1] as GeoadminOptions)
         )
         break
       case 'geonames':
         queryObservable = from(
-          queryGeonames(text, this.provider.options as GeonamesOptions)
+          queryGeonames(text, this.provider[1] as GeonamesOptions)
         )
         break
       case 'data-gouv-fr':
         queryObservable = from(
-          queryDataGouvFr(text, this.provider.options as DataGouvFrOptions)
+          queryDataGouvFr(text, this.provider[1] as DataGouvFrOptions)
         )
         break
       default:
         return throwError(
-          () => new Error(`Unsupported geocoding provider: ${this.provider.id}`)
+          () => new Error(`Unsupported geocoding provider: ${this.provider[0]}`)
         )
     }
     return queryObservable.pipe(catchError((error) => throwError(error)))

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@bartholomej/ngx-translate-extract": "^8.0.2",
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "^0.4.0",
-        "@geospatial-sdk/geocoding": "^0.0.5-alpha.1",
+        "@geospatial-sdk/geocoding": "^0.0.5-alpha.2",
         "@ltd/j-toml": "~1.35.2",
         "@messageformat/core": "^3.0.1",
         "@nestjs/common": "10.1.3",
@@ -4312,9 +4312,9 @@
       "dev": true
     },
     "node_modules/@geospatial-sdk/geocoding": {
-      "version": "0.0.5-alpha.1",
-      "resolved": "https://registry.npmjs.org/@geospatial-sdk/geocoding/-/geocoding-0.0.5-alpha.1.tgz",
-      "integrity": "sha512-LM1aKG1hl2hnJFLouyjUpCwwT2ToQXeUlExHUvGi/cq1vy2z4AeygLL9etPkEnCPz70B6713gN4mKsmDWdaDiQ=="
+      "version": "0.0.5-alpha.2",
+      "resolved": "https://registry.npmjs.org/@geospatial-sdk/geocoding/-/geocoding-0.0.5-alpha.2.tgz",
+      "integrity": "sha512-q9szQpj+/a0A1Dp9+na8wdkhouMhegLVTD5bB1DkHCJW5eG8CUA/cPzfg1REONNQgXMNUHZHp8mGjQEmTu/zHQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@bartholomej/ngx-translate-extract": "^8.0.2",
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
     "@camptocamp/ogc-client": "^0.4.0",
-    "@geospatial-sdk/geocoding": "^0.0.5-alpha.1",
+    "@geospatial-sdk/geocoding": "^0.0.5-alpha.2",
     "@ltd/j-toml": "~1.35.2",
     "@messageformat/core": "^3.0.1",
     "@nestjs/common": "10.1.3",


### PR DESCRIPTION
### Description

This pull request introduces a new service, `geocoding.service.ts`, in the `libs/feature/map/src/lib` directory. The purpose of this service is to facilitate the use of multiple geocoding providers.

The `GeocodingService` class in `geocoding.service.ts` uses an injection token, `GEOCODING_PROVIDER`, to inject a `GeocodingProvider` object. This object contains the ID of the geocoding provider and the options for that provider.

### Changes:  

- Added `geocoding.service.ts` in `libs/feature/map/src/lib`
- Updated `geocoding.component.ts` to use the new `GeocodingService`


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves


