### PR TITLE
Metadata Editor: implement record creation

### DIFF
--- a/apps/metadata-editor/src/app/app.routes.ts
+++ b/apps/metadata-editor/src/app/app.routes.ts
@@ -9,6 +9,7 @@ import { MyDraftComponent } from './records/my-draft/my-draft.component'
 import { MyLibraryComponent } from './records/my-library/my-library.component'
 import { SearchRecordsComponent } from './records/search-records/search-records-list.component'
 import { MyOrgUsersComponent } from './my-org-users/my-org-users.component'
+import { NewRecordResolver } from './new-record.resolver'
 
 export const appRoutes: Route[] = [
   { path: '', component: DashboardPageComponent, pathMatch: 'prefix' },
@@ -68,7 +69,11 @@ export const appRoutes: Route[] = [
     ],
   },
   { path: 'sign-in', component: SignInPageComponent },
-  { path: 'create', component: EditPageComponent },
+  {
+    path: 'create',
+    component: EditPageComponent,
+    resolve: { record: NewRecordResolver },
+  },
   {
     path: 'edit/:uuid',
     component: EditPageComponent,

--- a/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router'
 import { EditorFacade } from '@geonetwork-ui/feature/editor'
 import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { DATASET_RECORDS } from '@geonetwork-ui/common/fixtures'
-import { Subject } from 'rxjs'
+import { BehaviorSubject, Subject } from 'rxjs'
 import { NotificationsService } from '@geonetwork-ui/feature/notifications'
 import { TranslateModule } from '@ngx-translate/core'
 
@@ -24,6 +24,7 @@ class RouterMock {
 }
 
 class EditorFacadeMock {
+  record$ = new BehaviorSubject(DATASET_RECORDS[0])
   openRecord = jest.fn()
   saveError$ = new Subject<string>()
   saveSuccess$ = new Subject()
@@ -129,6 +130,21 @@ describe('EditPageComponent', () => {
       const navigateSpy = jest.spyOn(router, 'navigate')
       ;(facade.draftSaveSuccess$ as any).next()
       expect(navigateSpy).toHaveBeenCalledWith(['edit', 'my-dataset-001'])
+    })
+  })
+
+  describe('unique identifier of the current record changes', () => {
+    beforeEach(() => {
+      fixture.detectChanges()
+    })
+    it('navigates to /edit/newUuid', () => {
+      const router = TestBed.inject(Router)
+      const navigateSpy = jest.spyOn(router, 'navigate')
+      ;(facade.record$ as any).next({
+        ...DATASET_RECORDS[0],
+        uniqueIdentifier: 'new-uuid',
+      })
+      expect(navigateSpy).toHaveBeenCalledWith(['edit', 'new-uuid'])
     })
   })
 })

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -14,7 +14,7 @@ import {
   NotificationsService,
 } from '@geonetwork-ui/feature/notifications'
 import { TranslateService } from '@ngx-translate/core'
-import { Subscription, take } from 'rxjs'
+import { filter, Subscription, take } from 'rxjs'
 
 @Component({
   selector: 'md-editor-edit',
@@ -91,6 +91,19 @@ export class EditPageComponent implements OnInit, OnDestroy {
         this.router.navigate(['edit', currentRecord.uniqueIdentifier])
       })
     }
+
+    // if the record unique identifier changes, navigate to /edit/newUuid
+    this.facade.record$
+      .pipe(
+        filter(
+          (record) =>
+            record?.uniqueIdentifier !== currentRecord.uniqueIdentifier
+        ),
+        take(1)
+      )
+      .subscribe((savedRecord) => {
+        this.router.navigate(['edit', savedRecord.uniqueIdentifier])
+      })
   }
 
   ngOnDestroy() {

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common'
 import { Component, OnDestroy, OnInit } from '@angular/core'
-import { ActivatedRoute } from '@angular/router'
+import { ActivatedRoute, Router } from '@angular/router'
 import {
   EditorFacade,
   RecordFormComponent,
@@ -14,7 +14,7 @@ import {
   NotificationsService,
 } from '@geonetwork-ui/feature/notifications'
 import { TranslateService } from '@ngx-translate/core'
-import { Subscription } from 'rxjs'
+import { Subscription, take } from 'rxjs'
 
 @Component({
   selector: 'md-editor-edit',
@@ -38,7 +38,8 @@ export class EditPageComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private facade: EditorFacade,
     private notificationsService: NotificationsService,
-    private translateService: TranslateService
+    private translateService: TranslateService,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -83,6 +84,13 @@ export class EditPageComponent implements OnInit, OnDestroy {
         )
       })
     )
+
+    // if we're on the /create route, go to /edit/{uuid} on first change
+    if (this.route.snapshot.routeConfig?.path.includes('create')) {
+      this.facade.draftSaveSuccess$.pipe(take(1)).subscribe(() => {
+        this.router.navigate(['edit', currentRecord.uniqueIdentifier])
+      })
+    }
   }
 
   ngOnDestroy() {

--- a/apps/metadata-editor/src/app/new-record.resolver.spec.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing'
+import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
+import { NewRecordResolver } from './new-record.resolver'
+
+describe('NewRecordResolver', () => {
+  let resolver: NewRecordResolver
+  let resolvedData: [CatalogRecord, string, boolean]
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+    resolver = TestBed.inject(NewRecordResolver)
+  })
+
+  it('should be created', () => {
+    expect(resolver).toBeTruthy()
+  })
+
+  describe('new record', () => {
+    beforeEach(() => {
+      resolvedData = undefined
+      resolver.resolve().subscribe((r) => (resolvedData = r))
+    })
+    it('creates a new empty record with a pregenerated id', () => {
+      expect(resolvedData).toMatchObject([
+        {
+          abstract: '',
+          kind: 'dataset',
+          recordUpdated: expect.any(Date),
+          status: 'ongoing',
+          temporalExtents: [],
+          title: expect.stringMatching(/^My new record/),
+          uniqueIdentifier: expect.stringMatching(/^TEMP-ID-/),
+        },
+        null,
+        false,
+      ])
+    })
+  })
+})

--- a/apps/metadata-editor/src/app/new-record.resolver.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core'
+import { Observable, of } from 'rxjs'
+import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NewRecordResolver {
+  resolve(): Observable<[CatalogRecord, string, boolean]> {
+    return of([
+      {
+        uniqueIdentifier: `TEMP-ID-${Date.now()}`,
+        title: `My new record (${new Date().toISOString()})`,
+        abstract: '',
+        ownerOrganization: {},
+        contacts: [],
+        recordUpdated: new Date(),
+        updateFrequency: 'unknown',
+        languages: [],
+        topics: [],
+        keywords: [],
+        licenses: [],
+        legalConstraints: [],
+        securityConstraints: [],
+        otherConstraints: [],
+        overviews: [],
+        contactsForResource: [],
+        kind: 'dataset',
+        status: 'ongoing',
+        lineage: '',
+        distributions: [],
+        spatialExtents: [],
+        temporalExtents: [],
+      } as CatalogRecord,
+      null,
+      false,
+    ])
+  }
+}

--- a/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
@@ -73,7 +73,17 @@ class RecordsApiServiceMock {
   </gmd:fileIdentifier>
 </gmd:MD_Metadata>`).pipe(map((xml) => ({ body: xml })))
   )
-  insert = jest.fn(() => of({}))
+  insert = jest.fn(() =>
+    of({
+      metadataInfos: {
+        1234: [
+          {
+            uuid: '1234-5678-9012',
+          },
+        ],
+      },
+    })
+  )
 }
 
 describe('Gn4Repository', () => {
@@ -354,8 +364,8 @@ describe('Gn4Repository', () => {
                 <gco:CharacterString>my-dataset-001</gco:CharacterString>`)
         )
       })
-      it('returns the record as serialized', () => {
-        expect(recordSource).toMatch(/<mdb:MD_Metadata/)
+      it('returns the unique identifier of the record as it was saved', () => {
+        expect(recordSource).toEqual('1234-5678-9012')
       })
     })
     describe('without reference', () => {

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -265,14 +265,13 @@ export class Gn4Repository implements RecordsRepositoryInterface {
             undefined,
             recordXml
           )
-          .pipe(map(() => recordXml))
-      ),
-      tap(() => {
-        // if saving was successful, the associated draft can be discarded
-        window.localStorage.removeItem(
-          this.getLocalStorageKeyForRecord(record.uniqueIdentifier)
-        )
-      })
+          .pipe(
+            map((response) => {
+              const metadataId = Object.keys(response.metadataInfos)[0]
+              return response.metadataInfos[metadataId][0].uuid
+            })
+          )
+      )
     )
   }
 

--- a/libs/common/domain/src/lib/repository/records-repository.interface.ts
+++ b/libs/common/domain/src/lib/repository/records-repository.interface.ts
@@ -33,7 +33,7 @@ export abstract class RecordsRepositoryInterface {
   /**
    * @param record
    * @param referenceRecordSource
-   * @returns Observable<string> Returns the source of the record as it was serialized when saved
+   * @returns Observable<string> Returns the unique identifier of the record as it was when saved
    */
   abstract saveRecord(
     record: CatalogRecord,

--- a/libs/feature/editor/src/lib/+state/editor.actions.ts
+++ b/libs/feature/editor/src/lib/+state/editor.actions.ts
@@ -26,3 +26,5 @@ export const saveRecordFailure = createAction(
   '[Editor] Save record failure',
   props<{ error: SaveRecordError }>()
 )
+
+export const draftSaveSuccess = createAction('[Editor] Draft save success')

--- a/libs/feature/editor/src/lib/+state/editor.effects.spec.ts
+++ b/libs/feature/editor/src/lib/+state/editor.effects.spec.ts
@@ -128,7 +128,7 @@ describe('EditorEffects', () => {
         })
         expect(effects.saveRecordDraft$).toBeObservable(
           hot('--- 999ms b', {
-            b: '<xml>blabla</xml>', // this is emitted by the observable but not dispatched as an action
+            b: EditorActions.draftSaveSuccess(),
           })
         )
         expect(service.saveRecordAsDraft).toHaveBeenCalledWith(

--- a/libs/feature/editor/src/lib/+state/editor.effects.spec.ts
+++ b/libs/feature/editor/src/lib/+state/editor.effects.spec.ts
@@ -1,14 +1,15 @@
 import { TestBed } from '@angular/core/testing'
 import { provideMockActions } from '@ngrx/effects/testing'
 import { Action } from '@ngrx/store'
-import { provideMockStore } from '@ngrx/store/testing'
+import { MockStore, provideMockStore } from '@ngrx/store/testing'
 import { getTestScheduler, hot } from 'jasmine-marbles'
-import { Observable, of, throwError } from 'rxjs'
+import { firstValueFrom, Observable, of, throwError } from 'rxjs'
 import * as EditorActions from './editor.actions'
 import { EditorEffects } from './editor.effects'
 import { DATASET_RECORDS } from '@geonetwork-ui/common/fixtures'
 import { EditorService } from '../services/editor.service'
 import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
+import { EditorPartialState } from './editor.reducer'
 
 class EditorServiceMock {
   saveRecord = jest.fn((record) => of([record, '<xml>blabla</xml>']))
@@ -16,6 +17,16 @@ class EditorServiceMock {
 }
 class RecordsRepositoryMock {
   recordHasDraft = jest.fn(() => true)
+}
+
+const initialEditorState = {
+  record: DATASET_RECORDS[0],
+  recordSource: '<xml>blabla</xml>',
+  saving: false,
+  saveError: null,
+  changedSinceSave: false,
+  alreadySavedOnce: true,
+  fieldsConfig: [],
 }
 
 describe('EditorEffects', () => {
@@ -29,16 +40,9 @@ describe('EditorEffects', () => {
       providers: [
         EditorEffects,
         provideMockActions(() => actions),
-        provideMockStore({
+        provideMockStore<EditorPartialState>({
           initialState: {
-            editor: {
-              record: DATASET_RECORDS[0],
-              loading: false,
-              loadError: null,
-              saving: false,
-              saveError: null,
-              changedSinceSave: false,
-            },
+            editor: initialEditorState,
           },
         }),
         {
@@ -71,6 +75,27 @@ describe('EditorEffects', () => {
           }),
         })
         expect(effects.saveRecord$).toBeObservable(expected)
+        expect(service.saveRecord).toHaveBeenCalledWith(
+          DATASET_RECORDS[0],
+          [],
+          false
+        )
+      })
+      it('asks for a new unique identifier if the record was never saved', async () => {
+        const store = TestBed.inject(MockStore)
+        store.setState({
+          editor: {
+            ...initialEditorState,
+            alreadySavedOnce: false,
+          },
+        })
+        actions = of(EditorActions.saveRecord())
+        await firstValueFrom(effects.saveRecord$)
+        expect(service.saveRecord).toHaveBeenCalledWith(
+          DATASET_RECORDS[0],
+          [],
+          true
+        )
       })
     })
 

--- a/libs/feature/editor/src/lib/+state/editor.effects.ts
+++ b/libs/feature/editor/src/lib/+state/editor.effects.ts
@@ -53,15 +53,14 @@ export class EditorEffects {
     )
   )
 
-  saveRecordDraft$ = createEffect(
-    () =>
-      this.actions$.pipe(
-        ofType(EditorActions.updateRecordField),
-        debounceTime(1000),
-        withLatestFrom(this.store.select(selectRecord)),
-        switchMap(([, record]) => this.editorService.saveRecordAsDraft(record))
-      ),
-    { dispatch: false }
+  saveRecordDraft$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(EditorActions.updateRecordField),
+      debounceTime(1000),
+      withLatestFrom(this.store.select(selectRecord)),
+      switchMap(([, record]) => this.editorService.saveRecordAsDraft(record)),
+      map(() => EditorActions.draftSaveSuccess())
+    )
   )
 
   checkHasChangesOnOpen$ = createEffect(() =>

--- a/libs/feature/editor/src/lib/+state/editor.facade.ts
+++ b/libs/feature/editor/src/lib/+state/editor.facade.ts
@@ -26,6 +26,7 @@ export class EditorFacade {
     select(EditorSelectors.selectRecordChangedSinceSave)
   )
   recordFields$ = this.store.pipe(select(EditorSelectors.selectRecordFields))
+  draftSaveSuccess$ = this.actions$.pipe(ofType(EditorActions.draftSaveSuccess))
 
   openRecord(
     record: CatalogRecord,

--- a/libs/feature/editor/src/lib/+state/editor.selectors.spec.ts
+++ b/libs/feature/editor/src/lib/+state/editor.selectors.spec.ts
@@ -55,46 +55,69 @@ describe('Editor Selectors', () => {
       expect(result).toEqual(DEFAULT_FIELDS)
     })
 
-    it('selectRecordFields() should return the config and value for each field', () => {
-      const result = EditorSelectors.selectRecordFields(state)
-      expect(result).toEqual([
-        {
+    describe('selectRecordFields', () => {
+      it('should return the config and value for each field', () => {
+        const result = EditorSelectors.selectRecordFields(state)
+        expect(result).toEqual([
+          {
+            config: DEFAULT_FIELDS[0],
+            value: DATASET_RECORDS[0].title,
+          },
+          {
+            config: DEFAULT_FIELDS[1],
+            value: DATASET_RECORDS[0].abstract,
+          },
+          {
+            config: DEFAULT_FIELDS[2],
+            value: DATASET_RECORDS[0].uniqueIdentifier,
+          },
+          {
+            config: DEFAULT_FIELDS[3],
+            value: DATASET_RECORDS[0].recordUpdated,
+          },
+          {
+            config: DEFAULT_FIELDS[4],
+            value: DATASET_RECORDS[0].licenses,
+          },
+          {
+            config: DEFAULT_FIELDS[5],
+            value: DATASET_RECORDS[0].resourceUpdated,
+          },
+          {
+            config: DEFAULT_FIELDS[6],
+            value: DATASET_RECORDS[0].updateFrequency,
+          },
+          {
+            config: DEFAULT_FIELDS[7],
+            value: DATASET_RECORDS[0].temporalExtents,
+          },
+          {
+            config: DEFAULT_FIELDS[8],
+            value: DATASET_RECORDS[0].keywords,
+          },
+        ])
+      })
+      it('should not coerce falsy values to null', () => {
+        const result = EditorSelectors.selectRecordFields({
+          ...state,
+          editor: {
+            ...state.editor,
+            record: {
+              ...DATASET_RECORDS[0],
+              abstract: '',
+              title: '',
+            },
+          },
+        })
+        expect(result).toContainEqual({
           config: DEFAULT_FIELDS[0],
-          value: DATASET_RECORDS[0].title,
-        },
-        {
+          value: '',
+        })
+        expect(result).toContainEqual({
           config: DEFAULT_FIELDS[1],
-          value: DATASET_RECORDS[0].abstract,
-        },
-        {
-          config: DEFAULT_FIELDS[2],
-          value: DATASET_RECORDS[0].uniqueIdentifier,
-        },
-        {
-          config: DEFAULT_FIELDS[3],
-          value: DATASET_RECORDS[0].recordUpdated,
-        },
-        {
-          config: DEFAULT_FIELDS[4],
-          value: DATASET_RECORDS[0].licenses,
-        },
-        {
-          config: DEFAULT_FIELDS[5],
-          value: DATASET_RECORDS[0].resourceUpdated,
-        },
-        {
-          config: DEFAULT_FIELDS[6],
-          value: DATASET_RECORDS[0].updateFrequency,
-        },
-        {
-          config: DEFAULT_FIELDS[7],
-          value: DATASET_RECORDS[0].temporalExtents,
-        },
-        {
-          config: DEFAULT_FIELDS[8],
-          value: DATASET_RECORDS[0].keywords,
-        },
-      ])
+          value: '',
+        })
+      })
     })
   })
 })

--- a/libs/feature/editor/src/lib/+state/editor.selectors.ts
+++ b/libs/feature/editor/src/lib/+state/editor.selectors.ts
@@ -44,6 +44,6 @@ export const selectRecordFields = createSelector(
   (state: EditorState) =>
     state.fieldsConfig.map((fieldConfig) => ({
       config: fieldConfig,
-      value: state.record?.[fieldConfig.model] || null,
+      value: state.record?.[fieldConfig.model] ?? null,
     }))
 )

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-update-frequency/form-field-update-frequency.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-update-frequency/form-field-update-frequency.component.spec.ts
@@ -22,10 +22,19 @@ describe('FormFieldUpdateFrequencyComponent', () => {
     })
     component.control = control
     fixture.detectChanges()
+    await component.ngOnInit()
   })
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  it('should offer a set of initial choices', () => {
+    expect(component['choices']).toHaveLength(10)
+    expect(component['choices']).toContainEqual({
+      label: 'domain.record.updateFrequency.week',
+      value: 'week.3',
+    })
   })
 
   it('should parse the updatedTimes and per values', () => {
@@ -41,7 +50,7 @@ describe('FormFieldUpdateFrequencyComponent', () => {
   })
 
   it('should add the custom frequency to the dropdown choices', () => {
-    expect(component.choices).toContainEqual({
+    expect(component['choices']).toContainEqual({
       value: 'week.3',
       label: 'domain.record.updateFrequency.week',
     })

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-update-frequency/form-field-update-frequency.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-update-frequency/form-field-update-frequency.component.ts
@@ -5,12 +5,17 @@ import {
   OnInit,
 } from '@angular/core'
 import { FormControl } from '@angular/forms'
-import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import {
   CheckToggleComponent,
+  DropdownChoice,
   DropdownSelectorComponent,
 } from '@geonetwork-ui/ui/inputs'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
+import {
+  UpdateFrequency,
+  UpdateFrequencyCustom,
+} from '@geonetwork-ui/common/domain/model/record'
+import { firstValueFrom } from 'rxjs'
 
 @Component({
   selector: 'gn-ui-form-field-update-frequency',
@@ -21,26 +26,32 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core'
   imports: [CheckToggleComponent, DropdownSelectorComponent, TranslateModule],
 })
 export class FormFieldUpdateFrequencyComponent implements OnInit {
-  @Input() control: FormControl
+  @Input() control: FormControl<UpdateFrequency>
+
+  protected choices: DropdownChoice[] = []
 
   get planned() {
-    return this.control.value !== 'notPlanned'
+    return typeof this.control.value !== 'string'
   }
 
   constructor(private translateService: TranslateService) {}
 
-  ngOnInit() {
-    const updatedTimes = this.control.value?.updatedTimes
-    const per = this.control.value?.per
+  async ngOnInit() {
+    this.choices = await this.getInitialChoices()
+    if (typeof this.control.value === 'string') {
+      return
+    }
+    const updatedTimes = this.control.value.updatedTimes
+    const per = this.control.value.per
+    // the update frequency is not in the list; make it appear there
     if (updatedTimes && updatedTimes !== 1 && updatedTimes !== 2) {
       this.choices = [
         {
           value: `${per}.${updatedTimes}`,
-          label: this.translateService.instant(
-            `domain.record.updateFrequency.${per}`,
-            {
+          label: await firstValueFrom(
+            this.translateService.get(`domain.record.updateFrequency.${per}`, {
               count: updatedTimes,
-            }
+            })
           ),
         },
         ...this.choices,
@@ -56,88 +67,86 @@ export class FormFieldUpdateFrequencyComponent implements OnInit {
     }
   }
 
-  get selectedFrequency() {
+  get selectedFrequency(): string {
+    if (typeof this.control.value === 'string') return null
     const { updatedTimes, per } = this.control.value
     return `${per}.${updatedTimes}`
   }
 
   onSelectFrequencyValue(value: unknown) {
     const split = (value as string).split('.')
-    this.control.setValue({ updatedTimes: Number(split[1]), per: split[0] })
+    this.control.setValue({
+      updatedTimes: Number(split[1]),
+      per: split[0] as UpdateFrequencyCustom['per'],
+    })
   }
 
-  choices = [
-    {
-      value: 'day.1',
-      label: this.translateService.instant(
-        'domain.record.updateFrequency.day',
-        {
-          count: 1,
-        }
-      ),
-    },
-    {
-      value: 'day.2',
-      label: this.translateService.instant(
-        'domain.record.updateFrequency.day',
-        {
-          count: 2,
-        }
-      ),
-    },
-    {
-      value: 'week.1',
-      label: this.translateService.instant(
-        'domain.record.updateFrequency.week',
-        {
-          count: 1,
-        }
-      ),
-    },
-    {
-      value: 'week.2',
-      label: this.translateService.instant(
-        'domain.record.updateFrequency.week',
-        {
-          count: 2,
-        }
-      ),
-    },
-    {
-      value: 'month.1',
-      label: this.translateService.instant(
-        'domain.record.updateFrequency.month',
-        {
-          count: 1,
-        }
-      ),
-    },
-    {
-      value: 'month.2',
-      label: this.translateService.instant(
-        'domain.record.updateFrequency.month',
-        {
-          count: 2,
-        }
-      ),
-    },
-    {
-      value: 'year.1',
-      label: this.translateService.instant(
-        'domain.record.updateFrequency.year',
-        {
-          count: 1,
-        }
-      ),
-    },
-    {
-      value: 'year.2',
-      label: this.translateService.instant(
-        'domain.record.updateFrequency.year',
-        {
-          count: 2,
-        }
-      ),
-    },
-  ]
+  private async getInitialChoices() {
+    return [
+      {
+        value: 'day.1',
+        label: await firstValueFrom(
+          this.translateService.get('domain.record.updateFrequency.day', {
+            count: 1,
+          })
+        ),
+      },
+      {
+        value: 'day.2',
+        label: await firstValueFrom(
+          this.translateService.get('domain.record.updateFrequency.day', {
+            count: 2,
+          })
+        ),
+      },
+      {
+        value: 'week.1',
+        label: await firstValueFrom(
+          this.translateService.get('domain.record.updateFrequency.week', {
+            count: 1,
+          })
+        ),
+      },
+      {
+        value: 'week.2',
+        label: await firstValueFrom(
+          this.translateService.get('domain.record.updateFrequency.week', {
+            count: 2,
+          })
+        ),
+      },
+      {
+        value: 'month.1',
+        label: await firstValueFrom(
+          this.translateService.get('domain.record.updateFrequency.month', {
+            count: 1,
+          })
+        ),
+      },
+      {
+        value: 'month.2',
+        label: await firstValueFrom(
+          this.translateService.get('domain.record.updateFrequency.month', {
+            count: 2,
+          })
+        ),
+      },
+      {
+        value: 'year.1',
+        label: await firstValueFrom(
+          this.translateService.get('domain.record.updateFrequency.year', {
+            count: 1,
+          })
+        ),
+      },
+      {
+        value: 'year.2',
+        label: await firstValueFrom(
+          this.translateService.get('domain.record.updateFrequency.year', {
+            count: 2,
+          })
+        ),
+      },
+    ]
+  }
 }

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.html
@@ -68,24 +68,10 @@
   </ng-container>
   <ng-container *ngIf="isSimpleField">
     <gn-ui-form-field-simple
-      [type]="simpleType"
+      type="text"
       [control]="formControl"
-      [readonly]="isFieldLocked"
-      [invalid]="isFieldInvalid"
+      [readonly]="isReadOnly"
     ></gn-ui-form-field-simple>
-  </ng-container>
-  <ng-container *ngIf="isFileField">
-    <gn-ui-form-field-file
-      [control]="formControl"
-      [readonly]="isFieldLocked"
-      [invalid]="isFieldInvalid"
-    ></gn-ui-form-field-file>
-  </ng-container>
-  <ng-container *ngIf="isArrayField">
-    <gn-ui-form-field-array></gn-ui-form-field-array>
-  </ng-container>
-  <ng-container *ngIf="isObjectField">
-    <gn-ui-form-field-object></gn-ui-form-field-object>
   </ng-container>
   <ng-container *ngIf="isSpatialExtentField">
     <gn-ui-form-field-spatial-extent></gn-ui-form-field-spatial-extent>
@@ -95,10 +81,4 @@
       [control]="formControl"
     ></gn-ui-form-field-keywords>
   </ng-container>
-  <div
-    *ngIf="isFieldInvalid && config.invalidHintKey"
-    class="mt-2 text-pink-500 text-sm field-invalid-hint"
-  >
-    {{ config.invalidHintKey | translate }}
-  </div>
 </ng-template>

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.spec.ts
@@ -2,10 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
 import { FormFieldWrapperComponent } from '@geonetwork-ui/ui/layout'
 import { TranslateModule } from '@ngx-translate/core'
-import { FormFieldArrayComponent } from './form-field-array/form-field-array.component'
-import { FormFieldFileComponent } from './form-field-file/form-field-file.component'
 import { FormFieldLicenseComponent } from './form-field-license/form-field-license.component'
-import { FormFieldObjectComponent } from './form-field-object/form-field-object.component'
 import { FormFieldResourceUpdatedComponent } from './form-field-resource-updated/form-field-resource-updated.component'
 import { FormFieldRichComponent } from './form-field-rich/form-field-rich.component'
 import { FormFieldSimpleComponent } from './form-field-simple/form-field-simple.component'
@@ -121,7 +118,7 @@ describe('FormFieldComponent', () => {
     let fieldWrapper
     let formField
     beforeEach(async () => {
-      component.config.type = 'url'
+      component.model = 'uniqueIdentifier'
       fixture.detectChanges()
       await fixture.whenStable()
       fieldWrapper = fixture.debugElement.query(
@@ -131,109 +128,25 @@ describe('FormFieldComponent', () => {
         By.directive(FormFieldSimpleComponent)
       ).componentInstance
     })
-    it('creates a simple form field', () => {
+    it('creates a simple field field (unique identifier)', () => {
       expect(formField).toBeTruthy()
-      expect(formField.type).toEqual(component.config.type)
-      expect(formField.readonly).toEqual(component.config.locked)
-      expect(formField.invalid).toEqual(component.config.invalid)
+      expect(formField.type).toEqual('text')
+      expect(formField.readonly).toEqual(true)
     })
     it('creates a form field wrapper', () => {
       expect(fieldWrapper).toBeTruthy()
     })
   })
-  describe('simple field (invalid)', () => {
-    let formField
-    beforeEach(async () => {
-      component.config.type = 'number'
-      component.config.invalid = true
-      component.config.invalidHintKey = 'something.is.wrong'
-      fixture.detectChanges()
-      await fixture.whenStable()
-      formField = fixture.debugElement.query(
-        By.directive(FormFieldSimpleComponent)
-      ).componentInstance
-    })
-    it('shows a simple form field as invalid', () => {
-      expect(formField).toBeTruthy()
-      expect(formField.type).toEqual(component.config.type)
-      expect(formField.invalid).toEqual(true)
-    })
-    it('shows the invalid hint key', () => {
-      const hint = fixture.debugElement.query(By.css('.field-invalid-hint'))
-      expect(hint.nativeElement.textContent).toContain(
-        component.config.invalidHintKey
-      )
-    })
-  })
-  describe('simple field (invalid and locked)', () => {
-    let formField
-    beforeEach(async () => {
-      component.config.type = 'number'
-      component.config.locked = true
-      component.config.invalid = true
-      fixture.detectChanges()
-      await fixture.whenStable()
-      formField = fixture.debugElement.query(
-        By.directive(FormFieldSimpleComponent)
-      ).componentInstance
-    })
-    it('shows a simple form field as locked (but not invalid)', () => {
-      expect(formField).toBeTruthy()
-      expect(formField.type).toEqual(component.config.type)
-      expect(formField.readonly).toEqual(true)
-      expect(formField.invalid).toEqual(false)
-    })
-  })
-  describe('file field', () => {
-    let formField
-    beforeEach(() => {
-      component.config.type = 'file'
-      fixture.detectChanges()
-      formField = fixture.debugElement.query(
-        By.directive(FormFieldFileComponent)
-      ).componentInstance
-    })
-    it('creates a file form field', () => {
-      expect(formField).toBeTruthy()
-      expect(formField.readonly).toEqual(component.config.locked)
-    })
-  })
   describe('spatial extent field', () => {
     let formField
     beforeEach(() => {
-      component.config.type = 'spatial_extent'
+      component.model = 'spatialExtents'
       fixture.detectChanges()
       formField = fixture.debugElement.query(
         By.directive(FormFieldSpatialExtentComponent)
       ).componentInstance
     })
     it('creates an array form field', () => {
-      expect(formField).toBeTruthy()
-    })
-  })
-  describe('array field', () => {
-    let formField
-    beforeEach(() => {
-      component.config.type = 'array'
-      fixture.detectChanges()
-      formField = fixture.debugElement.query(
-        By.directive(FormFieldArrayComponent)
-      ).componentInstance
-    })
-    it('creates an array form field', () => {
-      expect(formField).toBeTruthy()
-    })
-  })
-  describe('object field', () => {
-    let formField
-    beforeEach(() => {
-      component.config.type = 'object'
-      fixture.detectChanges()
-      formField = fixture.debugElement.query(
-        By.directive(FormFieldObjectComponent)
-      ).componentInstance
-    })
-    it('creates an object form field', () => {
       expect(formField).toBeTruthy()
     })
   })

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.ts
@@ -27,6 +27,7 @@ import { FormFieldSimpleComponent } from './form-field-simple/form-field-simple.
 import { FormFieldSpatialExtentComponent } from './form-field-spatial-extent/form-field-spatial-extent.component'
 import { FormFieldConfig } from './form-field.model'
 import { FormFieldUpdateFrequencyComponent } from './form-field-update-frequency/form-field-update-frequency.component'
+import { CatalogRecordKeys } from '@geonetwork-ui/common/domain/model/record'
 import { FormFieldKeywordsComponent } from './form-field-keywords/form-field-keywords.component'
 
 @Component({
@@ -57,7 +58,7 @@ import { FormFieldKeywordsComponent } from './form-field-keywords/form-field-key
   ],
 })
 export class FormFieldComponent {
-  @Input() model: string
+  @Input() model: CatalogRecordKeys
   @Input() config: FormFieldConfig
   @Input() set value(v: unknown) {
     this.formControl.setValue(v, {
@@ -78,49 +79,6 @@ export class FormFieldComponent {
     this.titleInput.nativeElement.children[0].focus()
   }
 
-  get simpleType() {
-    return this.config.type as
-      | 'date'
-      | 'url'
-      | 'text'
-      | 'number'
-      | 'list'
-      | 'toggle'
-  }
-
-  get isSimpleField() {
-    return (
-      this.config.type === 'text' ||
-      this.config.type === 'number' ||
-      this.config.type === 'date' ||
-      this.config.type === 'list' ||
-      this.config.type === 'url' ||
-      this.config.type === 'toggle'
-    )
-  }
-  get isFileField() {
-    return this.config.type === 'file'
-  }
-  get isSpatialExtentField() {
-    return this.config.type === 'spatial_extent'
-  }
-  get isArrayField() {
-    return this.config.type === 'array'
-  }
-  get isObjectField() {
-    return this.config.type === 'object'
-  }
-
-  get isFieldOk() {
-    return !this.config.locked && !this.config.invalid
-  }
-  get isFieldLocked() {
-    return this.config.locked
-  }
-  get isFieldInvalid() {
-    return !this.config.locked && this.config.invalid
-  }
-
   get isTitle() {
     return this.model === 'title'
   }
@@ -138,6 +96,15 @@ export class FormFieldComponent {
   }
   get isTemporalExtents() {
     return this.model === 'temporalExtents'
+  }
+  get isSpatialExtentField() {
+    return this.model === 'spatialExtents'
+  }
+  get isSimpleField() {
+    return this.model === 'uniqueIdentifier' || this.model === 'recordUpdated'
+  }
+  get isReadOnly() {
+    return this.model === 'uniqueIdentifier' || this.model === 'recordUpdated'
   }
   get isKeywords() {
     return this.model === 'keywords'


### PR DESCRIPTION
### Description

This PR adds support for creating a new record in the catalog:

- when opening "/create", the user ends up on an edition form for a new record
- new records are almost empty but have a temporary unique ID; this is so that we can keep a draft of a record before it can be saved in the backend
- as soon as something is changed in the record, it is saved as a draft and the user is redirected to "/edit/<temporary-id>"
- when a record is saved in the backend for the first time, a new unique identifier is generated by the backend and replaced in the edition form; the user is redirected to "/edit/<final-id>"

This PR also contains a few fixes in the edition form to make it work with an empty record.

The previous fields have also been removed to only leave the "final" ones.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Screenshots

![image](https://github.com/geonetwork/geonetwork-ui/assets/10629150/d8e6a615-17c8-48f2-ac5f-836bfdcd34f6)



### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

