### PR TITLE
chore: update xlsx to v0.20.2 to fix vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "tslib": "^2.3.0",
         "typeorm": "^0.3.14",
         "whatwg-fetch": "^3.6.2",
-        "xlsx": "^0.17.3",
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
         "zone.js": "0.13.0"
       },
       "devDependencies": {
@@ -14008,16 +14008,9 @@
       }
     },
     "node_modules/adler-32": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
-      "integrity": "sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==",
-      "dependencies": {
-        "exit-on-epipe": "~1.0.1",
-        "printj": "~1.1.0"
-      },
-      "bin": {
-        "adler32": "bin/adler32.njs"
-      },
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
       "engines": {
         "node": ">=0.8"
       }
@@ -14117,14 +14110,6 @@
       },
       "engines": {
         "node": ">=15"
-      }
-    },
-    "node_modules/alasql/node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/alasql/node_modules/node-fetch": {
@@ -15600,14 +15585,6 @@
         "adler-32": "~1.3.0",
         "crc-32": "~1.2.0"
       },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/cfb/node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
       "engines": {
         "node": ">=0.8"
       }
@@ -18627,14 +18604,6 @@
       "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/exit-on-epipe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
-      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/expect": {
@@ -27787,17 +27756,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/printj": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
-      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
-      "bin": {
-        "printj": "bin/printj.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/proc-log": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -33187,18 +33145,10 @@
       }
     },
     "node_modules/xlsx": {
-      "version": "0.17.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.17.5.tgz",
-      "integrity": "sha512-lXNU0TuYsvElzvtI6O7WIVb9Zar1XYw7Xb3VAx2wn8N/n0whBYrCnHMxtFyIiUU1Wjf09WzmLALDfBO5PqTb1g==",
-      "dependencies": {
-        "adler-32": "~1.2.0",
-        "cfb": "^1.1.4",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.0",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
+      "version": "0.20.2",
+      "resolved": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
+      "integrity": "sha512-+nKZ39+nvK7Qq6i0PvWWRA4j/EkfWOtkP/YhMtupm+lJIiHxUrgTr1CcKv1nBk1rHtkRRQ3O2+Ih/q/sA+FXZA==",
+      "license": "Apache-2.0",
       "bin": {
         "xlsx": "bin/xlsx.njs"
       },

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "tslib": "^2.3.0",
     "typeorm": "^0.3.14",
     "whatwg-fetch": "^3.6.2",
-    "xlsx": "^0.17.3",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
     "zone.js": "0.13.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The lib is now hosted here: https://cdn.sheetjs.com/
