### PR TITLE
[Datahub][API form] Fix OGC API default limit

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -532,7 +532,7 @@ describe('api cards', () => {
   })
 })
 
-describe('api form', () => {
+describe.only('api form', () => {
   beforeEach(() => {
     cy.visit('/dataset/accroche_velos')
     cy.get('gn-ui-api-card').first().find('button').click()
@@ -605,7 +605,7 @@ describe('api form', () => {
       .find('gn-ui-copy-text-button')
       .find('input')
       .invoke('val')
-      .should('include', 'f=json')
+      .should('include', 'limit=-1&f=json')
   })
   it('should close the panel on click', () => {
     cy.get('gn-ui-record-api-form').prev().find('button').click()

--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -532,7 +532,7 @@ describe('api cards', () => {
   })
 })
 
-describe.only('api form', () => {
+describe('api form', () => {
   beforeEach(() => {
     cy.visit('/dataset/accroche_velos')
     cy.get('gn-ui-api-card').first().find('button').click()

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.html
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.html
@@ -20,7 +20,7 @@
           <gn-ui-text-input
             class="mr-2 w-20"
             (input)="setLimit($event.target.value)"
-            [value]="limit$ | async"
+            [value]="(limit$ | async) !== '-1' ? (limit$ | async) : ''"
             hint=""
           >
           </gn-ui-text-input>
@@ -28,8 +28,8 @@
             <input
               class="mr-2 cursor-pointer"
               type="checkbox"
-              [checked]="(limit$ | async) === ''"
-              (change)="setLimit('')"
+              [checked]="(limit$ | async) === '-1'"
+              (change)="setLimit('-1')"
             />
             <span class="text-sm" translate
               >record.metadata.api.form.limit.all</span

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
@@ -34,10 +34,10 @@ describe('RecordApFormComponent', () => {
     it('should set the links and initial values correctly', async () => {
       expect(component.apiBaseUrl).toBe('https://api.example.com/data')
       expect(component.offset$.getValue()).toBe('')
-      expect(component.limit$.getValue()).toBe('')
+      expect(component.limit$.getValue()).toBe('-1')
       expect(component.format$.getValue()).toBe('json')
       const url = await firstValueFrom(component.apiQueryUrl$)
-      expect(url).toBe('https://api.example.com/data?f=json')
+      expect(url).toBe('https://api.example.com/data?limit=-1&f=json')
     })
   })
   describe('When URL params are changed', () => {
@@ -83,7 +83,7 @@ describe('RecordApFormComponent', () => {
     it('should reset URL to default parameters', () => {
       component.resetUrl()
       expect(component.offset$.getValue()).toBe('')
-      expect(component.limit$.getValue()).toBe('')
+      expect(component.limit$.getValue()).toBe('-1')
       expect(component.format$.getValue()).toBe('json')
     })
   })

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, combineLatest, map } from 'rxjs'
 
 const DEFAULT_PARAMS = {
   OFFSET: '',
-  LIMIT: '',
+  LIMIT: '-1',
   FORMAT: 'json',
 }
 @Component({


### PR DESCRIPTION
### Description

This PR fixes an unwanted behavior on the OGC API form.
As specified in the OGC API features, the `limit` parameter has a default value of 10.

![screenshot-1](https://github.com/geonetwork/geonetwork-ui/assets/132347903/8886bbac-d6ae-477d-904d-a5239dedbd11)

Despite being an optional parameter, it appears that it still limits the returned items to 10 if no limit is specified, see for instance : https://mel.integration.apps.gs-fr-prod.camptocamp.com/data/ogcapi/collections/pav_etat_parc/items?f=json

This PR sets a default limit to `-1` to ensure all items are returned if no limit is set.
/!\ The `limit` input does not display `-1` to avoid confusion for the user.

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
