### PR TITLE
Datahub: Fix share link

### DIFF
--- a/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.spec.ts
@@ -86,7 +86,15 @@ describe('DataViewPermalinkComponent', () => {
     it('should generate URL based on configs', async () => {
       const url = await firstValueFrom(component.permalinkUrl$)
       expect(url).toBe(
-        `https://example.com/wc-embedder?v=${gnUiVersion}&e=gn-dataset-view-chart&a=api-url%3D${component.config.basePath}&a=dataset-id%3D${metadata.uniqueIdentifier}&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff&a=aggregation%3D${chartConfig1.aggregation}&a=x-property%3D${chartConfig1.xProperty}&a=y-property%3D${chartConfig1.yProperty}&a=chart-type%3D${chartConfig1.chartType}`
+        `https://example.com/wc-embedder?v=${gnUiVersion}&e=gn-dataset-view-chart&a=api-url%3D${encodeURIComponent(
+          component.config.basePath
+        )}&a=dataset-id%3D${
+          metadata.uniqueIdentifier
+        }&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff&a=aggregation%3D${
+          chartConfig1.aggregation
+        }&a=x-property%3D${chartConfig1.xProperty}&a=y-property%3D${
+          chartConfig1.yProperty
+        }&a=chart-type%3D${chartConfig1.chartType}`
       )
     })
   })
@@ -97,7 +105,15 @@ describe('DataViewPermalinkComponent', () => {
     it('should update URL based on configs', async () => {
       const url = await firstValueFrom(component.permalinkUrl$)
       expect(url).toBe(
-        `https://example.com/wc-embedder?v=${gnUiVersion}&e=gn-dataset-view-chart&a=api-url%3D${component.config.basePath}&a=dataset-id%3D${metadata.uniqueIdentifier}&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff&a=aggregation%3D${chartConfig2.aggregation}&a=x-property%3D${chartConfig2.xProperty}&a=y-property%3D${chartConfig2.yProperty}&a=chart-type%3D${chartConfig2.chartType}`
+        `https://example.com/wc-embedder?v=${gnUiVersion}&e=gn-dataset-view-chart&a=api-url%3D${encodeURIComponent(
+          component.config.basePath
+        )}&a=dataset-id%3D${
+          metadata.uniqueIdentifier
+        }&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff&a=aggregation%3D${
+          chartConfig2.aggregation
+        }&a=x-property%3D${chartConfig2.xProperty}&a=y-property%3D${
+          chartConfig2.yProperty
+        }&a=chart-type%3D${chartConfig2.chartType}`
       )
     })
   })

--- a/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.spec.ts
@@ -86,7 +86,7 @@ describe('DataViewPermalinkComponent', () => {
     it('should generate URL based on configs', async () => {
       const url = await firstValueFrom(component.permalinkUrl$)
       expect(url).toBe(
-        `https://example.com/wc-embedder?v=${gnUiVersion}&e=gn-dataset-view-chart&a=api-url=${component.config.basePath}&a=dataset-id=${metadata.uniqueIdentifier}&a=primary-color=%230f4395&a=secondary-color=%238bc832&a=main-color=%23555&a=background-color=%23fdfbff&a=aggregation=${chartConfig1.aggregation}&a=x-property=${chartConfig1.xProperty}&a=y-property=${chartConfig1.yProperty}&a=chart-type=${chartConfig1.chartType}`
+        `https://example.com/wc-embedder?v=${gnUiVersion}&e=gn-dataset-view-chart&a=api-url%3D${component.config.basePath}&a=dataset-id%3D${metadata.uniqueIdentifier}&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff&a=aggregation%3D${chartConfig1.aggregation}&a=x-property%3D${chartConfig1.xProperty}&a=y-property%3D${chartConfig1.yProperty}&a=chart-type%3D${chartConfig1.chartType}`
       )
     })
   })
