### PR TITLE
feat(DH): Change datasetUpdated, datasetCreated to resourceUpdated, resourceCreated in GN4 mapping

### DIFF
--- a/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
@@ -1057,8 +1057,6 @@ describe('Gn4Converter', () => {
                 role: 'publisher',
               },
             ],
-            datasetCreated: new Date('2012-01-01T00:00:00.000Z'),
-            datasetUpdated: new Date('2021-12-13T00:00:00.000Z'),
             distributions: [
               {
                 url: new URL(
@@ -1626,6 +1624,8 @@ describe('Gn4Converter', () => {
             recordCreated: new Date('2021-10-05T12:48:57.678Z'),
             recordUpdated: new Date('2021-10-05T12:48:57.678Z'),
             recordPublished: new Date('2021-04-01T00:00:00.000Z'),
+            resourceCreated: new Date('2012-01-01T00:00:00.000Z'),
+            resourceUpdated: new Date('2021-12-13T00:00:00.000Z'),
             status: 'ongoing',
             topics: ['Installations de suivi environnemental', 'Océans'],
             title: 'Surval - Données par paramètre',

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -120,13 +120,13 @@ export class Gn4FieldMapper {
     }),
     creationDateForResource: (output, source) => ({
       ...output,
-      datasetCreated: toDate(
+      resourceCreated: toDate(
         getFirstValue(selectField<string>(source, 'creationDateForResource'))
       ),
     }),
     revisionDateForResource: (output, source) => ({
       ...output,
-      datasetUpdated: toDate(
+      resourceUpdated: toDate(
         getFirstValue(selectField<string>(source, 'revisionDateForResource'))
       ),
     }),


### PR DESCRIPTION
As the `BaseRecord`of the metadata model already supports `resourceUpdated` and `resourceCreated` date this PR changes the names from previously `datasetUpdated`, `datasetCreated`.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

**This work is sponsored by [MEL](https://www.lillemetropole.fr/)**.
