### PR TITLE
Datahub: Catch OGC API error for geometry

### DIFF
--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core'
 import { select, Store } from '@ngrx/store'
 import {
+  catchError,
   defaultIfEmpty,
   filter,
   map,
   mergeMap,
-  scan,
   switchMap,
   toArray,
 } from 'rxjs/operators'
@@ -119,7 +119,11 @@ export class MdViewFacade {
                     ? link
                     : null
                 }),
-                defaultIfEmpty(null)
+                defaultIfEmpty(null),
+                catchError((e) => {
+                  console.error(e)
+                  return of(null)
+                })
               )
             } else {
               return of(link)


### PR DESCRIPTION
### Description

This PR catches errors for determining whether OGC API items have a geometry or not silently, in order still to display other links with a geometry on the map.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

**This work is sponsored by [MEL](https://www.lillemetropole.fr/)**.
