### PR TITLE
Datahub: Remove warning from console if filter geometry undefined

### DIFF
--- a/libs/feature/search/src/lib/state/effects.spec.ts
+++ b/libs/feature/search/src/lib/state/effects.spec.ts
@@ -492,8 +492,8 @@ describe('Effects', () => {
           it('skips the geometry in the search', async () => {
             await firstValueFrom(effects.loadResults$)
             expect(repository.search).toHaveBeenCalledWith(
-              expect.not.objectContaining({
-                filterGeometry: { type: 'Polygon', coordinates: [[]] },
+              expect.objectContaining({
+                filterGeometry: undefined,
               })
             )
           })

--- a/libs/feature/search/src/lib/state/effects.spec.ts
+++ b/libs/feature/search/src/lib/state/effects.spec.ts
@@ -483,6 +483,21 @@ describe('Effects', () => {
             )
           })
         })
+        describe('when geometry is undefined', () => {
+          beforeEach(() => {
+            effects['filterGeometry$'] = of(undefined) as any
+            effects = TestBed.inject(SearchEffects)
+            actions$ = of(new RequestMoreResults('main'))
+          })
+          it('skips the geometry in the search', async () => {
+            await firstValueFrom(effects.loadResults$)
+            expect(repository.search).toHaveBeenCalledWith(
+              expect.not.objectContaining({
+                filterGeometry: { type: 'Polygon', coordinates: [[]] },
+              })
+            )
+          })
+        })
       })
       describe('when useSpatialFilter is disabled', () => {
         beforeEach(() => {

--- a/libs/feature/search/src/lib/state/effects.ts
+++ b/libs/feature/search/src/lib/state/effects.ts
@@ -130,17 +130,19 @@ export class SearchEffects {
             }
             return this.filterGeometry$.pipe(
               tap((geom) => {
-                try {
-                  const trace = validGeoJson(geom, true) as string[]
-                  if (trace?.length > 0) {
-                    throw new Error(trace.join('\n'))
+                if (geom) {
+                  try {
+                    const trace = validGeoJson(geom, true) as string[]
+                    if (trace?.length > 0) {
+                      throw new Error(trace.join('\n'))
+                    }
+                  } catch (error) {
+                    console.warn(
+                      'Error while parsing the geometry filter\n',
+                      error
+                    )
+                    throw new Error()
                   }
-                } catch (error) {
-                  console.warn(
-                    'Error while parsing the geometry filter\n',
-                    error
-                  )
-                  throw new Error()
                 }
               }),
               map((geom) => [state, favorites, geom]),

--- a/libs/feature/search/src/lib/state/effects.ts
+++ b/libs/feature/search/src/lib/state/effects.ts
@@ -126,28 +126,27 @@ export class SearchEffects {
           ),
           switchMap(([state, favorites]) => {
             if (!state.params.useSpatialFilter || !this.filterGeometry$) {
-              return of([state, favorites, null])
+              return of([state, favorites, undefined])
             }
             return this.filterGeometry$.pipe(
               tap((geom) => {
-                if (geom) {
-                  try {
-                    const trace = validGeoJson(geom, true) as string[]
-                    if (trace?.length > 0) {
-                      throw new Error(trace.join('\n'))
-                    }
-                  } catch (error) {
-                    console.warn(
-                      'Error while parsing the geometry filter\n',
-                      error
-                    )
-                    throw new Error()
+                if (!geom) return
+                try {
+                  const trace = validGeoJson(geom, true) as string[]
+                  if (trace?.length > 0) {
+                    throw new Error(trace.join('\n'))
                   }
+                } catch (error) {
+                  console.warn(
+                    'Error while parsing the geometry filter\n',
+                    error
+                  )
+                  throw new Error()
                 }
               }),
               map((geom) => [state, favorites, geom]),
               catchError((e) => {
-                return of([state, favorites, null])
+                return of([state, favorites, undefined])
               })
             )
           }),
@@ -155,7 +154,7 @@ export class SearchEffects {
             ([state, favorites, geometry]: [
               SearchStateSearch,
               string[],
-              Geometry | null
+              Geometry | undefined
             ]) => {
               const { currentPage, pageSize, sort } = state.params
               const filters = {


### PR DESCRIPTION
### Description

This PR prevents displaying a warning in the console if no `filter_geometry` could be found (which is already logged in the console). This might occur when a request to the geometry aborts without success (due to access rights or a wrong url for example).

![image-2024-02-15-08-47-08-973](https://github.com/geonetwork/geonetwork-ui/assets/6329425/b0ae9120-27cf-4598-8009-64144c0b7624)

Follow-up on #635 

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
