### PR TITLE
Search: Do not change route path when clearing fuzzy search

### DIFF
--- a/apps/datahub-e2e/src/e2e/header.cy.ts
+++ b/apps/datahub-e2e/src/e2e/header.cy.ts
@@ -95,12 +95,25 @@ describe('header', () => {
         .find('input')
         .should('have.value', '')
     })
-    it('should reset search results on click on cancel button', () => {
-      cy.get('gn-ui-fuzzy-search').type('velo')
-      cy.get('mat-icon')
-        .contains('close')
-        .trigger('click', { waitForAnimations: false })
-      cy.get('gn-ui-record-preview-row').should('have.length.gt', 1)
+    describe('when on search url path', () => {
+      it('should reset search results on click on cancel button', () => {
+        cy.visit('/search')
+        cy.get('gn-ui-fuzzy-search').type('velo')
+        cy.get('mat-icon')
+          .contains('close')
+          .trigger('click', { waitForAnimations: false })
+        cy.get('gn-ui-record-preview-row').should('have.length.gt', 1)
+      })
+    })
+    describe('when on news url path', () => {
+      it('should stay on news url path', () => {
+        cy.visit('/')
+        cy.get('gn-ui-fuzzy-search').type('velo')
+        cy.get('mat-icon')
+          .contains('close')
+          .trigger('click', { waitForAnimations: false })
+        cy.url().should('include', '/news')
+      })
     })
   })
 

--- a/apps/metadata-editor-e2e/src/e2e/dashboard.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/dashboard.cy.ts
@@ -48,7 +48,12 @@ describe('dashboard', () => {
           originalFirstItem = list.trim()
           // order by title descending
           cy.get('.table-header-cell').eq(1).click()
+          cy.url().should('include', 'sort=resourceTitleObject.default.keyword')
           cy.get('.table-header-cell').eq(1).click()
+          cy.url().should(
+            'include',
+            'sort=-resourceTitleObject.default.keyword'
+          )
           cy.get('gn-ui-results-table')
             .find('.table-row-cell')
             .eq(1)
@@ -56,10 +61,6 @@ describe('dashboard', () => {
             .then((list) => {
               newFirstItem = list.trim()
               expect(newFirstItem).not.to.equal(originalFirstItem)
-              cy.url().should(
-                'include',
-                'sort=-resourceTitleObject.default.keyword'
-              )
             })
         })
     })

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
@@ -138,9 +138,10 @@ describe('FuzzySearchComponent', () => {
   })
 
   describe('search input clear', () => {
-    describe('when output is defined', () => {
+    describe('when output is defined and search filters are not empty', () => {
       beforeEach(() => {
         jest.resetAllMocks()
+        searchFacade.searchFilters$.next({ any: 'river' })
         component.inputSubmitted.subscribe()
         jest.spyOn(component.inputSubmitted, 'emit')
         component.handleInputCleared()
@@ -149,6 +150,21 @@ describe('FuzzySearchComponent', () => {
         expect(searchService.updateFilters).toHaveBeenCalledWith({
           any: '',
         })
+      })
+      it('does not emit inputSubmitted', () => {
+        expect(component.inputSubmitted.emit).not.toHaveBeenCalled()
+      })
+    })
+    describe('when output is defined but search filters are empty', () => {
+      beforeEach(() => {
+        jest.resetAllMocks()
+        searchFacade.searchFilters$.next({})
+        component.inputSubmitted.subscribe()
+        jest.spyOn(component.inputSubmitted, 'emit')
+        component.handleInputCleared()
+      })
+      it('does not clear the search filters (to prevent according navigation)', () => {
+        expect(searchService.updateFilters).not.toHaveBeenCalled()
       })
       it('does not emit inputSubmitted', () => {
         expect(component.inputSubmitted.emit).not.toHaveBeenCalled()

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
@@ -11,8 +11,8 @@ import {
   AutocompleteComponent,
   AutocompleteItem,
 } from '@geonetwork-ui/ui/inputs'
-import { Observable } from 'rxjs'
-import { map, tap } from 'rxjs/operators'
+import { Observable, firstValueFrom } from 'rxjs'
+import { map } from 'rxjs/operators'
 import { SearchFacade } from '../state/search.facade'
 import { SearchService } from '../utils/service/search.service'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
@@ -31,7 +31,6 @@ export class FuzzySearchComponent implements OnInit {
   @Output() itemSelected = new EventEmitter<CatalogRecord>()
   @Output() inputSubmitted = new EventEmitter<string>()
   searchInputValue$: Observable<{ title: string }>
-  currentSearchFilters: SearchFilters
 
   displayWithFn: (record: CatalogRecord) => string = (record) => record?.title
 
@@ -48,7 +47,6 @@ export class FuzzySearchComponent implements OnInit {
 
   ngOnInit(): void {
     this.searchInputValue$ = this.searchFacade.searchFilters$.pipe(
-      tap((searchFilter) => (this.currentSearchFilters = searchFilter)),
       map((searchFilter) => ({
         title: searchFilter.any as string,
       }))
@@ -78,8 +76,11 @@ export class FuzzySearchComponent implements OnInit {
     }
   }
 
-  handleInputCleared() {
-    if (this.currentSearchFilters.any) {
+  async handleInputCleared() {
+    const currentSearchFilters: SearchFilters = await firstValueFrom(
+      this.searchFacade.searchFilters$
+    )
+    if (currentSearchFilters.any) {
       this.searchService.updateFilters({ any: '' })
     }
   }

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
@@ -12,11 +12,12 @@ import {
   AutocompleteItem,
 } from '@geonetwork-ui/ui/inputs'
 import { Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { map, tap } from 'rxjs/operators'
 import { SearchFacade } from '../state/search.facade'
 import { SearchService } from '../utils/service/search.service'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
 import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
+import { SearchFilters } from '@geonetwork-ui/api/metadata-converter'
 
 @Component({
   selector: 'gn-ui-fuzzy-search',
@@ -30,6 +31,7 @@ export class FuzzySearchComponent implements OnInit {
   @Output() itemSelected = new EventEmitter<CatalogRecord>()
   @Output() inputSubmitted = new EventEmitter<string>()
   searchInputValue$: Observable<{ title: string }>
+  currentSearchFilters: SearchFilters
 
   displayWithFn: (record: CatalogRecord) => string = (record) => record?.title
 
@@ -46,6 +48,7 @@ export class FuzzySearchComponent implements OnInit {
 
   ngOnInit(): void {
     this.searchInputValue$ = this.searchFacade.searchFilters$.pipe(
+      tap((searchFilter) => (this.currentSearchFilters = searchFilter)),
       map((searchFilter) => ({
         title: searchFilter.any as string,
       }))
@@ -76,6 +79,8 @@ export class FuzzySearchComponent implements OnInit {
   }
 
   handleInputCleared() {
-    this.searchService.updateFilters({ any: '' })
+    if (this.currentSearchFilters.any) {
+      this.searchService.updateFilters({ any: '' })
+    }
   }
 }

--- a/package/package.json
+++ b/package/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
     "@camptocamp/ogc-client": "^0.4.0",
-    "@geospatial-sdk/geocoding": "^0.0.5-alpha.1",
+    "@geospatial-sdk/geocoding": "^0.0.5-alpha.2",
     "@ltd/j-toml": "~1.35.2",
     "@messageformat/core": "^3.0.1",
     "@nx/angular": "16.6.0",


### PR DESCRIPTION
### Description

Currently, the router navigates to the search when the fuzzy search entry is cleared (with the input's cross) on a different tab/page than the search. This PR intends to maintain the same path when clearing the search. The `fuzzy-search.component` now only calls `updateFilters` if `searchFilters.any` is not empty or undefined.

Also updates `@geospatial-sdk/geocoding` for the npm package and attempts to fix a flaky e2e test.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves


**This work is sponsored by [MEL](https://www.lillemetropole.fr/)**.
