### PR TITLE
Datahub: Add lastupdated date to record response

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -191,7 +191,6 @@ describe('dataset pages', () => {
       })
     })
     describe('features', () => {
-      let targetLink
       let keyword
       it('should go to provider website on click', () => {
         cy.get('datahub-record-metadata')
@@ -206,9 +205,7 @@ describe('dataset pages', () => {
         cy.get('@proviLink')
           .invoke('attr', 'href')
           .then((link) => {
-            targetLink = link
-            cy.get('@proviLink').invoke('removeAttr', 'target').click()
-            cy.url().should('include', targetLink)
+            expect(link).to.eq('https://www.geo2france.fr/')
           })
       })
       it('should go to dataset search page when clicking on org name and filter by org', () => {

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
@@ -1058,6 +1058,7 @@ describe('Gn4Converter', () => {
               },
             ],
             datasetCreated: new Date('2012-01-01T00:00:00.000Z'),
+            datasetUpdated: new Date('2021-12-13T00:00:00.000Z'),
             distributions: [
               {
                 url: new URL(

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -124,6 +124,12 @@ export class Gn4FieldMapper {
         getFirstValue(selectField<string>(source, 'creationDateForResource'))
       ),
     }),
+    revisionDateForResource: (output, source) => ({
+      ...output,
+      datasetUpdated: toDate(
+        getFirstValue(selectField<string>(source, 'revisionDateForResource'))
+      ),
+    }),
     createDate: (output, source) => ({
       ...output,
       recordCreated: toDate(selectField<string>(source, 'createDate')),


### PR DESCRIPTION
### Description

This PR introduces a new field in the fieldmapper to be able to get the updated date of the resource (revision). Right now we only have the updated date of the record.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [MEL](https://www.lillemetropole.fr/)**.
