### PR TITLE
[Fix] : Handle non geospatial ogc services

### DIFF
--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
@@ -39,6 +39,7 @@ class MdViewFacadeMock {
   mapApiLinks$ = new BehaviorSubject([])
   dataLinks$ = new BehaviorSubject([])
   geoDataLinks$ = new BehaviorSubject([])
+  geospatialLinks$ = new BehaviorSubject([])
   downloadLinks$ = new BehaviorSubject([])
   apiLinks$ = new BehaviorSubject([])
   otherLinks$ = new BehaviorSubject([])
@@ -377,6 +378,7 @@ describe('RecordMetadataComponent', () => {
     })
     describe('when a GEODATA link present', () => {
       beforeEach(() => {
+        facade.geospatialLinks$.next(['link'])
         facade.geoDataLinks$.next(['link'])
         fixture.detectChanges()
         mapTab = fixture.debugElement.queryAll(By.css('mat-tab'))[0]
@@ -399,7 +401,7 @@ describe('RecordMetadataComponent', () => {
       beforeEach(() => {
         facade.mapApiLinks$.next(['link'])
         facade.dataLinks$.next(null)
-        facade.geoDataLinks$.next(null)
+        facade.geospatialLinks$.next(null)
         fixture.detectChanges()
         tableTab = fixture.debugElement.queryAll(By.css('mat-tab'))[1]
         chartTab = fixture.debugElement.queryAll(By.css('mat-tab'))[2]

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
@@ -39,7 +39,7 @@ class MdViewFacadeMock {
   mapApiLinks$ = new BehaviorSubject([])
   dataLinks$ = new BehaviorSubject([])
   geoDataLinks$ = new BehaviorSubject([])
-  geospatialLinks$ = new BehaviorSubject([])
+  geoDataLinksWithGeometry$ = new BehaviorSubject([])
   downloadLinks$ = new BehaviorSubject([])
   apiLinks$ = new BehaviorSubject([])
   otherLinks$ = new BehaviorSubject([])
@@ -378,7 +378,7 @@ describe('RecordMetadataComponent', () => {
     })
     describe('when a GEODATA link present', () => {
       beforeEach(() => {
-        facade.geospatialLinks$.next(['link'])
+        facade.geoDataLinksWithGeometry$.next(['link'])
         facade.geoDataLinks$.next(['link'])
         fixture.detectChanges()
         mapTab = fixture.debugElement.queryAll(By.css('mat-tab'))[0]
@@ -401,7 +401,7 @@ describe('RecordMetadataComponent', () => {
       beforeEach(() => {
         facade.mapApiLinks$.next(['link'])
         facade.dataLinks$.next(null)
-        facade.geospatialLinks$.next(null)
+        facade.geoDataLinksWithGeometry$.next(null)
         fixture.detectChanges()
         tableTab = fixture.debugElement.queryAll(By.css('mat-tab'))[1]
         chartTab = fixture.debugElement.queryAll(By.css('mat-tab'))[2]

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -26,7 +26,6 @@ export class RecordMetadataComponent {
     this.metadataViewFacade.geospatialLinks$,
   ]).pipe(
     map(([mapApiLinks, geospatialLinks]) => {
-      console.log(geospatialLinks)
       return mapApiLinks?.length > 0 || geospatialLinks?.length > 0
     })
   )

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -3,7 +3,7 @@ import { SourcesService } from '@geonetwork-ui/feature/catalog'
 import { SearchService } from '@geonetwork-ui/feature/search'
 import { ErrorType } from '@geonetwork-ui/ui/elements'
 import { BehaviorSubject, combineLatest } from 'rxjs'
-import { filter, map, mergeMap } from 'rxjs/operators'
+import { filter, map, mergeMap, startWith } from 'rxjs/operators'
 import { OrganizationsServiceInterface } from '@geonetwork-ui/common/domain/organizations.service.interface'
 import {
   Keyword,
@@ -26,7 +26,8 @@ export class RecordMetadataComponent {
   ]).pipe(
     map(([mapApiLinks, geoDataLinksWithGeometry]) => {
       return mapApiLinks?.length > 0 || geoDataLinksWithGeometry?.length > 0
-    })
+    }),
+    startWith(false)
   )
 
   displayData$ = combineLatest([

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -25,10 +25,10 @@ export class RecordMetadataComponent {
     this.metadataViewFacade.mapApiLinks$,
     this.metadataViewFacade.geospatialLinks$,
   ]).pipe(
-    map(
-      ([mapApiLinks, geospatialLinks]) =>
-        mapApiLinks?.length > 0 || geospatialLinks?.length > 0
-    )
+    map(([mapApiLinks, geospatialLinks]) => {
+      console.log(geospatialLinks)
+      return mapApiLinks?.length > 0 || geospatialLinks?.length > 0
+    })
   )
 
   displayData$ = combineLatest([

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -2,15 +2,14 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { SourcesService } from '@geonetwork-ui/feature/catalog'
 import { SearchService } from '@geonetwork-ui/feature/search'
 import { ErrorType } from '@geonetwork-ui/ui/elements'
-import { BehaviorSubject, combineLatest, from, of } from 'rxjs'
-import { filter, map, mergeMap, switchMap } from 'rxjs/operators'
+import { BehaviorSubject, combineLatest } from 'rxjs'
+import { filter, map, mergeMap } from 'rxjs/operators'
 import { OrganizationsServiceInterface } from '@geonetwork-ui/common/domain/organizations.service.interface'
 import {
   Keyword,
   Organization,
 } from '@geonetwork-ui/common/domain/model/record'
 import { MdViewFacade } from '@geonetwork-ui/feature/record'
-import { DataService } from '@geonetwork-ui/feature/dataviz'
 
 @Component({
   selector: 'datahub-record-metadata',
@@ -23,10 +22,10 @@ export class RecordMetadataComponent {
 
   displayMap$ = combineLatest([
     this.metadataViewFacade.mapApiLinks$,
-    this.metadataViewFacade.geospatialLinks$,
+    this.metadataViewFacade.geoDataLinksWithGeometry$,
   ]).pipe(
-    map(([mapApiLinks, geospatialLinks]) => {
-      return mapApiLinks?.length > 0 || geospatialLinks?.length > 0
+    map(([mapApiLinks, geoDataLinksWithGeometry]) => {
+      return mapApiLinks?.length > 0 || geoDataLinksWithGeometry?.length > 0
     })
   )
 
@@ -104,8 +103,7 @@ export class RecordMetadataComponent {
     public metadataViewFacade: MdViewFacade,
     private searchService: SearchService,
     private sourceService: SourcesService,
-    private orgsService: OrganizationsServiceInterface,
-    private dataService: DataService
+    private orgsService: OrganizationsServiceInterface
   ) {}
 
   onTabIndexChange(index: number): void {

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -23,38 +23,12 @@ export class RecordMetadataComponent {
 
   displayMap$ = combineLatest([
     this.metadataViewFacade.mapApiLinks$,
-    this.metadataViewFacade.geoDataLinks$,
+    this.metadataViewFacade.geospatialLinks$,
   ]).pipe(
-    switchMap(([mapApiLinks, geoDataLinks]) => {
-      const allLinks = [...mapApiLinks, ...geoDataLinks]
-      const ogcLinks = allLinks.filter(
-        (link) =>
-          link.type === 'service' &&
-          link.accessServiceProtocol === 'ogcFeatures'
-      )
-      const otherLinks = allLinks.filter((link) => !ogcLinks.includes(link))
-      if (ogcLinks.length === 0) {
-        return of(otherLinks?.length > 0)
-      }
-      return from(ogcLinks).pipe(
-        mergeMap((link) =>
-          this.dataService.readAsGeoJson(link).pipe(
-            map((data) => {
-              const firstFeatures = data.features.slice(0, 10)
-              return {
-                link,
-                hasGeometry: firstFeatures.some(
-                  (feature) => feature.geometry != null
-                ),
-              }
-            })
-          )
-        ),
-        map((features) => {
-          return features.hasGeometry || otherLinks?.length > 0
-        })
-      )
-    })
+    map(
+      ([mapApiLinks, geospatialLinks]) =>
+        mapApiLinks?.length > 0 || geospatialLinks?.length > 0
+    )
   )
 
   displayData$ = combineLatest([

--- a/libs/common/fixtures/src/lib/records.fixtures.ts
+++ b/libs/common/fixtures/src/lib/records.fixtures.ts
@@ -117,6 +117,14 @@ Cette section contient des *caractères internationaux* (ainsi que des "caractè
         description: 'This WFS service offers direct download capability',
         identifierInService: 'my:featuretype',
       },
+      {
+        type: 'service',
+        url: new URL('https://my-org.net/ogc'),
+        accessServiceProtocol: 'ogcFeatures',
+        name: 'my:featuretype',
+        description: 'This OGC service offers direct download capability',
+        identifierInService: 'my:featuretype',
+      },
     ],
     lineage: `This record was edited manually to test the conversion processes
 

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -93,6 +93,13 @@ jest.mock('@camptocamp/ogc-client', () => ({
       })
     }
     allCollections = Promise.resolve([{ name: 'collection1' }])
+    featureCollections =
+      this.url.indexOf('error.http') > -1
+        ? Promise.reject(new Error())
+        : Promise.resolve(['collection1', 'collection2'])
+    getCollectionItem(collection, id) {
+      return Promise.resolve('item1')
+    }
   },
 }))
 
@@ -698,6 +705,26 @@ describe('DataService', () => {
           'http://proxy.local/?url=http%3A%2F%2Fsample%2Fgeojson',
           'csv'
         )
+      })
+    })
+    describe('#getItemsFromOgcApi', () => {
+      describe('calling getItemsFromOgcApi() with a valid URL', () => {
+        it('returns the first collection item when collections array is not empty', async () => {
+          const item = await service.getItemsFromOgcApi(
+            'https://my.ogc.api/features'
+          )
+          expect(item).toBe('item1')
+        })
+      })
+
+      describe('calling getItemsFromOgcApi() with an erroneous URL', () => {
+        it('throws an error', async () => {
+          try {
+            await service.getItemsFromOgcApi('http://error.http/ogcapi')
+          } catch (e) {
+            expect(e.message).toBe('ogc.unreachable.unknown')
+          }
+        })
       })
     })
   })

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -188,7 +188,9 @@ export class DataService {
     const endpoint = new OgcApiEndpoint(this.proxy.getProxiedUrl(url))
     return await endpoint.featureCollections
       .then((collections) => {
-        return endpoint.getCollectionItem(collections[0], '1')
+        return collections.length
+          ? endpoint.getCollectionItem(collections[0], '1')
+          : null
       })
       .catch((error) => {
         throw new Error(`ogc.unreachable.unknown`)

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -184,14 +184,11 @@ export class DataService {
       })
   }
 
-  async getItemsFromOgcApi(
-    url: string,
-    itemsLimit?: number
-  ): Promise<OgcApiRecord[]> {
+  async getItemsFromOgcApi(url: string): Promise<OgcApiRecord> {
     const endpoint = new OgcApiEndpoint(this.proxy.getProxiedUrl(url))
     return await endpoint.featureCollections
       .then((collections) => {
-        return endpoint.getCollectionItems(collections[0], itemsLimit)
+        return endpoint.getCollectionItem(collections[0], '10')
       })
       .catch((error) => {
         throw new Error(`ogc.unreachable.unknown`)

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -161,6 +161,7 @@ export class DataService {
       ogcApiLink.url.href
     )
     return Object.keys(collectionInfo.bulkDownloadLinks).map((downloadLink) => {
+      console.log(downloadLink)
       return {
         ...ogcApiLink,
         type: 'download',

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -3,6 +3,7 @@ import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import {
   OgcApiCollectionInfo,
   OgcApiEndpoint,
+  OgcApiRecord,
   WfsEndpoint,
   WfsVersion,
 } from '@camptocamp/ogc-client'
@@ -161,7 +162,6 @@ export class DataService {
       ogcApiLink.url.href
     )
     return Object.keys(collectionInfo.bulkDownloadLinks).map((downloadLink) => {
-      console.log(downloadLink)
       return {
         ...ogcApiLink,
         type: 'download',
@@ -178,6 +178,20 @@ export class DataService {
     return await endpoint.allCollections
       .then((collections) => {
         return endpoint.getCollectionInfo(collections[0].name)
+      })
+      .catch((error) => {
+        throw new Error(`ogc.unreachable.unknown`)
+      })
+  }
+
+  async getItemsFromOgcApi(
+    url: string,
+    itemsLimit?: number
+  ): Promise<OgcApiRecord[]> {
+    const endpoint = new OgcApiEndpoint(this.proxy.getProxiedUrl(url))
+    return await endpoint.featureCollections
+      .then((collections) => {
+        return endpoint.getCollectionItems(collections[0], itemsLimit)
       })
       .catch((error) => {
         throw new Error(`ogc.unreachable.unknown`)

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -188,7 +188,7 @@ export class DataService {
     const endpoint = new OgcApiEndpoint(this.proxy.getProxiedUrl(url))
     return await endpoint.featureCollections
       .then((collections) => {
-        return endpoint.getCollectionItem(collections[0], '10')
+        return endpoint.getCollectionItem(collections[0], '1')
       })
       .catch((error) => {
         throw new Error(`ogc.unreachable.unknown`)

--- a/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
@@ -327,6 +327,16 @@ describe('MapUtilsService', () => {
     })
   })
 
+  describe('getRecordExtent', () => {
+    it('should return null if spatialExtents is not present or is an empty array', () => {
+      const record1: Partial<CatalogRecord> = {}
+      const record2: Partial<CatalogRecord> = { spatialExtents: [] }
+
+      expect(service.getRecordExtent(record1)).toBeNull()
+      expect(service.getRecordExtent(record2)).toBeNull()
+    })
+  })
+
   describe('#prioritizePageScroll', () => {
     const interactions = defaults()
     let dragRotate

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -219,16 +219,19 @@ export class MapUtilsService {
   getRecordExtent(record: Partial<CatalogRecord>): Extent {
     if (!('spatialExtents' in record)) {
       return null
+    } else if (record.spatialExtents.length > 0) {
+      // transform an array of geojson geometries into a bbox
+      const totalExtent = record.spatialExtents.reduce(
+        (prev, curr) => {
+          const geom = GEOJSON.readGeometry(curr.geometry)
+          return extend(prev, geom.getExtent())
+        },
+        [Infinity, Infinity, -Infinity, -Infinity]
+      )
+      return transformExtent(totalExtent, 'EPSG:4326', 'EPSG:3857')
+    } else {
+      return null
     }
-    // transform an array of geojson geometries into a bbox
-    const totalExtent = record.spatialExtents.reduce(
-      (prev, curr) => {
-        const geom = GEOJSON.readGeometry(curr.geometry)
-        return extend(prev, geom.getExtent())
-      },
-      [Infinity, Infinity, -Infinity, -Infinity]
-    )
-    return transformExtent(totalExtent, 'EPSG:4326', 'EPSG:3857')
   }
 }
 

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -217,21 +217,18 @@ export class MapUtilsService {
   }
 
   getRecordExtent(record: Partial<CatalogRecord>): Extent {
-    if (!('spatialExtents' in record)) {
-      return null
-    } else if (record.spatialExtents.length > 0) {
-      // transform an array of geojson geometries into a bbox
-      const totalExtent = record.spatialExtents.reduce(
-        (prev, curr) => {
-          const geom = GEOJSON.readGeometry(curr.geometry)
-          return extend(prev, geom.getExtent())
-        },
-        [Infinity, Infinity, -Infinity, -Infinity]
-      )
-      return transformExtent(totalExtent, 'EPSG:4326', 'EPSG:3857')
-    } else {
+    if (!('spatialExtents' in record) || record.spatialExtents.length === 0) {
       return null
     }
+    // transform an array of geojson geometries into a bbox
+    const totalExtent = record.spatialExtents.reduce(
+      (prev, curr) => {
+        const geom = GEOJSON.readGeometry(curr.geometry)
+        return extend(prev, geom.getExtent())
+      },
+      [Infinity, Infinity, -Infinity, -Infinity]
+    )
+    return transformExtent(totalExtent, 'EPSG:4326', 'EPSG:3857')
   }
 }
 

--- a/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
@@ -67,7 +67,7 @@ jest.mock('@geonetwork-ui/util/app-config', () => ({
 
 class MdViewFacadeMock {
   mapApiLinks$ = new Subject()
-  geospatialLinks$ = new Subject()
+  geoDataLinksWithGeometry$ = new Subject()
   metadata$ = of({ title: 'abcd' })
 }
 
@@ -272,7 +272,7 @@ describe('MapViewComponent', () => {
     describe('with no link compatible with MAP_API or GEODATA usage', () => {
       beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geospatialLinks$.next([])
+        mdViewFacade.geoDataLinksWithGeometry$.next([])
         tick()
         fixture.detectChanges()
       }))
@@ -317,7 +317,7 @@ describe('MapViewComponent', () => {
             accessServiceProtocol: 'wms',
           },
         ])
-        mdViewFacade.geospatialLinks$.next([])
+        mdViewFacade.geoDataLinksWithGeometry$.next([])
         tick()
         fixture.detectChanges()
       }))
@@ -365,7 +365,7 @@ describe('MapViewComponent', () => {
             accessServiceProtocol: 'wms',
           },
         ])
-        mdViewFacade.geospatialLinks$.next([
+        mdViewFacade.geoDataLinksWithGeometry$.next([
           {
             url: new URL('http://abcd.com/wfs'),
             name: 'featuretype',
@@ -419,7 +419,7 @@ describe('MapViewComponent', () => {
     describe('with a link using WFS protocol', () => {
       beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geospatialLinks$.next([
+        mdViewFacade.geoDataLinksWithGeometry$.next([
           {
             url: new URL('http://abcd.com/wfs'),
             name: 'featuretype',
@@ -453,7 +453,7 @@ describe('MapViewComponent', () => {
             accessServiceProtocol: 'wmts',
           },
         ])
-        mdViewFacade.geospatialLinks$.next([])
+        mdViewFacade.geoDataLinksWithGeometry$.next([])
         tick(200)
         fixture.detectChanges()
       }))
@@ -474,7 +474,7 @@ describe('MapViewComponent', () => {
     describe('with a link using ESRI:REST protocol', () => {
       beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geospatialLinks$.next([
+        mdViewFacade.geoDataLinksWithGeometry$.next([
           {
             name: 'mes_hdf',
             url: new URL(
@@ -503,7 +503,7 @@ describe('MapViewComponent', () => {
     describe('with a link using OGC API protocol', () => {
       beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geospatialLinks$.next([
+        mdViewFacade.geoDataLinksWithGeometry$.next([
           {
             name: 'ogc layer',
             url: new URL('http://abcd.com/data/ogcapi'),
@@ -530,7 +530,7 @@ describe('MapViewComponent', () => {
     describe('with a link using WFS which returns an error', () => {
       beforeEach(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geospatialLinks$.next([
+        mdViewFacade.geoDataLinksWithGeometry$.next([
           {
             url: new URL('http://abcd.com/wfs/error'),
             name: 'featuretype',
@@ -548,7 +548,7 @@ describe('MapViewComponent', () => {
       describe('during download', () => {
         beforeEach(fakeAsync(() => {
           mdViewFacade.mapApiLinks$.next([])
-          mdViewFacade.geospatialLinks$.next([
+          mdViewFacade.geoDataLinksWithGeometry$.next([
             {
               url: new URL('http://abcd.com/data.geojson'),
               name: 'data.geojson',
@@ -571,7 +571,7 @@ describe('MapViewComponent', () => {
       describe('after download', () => {
         beforeEach(fakeAsync(() => {
           mdViewFacade.mapApiLinks$.next([])
-          mdViewFacade.geospatialLinks$.next([
+          mdViewFacade.geoDataLinksWithGeometry$.next([
             {
               url: new URL('http://abcd.com/data.geojson'),
               name: 'data.geojson',
@@ -605,7 +605,7 @@ describe('MapViewComponent', () => {
     describe('when receiving several metadata records', () => {
       beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geospatialLinks$.next([
+        mdViewFacade.geoDataLinksWithGeometry$.next([
           {
             url: new URL('http://abcd.com/data.geojson'),
             name: 'data.geojson',
@@ -620,7 +620,7 @@ describe('MapViewComponent', () => {
             accessServiceProtocol: 'wms',
           },
         ])
-        mdViewFacade.geospatialLinks$.next([])
+        mdViewFacade.geoDataLinksWithGeometry$.next([])
         tick()
         fixture.detectChanges()
       }))
@@ -671,7 +671,7 @@ describe('MapViewComponent', () => {
             accessServiceProtocol: 'wms',
           },
         ])
-        mdViewFacade.geospatialLinks$.next([])
+        mdViewFacade.geoDataLinksWithGeometry$.next([])
         dropdownComponent.selectValue.emit(1)
         tick()
         fixture.detectChanges()
@@ -856,7 +856,7 @@ describe('MapViewComponent', () => {
     describe('changing the map context', () => {
       beforeEach(() => {
         jest.spyOn(component, 'resetSelection')
-        mdViewFacade.geospatialLinks$.next([])
+        mdViewFacade.geoDataLinksWithGeometry$.next([])
         mdViewFacade.mapApiLinks$.next([])
       })
       it('resets selection', () => {

--- a/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
@@ -67,7 +67,7 @@ jest.mock('@geonetwork-ui/util/app-config', () => ({
 
 class MdViewFacadeMock {
   mapApiLinks$ = new Subject()
-  geoDataLinks$ = new Subject()
+  geospatialLinks$ = new Subject()
   metadata$ = of({ title: 'abcd' })
 }
 
@@ -272,7 +272,7 @@ describe('MapViewComponent', () => {
     describe('with no link compatible with MAP_API or GEODATA usage', () => {
       beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geoDataLinks$.next([])
+        mdViewFacade.geospatialLinks$.next([])
         tick()
         fixture.detectChanges()
       }))
@@ -317,7 +317,7 @@ describe('MapViewComponent', () => {
             accessServiceProtocol: 'wms',
           },
         ])
-        mdViewFacade.geoDataLinks$.next([])
+        mdViewFacade.geospatialLinks$.next([])
         tick()
         fixture.detectChanges()
       }))
@@ -365,7 +365,7 @@ describe('MapViewComponent', () => {
             accessServiceProtocol: 'wms',
           },
         ])
-        mdViewFacade.geoDataLinks$.next([
+        mdViewFacade.geospatialLinks$.next([
           {
             url: new URL('http://abcd.com/wfs'),
             name: 'featuretype',
@@ -419,7 +419,7 @@ describe('MapViewComponent', () => {
     describe('with a link using WFS protocol', () => {
       beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geoDataLinks$.next([
+        mdViewFacade.geospatialLinks$.next([
           {
             url: new URL('http://abcd.com/wfs'),
             name: 'featuretype',
@@ -453,7 +453,7 @@ describe('MapViewComponent', () => {
             accessServiceProtocol: 'wmts',
           },
         ])
-        mdViewFacade.geoDataLinks$.next([])
+        mdViewFacade.geospatialLinks$.next([])
         tick(200)
         fixture.detectChanges()
       }))
@@ -474,7 +474,7 @@ describe('MapViewComponent', () => {
     describe('with a link using ESRI:REST protocol', () => {
       beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geoDataLinks$.next([
+        mdViewFacade.geospatialLinks$.next([
           {
             name: 'mes_hdf',
             url: new URL(
@@ -503,7 +503,7 @@ describe('MapViewComponent', () => {
     describe('with a link using OGC API protocol', () => {
       beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geoDataLinks$.next([
+        mdViewFacade.geospatialLinks$.next([
           {
             name: 'ogc layer',
             url: new URL('http://abcd.com/data/ogcapi'),
@@ -530,7 +530,7 @@ describe('MapViewComponent', () => {
     describe('with a link using WFS which returns an error', () => {
       beforeEach(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geoDataLinks$.next([
+        mdViewFacade.geospatialLinks$.next([
           {
             url: new URL('http://abcd.com/wfs/error'),
             name: 'featuretype',
@@ -548,7 +548,7 @@ describe('MapViewComponent', () => {
       describe('during download', () => {
         beforeEach(fakeAsync(() => {
           mdViewFacade.mapApiLinks$.next([])
-          mdViewFacade.geoDataLinks$.next([
+          mdViewFacade.geospatialLinks$.next([
             {
               url: new URL('http://abcd.com/data.geojson'),
               name: 'data.geojson',
@@ -571,7 +571,7 @@ describe('MapViewComponent', () => {
       describe('after download', () => {
         beforeEach(fakeAsync(() => {
           mdViewFacade.mapApiLinks$.next([])
-          mdViewFacade.geoDataLinks$.next([
+          mdViewFacade.geospatialLinks$.next([
             {
               url: new URL('http://abcd.com/data.geojson'),
               name: 'data.geojson',
@@ -605,7 +605,7 @@ describe('MapViewComponent', () => {
     describe('when receiving several metadata records', () => {
       beforeEach(fakeAsync(() => {
         mdViewFacade.mapApiLinks$.next([])
-        mdViewFacade.geoDataLinks$.next([
+        mdViewFacade.geospatialLinks$.next([
           {
             url: new URL('http://abcd.com/data.geojson'),
             name: 'data.geojson',
@@ -620,7 +620,7 @@ describe('MapViewComponent', () => {
             accessServiceProtocol: 'wms',
           },
         ])
-        mdViewFacade.geoDataLinks$.next([])
+        mdViewFacade.geospatialLinks$.next([])
         tick()
         fixture.detectChanges()
       }))
@@ -671,7 +671,7 @@ describe('MapViewComponent', () => {
             accessServiceProtocol: 'wms',
           },
         ])
-        mdViewFacade.geoDataLinks$.next([])
+        mdViewFacade.geospatialLinks$.next([])
         dropdownComponent.selectValue.emit(1)
         tick()
         fixture.detectChanges()
@@ -856,7 +856,7 @@ describe('MapViewComponent', () => {
     describe('changing the map context', () => {
       beforeEach(() => {
         jest.spyOn(component, 'resetSelection')
-        mdViewFacade.geoDataLinks$.next([])
+        mdViewFacade.geospatialLinks$.next([])
         mdViewFacade.mapApiLinks$.next([])
       })
       it('resets selection', () => {

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -60,10 +60,9 @@ export class MapViewComponent implements OnInit, OnDestroy {
     this.mdViewFacade.mapApiLinks$,
     this.mdViewFacade.geospatialLinks$,
   ]).pipe(
-    map(([mapApiLinks, geospatialLinks]) => [
-      ...mapApiLinks,
-      ...geospatialLinks,
-    ])
+    map(([mapApiLinks, geospatialLinks]) => {
+      return [...mapApiLinks, ...geospatialLinks]
+    })
   )
 
   dropdownChoices$ = this.compatibleMapLinks$.pipe(

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -58,36 +58,12 @@ export class MapViewComponent implements OnInit, OnDestroy {
 
   compatibleMapLinks$ = combineLatest([
     this.mdViewFacade.mapApiLinks$,
-    this.mdViewFacade.geoDataLinks$,
+    this.mdViewFacade.geospatialLinks$,
   ]).pipe(
-    switchMap(([mapApiLinks, geoDataLinks]) => {
-      const allLinks = [...mapApiLinks, ...geoDataLinks]
-      const ogcLinks = allLinks.filter(
-        (link) =>
-          link.type === 'service' &&
-          link.accessServiceProtocol === 'ogcFeatures'
-      )
-      const otherLinks = allLinks.filter((link) => !ogcLinks.includes(link))
-      return from(ogcLinks).pipe(
-        mergeMap((link) =>
-          this.dataService.readAsGeoJson(link).pipe(
-            map((data) => {
-              const firstFeatures = data.features.slice(0, 10)
-              return {
-                link,
-                hasGeometry: firstFeatures.every((feature) => feature.geometry),
-              }
-            })
-          )
-        ),
-        filter(({ hasGeometry }) => hasGeometry),
-        map(({ link }) => {
-          return link
-        }),
-        toArray(),
-        map((ogcLinksWithGeometry) => [...otherLinks, ...ogcLinksWithGeometry])
-      )
-    })
+    map(([mapApiLinks, geospatialLinks]) => [
+      ...mapApiLinks,
+      ...geospatialLinks,
+    ])
   )
 
   dropdownChoices$ = this.compatibleMapLinks$.pipe(

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -32,13 +32,10 @@ import {
 import {
   catchError,
   distinctUntilChanged,
-  filter,
   finalize,
   map,
-  mergeMap,
   switchMap,
   tap,
-  toArray,
 } from 'rxjs/operators'
 import { MdViewFacade } from '../state/mdview.facade'
 import { DataService } from '@geonetwork-ui/feature/dataviz'
@@ -58,10 +55,10 @@ export class MapViewComponent implements OnInit, OnDestroy {
 
   compatibleMapLinks$ = combineLatest([
     this.mdViewFacade.mapApiLinks$,
-    this.mdViewFacade.geospatialLinks$,
+    this.mdViewFacade.geoDataLinksWithGeometry$,
   ]).pipe(
-    map(([mapApiLinks, geospatialLinks]) => {
-      return [...mapApiLinks, ...geospatialLinks]
+    map(([mapApiLinks, geoDataLinksWithGeometry]) => {
+      return [...mapApiLinks, ...geoDataLinksWithGeometry]
     })
   )
 
@@ -107,8 +104,8 @@ export class MapViewComponent implements OnInit, OnDestroy {
   mapContext$ = this.currentLayers$.pipe(
     switchMap((layers) =>
       from(this.mapUtils.getLayerExtent(layers[0])).pipe(
-        catchError((error) => {
-          console.warn(error) // FIXME: report this to the user somehow
+        catchError(() => {
+          this.error = 'The layer has no extent'
           return of(undefined)
         }),
         map(

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -106,8 +106,9 @@ export class MdViewFacade {
         ) {
           return from(this.dataService.getItemsFromOgcApi(link.url.href)).pipe(
             map((collectionRecords: OgcApiRecord) => {
-              const hasGeometry = collectionRecords.geometry
-              return hasGeometry ? link : null
+              return collectionRecords && collectionRecords.geometry
+                ? link
+                : null
             }),
             defaultIfEmpty(null)
           )

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -24,9 +24,9 @@ import { DataService } from '@geonetwork-ui/feature/dataviz'
 export class MdViewFacade {
   constructor(
     private store: Store,
-    private linkClassifier: LinkClassifierService,
+    public linkClassifier: LinkClassifierService,
     private avatarService: AvatarServiceInterface,
-    private dataService: DataService
+    public dataService: DataService
   ) {}
 
   isPresent$ = this.store.pipe(

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -1,16 +1,6 @@
 import { Injectable } from '@angular/core'
 import { select, Store } from '@ngrx/store'
-import {
-  defaultIfEmpty,
-  distinct,
-  filter,
-  map,
-  mergeMap,
-  scan,
-  switchMap,
-  tap,
-  toArray,
-} from 'rxjs/operators'
+import { defaultIfEmpty, filter, map, mergeMap, scan } from 'rxjs/operators'
 import * as MdViewActions from './mdview.actions'
 import * as MdViewSelectors from './mdview.selectors'
 import { LinkClassifierService, LinkUsage } from '@geonetwork-ui/util/shared'
@@ -104,7 +94,7 @@ export class MdViewFacade {
     )
   )
 
-  geospatialLinks$ = this.allLinks$.pipe(
+  geoDataLinksWithGeometry$ = this.allLinks$.pipe(
     mergeMap((links) => {
       return from(links)
     }),


### PR DESCRIPTION
### Description

This PR fixes a bug found in MEL datahub, where the OGC API services that are non geospatial were wrongfully displayed on the map component.
In this PR, we test if one of the features of the service has or not a geometry. Depending on that, if it's the only service, the map will or will not be displayed. If there are other services viewable in the map, the OGC service will be removed from the dropdown list if not geospatial. 

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

---

**This work is sponsored by MEL**.
