### PR TITLE
[Backport 2.3.x] [Fix]: Reset map dropdown links [re-applied]

### DIFF
--- a/libs/common/fixtures/src/lib/records.fixtures.ts
+++ b/libs/common/fixtures/src/lib/records.fixtures.ts
@@ -233,6 +233,14 @@ Malgré l'attention portée à la création de ces données, il est rappelé que
         description: 'Téléchargement du fichier',
         mimeType: 'x-gis/x-shapefile',
       },
+      {
+        type: 'service',
+        url: new URL('https://my-org.net/ogc'),
+        accessServiceProtocol: 'ogcFeatures',
+        name: 'ogcFeaturesSecondRecord',
+        description: 'This OGC service is the second part of the download',
+        identifierInService: 'my:featuretype',
+      },
     ],
     lineage: `Document d’urbanisme numérisé conformément aux prescriptions nationales du CNIG par le Service d'Information Géographique de l'Agglomération de la Région de Compiègne.
 Ce lot de données produit en 2019, a été numérisé à partir du PCI Vecteur de 2019 et contrôlé par le Service d'Information Géographique de l'Agglomération de la Région de Compiègne.`,

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -64,6 +64,7 @@ export class MapViewComponent implements OnInit, OnDestroy {
   )
 
   dropdownChoices$ = this.compatibleMapLinks$.pipe(
+    tap(() => (this.loading = true)),
     map((links) =>
       links.length
         ? links.map((link, index) => ({
@@ -71,7 +72,8 @@ export class MapViewComponent implements OnInit, OnDestroy {
             value: index,
           }))
         : [{ label: 'No preview layer', value: 0 }]
-    )
+    ),
+    finalize(() => (this.loading = false))
   )
   selectedLinkIndex$ = new BehaviorSubject(0)
 

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -64,7 +64,6 @@ export class MapViewComponent implements OnInit, OnDestroy {
   )
 
   dropdownChoices$ = this.compatibleMapLinks$.pipe(
-    tap(() => (this.loading = true)),
     map((links) =>
       links.length
         ? links.map((link, index) => ({
@@ -72,8 +71,7 @@ export class MapViewComponent implements OnInit, OnDestroy {
             value: index,
           }))
         : [{ label: 'No preview layer', value: 0 }]
-    ),
-    finalize(() => (this.loading = false))
+    )
   )
   selectedLinkIndex$ = new BehaviorSubject(0)
 

--- a/libs/feature/record/src/lib/state/mdview.facade.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.spec.ts
@@ -328,5 +328,45 @@ describe('MdViewFacade', () => {
       tick()
       expect(result).toEqual(values.a)
     }))
+    describe('When the user switches datasets and allLinks emits again', () => {
+      beforeEach(() => {
+        store.setState({
+          [METADATA_VIEW_FEATURE_STATE_KEY]: {
+            ...initialMetadataViewState,
+            metadata: DATASET_RECORDS[1],
+          },
+        })
+      })
+      it('should return only the last links from allLinks', fakeAsync(() => {
+        const values = {
+          a: [
+            {
+              type: 'service',
+              url: new URL('https://my-org.net/ogc'),
+              accessServiceProtocol: 'ogcFeatures',
+              name: 'ogcFeaturesSecondRecord',
+              description:
+                'This OGC service is the second part of the download',
+              identifierInService: 'my:featuretype',
+            },
+          ],
+        }
+        jest.spyOn(facade.dataService, 'getItemsFromOgcApi').mockResolvedValue({
+          id: '123',
+          type: 'Feature',
+          time: null,
+          properties: {
+            type: '',
+            title: '',
+          },
+          links: [],
+          geometry: { type: 'MultiPolygon', coordinates: [] },
+        })
+        let result
+        facade.geoDataLinksWithGeometry$.subscribe((v) => (result = v))
+        tick()
+        expect(result).toEqual(values.a)
+      }))
+    })
   })
 })


### PR DESCRIPTION
Backport of https://github.com/geonetwork/geonetwork-ui/pull/900

Re-applies #904 manually, after resetting 2.3.x on correct commit in history to diverge from `main`.
