### PR TITLE
MEL - datahub - tile WMS

### DIFF
--- a/conf/default.toml
+++ b/conf/default.toml
@@ -141,6 +141,9 @@ background_color = "#fdfbff"
 # Optional; if true, opens external viewer in new tab (default false)
 # external_viewer_open_new_tab = false
 
+# Optional; Will not tile WMS. False by default.
+# do_not_tile_wms = false
+
 # Optional; if true, the default basemap will not be added to the map.
 # Use [[map_layer]] sections to define your own custom layers (see below)
 # do_not_use_default_basemap = false

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -214,6 +214,10 @@ The map section lets you customize how maps appear and behave across GeoNetwork-
   max_extent = [-418263.418776, 5251529.591305, 961272.067714, 6706890.609855]
   ```
 
+- `do_not_tile_wms` (optional)
+
+  Will not use tiling when requesting WMS services. Defaults to `false` (WMS are tiled). Not using tiles for WMS might incur performance loss since the client will not benefit from an eventual tile cache anymore. On the other hand, visual quality might improve in case a map tile server does not handle neighbouring tiles correctly, e.g. symbols or text being cropped at tile boundaries. This can be set true to prevent visual conflicts on tile borders, if the WMS server does not add a gutter, for example. gn-ui does not add a gutter on the client side, in order to allow server-side caching.
+
 - `do_not_use_default_basemap` (optional)
 
   If set to `true`, the default basemap will not be added to the map. Defaults to `false` (base map is shown).

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -15,7 +15,7 @@ import {
   MapUtilsService,
 } from '@geonetwork-ui/feature/map'
 import { getOptionalMapConfig, MapConfig } from '@geonetwork-ui/util/app-config'
-import { getLinkLabel, ProxyService } from '@geonetwork-ui/util/shared'
+import { getLinkLabel } from '@geonetwork-ui/util/shared'
 import Feature from 'ol/Feature'
 import { Geometry } from 'ol/geom'
 import { StyleLike } from 'ol/style/Style'
@@ -23,10 +23,8 @@ import {
   BehaviorSubject,
   combineLatest,
   from,
-  lastValueFrom,
   Observable,
   of,
-  startWith,
   Subscription,
   throwError,
   withLatestFrom,
@@ -117,7 +115,9 @@ export class MapViewComponent implements OnInit, OnDestroy {
               },
             } as MapContextModel)
         ),
-        tap(() => this.resetSelection())
+        tap((res) => {
+          this.resetSelection()
+        })
       )
     ),
     withLatestFrom(this.mdViewFacade.metadata$),

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -144,6 +144,7 @@ export function loadAppConfig() {
         [],
         [
           'max_zoom',
+          'do_not_tile_wms',
           'max_extent',
           'baselayer',
           'do_not_use_default_basemap',
@@ -158,6 +159,7 @@ export function loadAppConfig() {
           ? null
           : ({
               MAX_ZOOM: parsedMapSection.max_zoom,
+              DO_NOT_TILE_WMS: parsedMapSection.do_not_tile_wms,
               MAX_EXTENT: parsedMapSection.max_extent,
               EXTERNAL_VIEWER_URL_TEMPLATE:
                 parsedMapSection.external_viewer_url_template,

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -81,6 +81,7 @@ export const MAP_CONFIG_FIXTURE: MapConfig = {
   MAX_ZOOM: 10,
   MAX_EXTENT: [-418263.418776, 5251529.591305, 961272.067714, 6706890.609855],
   DO_NOT_USE_DEFAULT_BASEMAP: false,
+  DO_NOT_TILE_WMS: false,
   EXTERNAL_VIEWER_URL_TEMPLATE:
     'https://example.com/myviewer/#/?actions=[{"type":"CATALOG:ADD_LAYERS_FROM_CATALOGS","layers":["${layer_name}"],"sources":[{"url":"${service_url}","type":"${service_type}"}]}]',
   EXTERNAL_VIEWER_OPEN_NEW_TAB: true,

--- a/libs/util/app-config/src/lib/model.ts
+++ b/libs/util/app-config/src/lib/model.ts
@@ -20,6 +20,7 @@ export interface LayerConfig {
 
 export interface MapConfig {
   MAX_ZOOM?: number
+  DO_NOT_TILE_WMS: boolean
   MAX_EXTENT?: [number, number, number, number] // Expressed as [minx, miny, maxx, maxy]
   EXTERNAL_VIEWER_URL_TEMPLATE?: string
   EXTERNAL_VIEWER_OPEN_NEW_TAB?: boolean


### PR DESCRIPTION
### Description

This PR introduces a new parameter in the default.toml config file: `do_not_tile_wms` which is false by default.

### Screenshots

- When the parameter is set to false (by default), we can see on this dataset in the network that 15 tiles are fetched :

![image](https://github.com/geonetwork/geonetwork-ui/assets/79055061/ab5c606e-a406-409b-9571-24e069223526)

- When the parameter is set to true, we can see that only one image is fetched :

![image](https://github.com/geonetwork/geonetwork-ui/assets/79055061/6a8d50c4-660b-4f4d-a072-c08b53e902b8)


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [x] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by MEL**.
