### PR TITLE
[Datahub] OGC API custom URL Generation using ogc-client

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -684,7 +684,7 @@ describe('api form', () => {
       .find('gn-ui-copy-text-button')
       .find('input')
       .invoke('val')
-      .should('include', 'offset=87&limit=54&f=geojson')
+      .should('include', 'f=geojson&limit=54&offset=87')
 
     cy.get('@apiForm').children('div').first().find('button').first().click()
 
@@ -699,7 +699,7 @@ describe('api form', () => {
       .find('gn-ui-copy-text-button')
       .find('input')
       .invoke('val')
-      .should('include', 'limit=-1&f=json')
+      .should('include', 'f=json&limit=-1')
   })
   it('should close the panel on click', () => {
     cy.get('gn-ui-record-api-form').prev().find('button').click()

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
@@ -93,7 +93,7 @@ describe('RecordApFormComponent', () => {
       expect(component.format$.getValue()).toBe('json')
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        'https://api.example.com/data/collections/mockFeatureType/items?f=json'
+        'https://api.example.com/data/collections/feature1/items?limit=-1&f=json'
       )
     })
   })
@@ -107,7 +107,7 @@ describe('RecordApFormComponent', () => {
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data/collections/mockFeatureType/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
+        `https://api.example.com/data/collections/feature1/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
       )
     })
     it('should remove the param in url if value is null', async () => {
@@ -119,7 +119,7 @@ describe('RecordApFormComponent', () => {
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data/collections/mockFeatureType/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
+        `https://api.example.com/data/collections/feature1/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
       )
     })
     it('should remove the param in url if value is zero', async () => {
@@ -131,7 +131,7 @@ describe('RecordApFormComponent', () => {
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data/collections/mockFeatureType/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
+        `https://api.example.com/data/collections/feature1/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
       )
     })
   })
@@ -177,7 +177,7 @@ describe('RecordApFormComponent', () => {
       expect(component.format$.getValue()).toBe('json')
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"json"}`
+        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"json","limit":-1}`
       )
     })
   })

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
@@ -9,6 +9,7 @@ const mockDatasetServiceDistribution: DatasetServiceDistribution = {
   url: new URL('https://api.example.com/data'),
   type: 'service',
   accessServiceProtocol: 'ogcFeatures',
+  name: 'mockFeatureType',
 }
 
 jest.mock('@camptocamp/ogc-client', () => ({
@@ -27,6 +28,16 @@ jest.mock('@camptocamp/ogc-client', () => ({
           'application/json',
         ],
       })
+    }
+    getCollectionItemsUrl(collectionName, options) {
+      const queryParams = new URLSearchParams()
+      if (options.limit !== undefined) queryParams.set('limit', options.limit)
+      if (options.offset !== undefined)
+        queryParams.set('offset', options.offset)
+      queryParams.set('f', options.outputFormat)
+      return `${
+        this.url
+      }/collections/${collectionName}/items?${queryParams.toString()}`
     }
   },
   WfsEndpoint: class {
@@ -81,7 +92,9 @@ describe('RecordApFormComponent', () => {
       expect(component.limit$.getValue()).toBe('-1')
       expect(component.format$.getValue()).toBe('json')
       const url = await firstValueFrom(component.apiQueryUrl$)
-      expect(url).toBe('https://api.example.com/data?limit=-1&f=json')
+      expect(url).toBe(
+        'https://api.example.com/data/collections/mockFeatureType/items?f=json'
+      )
     })
   })
   describe('When URL params are changed', () => {
@@ -94,11 +107,11 @@ describe('RecordApFormComponent', () => {
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data?offset=${mockOffset}&limit=${mockLimit}&f=${mockFormat}`
+        `https://api.example.com/data/collections/mockFeatureType/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
       )
     })
     it('should remove the param in url if value is null', async () => {
-      const mockOffset = null
+      const mockOffset = '0'
       const mockLimit = '20'
       const mockFormat = 'json'
       component.setOffset(mockOffset)
@@ -106,7 +119,7 @@ describe('RecordApFormComponent', () => {
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data?limit=${mockLimit}&f=${mockFormat}`
+        `https://api.example.com/data/collections/mockFeatureType/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
       )
     })
     it('should remove the param in url if value is zero', async () => {
@@ -118,7 +131,7 @@ describe('RecordApFormComponent', () => {
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data?offset=${mockOffset}&f=${mockFormat}`
+        `https://api.example.com/data/collections/mockFeatureType/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
       )
     })
   })
@@ -164,7 +177,7 @@ describe('RecordApFormComponent', () => {
       expect(component.format$.getValue()).toBe('json')
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        'https://api.example.com/data?type=undefined&options={"outputFormat":"json","startIndex":0}'
+        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"json"}`
       )
     })
   })

--- a/package/package.json
+++ b/package/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-    "@camptocamp/ogc-client": "^1.1.0-RC.3",
+    "@camptocamp/ogc-client": "1.1.1-dev.ddbb5b0",
     "@geospatial-sdk/geocoding": "^0.0.5-alpha.2",
     "@ltd/j-toml": "~1.35.2",
     "@messageformat/core": "^3.0.1",


### PR DESCRIPTION
### Description

This PR updates the method for generating custom OGC API URL, now utilizing `ogc-client`. Additionally, it refactors the code to enhance its quality.

- Using `getCollectionItemsUrl` from ogc-client library to generate the custom URL
- Refactored `record-api-form` component to simplify endpoint handling.
- Created a single instance of the endpoint and reused it across methods.
- Improved logic to handle both OGC API and WFS protocols with fewer conditional checks.
- Fixed tests to check the new way URLs are built.


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves


