### PR TITLE
chore(carousel): Remove dot from carousel component if less than 2 dots

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -466,13 +466,21 @@ describe('dataset pages', () => {
     describe('display', () => {
       it('should have external, API and internal links with one option', () => {
         cy.get('datahub-record-otherlinks')
-          .find('.carousel-step-dot')
-          .should('exist')
           .find('gn-ui-link-card')
           .should('have.length.gt', 0)
         cy.get('datahub-record-apis')
           .find('gn-ui-api-card')
           .should('have.length.gt', 0)
+      })
+      it('should not display carousel dot button for 4 link cards', () => {
+        cy.get('datahub-record-otherlinks')
+          .find('.carousel-step-dot')
+          .should('exist')
+      })
+      it('should not display carousel dot button for 2 API cards', () => {
+        cy.get('datahub-record-apis')
+          .find('.carousel-step-dot')
+          .should('not.exist')
       })
     })
     describe('features', () => {
@@ -497,8 +505,6 @@ describe('dataset pages', () => {
           .find('button')
           .first()
           .realClick()
-          .get('.carousel-step-dot')
-          .should('not.exist')
         // attempt to make the whole page focused
         cy.get('body').focus()
         cy.get('body').realClick()

--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -466,6 +466,8 @@ describe('dataset pages', () => {
     describe('display', () => {
       it('should have external, API and internal links with one option', () => {
         cy.get('datahub-record-otherlinks')
+          .find('.carousel-step-dot')
+          .should('exist')
           .find('gn-ui-link-card')
           .should('have.length.gt', 0)
         cy.get('datahub-record-apis')
@@ -495,6 +497,8 @@ describe('dataset pages', () => {
           .find('button')
           .first()
           .realClick()
+          .get('.carousel-step-dot')
+          .should('not.exist')
         // attempt to make the whole page focused
         cy.get('body').focus()
         cy.get('body').realClick()

--- a/libs/common/fixtures/src/lib/records.fixtures.ts
+++ b/libs/common/fixtures/src/lib/records.fixtures.ts
@@ -240,5 +240,6 @@ Ce lot de données produit en 2019, a été numérisé à partir du PCI Vecteur 
     temporalExtents: [],
     status: 'completed',
     updateFrequency: 'unknown',
+    languages: ['fr', 'de'],
   },
 ])

--- a/libs/ui/layout/src/lib/carousel/carousel.component.html
+++ b/libs/ui/layout/src/lib/carousel/carousel.component.html
@@ -4,6 +4,7 @@
   </div>
 </div>
 <div
+  *ngIf="steps.length > 1"
   class="absolute right-0 top-0 flex flex-row justify-center gap-[10px] p-1"
   [ngClass]="stepsContainerClass"
 >


### PR DESCRIPTION
### Description

This PR removes the dot below the carousel if there is only one. With one dot there is no action available and it looks a bit out of place.

We did the same on the MEL project: https://github.com/camptocamp/mel-dataplatform/pull/31


### Screenshots
before:
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/57e87739-6243-464a-ace5-d225cb23af82)


after:
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/b00a9ec1-46d1-4d51-8d9c-306ddc4c103b)


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->