### PR TITLE
chore(ui): fix carousel buttons not showing up on Firefox

### DIFF
--- a/libs/ui/layout/src/lib/carousel/carousel.component.css
+++ b/libs/ui/layout/src/lib/carousel/carousel.component.css
@@ -4,6 +4,7 @@
 
 :host {
   position: relative;
+  display: block;
 }
 
 .carousel-step-dot {


### PR DESCRIPTION
The buttons are positioned absolutely and the component host is positioned relatively; without a "display: block" setting as well, the buttons were simply not showing up on Firefox.

![image](https://github.com/geonetwork/geonetwork-ui/assets/10629150/1005aa93-34ec-4224-add5-71a3d2997041)

Conclusion: do not position relatively something that isn't a block.