### PR TITLE
Map: Add default baselayer to map when no mapConfig exists

### DIFF
--- a/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.spec.ts
@@ -286,12 +286,18 @@ describe('MapContextService', () => {
       })
       it('add layers', () => {
         const layers = map.getLayers().getArray()
-        expect(layers.length).toEqual(3)
+        expect(layers.length).toEqual(4)
       })
       it('set view', () => {
         const view = map.getView()
         expect(view).toBeTruthy()
         expect(view).toBeInstanceOf(View)
+      })
+      it('set first layer as baselayer', () => {
+        const baselayerUrls = (map.getLayers().item(0) as TileLayer<XYZ>)
+          .getSource()
+          .getUrls()
+        expect(baselayerUrls).toEqual(DEFAULT_BASELAYER_CONTEXT.urls)
       })
     })
     describe('with config', () => {
@@ -364,7 +370,7 @@ describe('MapContextService', () => {
       })
       it('add layers', () => {
         const layers = map.getLayers().getArray()
-        expect(layers.length).toEqual(3)
+        expect(layers.length).toEqual(4)
       })
       it('set view', () => {
         view = map.getView()

--- a/libs/feature/map/src/lib/map-context/map-context.service.ts
+++ b/libs/feature/map/src/lib/map-context/map-context.service.ts
@@ -58,6 +58,8 @@ export class MapContextService {
   ): Map {
     if (mapConfig) {
       mapContext = this.mergeMapConfigWithContext(mapContext, mapConfig)
+    } else {
+      mapContext.layers = this.addDefaultBaselayerContext(mapContext.layers)
     }
     if (
       !mapContext.view?.extent &&
@@ -177,6 +179,14 @@ export class MapContextService {
       })
     }
     return view
+  }
+
+  addDefaultBaselayerContext(
+    layers: MapContextLayerModel[]
+  ): MapContextLayerModel[] {
+    return layers.includes(DEFAULT_BASELAYER_CONTEXT)
+      ? layers
+      : [DEFAULT_BASELAYER_CONTEXT, ...layers]
   }
 
   mergeMapConfigWithContext(


### PR DESCRIPTION
### Description

This PR adds the default baselayer to the map even if no mapConfig exists. This case can occur in particular in custom applications without a config.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

**This work is sponsored by [MEL](https://www.lillemetropole.fr/)**.
