### PR TITLE
fix(data-service): rely on ogc-client to get the name of the json format

### DIFF
--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -375,7 +375,7 @@ describe('DataService', () => {
             service.getDownloadUrlsFromWfs('http://local/wfs', 'abcd')
           ).then((urls) => urls.geojson)
           expect(url).toEqual(
-            'http://local/wfs?GetFeature&FeatureType=abcd&format=application/json'
+            'http://local/wfs?GetFeature&FeatureType=abcd&format=geojson'
           )
         })
       })
@@ -396,7 +396,7 @@ describe('DataService', () => {
             service.getDownloadUrlsFromWfs('http://unique-feature-type/wfs', '')
           ).then((urls) => urls.geojson)
           expect(url).toEqual(
-            'http://unique-feature-type/wfs?GetFeature&FeatureType=myOnlyOne&format=application/json'
+            'http://unique-feature-type/wfs?GetFeature&FeatureType=myOnlyOne&format=geojson'
           )
         })
       })
@@ -584,7 +584,7 @@ describe('DataService', () => {
           service.getDownloadUrlsFromWfs('http://local/wfs', 'abcd')
         ).then((urls) => urls.geojson)
         expect(url).toEqual(
-          'http://proxy.local/?url=http%3A%2F%2Flocal%2Fwfs?GetFeature&FeatureType=abcd&format=application/json'
+          'http://proxy.local/?url=http%3A%2F%2Flocal%2Fwfs?GetFeature&FeatureType=abcd&format=geojson'
         )
       })
     })

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -94,7 +94,7 @@ export class DataService {
           ),
           geojson: endpoint.supportsJson(featureType.name)
             ? endpoint.getFeatureUrl(featureType.name, {
-                outputFormat: 'application/json',
+                asJson: true,
                 outputCrs: 'EPSG:4326',
               })
             : null,


### PR DESCRIPTION
Will allow showing the data for e.g. https://dev.geo2france.fr/datahub/dataset/91611b25-62de-49f7-aa10-27715dff6b06 where the WFS service has a different name for its json output.