### PR TITLE
Datahub: Handle non existing urls

### DIFF
--- a/apps/datahub/src/app/router/datahub-router.service.spec.ts
+++ b/apps/datahub/src/app/router/datahub-router.service.spec.ts
@@ -57,6 +57,7 @@ const expectedRoutes = [
     path: `dataset/:metadataUuid`,
     component: RecordPageComponent,
   },
+  { path: '**', redirectTo: '', pathMatch: 'full' },
 ]
 describe('DatahubRouterService', () => {
   let service: DatahubRouterService

--- a/apps/datahub/src/app/router/datahub-router.service.ts
+++ b/apps/datahub/src/app/router/datahub-router.service.ts
@@ -71,6 +71,7 @@ export class DatahubRouterService {
         path: `${ROUTER_ROUTE_DATASET}/:metadataUuid`,
         component: RecordPageComponent,
       },
+      { path: '**', redirectTo: '', pathMatch: 'full' },
     ]
   }
 


### PR DESCRIPTION
### Description

This PR adds a fallback route for erroneous routes to redirect to the default page of the datahub router (eg. http://localhost:4200/test). For an erroneous dataset id the error page is still displayed (eg. http://localhost:4200/dataset/test)

Note: This PR is for the datahub. Adding the same fallback into the `RouterService` breaks the router, like navigating to dataset.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

**This work is sponsored by [MEL](https://www.lillemetropole.fr/)**.
