### PR TITLE
Datahub: fixes to OGC API query form and redundant requests

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -656,10 +656,8 @@ describe('api form', () => {
           .find('gn-ui-copy-text-button')
           .find('input')
           .invoke('val')
-          .then((newUrl) => {
-            expect(newUrl).to.not.eq(url)
-            expect(newUrl).to.include('54')
-          })
+          .should('not.eq', url)
+          .and('include', '54')
       })
   })
   it('should set limit to zero on click on "All" button', () => {
@@ -718,9 +716,7 @@ describe('api form', () => {
           .find('gn-ui-copy-text-button')
           .find('input')
           .invoke('val')
-          .then((newUrl) => {
-            expect(newUrl).to.not.eq(url)
-          })
+          .should('not.eq', url)
       })
   })
 })
@@ -747,16 +743,12 @@ describe('userFeedback', () => {
             .eq(1)
             .click()
 
-          // eslint-disable-next-line cypress/no-unnecessary-waiting
-          cy.wait(1000)
-
           cy.get('gn-ui-user-feedback-item')
             .find('[data-cy="commentText"]')
             .first()
-            .then((div) => {
-              const firstCommentAfterSort = div.text().trim()
-              expect(firstCommentBeforeSort).to.not.eq(firstCommentAfterSort)
-            })
+            .invoke('text')
+            .invoke('trim')
+            .should('not.eq', firstCommentBeforeSort)
         })
     })
     it("shouldn't be able to comment", () => {
@@ -804,5 +796,6 @@ describe('When the metadata does not exists', () => {
   })
   it('should display an error message', () => {
     cy.get('gn-ui-search-results-error').should('exist')
+    cy.screenshot({ capture: 'viewport' })
   })
 })

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -92,7 +92,7 @@ jest.mock('@camptocamp/ogc-client', () => ({
         bulkDownloadLinks: { json: 'http://json', csv: 'http://csv' },
       })
     }
-    featureCollections = Promise.resolve(['collection1'])
+    allCollections = Promise.resolve([{ name: 'collection1' }])
   },
 }))
 

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -174,9 +174,9 @@ export class DataService {
 
   async getDownloadUrlsFromOgcApi(url: string): Promise<OgcApiCollectionInfo> {
     const endpoint = new OgcApiEndpoint(this.proxy.getProxiedUrl(url))
-    return await endpoint.featureCollections
+    return await endpoint.allCollections
       .then((collections) => {
-        return endpoint.getCollectionInfo(collections[0])
+        return endpoint.getCollectionInfo(collections[0].name)
       })
       .catch((error) => {
         throw new Error(`ogc.unreachable.unknown`)

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, ComponentFixture } from '@angular/core/testing'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { RecordApiFormComponent } from './record-api-form.component'
 import { DatasetServiceDistribution } from '@geonetwork-ui/common/domain/model/record'
 import { firstValueFrom } from 'rxjs'
@@ -15,8 +15,8 @@ const mockDatasetServiceDistribution: DatasetServiceDistribution = {
 jest.mock('@camptocamp/ogc-client', () => ({
   OgcApiEndpoint: class {
     constructor(private url) {}
-    get featureCollections() {
-      return Promise.resolve(['feature1'])
+    get allCollections() {
+      return Promise.resolve([{ name: 'feature1' }])
     }
     getCollectionInfo(collectionId) {
       return Promise.resolve({
@@ -66,7 +66,7 @@ jest.mock('@camptocamp/ogc-client', () => ({
   },
 }))
 
-describe('RecordApFormComponent', () => {
+describe('RecordApiFormComponent', () => {
   let component: RecordApiFormComponent
   let fixture: ComponentFixture<RecordApiFormComponent>
 

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.ts
@@ -121,11 +121,9 @@ export class RecordApiFormComponent {
       this.supportOffset = this.endpoint.supportsStartIndex()
       return this.endpoint.getServiceInfo() as OutputFormats
     } else {
-      {
-        return (await this.endpoint.getCollectionInfo(
-          this.firstCollection
-        )) as OutputFormats
-      }
+      return (await this.endpoint.getCollectionInfo(
+        this.firstCollection
+      )) as OutputFormats
     }
   }
 
@@ -136,7 +134,7 @@ export class RecordApiFormComponent {
       await (this.endpoint as WfsEndpoint).isReady()
     } else {
       this.endpoint = new OgcApiEndpoint(this.apiBaseUrl)
-      this.firstCollection = (await this.endpoint.featureCollections)[0]
+      this.firstCollection = (await this.endpoint.allCollections)[0].name
     }
     this.endpoint$.next(this.endpoint)
   }

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.ts
@@ -5,7 +5,7 @@ import {
   ServiceProtocol,
 } from '@geonetwork-ui/common/domain/model/record'
 import { mimeTypeToFormat } from '@geonetwork-ui/util/shared'
-import { BehaviorSubject, combineLatest, map, switchMap } from 'rxjs'
+import { BehaviorSubject, combineLatest, filter, map, switchMap } from 'rxjs'
 
 const DEFAULT_PARAMS = {
   OFFSET: '',
@@ -54,7 +54,8 @@ export class RecordApiFormComponent {
     this.offset$,
     this.limit$,
     this.format$,
-    this.endpoint$,
+    // only compute the url if the endpoint was created
+    this.endpoint$.pipe(filter((endpoint) => !!endpoint)),
   ]).pipe(
     switchMap(([offset, limit, format]) =>
       this.generateApiQueryUrl(offset, limit, format)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@angular/router": "16.1.7",
         "@bartholomej/ngx-translate-extract": "^8.0.2",
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-        "@camptocamp/ogc-client": "^1.1.1-dev.ddbb5b0",
+        "@camptocamp/ogc-client": "1.1.1-dev.ad6d9ab",
         "@geospatial-sdk/geocoding": "^0.0.5-alpha.2",
         "@ltd/j-toml": "~1.35.2",
         "@messageformat/core": "^3.0.1",
@@ -3652,9 +3652,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.1.1-dev.ddbb5b0",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.1.1-dev.ddbb5b0.tgz",
-      "integrity": "sha512-XBunVVWEh/e/CXpAx9QxysT2v0uNDOKXz4VsFINt5uFXZimovl6wKzgI1pt7lU6gxLuAeWXHnwnLm3XfUHmKag==",
+      "version": "1.1.1-dev.ad6d9ab",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.1.1-dev.ad6d9ab.tgz",
+      "integrity": "sha512-YK0xaVij5bScgYeXJKIItLu6eoVC/lrCIoH5UepkXG3oUSERnFNs60PumwwH8mAWclV2AAPeOwFe60dNvY356Q==",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/router": "16.1.7",
     "@bartholomej/ngx-translate-extract": "^8.0.2",
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-    "@camptocamp/ogc-client": "^1.1.1-dev.ddbb5b0",
+    "@camptocamp/ogc-client": "1.1.1-dev.ad6d9ab",
     "@geospatial-sdk/geocoding": "^0.0.5-alpha.2",
     "@ltd/j-toml": "~1.35.2",
     "@messageformat/core": "^3.0.1",

--- a/package/package.json
+++ b/package/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
-    "@camptocamp/ogc-client": "1.1.1-dev.ddbb5b0",
+    "@camptocamp/ogc-client": "1.1.1-dev.ad6d9ab",
     "@geospatial-sdk/geocoding": "^0.0.5-alpha.2",
     "@ltd/j-toml": "~1.35.2",
     "@messageformat/core": "^3.0.1",


### PR DESCRIPTION
### Description

This PR fixes the following issues with the OGC API integration in the Datahub:
- Redundant parallel requests will now be merged, reducing the amount of requests by around 75%
- OGC API links pointing to a collection of type "record" will now work (previously they were crashing)
- Removed an error that was happening when opening the API query form (the query URL was computed before the endpoint object was ready)

This PR upgrades ogc-client to the latest version to benefit from https://github.com/camptocamp/ogc-client/pull/45 and https://github.com/camptocamp/ogc-client/pull/46.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by MEL**.
