### PR TITLE
e2e(datahub): wait more precisely for favorite to be registered

### DIFF
--- a/apps/datahub-e2e/src/e2e/home.cy.ts
+++ b/apps/datahub-e2e/src/e2e/home.cy.ts
@@ -96,7 +96,12 @@ describe('home', () => {
         .invoke('text')
         .as('favoriteTitle')
       cy.get('@favoriteItem').find('gn-ui-favorite-star button').click()
-      cy.wait(100)
+
+      // wait for the favorite count to change before filtering
+      cy.get('@favoriteItem')
+        .find('[data-test=favorite-count]')
+        .invoke('text')
+        .should('eq', '1')
 
       // show my favorites only
       cy.get('datahub-header-badge-button[label$=favorites] button').click({

--- a/libs/feature/search/src/lib/favorites/favorite-star/favorite-star.component.html
+++ b/libs/feature/search/src/lib/favorites/favorite-star/favorite-star.component.html
@@ -1,6 +1,7 @@
 <div class="flex flex-row items-center">
   <span
-    class="align-text-top mr-1.5 favorite-count"
+    class="align-text-top mr-1.5"
+    data-test="favorite-count"
     *ngIf="hasFavoriteCount && displayCount"
     >{{ favoriteCount }}</span
   >
@@ -10,7 +11,8 @@
     [disabled]="loading || (isAnonymous$ | async)"
   ></gn-ui-star-toggle>
   <span
-    class="align-text-top ml-1.5 favorite-count"
+    class="align-text-top ml-1.5"
+    data-test="favorite-count"
     *ngIf="!displayCount"
     translate="datahub.record.addToFavorites"
   ></span>

--- a/libs/feature/search/src/lib/favorites/favorite-star/favorite-star.component.spec.ts
+++ b/libs/feature/search/src/lib/favorites/favorite-star/favorite-star.component.spec.ts
@@ -88,7 +88,7 @@ describe('FavoriteStarComponent', () => {
       })
       it('shows the amount of favorites on the record', () => {
         favoriteCountHTMLEl = fixture.debugElement.query(
-          By.css('.favorite-count')
+          By.css('[data-test=favorite-count]')
         ).nativeElement
         expect(favoriteCountHTMLEl).toBeTruthy()
         expect(favoriteCountHTMLEl.textContent).toEqual(
@@ -103,7 +103,7 @@ describe('FavoriteStarComponent', () => {
       })
       it('does not show the amount of favorites on the record', () => {
         const favoriteCountEl = fixture.debugElement.query(
-          By.css('.favorite-count')
+          By.css('[data-test=favorite-count]')
         )
         expect(favoriteCountEl).toBeFalsy()
       })
@@ -182,7 +182,7 @@ describe('FavoriteStarComponent', () => {
       }
       fixture.detectChanges()
       favoriteCountHTMLEl = fixture.debugElement.query(
-        By.css('.favorite-count')
+        By.css('[data-test=favorite-count]')
       ).nativeElement
     })
     describe('When my record is part of the updates', () => {


### PR DESCRIPTION
Before that the filtering on favorites was sometimes done too early