### PR TITLE
[Datahub] Update Default Main and Title Fonts to Rubik and Readex Pro

### DIFF
--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -211,10 +211,10 @@ export class AppModule {
       getThemeConfig().SECONDARY_COLOR,
       getThemeConfig().MAIN_COLOR,
       getThemeConfig().BACKGROUND_COLOR,
-      getThemeConfig().MAIN_FONT || "'Source Sans', sans-serif",
-      getThemeConfig().TITLE_FONT || "'Public Sans Semi-Bold', sans-serif",
+      getThemeConfig().MAIN_FONT || "'Rubik', sans-serif",
+      getThemeConfig().TITLE_FONT || "'Readex Pro', sans-serif",
       getThemeConfig().FONTS_STYLESHEET_URL ||
-        'https://fonts.googleapis.com/css2?family=Public+Sans:wght@600&family=Source+Sans+Pro&display=swap'
+        'https://fonts.googleapis.com/css2?family=Readex+Pro&family=Rubik&display=swap'
     )
     ThemeService.generateBgOpacityClasses(
       'primary',

--- a/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.html
+++ b/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.html
@@ -6,7 +6,7 @@
       ? 'decoration-primary'
       : 'decoration-transparent hover:decoration-primary transition-colors'
   "
-  class="hidden sm:block sm:py-4 uppercase truncate font-title text-sm underline decoration-4 underline-offset-[19px]"
+  class="hidden sm:block sm:py-4 uppercase truncate underline decoration-4 underline-offset-[19px]"
   [style.color]="foregroundColor"
   translate
 >

--- a/tailwind.base.config.js
+++ b/tailwind.base.config.js
@@ -52,9 +52,6 @@ module.exports = {
           'var(--font-family-title, ui-serif, Georgia, Cambria, "Times New Roman", Times, serif)', // alias for serif
         mono: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
       },
-      fontWeight: {
-        title: '600',
-      },
       fontSize: {
         13: '13px',
         21: [


### PR DESCRIPTION
### Description

This PR updates the default main and title fonts used in the Datahub application. The changes are as follows:

- The main font has been changed to 'Rubik'.
- The title font has been changed to 'Readex Pro'.



### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves


