### PR TITLE
[Search page] : Add new filtering options

### DIFF
--- a/libs/feature/search/src/lib/utils/service/fields.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.spec.ts
@@ -99,6 +99,8 @@ describe('FieldsService', () => {
           'q',
           'license',
           'owner',
+          'qualityScore',
+          'territories',
         ])
       })
     })
@@ -180,6 +182,8 @@ describe('FieldsService', () => {
           resourceType: [],
           topic: [],
           owner: [],
+          qualityScore: [],
+          territories: [],
         })
       })
     })

--- a/libs/feature/search/src/lib/utils/service/fields.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.spec.ts
@@ -100,7 +100,7 @@ describe('FieldsService', () => {
           'license',
           'owner',
           'qualityScore',
-          'territories',
+          'customTranslatedSearchField',
         ])
       })
     })
@@ -183,7 +183,7 @@ describe('FieldsService', () => {
           topic: [],
           owner: [],
           qualityScore: [],
-          territories: [],
+          customTranslatedSearchField: [],
         })
       })
     })

--- a/libs/feature/search/src/lib/utils/service/fields.service.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.ts
@@ -32,7 +32,7 @@ marker('search.filters.standard')
 marker('search.filters.topic')
 marker('search.filters.contact')
 marker('search.filters.qualityScore')
-marker('search.filters.territories')
+marker('search.filters.customTranslatedSearchField')
 
 @Injectable({
   providedIn: 'root',
@@ -73,7 +73,11 @@ export class FieldsService {
     license: new LicenseSearchField(this.injector),
     owner: new OwnerSearchField(this.injector),
     qualityScore: new SimpleSearchField('qualityScore', this.injector, 'desc'),
-    territories: new TranslatedSearchField(undefined, this.injector, 'asc'),
+    customTranslatedSearchField: new TranslatedSearchField(
+      undefined,
+      this.injector,
+      'asc'
+    ),
   } as Record<string, AbstractSearchField>
 
   get supportedFields() {
@@ -86,7 +90,7 @@ export class FieldsService {
     if (this.supportedFields.indexOf(fieldName) === -1) {
       throw new Error(`Unsupported search field: ${fieldName}`)
     }
-    if (fieldName === 'territories' && thesaurusName) {
+    if (fieldName === 'customTranslatedSearchField' && thesaurusName) {
       this.fields[fieldName] = new TranslatedSearchField(
         thesaurusName,
         this.injector,

--- a/libs/feature/search/src/lib/utils/service/fields.service.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.ts
@@ -31,6 +31,8 @@ marker('search.filters.resourceType')
 marker('search.filters.standard')
 marker('search.filters.topic')
 marker('search.filters.contact')
+marker('search.filters.qualityScore')
+marker('search.filters.territories')
 
 @Injectable({
   providedIn: 'root',
@@ -70,6 +72,8 @@ export class FieldsService {
     q: new FullTextSearchField(),
     license: new LicenseSearchField(this.injector),
     owner: new OwnerSearchField(this.injector),
+    qualityScore: new SimpleSearchField('qualityScore', this.injector, 'desc'),
+    territories: new TranslatedSearchField(undefined, this.injector, 'asc'),
   } as Record<string, AbstractSearchField>
 
   get supportedFields() {
@@ -78,9 +82,17 @@ export class FieldsService {
 
   constructor(protected injector: Injector) {}
 
-  getAvailableValues(fieldName: string) {
-    if (this.supportedFields.indexOf(fieldName) === -1)
+  getAvailableValues(fieldName: string, thesaurusName?: string) {
+    if (this.supportedFields.indexOf(fieldName) === -1) {
       throw new Error(`Unsupported search field: ${fieldName}`)
+    }
+    if (fieldName === 'territories' && thesaurusName) {
+      this.fields[fieldName] = new TranslatedSearchField(
+        thesaurusName,
+        this.injector,
+        'asc'
+      )
+    }
     return this.fields[fieldName].getAvailableValues()
   }
 


### PR DESCRIPTION
### Description

This PR introduces two new filtering options : 

- Data quality score
- Territories

For the territory one, since the thesaurus name is specific to MEL (and to each instance, actually), it needs to be passed down to fields.service, where the filter is initialized with no thesaurus name. If someone has a better solution, it's very welcomed :slightly_smiling_face: 