@@ -97,7 +97,7 @@ describe('DataViewPermalinkComponent', () => {
     it('should update URL based on configs', async () => {
       const url = await firstValueFrom(component.permalinkUrl$)
       expect(url).toBe(
-        `https://example.com/wc-embedder?v=${gnUiVersion}&e=gn-dataset-view-chart&a=api-url=${component.config.basePath}&a=dataset-id=${metadata.uniqueIdentifier}&a=primary-color=%230f4395&a=secondary-color=%238bc832&a=main-color=%23555&a=background-color=%23fdfbff&a=aggregation=${chartConfig2.aggregation}&a=x-property=${chartConfig2.xProperty}&a=y-property=${chartConfig2.yProperty}&a=chart-type=${chartConfig2.chartType}`
+        `https://example.com/wc-embedder?v=${gnUiVersion}&e=gn-dataset-view-chart&a=api-url%3D${component.config.basePath}&a=dataset-id%3D${metadata.uniqueIdentifier}&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff&a=aggregation%3D${chartConfig2.aggregation}&a=x-property%3D${chartConfig2.xProperty}&a=y-property%3D${chartConfig2.yProperty}&a=chart-type%3D${chartConfig2.chartType}`
       )
     })
   })

--- a/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.ts
+++ b/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.ts
@@ -29,18 +29,18 @@ export class DataViewPermalinkComponent {
       if (config) {
         const { aggregation, xProperty, yProperty, chartType } = config
         const url = new URL(`${this.wcEmbedderBaseUrl}`, window.location.origin)
-        url.search = `?v=${this.version}
-&e=gn-dataset-view-chart
-&a=api-url%3D${this.config.basePath}
-&a=dataset-id%3D${metadata.uniqueIdentifier}
-&a=primary-color%3D%230f4395
-&a=secondary-color%3D%238bc832
-&a=main-color%3D%23555
-&a=background-color%3D%23fdfbff
-&a=aggregation%3D${aggregation}
-&a=x-property%3D${xProperty}
-&a=y-property%3D${yProperty}
-&a=chart-type%3D${chartType}`
+        url.searchParams.set('v', `${this.version}`)
+        url.searchParams.append('e', `gn-dataset-view-chart`)
+        url.searchParams.append('a', `api-url=${this.config.basePath}`)
+        url.searchParams.append('a', `dataset-id=${metadata.uniqueIdentifier}`)
+        url.searchParams.append('a', `primary-color=#0f4395`)
+        url.searchParams.append('a', `secondary-color=#8bc832`)
+        url.searchParams.append('a', `main-color=#555`)
+        url.searchParams.append('a', `background-color=#fdfbff`)
+        url.searchParams.append('a', `aggregation=${aggregation}`)
+        url.searchParams.append('a', `x-property=${xProperty}`)
+        url.searchParams.append('a', `y-property=${yProperty}`)
+        url.searchParams.append('a', `chart-type=${chartType}`)
         return url.toString()
       }
       return ''

--- a/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.ts
+++ b/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.ts
@@ -31,16 +31,16 @@ export class DataViewPermalinkComponent {
         const url = new URL(`${this.wcEmbedderBaseUrl}`, window.location.origin)
         url.search = `?v=${this.version}
 &e=gn-dataset-view-chart
-&a=api-url=${this.config.basePath}
-&a=dataset-id=${metadata.uniqueIdentifier}
-&a=primary-color=%230f4395
-&a=secondary-color=%238bc832
-&a=main-color=%23555
-&a=background-color=%23fdfbff
-&a=aggregation=${aggregation}
-&a=x-property=${xProperty}
-&a=y-property=${yProperty}
-&a=chart-type=${chartType}`
+&a=api-url%3D${this.config.basePath}
+&a=dataset-id%3D${metadata.uniqueIdentifier}
+&a=primary-color%3D%230f4395
+&a=secondary-color%3D%238bc832
+&a=main-color%3D%23555
+&a=background-color%3D%23fdfbff
+&a=aggregation%3D${aggregation}
+&a=x-property%3D${xProperty}
+&a=y-property%3D${yProperty}
+&a=chart-type%3D${chartType}`
         return url.toString()
       }
       return ''


### PR DESCRIPTION
### Description

This PR encodes the second equals sign of an attribute param that is passed to the web component embedder, as the `=` is part of the param value. This should notably resolve an issue routing via georchestra's gateway, that can be reproduced [here](https://mel.integration.apps.gs-fr-prod.camptocamp.com/datahub/wc-embedder.html?v=main&e=gn-dataset-view-chart&a=api-url=/geonetwork/srv/api&a=dataset-id=54954a05-d775-447d-9946-bbbbe040093a&a=primary-color=%230f4395&a=secondary-color=%238bc832&a=main-color=%23555&a=background-color=%23fdfbff&a=aggregation=sum&a=x-property=FID&a=y-property=code_insee&a=chart-type=bar).


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves


**This work is sponsored by [MEL](https://www.lillemetropole.fr/)**.
