### PR TITLE
Add slight gradient to "show more" block

### DIFF
--- a/libs/ui/elements/src/lib/max-lines/max-lines.component.html
+++ b/libs/ui/elements/src/lib/max-lines/max-lines.component.html
@@ -1,10 +1,14 @@
 <div
   #container
-  class="max-lines overflow-hidden transition-[max-height] duration-300"
+  class="max-lines overflow-hidden transition-[max-height] duration-300 relative"
   [ngClass]="isExpanded ? 'ease-in' : 'ease-out'"
   [style.maxHeight]="maxHeight"
 >
   <ng-content></ng-content>
+  <div
+    *ngIf="showToggleButton && !isExpanded"
+    class="absolute inset-x-0 bottom-0 bg-gradient-to-b from-transparent to-white h-3"
+  ></div>
 </div>
 <div
   *ngIf="showToggleButton"

--- a/libs/ui/elements/src/lib/max-lines/max-lines.component.stories.ts
+++ b/libs/ui/elements/src/lib/max-lines/max-lines.component.stories.ts
@@ -6,6 +6,12 @@ import {
   StoryObj,
 } from '@storybook/angular'
 import { MaxLinesComponent } from './max-lines.component'
+import { TranslateModule } from '@ngx-translate/core'
+import {
+  TRANSLATE_DEFAULT_CONFIG,
+  UtilI18nModule,
+} from '@geonetwork-ui/util/i18n'
+import { importProvidersFrom } from '@angular/core'
 
 export default {
   title: 'Elements/MaxLinesComponent',
@@ -13,13 +19,17 @@ export default {
   decorators: [
     moduleMetadata({
       declarations: [MaxLinesComponent],
-      imports: [],
+      imports: [TranslateModule],
     }),
     applicationConfig({
-      providers: [],
+      providers: [
+        importProvidersFrom(UtilI18nModule),
+        importProvidersFrom(TranslateModule.forRoot(TRANSLATE_DEFAULT_CONFIG)),
+      ],
     }),
     componentWrapperDecorator(
-      (story) => `<div style="max-width: 800px">${story}</div>`
+      (story) =>
+        `<div class="border border-gray-300 p-2" style="width: 600px; height:400px; resize: both; overflow: auto">${story}</div>`
     ),
   ],
 } as Meta<MaxLinesComponent>

--- a/libs/ui/elements/src/lib/max-lines/max-lines.component.ts
+++ b/libs/ui/elements/src/lib/max-lines/max-lines.component.ts
@@ -78,6 +78,7 @@ export class MaxLinesComponent implements AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    if (!this.observer) return
     this.observer.unobserve(this.container.nativeElement.children[0])
   }
 }

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -63,15 +63,12 @@
   "
   [title]="'record.metadata.details' | translate"
 >
-  <div
-    *ngIf="metadata.lineage"
-    class="text-gray-900 flex flex-col mb-5 pt-4 gap-2"
-  >
+  <div *ngIf="metadata.lineage" class="text-gray-900 flex flex-col mt-4 gap-2">
     <p class="whitespace-pre-line break-words text-gray-900" gnUiLinkify>
       {{ metadata.lineage }}
     </p>
   </div>
-  <div class="flex flex-row gap-6 mb-8" *ngIf="resourceContact">
+  <div class="flex flex-row gap-6 mt-5 mb-8" *ngIf="resourceContact">
     <div
       *ngIf="resourceContact.organization?.logoUrl?.href"
       class="flex items-center justify-center border-solid border border-gray-300 rounded-md bg-white h-32 overflow-hidden"


### PR DESCRIPTION
### Description

This PR improves the "show more" component (`gn-ui-max-lines`) visually by adding a gradient on top:

Also fixes a layout issue within the Datahub if the data producer has no logo.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

none

### Screenshots

![image](https://github.com/geonetwork/geonetwork-ui/assets/10629150/627aedba-969e-4c4c-9ba9-6553cef5ce9b)

![image](https://github.com/geonetwork/geonetwork-ui/assets/10629150/b6ca9f60-cbda-4db6-a671-5fb536ca9141)


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [Swisstopo](geocat.ch)**.
