### PR TITLE
feat(dh): move keywords back below abstract, improve badges

### DIFF
--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -7,6 +7,20 @@
         ></gn-ui-markdown-parser>
       </div>
     </gn-ui-max-lines>
+    <div *ngIf="metadata.keywords?.length">
+      <p class="mt-6 mb-3 font-medium text-primary text-sm" translate>
+        record.metadata.keywords
+      </p>
+      <div class="sm:pb-4 flex flex-wrap gap-2">
+        <gn-ui-badge
+          class="inline-block lowercase"
+          (click)="onKeywordClick(keyword)"
+          [clickable]="true"
+          *ngFor="let keyword of metadata.keywords"
+          >{{ keyword.label }}</gn-ui-badge
+        >
+      </div>
+    </div>
   </gn-ui-content-ghost>
 </div>
 
@@ -234,18 +248,6 @@
           class="inline-block mr-2 mb-2 lowercase"
           *ngFor="let topic of metadata.topics"
           >{{ topic }}</gn-ui-badge
-        >
-      </div>
-    </div>
-    <div *ngIf="metadata.keywords?.length">
-      <p class="text-sm mb-1" translate>record.metadata.keywords</p>
-      <div class="sm:pb-4 sm:pr-16">
-        <gn-ui-badge
-          class="inline-block mr-2 mb-2 lowercase"
-          (click)="onKeywordClick(keyword)"
-          [clickable]="true"
-          *ngFor="let keyword of metadata.keywords"
-          >{{ keyword.label }}</gn-ui-badge
         >
       </div>
     </div>

--- a/libs/ui/widgets/src/lib/badge/badge.component.html
+++ b/libs/ui/widgets/src/lib/badge/badge.component.html
@@ -1,7 +1,9 @@
 <div
   class="inline-block bg-black opacity-70 py-1.5 px-3 rounded font-medium text-gray-50 text-sm leading-none"
   [ngClass]="
-    clickable ? 'hover:bg-gray-800 cursor-pointer transition-colors' : ''
+    clickable
+      ? 'hover:bg-primary cursor-pointer transition-colors duration-100'
+      : ''
   "
 >
   <ng-content></ng-content>


### PR DESCRIPTION
### Description

This PR moves the keywords back to their original place to make them more visible and accessible.

### Screenshots

![image](https://github.com/geonetwork/geonetwork-ui/assets/10629150/c92c2a58-bc46-4218-b2f9-eeb765f847c0)


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

