### PR TITLE
Routing: Allow implementing other search routes than /search in other router services

### DIFF
--- a/apps/datahub/src/app/router/datahub-router.service.ts
+++ b/apps/datahub/src/app/router/datahub-router.service.ts
@@ -76,6 +76,6 @@ export class DatahubRouterService {
   }
 
   getSearchRoute(): string {
-    return `${ROUTER_ROUTE_HOME}/${ROUTER_ROUTE_SEARCH}`
+    return ROUTER_ROUTE_SEARCH
   }
 }

--- a/libs/feature/router/src/lib/default/state/router.facade.ts
+++ b/libs/feature/router/src/lib/default/state/router.facade.ts
@@ -25,7 +25,9 @@ export class RouterFacade {
 
   searchParams$ = this.currentRoute$.pipe(
     filter((route) => !!route),
-    filter((route) => route.url[0]?.path.startsWith(ROUTER_ROUTE_SEARCH)),
+    filter((route) =>
+      route.url[0]?.path.startsWith(this.routerService.getSearchRoute())
+    ),
     map((route) => route.queryParams),
     distinctUntilChanged((a, b) => JSON.stringify(a) === JSON.stringify(b))
   )


### PR DESCRIPTION
### Description

This PR introduces uses `getSearchRoute()` instead of `ROUTER_ROUTE_SEARCH` within the `router.facade` to allow implementing other search routes than `/search` in other router services.

Note: Needs to remove `ROUTER_ROUTE_HOME` from the `datahub-router.service` to work (which is not part of the path due to a redirect).

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
