### PR TITLE
Metadata Editor: Use gnUiEditableLabel directive for title input

### DIFF
--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-rich/form-field-rich.component.css
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-rich/form-field-rich.component.css
@@ -1,5 +1,0 @@
-.icon-small {
-  font-size: 16px;
-  height: 16px;
-  width: 16px;
-}

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-rich/form-field-rich.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-rich/form-field-rich.component.html
@@ -4,7 +4,7 @@
     [extraClass]="getButtonExtraClass()"
     (buttonClick)="togglePreview()"
   >
-    <span class="material-symbols-outlined mr-1 icon-small">{{
+    <span class="material-symbols-outlined mr-1 gn-ui-icon-small">{{
       preview ? 'visibility' : 'visibility_off'
     }}</span>
     {{ preview ? 'WYSIWYG' : 'Markdown' }}

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.html
@@ -24,6 +24,30 @@
       >cancel</mat-icon
     >
   </div>
+  <ng-container *ngIf="isTitle">
+    <div class="flex justify-between items-center gap-3">
+      <h2
+        #titleInput
+        class="grow text-3xl font-normal"
+        [gnUiEditableLabel]="true"
+        (editableLabelChanged)="formControl.setValue($event)"
+      >
+        {{ formControl.value }}
+      </h2>
+      <span
+        class="material-symbols-outlined gn-ui-icon-small m-2 cursor-pointer"
+        (click)="focusTitleInput()"
+        >edit</span
+      >
+      <span
+        class="material-symbols-outlined gn-ui-icon-small m-2"
+        [matTooltip]="config.hintKey | translate"
+        matTooltipPosition="above"
+      >
+        help
+      </span>
+    </div>
+  </ng-container>
   <ng-container *ngIf="isSimpleField">
     <gn-ui-form-field-simple
       [type]="simpleType"

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.ts
@@ -1,11 +1,16 @@
+import { CommonModule } from '@angular/common'
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   Input,
   Output,
+  ViewChild,
 } from '@angular/core'
 import { FormControl, ReactiveFormsModule } from '@angular/forms'
 import { MatIconModule } from '@angular/material/icon'
+import { MatTooltipModule } from '@angular/material/tooltip'
+import { EditableLabelDirective } from '@geonetwork-ui/ui/inputs'
 import { TranslateModule } from '@ngx-translate/core'
 import { Observable } from 'rxjs'
 import { FormFieldArrayComponent } from './form-field-array/form-field-array.component'
@@ -16,7 +21,6 @@ import { FormFieldSimpleComponent } from './form-field-simple/form-field-simple.
 import { FormFieldSpatialExtentComponent } from './form-field-spatial-extent/form-field-spatial-extent.component'
 import { FormFieldTemporalExtentComponent } from './form-field-temporal-extent/form-field-temporal-extent.component'
 import { FormFieldConfig } from './form-field.model'
-import { CommonModule } from '@angular/common'
 
 @Component({
   selector: 'gn-ui-form-field',
@@ -25,6 +29,11 @@ import { CommonModule } from '@angular/common'
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    EditableLabelDirective,
+    MatIconModule,
+    MatTooltipModule,
     FormFieldSimpleComponent,
     FormFieldRichComponent,
     FormFieldObjectComponent,
@@ -32,10 +41,7 @@ import { CommonModule } from '@angular/common'
     FormFieldTemporalExtentComponent,
     FormFieldFileComponent,
     FormFieldArrayComponent,
-    CommonModule,
-    ReactiveFormsModule,
     TranslateModule,
-    MatIconModule,
   ],
 })
 export class FormFieldComponent {
@@ -48,10 +54,16 @@ export class FormFieldComponent {
   }
   @Output() valueChange: Observable<unknown>
 
+  @ViewChild('titleInput') titleInput: ElementRef
+
   formControl = new FormControl()
 
   constructor() {
     this.valueChange = this.formControl.valueChanges
+  }
+
+  focusTitleInput() {
+    this.titleInput.nativeElement.children[0].focus()
   }
 
   get simpleType() {
@@ -100,6 +112,9 @@ export class FormFieldComponent {
     return !this.config.locked && this.config.invalid
   }
 
+  get isTitle() {
+    return this.model === 'title'
+  }
   get isAbstract() {
     return this.model === 'abstract'
   }

--- a/libs/feature/editor/src/lib/components/record-form/record-form.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/record-form.component.ts
@@ -2,16 +2,7 @@ import { CommonModule } from '@angular/common'
 import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { EditorFacade } from '../../+state/editor.facade'
 import { EditorFieldState, EditorFieldValue } from '../../models/fields.model'
-import {
-  FormFieldArrayComponent,
-  FormFieldComponent,
-  FormFieldFileComponent,
-  FormFieldObjectComponent,
-  FormFieldRichComponent,
-  FormFieldSimpleComponent,
-  FormFieldSpatialExtentComponent,
-  FormFieldTemporalExtentComponent,
-} from './form-field'
+import { FormFieldComponent } from './form-field'
 
 @Component({
   selector: 'gn-ui-record-form',
@@ -19,17 +10,7 @@ import {
   styleUrls: ['./record-form.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [
-    CommonModule,
-    FormFieldComponent,
-    FormFieldArrayComponent,
-    FormFieldFileComponent,
-    FormFieldObjectComponent,
-    FormFieldRichComponent,
-    FormFieldSimpleComponent,
-    FormFieldSpatialExtentComponent,
-    FormFieldTemporalExtentComponent,
-  ],
+  imports: [CommonModule, FormFieldComponent],
 })
 export class RecordFormComponent {
   fields$ = this.facade.recordFields$

--- a/libs/ui/layout/src/lib/form-field-wrapper/form-field-wrapper.component.css
+++ b/libs/ui/layout/src/lib/form-field-wrapper/form-field-wrapper.component.css
@@ -1,5 +1,0 @@
-.icon-small {
-  font-size: 16px;
-  height: 16px;
-  width: 16px;
-}

--- a/libs/ui/layout/src/lib/form-field-wrapper/form-field-wrapper.component.html
+++ b/libs/ui/layout/src/lib/form-field-wrapper/form-field-wrapper.component.html
@@ -4,7 +4,7 @@
     <div class="flex-1 flex justify-end items-center">
       <ng-content select="[form-field-interaction]"></ng-content>
       <span
-        class="material-symbols-outlined m-2 icon-small"
+        class="material-symbols-outlined m-2 gn-ui-icon-small"
         [matTooltip]="hint"
         matTooltipPosition="above"
       >

--- a/tailwind.base.css
+++ b/tailwind.base.css
@@ -9,6 +9,13 @@
     @apply shadow-xl hover:shadow-xl-hover transition-shadow;
   }
 
+  /* ICON CLASSES */
+  .gn-ui-icon-small {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+
   /* LINK CLASSES */
   .gn-ui-link {
     @apply text-blue-600 hover:text-blue-700 hover:underline;


### PR DESCRIPTION
### Description

This PR uses the gnUiEditableLabel directive for the title input.

### Screenshots

![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/e9ab4359-816b-4977-aac2-41b914948323)

### Todo
- [x] Wait for https://github.com/geonetwork/geonetwork-ui/pull/854 to move rendering logic to form-field

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->