### PR TITLE
Fix [Datahub]: Map keyword link to key

### DIFF
--- a/libs/api/metadata-converter/src/lib/gn4/atomic-operations.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/atomic-operations.spec.ts
@@ -30,29 +30,65 @@ describe('atomic operations', () => {
           id: '1',
           theme: 'theme',
           keywords: [
-            { en: 'keyword1', fr: 'mot-clé1' },
-            { en: 'keyword2', fr: 'mot-clé2' },
+            {
+              en: 'keyword1',
+              fr: 'mot-clé1',
+              link: 'https://some-uri.org/thematique/categories/culture_tourisme_sport',
+            },
+            {
+              en: 'keyword2',
+              fr: 'mot-clé2',
+              link: 'https://some-uri.org/thematique/categories/services_social_sante',
+            },
           ],
         },
         {
           id: '2',
           theme: 'place',
           keywords: [
-            { en: 'keyword3', fr: 'mot-clé3' },
-            { en: 'keyword4', fr: 'mot-clé4' },
+            {
+              en: 'keyword3',
+              fr: 'mot-clé3',
+              link: 'https://some-uri.org/place/france',
+            },
+            {
+              en: 'keyword4',
+              fr: 'mot-clé4',
+              link: 'https://some-uri.org/place/europe',
+            },
           ],
         },
       ]
       const expected = [
-        { label: 'keyword1', type: 'theme', thesaurus: { id: '1' } },
-        { label: 'keyword2', type: 'theme', thesaurus: { id: '1' } },
-        { label: 'keyword3', type: 'place', thesaurus: { id: '2' } },
-        { label: 'keyword4', type: 'place', thesaurus: { id: '2' } },
+        {
+          label: 'keyword1',
+          type: 'theme',
+          key: 'https://some-uri.org/thematique/categories/culture_tourisme_sport',
+          thesaurus: { id: '1' },
+        },
+        {
+          label: 'keyword2',
+          type: 'theme',
+          key: 'https://some-uri.org/thematique/categories/services_social_sante',
+          thesaurus: { id: '1' },
+        },
+        {
+          label: 'keyword3',
+          type: 'place',
+          key: 'https://some-uri.org/place/france',
+          thesaurus: { id: '2' },
+        },
+        {
+          label: 'keyword4',
+          type: 'place',
+          key: 'https://some-uri.org/place/europe',
+          thesaurus: { id: '2' },
+        },
       ]
       expect(mapKeywords(thesauri, 'en')).toEqual(expected)
     })
 
-    it('should default type to "other" if theme is not provided', () => {
+    it('should default type to "other" if theme is not provided and not break without link', () => {
       const thesauri = [
         {
           id: '1',

--- a/libs/api/metadata-converter/src/lib/gn4/atomic-operations.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/atomic-operations.ts
@@ -120,6 +120,7 @@ export const mapKeywords = (thesauri: Thesaurus[], language: string) => {
       keywords.push({
         label: selectTranslatedValue<string>(keyword, language),
         type: getKeywordTypeFromKeywordTypeCode(rawThesaurus.theme),
+        ...(keyword.link && { key: keyword.link }),
         ...(thesaurus && { thesaurus }),
       })
     }

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
@@ -954,6 +954,7 @@ describe('Gn4Converter', () => {
                 name: 'GEMET themes',
               },
               type: 'theme',
+              key: 'http://www.eionet.europa.eu/gemet/theme/1',
             },
             {
               label: 'Unterschlupf',

--- a/libs/api/metadata-converter/src/lib/gn4/types/metadata.model.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/types/metadata.model.ts
@@ -5,6 +5,7 @@ type MultilingualField = {
   [K in `lang${LangCode}`]: string
 } & {
   default: string
+  link?: string
 }
 
 type BooleanString = 'true' | 'false'


### PR DESCRIPTION
### Description

The PR maps the ES `keyword.link` from `allKeywords` to gn-ui's `Keyword.key`, which we forgot in https://github.com/geonetwork/geonetwork-ui/pull/811 I think. This is necessary to allow updating search (filters) using the key.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

**This work is sponsored by [MEL](https://www.lillemetropole.fr/)**.
