### PR TITLE
[Datahub] : Handle erroneous api links

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -738,6 +738,16 @@ describe('api form', () => {
           .should('not.eq', url)
       })
   })
+  describe('When the api link has an error', () => {
+    beforeEach(() => {
+      cy.visit('/dataset/ee965118-2416-4d48-b07e-bbc696f002c2')
+      cy.get('gn-ui-api-card').last().find('button').eq(1).click()
+    })
+
+    it('should display the error message', () => {
+      cy.get('gn-ui-error').should('be.visible')
+    })
+  })
 })
 
 describe('userFeedback', () => {

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.html
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.html
@@ -1,5 +1,8 @@
 <div class="flex flex-col gap-8">
-  <div class="flex flex-col bg-white p-8 ng-star-inserted shadow-xl gap-8">
+  <div
+    class="flex flex-col bg-white p-8 ng-star-inserted shadow-xl gap-8"
+    *ngIf="apiQueryUrl$ | async"
+  >
     <div class="flex flex-row">
       <div class="text-[16px] text-black truncate font-title w-11/12" translate>
         record.metadata.api.form.create
@@ -78,7 +81,7 @@
       </div>
     </div>
   </div>
-  <div class="flex flex-col gap-3 mb-3">
+  <div class="flex flex-col gap-3 mb-3" *ngIf="apiQueryUrl$ | async">
     <div class="text-sm text-black truncate font-title w-11/12" translate>
       record.metadata.api.form.customUrl
     </div>
@@ -88,4 +91,12 @@
       ></gn-ui-copy-text-button>
     </div>
   </div>
+  <ng-container *ngIf="isLoading">
+    <gn-ui-spinning-loader class="ml-[30rem]"></gn-ui-spinning-loader>
+  </ng-container>
+  <gn-ui-error
+    *ngIf="(apiQueryUrl$ | async) === undefined && !isLoading"
+    [type]="errorTypes.RECEIVED_ERROR"
+    [error]="'record.metadata.api.form.error' | translate"
+  ></gn-ui-error>
 </div>

--- a/translations/de.json
+++ b/translations/de.json
@@ -282,6 +282,7 @@
   "record.metadata.api.form.closeForm": "Formular schließen",
   "record.metadata.api.form.create": "Ihre Anfrage erstellen",
   "record.metadata.api.form.customUrl": "Benutzerdefinierte URL",
+  "record.metadata.api.form.error": "",
   "record.metadata.api.form.limit": "Anzahl der Datensätze",
   "record.metadata.api.form.limit.all": "Alle",
   "record.metadata.api.form.offset": "Anzahl des ersten Datensatzes",

--- a/translations/en.json
+++ b/translations/en.json
@@ -282,6 +282,7 @@
   "record.metadata.api.form.closeForm": "Close the form",
   "record.metadata.api.form.create": "Create your request",
   "record.metadata.api.form.customUrl": "Custom URL",
+  "record.metadata.api.form.error": "The service returned an error.",
   "record.metadata.api.form.limit": "Count of records",
   "record.metadata.api.form.limit.all": "All",
   "record.metadata.api.form.offset": "Count of first record",

--- a/translations/es.json
+++ b/translations/es.json
@@ -282,6 +282,7 @@
   "record.metadata.api.form.closeForm": "",
   "record.metadata.api.form.create": "",
   "record.metadata.api.form.customUrl": "",
+  "record.metadata.api.form.error": "",
   "record.metadata.api.form.limit": "",
   "record.metadata.api.form.limit.all": "",
   "record.metadata.api.form.offset": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -282,6 +282,7 @@
   "record.metadata.api.form.closeForm": "Fermer le panneau de personnalisation",
   "record.metadata.api.form.create": "Paramétrer votre requête",
   "record.metadata.api.form.customUrl": "URL personnalisée",
+  "record.metadata.api.form.error": "Le service a renvoyé un message d'erreur.",
   "record.metadata.api.form.limit": "Nombre d'enregistrements",
   "record.metadata.api.form.limit.all": "Tous",
   "record.metadata.api.form.offset": "Numéro du 1er enregistrement",

--- a/translations/it.json
+++ b/translations/it.json
@@ -282,6 +282,7 @@
   "record.metadata.api.form.closeForm": "Chiudi il pannello di personalizzazione",
   "record.metadata.api.form.create": "Configura la sua richiesta",
   "record.metadata.api.form.customUrl": "URL personalizzata",
+  "record.metadata.api.form.error": "",
   "record.metadata.api.form.limit": "Numero di record",
   "record.metadata.api.form.limit.all": "Tutti",
   "record.metadata.api.form.offset": "Numero del primo record",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -282,6 +282,7 @@
   "record.metadata.api.form.closeForm": "",
   "record.metadata.api.form.create": "",
   "record.metadata.api.form.customUrl": "",
+  "record.metadata.api.form.error": "",
   "record.metadata.api.form.limit": "",
   "record.metadata.api.form.limit.all": "",
   "record.metadata.api.form.offset": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -282,6 +282,7 @@
   "record.metadata.api.form.closeForm": "",
   "record.metadata.api.form.create": "",
   "record.metadata.api.form.customUrl": "",
+  "record.metadata.api.form.error": "",
   "record.metadata.api.form.limit": "",
   "record.metadata.api.form.limit.all": "",
   "record.metadata.api.form.offset": "",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -282,6 +282,7 @@
   "record.metadata.api.form.closeForm": "Zavrieť formulár",
   "record.metadata.api.form.create": "Vytvoriť požiadavku",
   "record.metadata.api.form.customUrl": "Vlastná URL",
+  "record.metadata.api.form.error": "",
   "record.metadata.api.form.limit": "Počet záznamov",
   "record.metadata.api.form.limit.all": "Všetky",
   "record.metadata.api.form.offset": "Počet prvých záznamov",


### PR DESCRIPTION
### Description

This PR aims at displaying an error message in the API form when the link is erroneous/dead/not responding. It would also add a spinning loader for the delay during which the initial requests are made.

### Screenshots

![image](https://github.com/geonetwork/geonetwork-ui/assets/132347903/9c0a57f0-4888-466e-9105-02a6f940dd76)

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [MEL](xx)**.
