### PR TITLE
[Datahub]: Fix missing "record not found" message

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -797,3 +797,12 @@ describe('userFeedback', () => {
     })
   })
 })
+
+describe('When the metadata does not exists', () => {
+  beforeEach(() => {
+    cy.visit('/dataset/xyz')
+  })
+  it('should display an error message', () => {
+    cy.get('gn-ui-search-results-error').should('exist')
+  })
+})

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
@@ -149,7 +149,7 @@
     </div>
   </div>
   <div
-    *ngIf="loadFeedBacks$ | async"
+    *ngIf="(metadataViewFacade.isPresent$ | async) === true"
     id="userFeedbacks"
     class="bg-primary-opacity-10 py-16 mt-[32px]"
   >

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
@@ -148,13 +148,17 @@
       <div class="container-lg mx-auto h-[1096px] sm:h-96"></div>
     </div>
   </div>
-</div>
-<div id="userFeedbacks" class="bg-primary-opacity-10 py-16 mt-[32px]">
-  <div class="container-lg px-4 lg:mx-auto">
-    <datahub-record-user-feedbacks
-      [organisationName$]="organisationName$"
-      [metadataUuid]="metadataUuid$ | async"
-    ></datahub-record-user-feedbacks>
+  <div
+    *ngIf="loadFeedBacks$ | async"
+    id="userFeedbacks"
+    class="bg-primary-opacity-10 py-16 mt-[32px]"
+  >
+    <div class="container-lg px-4 lg:mx-auto">
+      <datahub-record-user-feedbacks
+        [organisationName$]="organisationName$"
+        [metadataUuid]="metadataUuid$ | async"
+      ></datahub-record-user-feedbacks>
+    </div>
   </div>
 </div>
 <div

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -70,6 +70,11 @@ export class RecordMetadataComponent {
     mergeMap((uuid) => this.sourceService.getSourceLabel(uuid))
   )
 
+  loadFeedBacks$ = this.metadataViewFacade.metadata$.pipe(
+    map((record) => record?.title),
+    filter(Boolean)
+  )
+
   errorTypes = ErrorType
 
   selectedTabIndex$ = new BehaviorSubject(0)

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -70,11 +70,6 @@ export class RecordMetadataComponent {
     mergeMap((uuid) => this.sourceService.getSourceLabel(uuid))
   )
 
-  loadFeedBacks$ = this.metadataViewFacade.metadata$.pipe(
-    map((record) => record?.title),
-    filter(Boolean)
-  )
-
   errorTypes = ErrorType
 
   selectedTabIndex$ = new BehaviorSubject(0)

--- a/libs/feature/record/src/lib/state/mdview.reducer.ts
+++ b/libs/feature/record/src/lib/state/mdview.reducer.ts
@@ -82,7 +82,6 @@ const metadataViewReducer = createReducer(
   */
   on(MetadataViewActions.loadUserFeedbacks, (state) => ({
     ...state,
-    error: null,
     allUserFeedbacksLoading: true,
   })),
   on(MetadataViewActions.addUserFeedback, (state) => ({
@@ -93,7 +92,6 @@ const metadataViewReducer = createReducer(
     MetadataViewActions.loadUserFeedbacksSuccess,
     (state, { userFeedbacks }) => ({
       ...state,
-      error: null,
       userFeedbacks: userFeedbacks,
       addUserFeedbackLoading: false,
       allUserFeedbacksLoading: false,


### PR DESCRIPTION
### Description

This PR fixes the absence of the "record not found" message. 

The issue was indeed linked to the userFeedbacks loading, regardless of the "notFound" error. 
It was linked to the fact that userFeedBacks component only needs a metadataUuid to load, and any fake record (eg "abcd") was working with it. 

This workaround simply hides the userFeedBack when the metadata does not have a title, since it's not possible to use the error state as long as a metadataUuid exists.

It also adds a e2e test to make sure this error will be caught for now on.

---

**This work is sponsored by [IGN]**.
