### PR TITLE
Datahub: Get logoUrl from group as fallback

### DIFF
--- a/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.ts
+++ b/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.ts
@@ -25,7 +25,14 @@ import {
   SourceWithUnknownProps,
 } from '@geonetwork-ui/api/metadata-converter'
 import { combineLatest, Observable, of, switchMap, takeLast } from 'rxjs'
-import { filter, map, shareReplay, startWith, tap } from 'rxjs/operators'
+import {
+  filter,
+  map,
+  shareReplay,
+  startWith,
+  tap,
+  withLatestFrom,
+} from 'rxjs/operators'
 import { LangService } from '@geonetwork-ui/util/i18n'
 import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.service.interface'
 import { coerce, satisfies, valid } from 'semver'
@@ -296,9 +303,20 @@ export class OrganizationsFromMetadataService
 
     const ownerOrganization = allContactOrgs[0]
 
+    // read the owner group as well to have a fallback logo
+    const groupId = selectField(source, 'groupOwner')
+    const group$ = this.groups$.pipe(
+      map((groups) =>
+        groups.find((group) => {
+          return group.id === Number(groupId)
+        })
+      )
+    )
+
     return this.organisations$.pipe(
       takeLast(1),
-      map((organisations: IncompleteOrganization[]) => {
+      withLatestFrom(group$),
+      map(([organisations, group]: [Organization[], GroupApiModel]) => {
         const recordOrganisation = organisations.filter(
           (org) => org.name === ownerOrganization.name
         )[0]
@@ -307,6 +325,10 @@ export class OrganizationsFromMetadataService
           ownerOrganization: {
             ...ownerOrganization,
             ...recordOrganisation,
+            logoUrl:
+              ownerOrganization?.logoUrl ||
+              recordOrganisation?.logoUrl ||
+              (group?.logo && getAsUrl(`${IMAGE_URL}${group.logo}`)),
           },
         }
       })

--- a/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.ts
+++ b/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.ts
@@ -320,15 +320,13 @@ export class OrganizationsFromMetadataService
         const recordOrganisation = organisations.filter(
           (org) => org.name === ownerOrganization.name
         )[0]
+        const logoUrl = group?.logo && getAsUrl(`${IMAGE_URL}${group.logo}`)
         return {
           ...record,
           ownerOrganization: {
+            logoUrl,
             ...ownerOrganization,
             ...recordOrganisation,
-            logoUrl:
-              ownerOrganization?.logoUrl ||
-              recordOrganisation?.logoUrl ||
-              (group?.logo && getAsUrl(`${IMAGE_URL}${group.logo}`)),
           },
         }
       })

--- a/libs/common/fixtures/src/lib/gn4/groups.fixtures.ts
+++ b/libs/common/fixtures/src/lib/gn4/groups.fixtures.ts
@@ -64,7 +64,7 @@ export const GROUPS_FIXTURE = deepFreeze([
     defaultCategory: null,
     allowedCategories: [],
     enableAllowedCategories: false,
-    id: 348385324,
+    id: 2,
     email: 'ifremer.ifremer@ifremer.admin.fr',
     referrer: null,
     description: "Institut français de recherche pour l'exploitation de la mer",


### PR DESCRIPTION
### Description

This PR gets the `logoUrl` for a record from the publishing `group` as a fallback if 
- no `logoUrl` is present in the record metadata and 
- no `logoUrl` can be determined by the organization - group matching based on `name` and `emails`.

It might be worth noting that this also impacts the thumbnail in the search preview and the contact block on the record page, where the organization logo already seems to be used as a fallback before using the placeholder. As this PR will help to find organization/group logos in more cases, the placeholder will likely be less used in these two places as well.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

**This work is sponsored by [MEL](https://www.lillemetropole.fr/)**.
