### PR TITLE
feat(ui-inputs): Fix and extend autocomplete component

### DIFF
--- a/libs/feature/dataviz/src/lib/feature-dataviz.module.ts
+++ b/libs/feature/dataviz/src/lib/feature-dataviz.module.ts
@@ -12,7 +12,7 @@ import {
 import { TableViewComponent } from './table-view/table-view.component'
 import { ChartViewComponent } from './chart-view/chart-view.component'
 import { TranslateModule } from '@ngx-translate/core'
-import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
+import { PopupAlertComponent, UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
 import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
 
 @NgModule({
@@ -26,6 +26,7 @@ import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
     TranslateModule,
     ChartComponent,
     UiInputsModule,
+    PopupAlertComponent,
   ],
   declarations: [
     GeoTableViewComponent,

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-keywords/form-field-keywords.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-keywords/form-field-keywords.component.html
@@ -4,10 +4,9 @@
     [displayWithFn]="displayWithFn"
     [action]="autoCompleteAction"
     (itemSelected)="handleItemSelection($event)"
-    (inputSubmitted)="handleInputSubmission($event)"
-    (inputCleared)="handleInputCleared()"
-    [value]="searchInputValue$ | async"
     [clearOnSelection]="true"
+    [minCharacterCount]="0"
+    [allowSubmit]="false"
   ></gn-ui-autocomplete>
   <div class="flex gap-2 flex-wrap">
     <gn-ui-badge

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-keywords/form-field-keywords.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-keywords/form-field-keywords.component.ts
@@ -1,24 +1,17 @@
 import { CommonModule } from '@angular/common'
-import {
-  ChangeDetectionStrategy,
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-} from '@angular/core'
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
 import { FormControl } from '@angular/forms'
-import {
-  KeywordType,
-  ThesaurusModel,
-} from '@geonetwork-ui/common/domain/model/thesaurus'
 import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.service.interface'
 import {
+  AutocompleteComponent,
   DropdownSelectorComponent,
   UiInputsModule,
 } from '@geonetwork-ui/ui/inputs'
 import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
-import { Observable, map } from 'rxjs'
+import { map } from 'rxjs'
+import { Keyword } from '@geonetwork-ui/common/domain/model/record'
+
+type AutocompleteItem = { title: string; value: Keyword }
 
 @Component({
   selector: 'gn-ui-form-field-keywords',
@@ -31,69 +24,34 @@ import { Observable, map } from 'rxjs'
     UiInputsModule,
     CommonModule,
     UiWidgetsModule,
+    AutocompleteComponent,
   ],
 })
-export class FormFieldKeywordsComponent implements OnInit {
-  @Input() control: FormControl<any>
-  @Output() itemSelected = new EventEmitter<string>()
-  @Output() inputSubmitted = new EventEmitter<string>()
-  searchInputValue$: Observable<void | { title: string }>
-  allThesaurus$: Observable<any[]>
+export class FormFieldKeywordsComponent {
+  @Input() control: FormControl<Keyword[]>
 
-  displayWithFn = (item) => {
-    if (item) {
-      return `${item?.title} (${item?.value?.name})`
-    }
-    return null
+  displayWithFn = (item: AutocompleteItem) => {
+    return `${item.title} (${item.value.thesaurus?.name})`
   }
 
   autoCompleteAction = (query: string) => {
-    const keywords$ = this.platformService.searchKeywords(query).pipe(
-      map((thesaurus) =>
-        thesaurus.map((thes) => {
-          return { title: thes.label, value: thes.thesaurus }
+    return this.platformService.searchKeywords(query).pipe(
+      map((keywords) =>
+        keywords.map((keyword) => {
+          return { title: keyword.label, value: keyword }
         })
       )
     )
-
-    return keywords$
   }
 
   constructor(private platformService: PlatformServiceInterface) {}
 
-  ngOnInit(): void {
-    this.searchInputValue$ = this.autoCompleteAction('')[0]
+  handleItemSelection(item: AutocompleteItem) {
+    this.addKeyword(item.value)
   }
 
-  // type: { title: string; value: ThesaurusModel }
-  handleItemSelection(item) {
-    this.addKeyword({
-      label: item.title,
-      thesaurus: item.value,
-      type: item.value.type,
-    })
-  }
-
-  handleInputSubmission(any: string) {
-    // Should there be an input submission?
-
-    if (this.inputSubmitted.observers.length > 0) {
-      this.inputSubmitted.emit(any)
-    } else {
-      // this.searchService.updateFilters({ any })
-    }
-  }
-
-  async handleInputCleared() {
-    this.autoCompleteAction('')
-  }
-
-  addKeyword(item: {
-    label: string
-    thesaurus: ThesaurusModel
-    type: KeywordType
-  }) {
-    const addedKeywords = [...this.control.value, item]
+  addKeyword(keyword: Keyword) {
+    const addedKeywords = [...this.control.value, keyword]
 
     // remove duplicates from keyword
     const filteredKeywords = addedKeywords.filter((value, index, self) => {

--- a/libs/feature/record/src/lib/feature-record.module.ts
+++ b/libs/feature/record/src/lib/feature-record.module.ts
@@ -1,4 +1,4 @@
-import { InjectionToken, NgModule } from '@angular/core'
+import { NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { UiMapModule } from '@geonetwork-ui/ui/map'
 import { StoreModule } from '@ngrx/store'
@@ -17,7 +17,7 @@ import {
 } from './state/mdview.reducer'
 import { MatTabsModule } from '@angular/material/tabs'
 import { MatIconModule } from '@angular/material/icon'
-import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
+import { PopupAlertComponent, UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
 import { TranslateModule } from '@ngx-translate/core'
 import { ExternalViewerButtonComponent } from './external-viewer-button/external-viewer-button.component'
 import { FeatureCatalogModule } from '@geonetwork-ui/feature/catalog'
@@ -52,6 +52,7 @@ import { DataViewShareComponent } from './data-view-share/data-view-share.compon
     TranslateModule,
     TableComponent,
     FeatureDatavizModule,
+    PopupAlertComponent,
   ],
   providers: [MdViewFacade],
   exports: [

--- a/libs/feature/search/src/lib/feature-search.module.ts
+++ b/libs/feature/search/src/lib/feature-search.module.ts
@@ -14,7 +14,7 @@ import { SearchEffects } from './state/effects'
 import { initialState, reducer, SEARCH_FEATURE_KEY } from './state/reducer'
 import { ResultsHitsContainerComponent } from './results-hits-number/results-hits.container.component'
 import { SearchStateContainerDirective } from './state/container/search-state.container.directive'
-import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
+import { AutocompleteComponent, UiInputsModule } from '@geonetwork-ui/ui/inputs'
 import { NgModule } from '@angular/core'
 import { UiElementsModule } from '@geonetwork-ui/ui/elements'
 import { FavoriteStarComponent } from './favorites/favorite-star/favorite-star.component'
@@ -51,6 +51,7 @@ import { Gn4Repository } from '@geonetwork-ui/api/repository'
     FacetsModule,
     MatIconModule,
     UiWidgetsModule,
+    AutocompleteComponent,
   ],
   exports: [
     SortByComponent,

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
@@ -49,7 +49,11 @@ describe('FuzzySearchComponent', () => {
           useClass: RecordsRepositoryMock,
         },
       ],
-      imports: [UiInputsModule, TranslateModule.forRoot()],
+      imports: [
+        AutocompleteComponent,
+        UiInputsModule,
+        TranslateModule.forRoot(),
+      ],
     }).compileComponents()
 
     searchService = TestBed.inject(SearchService)

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
@@ -11,7 +11,7 @@ import {
   AutocompleteComponent,
   AutocompleteItem,
 } from '@geonetwork-ui/ui/inputs'
-import { Observable, firstValueFrom } from 'rxjs'
+import { firstValueFrom, Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { SearchFacade } from '../state/search.facade'
 import { SearchService } from '../utils/service/search.service'
@@ -32,7 +32,7 @@ export class FuzzySearchComponent implements OnInit {
   @Output() inputSubmitted = new EventEmitter<string>()
   searchInputValue$: Observable<{ title: string }>
 
-  displayWithFn: (record: CatalogRecord) => string = (record) => record?.title
+  displayWithFn: (record: CatalogRecord) => string = (record) => record.title
 
   autoCompleteAction = (query: string) =>
     this.recordsRepository

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.css
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.css
@@ -3,7 +3,6 @@
 }
 .clear-btn {
   width: var(--input-height);
-  right: var(--input-height);
   height: 100%;
 }
 .search-btn {

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
@@ -8,23 +8,27 @@
     [matAutocomplete]="auto"
     (keyup.enter)="handleEnter(searchInput.value)"
   />
-  <button
-    type="button"
-    class="text-primary-lightest hover:text-primary hover:bg-gray-50 absolute transition-all duration-100 clear-btn inset-y-0"
-    *ngIf="searchInput.value"
-    aria-label="Clear"
-    (click)="clear()"
-  >
-    <mat-icon class="material-symbols-outlined">close</mat-icon>
-  </button>
-  <button
-    type="button"
-    class="text-primary bg-white hover:text-primary-darkest hover:bg-gray-100 border-gray-300 hover:border-gray-500 absolute transition-all duration-100 search-btn rounded-r inset-y-0 right-0"
-    aria-label="Trigger search"
-    (click)="handleClickSearch()"
-  >
-    <mat-icon class="material-symbols-outlined">search</mat-icon>
-  </button>
+  <div class="flex flex-row absolute inset-y-0 right-0">
+    <button
+      type="button"
+      class="text-primary-lightest hover:text-primary hover:bg-gray-50 transition-all duration-100 clear-btn"
+      *ngIf="searchInput.value"
+      aria-label="Clear"
+      (click)="clear()"
+    >
+      <mat-icon class="material-symbols-outlined">close</mat-icon>
+    </button>
+    <button
+      type="button"
+      class="text-primary bg-white hover:text-primary-darkest hover:bg-gray-100 border-gray-300 hover:border-gray-500 transition-all duration-100 search-btn rounded-r"
+      aria-label="Trigger search"
+      *ngIf="allowSubmit"
+      data-test="autocomplete-submit-btn"
+      (click)="handleClickSearch()"
+    >
+      <mat-icon class="material-symbols-outlined">search</mat-icon>
+    </button>
+  </div>
   <gn-ui-popup-alert
     *ngIf="error"
     class="absolute mt-2 w-full top-[100%] left-0"

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
@@ -39,13 +39,13 @@
 <mat-autocomplete
   #auto="matAutocomplete"
   (optionSelected)="handleSelection($event)"
-  [displayWith]="displayWithFn"
+  [displayWith]="displayWithFnInternal"
 >
   <mat-option
     *ngFor="let suggestion of suggestions$ | async"
     [value]="suggestion"
     class="p-2 suggestion"
   >
-    {{ displayWithFn(suggestion) }}
+    {{ displayWithFnInternal(suggestion) }}
   </mat-option>
 </mat-autocomplete>

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -183,7 +183,6 @@ describe('AutocompleteComponent', () => {
   })
 
   describe('@Input() value', () => {
-    let anyEmitted
     describe('when set', () => {
       beforeEach(() => {
         const simpleChanges: any = {
@@ -192,8 +191,7 @@ describe('AutocompleteComponent', () => {
             currentValue: { title: 'hello' },
           },
         }
-        component.displayWithFn = (item) => item?.title
-        component.inputSubmitted.subscribe((event) => (anyEmitted = event))
+        component.displayWithFn = (item) => item.title
         component.ngOnChanges(simpleChanges)
       })
       it('set control value', () => {
@@ -208,8 +206,7 @@ describe('AutocompleteComponent', () => {
             currentValue: { title: 'good bye' },
           },
         }
-        component.displayWithFn = (item) => item?.title
-        component.inputSubmitted.subscribe((event) => (anyEmitted = event))
+        component.displayWithFn = (item) => item.title
         component.ngOnChanges(simpleChanges)
       })
       it('set control value', () => {
@@ -225,7 +222,7 @@ describe('AutocompleteComponent', () => {
             currentValue: { title: 'good bye' },
           },
         }
-        component.displayWithFn = (item) => item?.title
+        component.displayWithFn = (item) => item.title
         component.inputSubmitted.subscribe((event) => (anyEmitted = event))
         component.ngOnChanges(simpleChanges)
       })
@@ -238,7 +235,6 @@ describe('AutocompleteComponent', () => {
     })
     describe('when not set on init (firstChange == true)', () => {
       beforeEach(() => {
-        component.inputSubmitted.subscribe((event) => (anyEmitted = event))
         const simpleChanges: any = {
           value: {
             firstChange: true,
@@ -291,7 +287,7 @@ describe('AutocompleteComponent', () => {
     let suggestions
     beforeEach(() => {
       suggestions = null
-      component.action = jest.fn(() => throwError(new Error('blargz')))
+      component.action = jest.fn(() => throwError(() => new Error('blargz')))
       fixture.detectChanges()
       component.suggestions$.subscribe((value) => (suggestions = value))
 

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -1,15 +1,13 @@
 import { ChangeDetectionStrategy } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { ReactiveFormsModule } from '@angular/forms'
-import { MatAutocompleteModule } from '@angular/material/autocomplete'
-import { MatIconModule } from '@angular/material/icon'
 import { By } from '@angular/platform-browser'
-import { of, throwError } from 'rxjs'
+import { of, Subscription, throwError } from 'rxjs'
 import {
   AutocompleteComponent,
   AutocompleteItem,
 } from './autocomplete.component'
-import { UiWidgetsModule } from '@geonetwork-ui/ui/widgets'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
+import { TranslateModule } from '@ngx-translate/core'
 
 describe('AutocompleteComponent', () => {
   let component: AutocompleteComponent
@@ -18,12 +16,10 @@ describe('AutocompleteComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        MatAutocompleteModule,
-        ReactiveFormsModule,
-        MatIconModule,
-        UiWidgetsModule,
+        AutocompleteComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
       ],
-      declarations: [AutocompleteComponent],
     })
       .overrideComponent(AutocompleteComponent, {
         set: { changeDetection: ChangeDetectionStrategy.Default },
@@ -44,54 +40,78 @@ describe('AutocompleteComponent', () => {
   })
 
   describe('suggestions', () => {
-    let emitted
-    let sub
-    beforeEach(() => {
-      fixture.detectChanges()
-      emitted = null
-      sub = component.suggestions$.subscribe((e) => (emitted = e))
-    })
-    afterEach(() => {
-      sub.unsubscribe()
-    })
-    describe('when writing text over 2 chars', () => {
+    let emitted: unknown
+    let sub: Subscription
+    describe('with minCharacterCount above 0', () => {
       beforeEach(() => {
-        component.inputRef.nativeElement.value = 'bla'
-        component.inputRef.nativeElement.dispatchEvent(new InputEvent('input'))
+        fixture.detectChanges()
+        emitted = null
+        sub = component.suggestions$.subscribe((e) => (emitted = e))
       })
-      it('calls the action given as input after debounce', () => {
+      afterEach(() => {
+        sub.unsubscribe()
+      })
+      describe('when writing text over 2 chars', () => {
+        beforeEach(() => {
+          component.inputRef.nativeElement.value = 'bla'
+          component.inputRef.nativeElement.dispatchEvent(
+            new InputEvent('input')
+          )
+        })
+        it('calls the action given as input after debounce', () => {
+          jest.runOnlyPendingTimers()
+          expect(component.action).toHaveBeenCalledWith('bla')
+        })
+        it('emits suggestions', () => {
+          jest.runOnlyPendingTimers()
+          expect(emitted).toEqual(['aa', 'bb', 'cc'])
+        })
+        it('does not show an error popup', () => {
+          const popup = fixture.debugElement.query(By.css('gn-ui-popup-alert'))
+          expect(popup).toBeFalsy()
+        })
+      })
+      describe('when clicking a predefined button', () => {
+        beforeEach(() => {
+          component.updateInputValue({ title: 'cc' } as AutocompleteItem)
+        })
+        it('calls the action with object given as input', () => {
+          expect(component.action).toHaveBeenCalledWith('cc')
+        })
+      })
+      describe('when writing text with 2 chars or less', () => {
+        beforeEach(() => {
+          component.inputRef.nativeElement.value = 'bl'
+          component.inputRef.nativeElement.dispatchEvent(
+            new InputEvent('input')
+          )
+        })
+        it('does not call the action given as input after debounce', () => {
+          jest.runOnlyPendingTimers()
+          expect(component.action).not.toHaveBeenCalled()
+        })
+        it('emit an empty suggestions list', () => {
+          jest.runOnlyPendingTimers()
+          expect(emitted).toEqual([])
+        })
+      })
+    })
+    describe('when minCharacterCount is 0', () => {
+      beforeEach(() => {
+        component.minCharacterCount = 0
+        fixture.detectChanges()
+        emitted = null
+        sub = component.suggestions$.subscribe((e) => (emitted = e))
+        component.inputRef.nativeElement.value = ''
+        component.inputRef.nativeElement.dispatchEvent(new InputEvent('focus'))
+      })
+      it('calls action and shows suggestions on focus', () => {
         jest.runOnlyPendingTimers()
-        expect(component.action).toHaveBeenCalledWith('bla')
+        expect(component.action).toHaveBeenCalled()
       })
       it('emits suggestions', () => {
         jest.runOnlyPendingTimers()
         expect(emitted).toEqual(['aa', 'bb', 'cc'])
-      })
-      it('does not show an error popup', () => {
-        const popup = fixture.debugElement.query(By.css('gn-ui-popup-alert'))
-        expect(popup).toBeFalsy()
-      })
-    })
-    describe('when clicking a predefined button', () => {
-      beforeEach(() => {
-        component.updateInputValue({ title: 'cc' } as AutocompleteItem)
-      })
-      it('calls the action with object given as input', () => {
-        expect(component.action).toHaveBeenCalledWith('cc')
-      })
-    })
-    describe('when writing text with 2 chars or less', () => {
-      beforeEach(() => {
-        component.inputRef.nativeElement.value = 'bl'
-        component.inputRef.nativeElement.dispatchEvent(new InputEvent('input'))
-      })
-      it('does not call the action given as input after debounce', () => {
-        jest.runOnlyPendingTimers()
-        expect(component.action).not.toHaveBeenCalled()
-      })
-      it('does not emit', () => {
-        jest.runOnlyPendingTimers()
-        expect(emitted).toEqual(null)
       })
     })
   })
@@ -164,9 +184,6 @@ describe('AutocompleteComponent', () => {
       it('sends a submitted value', () => {
         expect(anyEmitted).toEqual(['bla'])
       })
-      it('closes the autocomplete panel', () => {
-        expect(component.triggerRef.closePanel).toHaveBeenCalled()
-      })
     })
     describe('with an empty text value', () => {
       beforeEach(() => {
@@ -178,6 +195,32 @@ describe('AutocompleteComponent', () => {
       })
       it('sends an empty value', () => {
         expect(anyEmitted).toEqual([''])
+      })
+    })
+    describe('allowSubmit is false', () => {
+      let emitted
+      beforeEach(() => {
+        component.allowSubmit = false
+        fixture.detectChanges()
+        emitted = null
+        component.cancelEnter = false
+        component.inputSubmitted.subscribe((e) => (emitted = e))
+        component.inputRef.nativeElement.value = 'blarg'
+        component.inputRef.nativeElement.dispatchEvent(
+          new KeyboardEvent('keyup', {
+            key: 'Enter',
+            bubbles: true,
+          })
+        )
+      })
+      it('does not show a submit button', () => {
+        const button = fixture.debugElement.query(
+          By.css('[data-test=autocomplete-submit-btn]')
+        )
+        expect(button).toBeFalsy()
+      })
+      it('does not emit inputSubmitted on enter', () => {
+        expect(emitted).toBeNull()
       })
     })
   })

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
@@ -13,25 +13,29 @@ import {
   SimpleChanges,
   ViewChild,
 } from '@angular/core'
-import { UntypedFormControl } from '@angular/forms'
+import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms'
 import {
   MatAutocomplete,
+  MatAutocompleteModule,
   MatAutocompleteSelectedEvent,
   MatAutocompleteTrigger,
 } from '@angular/material/autocomplete'
-import { merge, Observable, of, ReplaySubject, Subscription } from 'rxjs'
+import { first, merge, Observable, of, ReplaySubject, Subscription } from 'rxjs'
 import {
   catchError,
   debounceTime,
   distinctUntilChanged,
   filter,
   finalize,
-  first,
   map,
   switchMap,
   take,
   tap,
 } from 'rxjs/operators'
+import { MatIconModule } from '@angular/material/icon'
+import { PopupAlertComponent } from '@geonetwork-ui/ui/widgets'
+import { CommonModule } from '@angular/common'
+import { TranslateModule } from '@ngx-translate/core'
 
 export type AutocompleteItem = unknown
 
@@ -40,6 +44,15 @@ export type AutocompleteItem = unknown
   templateUrl: './autocomplete.component.html',
   styleUrls: ['./autocomplete.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [
+    MatIconModule,
+    PopupAlertComponent,
+    MatAutocompleteModule,
+    CommonModule,
+    TranslateModule,
+    ReactiveFormsModule,
+  ],
 })
 export class AutocompleteComponent
   implements OnInit, AfterViewInit, OnDestroy, OnChanges
@@ -49,6 +62,8 @@ export class AutocompleteComponent
   @Input() value?: AutocompleteItem
   @Input() clearOnSelection = false
   @Input() autoFocus = false
+  @Input() minCharacterCount? = 3
+  @Input() allowSubmit = true
   @Output() itemSelected = new EventEmitter<AutocompleteItem>()
   @Output() inputSubmitted = new EventEmitter<string>()
   @Output() inputCleared = new EventEmitter<void>()
@@ -57,18 +72,18 @@ export class AutocompleteComponent
   @ViewChild('searchInput') inputRef: ElementRef<HTMLInputElement>
 
   searching: boolean
-  suggestions$: Observable<AutocompleteItem[]>
   control = new UntypedFormControl()
-  subscription = new Subscription()
   cancelEnter = true
   selectionSubject = new ReplaySubject<MatAutocompleteSelectedEvent>(1)
   lastInputValue$ = new ReplaySubject<string>(1)
   error: string | null = null
+  suggestions$: Observable<AutocompleteItem[]>
+  subscription = new Subscription()
 
   @Input() displayWithFn: (item: AutocompleteItem) => string = (item) =>
-    JSON.stringify(item)
+    item.toString()
 
-  displayWithFnInternal = (item: AutocompleteItem) => {
+  displayWithFnInternal = (item?: AutocompleteItem) => {
     if (item === null || item === undefined) return null
     return this.displayWithFn(item)
   }
@@ -86,20 +101,33 @@ export class AutocompleteComponent
   }
 
   ngOnInit(): void {
-    this.suggestions$ = merge(
+    const newValue$ = merge(
+      of(''),
+      this.inputCleared.pipe(map(() => '')),
       this.control.valueChanges.pipe(
         filter((value) => typeof value === 'string'),
-        filter((value: string) => value.length > 2),
-        debounceTime(400),
         distinctUntilChanged(),
-        tap(() => (this.searching = true))
-      ),
-      this.control.valueChanges.pipe(
-        filter((value) => typeof value === 'object' && value.title),
-        map((item) => item.title)
+        debounceTime(400)
       )
+    )
+
+    const externalValueChange$ = this.control.valueChanges.pipe(
+      filter((value) => typeof value === 'object' && value.title),
+      map((item) => item.title)
+    )
+
+    // this observable emits arrays of suggestions loaded using the given action
+    const suggestionsFromAction = merge(
+      newValue$.pipe(
+        filter((value: string) => value.length >= this.minCharacterCount)
+      ),
+      externalValueChange$
     ).pipe(
-      switchMap((value) => (value ? this.action(value) : of([]))),
+      tap(() => {
+        this.searching = true
+        this.error = null
+      }),
+      switchMap((value) => this.action(value)),
       catchError((error: Error) => {
         this.error = error.message
         return of([])
@@ -107,11 +135,32 @@ export class AutocompleteComponent
       finalize(() => (this.searching = false))
     )
 
-    this.subscription = this.control.valueChanges.subscribe((any) => {
-      if (any !== '') {
-        this.cancelEnter = false
-      }
-    })
+    this.suggestions$ = merge(
+      suggestionsFromAction,
+      // if a new value is under the min char count, clear suggestions
+      newValue$.pipe(
+        filter((value: string) => value.length < this.minCharacterCount),
+        map(() => [])
+      )
+    )
+
+    // close the panel whenever suggestions are cleared
+    this.subscription.add(
+      this.suggestions$
+        .pipe(filter((suggestions) => suggestions.length === 0))
+        .subscribe(() => {
+          this.triggerRef?.closePanel()
+        })
+    )
+
+    this.subscription.add(
+      this.control.valueChanges.subscribe((any) => {
+        if (any !== '') {
+          this.cancelEnter = false
+        }
+      })
+    )
+
     this.control.valueChanges
       .pipe(filter((value) => typeof value === 'string'))
       .subscribe(this.lastInputValue$)
@@ -126,7 +175,7 @@ export class AutocompleteComponent
   }
 
   ngOnDestroy(): void {
-    this.subscription.unsubscribe()
+    this.subscription?.unsubscribe()
   }
 
   updateInputValue(value: AutocompleteItem) {
@@ -145,19 +194,16 @@ export class AutocompleteComponent
       .pipe(take(1))
       .subscribe((selection) => selection && selection.option.deselect())
     this.inputRef.nativeElement.focus()
-    this.triggerRef.closePanel()
   }
 
   handleEnter(any: string) {
-    if (!this.cancelEnter) {
+    if (!this.cancelEnter && this.allowSubmit) {
       this.inputSubmitted.emit(any)
-      this.triggerRef.closePanel()
     }
   }
 
   handleClickSearch() {
     this.inputSubmitted.emit(this.inputRef.nativeElement.value)
-    this.triggerRef.closePanel()
   }
 
   handleSelection(event: MatAutocompleteSelectedEvent) {

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
@@ -65,14 +65,20 @@ export class AutocompleteComponent
   lastInputValue$ = new ReplaySubject<string>(1)
   error: string | null = null
 
-  @Input() displayWithFn: (AutocompleteItem) => string = (item) => item
+  @Input() displayWithFn: (item: AutocompleteItem) => string = (item) =>
+    JSON.stringify(item)
+
+  displayWithFnInternal = (item: AutocompleteItem) => {
+    if (item === null || item === undefined) return null
+    return this.displayWithFn(item)
+  }
 
   constructor(private cdRef: ChangeDetectorRef) {}
   ngOnChanges(changes: SimpleChanges): void {
     const { value } = changes
     if (value) {
-      const previousTextValue = this.displayWithFn(value.previousValue)
-      const currentTextValue = this.displayWithFn(value.currentValue)
+      const previousTextValue = this.displayWithFnInternal(value.previousValue)
+      const currentTextValue = this.displayWithFnInternal(value.currentValue)
       if (previousTextValue !== currentTextValue) {
         this.updateInputValue(value.currentValue)
       }

--- a/libs/ui/inputs/src/lib/ui-inputs.module.ts
+++ b/libs/ui/inputs/src/lib/ui-inputs.module.ts
@@ -4,7 +4,6 @@ import { UtilSharedModule } from '@geonetwork-ui/util/shared'
 import { TranslateModule } from '@ngx-translate/core'
 import { TagInputModule } from 'ngx-chips'
 import { NgxDropzoneModule } from 'ngx-dropzone'
-import { AutocompleteComponent } from './autocomplete/autocomplete.component'
 import { ButtonComponent } from './button/button.component'
 import { BadgeComponent } from './badge/badge.component'
 import { ChipsInputComponent } from './chips-input/chips-input.component'
@@ -37,7 +36,6 @@ import { ImageInputComponent } from './image-input/image-input.component'
 
 @NgModule({
   declarations: [
-    AutocompleteComponent,
     TextInputComponent,
     DragAndDropFileInputComponent,
     ChipsInputComponent,
@@ -78,7 +76,6 @@ import { ImageInputComponent } from './image-input/image-input.component'
   ],
   exports: [
     DropdownSelectorComponent,
-    AutocompleteComponent,
     ButtonComponent,
     TextInputComponent,
     DragAndDropFileInputComponent,

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.spec.ts
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.spec.ts
@@ -3,7 +3,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { PopupAlertComponent } from './popup-alert.component'
 import { Component, Input } from '@angular/core'
 import { By } from '@angular/platform-browser'
-import { MatIconModule } from '@angular/material/icon'
 
 @Component({
   template: '<gn-ui-popup-alert>{{message}}</gn-ui-popup-alert>',
@@ -19,8 +18,8 @@ describe('PopupAlertComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [PopupAlertComponent, PopupAlertWrapperComponent],
-      imports: [MatIconModule],
+      declarations: [PopupAlertWrapperComponent],
+      imports: [PopupAlertComponent],
     }).compileComponents()
   })
 

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.stories.ts
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.stories.ts
@@ -1,19 +1,10 @@
-import {
-  componentWrapperDecorator,
-  Meta,
-  moduleMetadata,
-  StoryObj,
-} from '@storybook/angular'
+import { componentWrapperDecorator, Meta, StoryObj } from '@storybook/angular'
 import { PopupAlertComponent } from './popup-alert.component'
-import { MatIconModule } from '@angular/material/icon'
 
 export default {
   title: 'Widgets/PopupAlertComponent',
   component: PopupAlertComponent,
   decorators: [
-    moduleMetadata({
-      imports: [MatIconModule],
-    }),
     componentWrapperDecorator(
       (story) => `
 <div class="border border-gray-300 p-2" style="width: 600px; height:300px; resize: both; overflow: auto">
@@ -46,6 +37,6 @@ export const Primary: StoryObj<PopupAlertComponentWithContent> = {
   },
   render: (args) => ({
     props: args,
-    template: `<gn-ui-popup-alert [icon]='icon' [position]='position'>${content}</gn-ui-popup-alert>`,
+    template: `<gn-ui-popup-alert [icon]='icon' [position]='position' [type]='type'>${content}</gn-ui-popup-alert>`,
   }),
 }

--- a/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.ts
+++ b/libs/ui/widgets/src/lib/popup-alert/popup-alert.component.ts
@@ -7,12 +7,16 @@ import {
   OnInit,
   ViewChild,
 } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import { MatIconModule } from '@angular/material/icon'
 
 @Component({
   selector: 'gn-ui-popup-alert',
   templateUrl: './popup-alert.component.html',
   styleUrls: ['./popup-alert.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [CommonModule, MatIconModule],
 })
 export class PopupAlertComponent implements OnInit {
   @Input() icon: string

--- a/libs/ui/widgets/src/lib/ui-widgets.module.ts
+++ b/libs/ui/widgets/src/lib/ui-widgets.module.ts
@@ -9,7 +9,6 @@ import { TagInputModule } from 'ngx-chips'
 import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { LoadingMaskComponent } from './loading-mask/loading-mask.component'
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner'
-import { PopupAlertComponent } from './popup-alert/popup-alert.component'
 import { MatIconModule } from '@angular/material/icon'
 import { SpinningLoaderComponent } from './spinning-loader/spinning-loader.component'
 import { CommonModule } from '@angular/common'
@@ -20,7 +19,6 @@ import { CommonModule } from '@angular/common'
     ProgressBarComponent,
     StepBarComponent,
     LoadingMaskComponent,
-    PopupAlertComponent,
     SpinningLoaderComponent,
   ],
   imports: [
@@ -38,7 +36,6 @@ import { CommonModule } from '@angular/common'
     ProgressBarComponent,
     StepBarComponent,
     LoadingMaskComponent,
-    PopupAlertComponent,
     SpinningLoaderComponent,
   ],
 })


### PR DESCRIPTION
Add a new Input `minCharacterCount` to the autocomplete component to allow for a minimum character count before triggering the action. That means that if `minCharacterCount`  is 0, the dropdown should be filled initially with all available values. Additionally after clearing the input value, the dropdown is also populated with all available values instead of using the previous selected value.
The storybook was updated to reflect these changes. 

To Do:
- Make `action` be an input also in the storybook 

### Screenshots
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/7df31d6c-3e93-4f6d-8e36-677e0929aadb)
![image](https://github.com/geonetwork/geonetwork-ui/assets/133115263/3eb58fd9-8cca-4cb9-b247-32493e96a1ff)


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves