### PR TITLE
ME: duplicate local record

### DIFF
--- a/apps/metadata-editor/src/app/app.routes.ts
+++ b/apps/metadata-editor/src/app/app.routes.ts
@@ -10,6 +10,7 @@ import { SearchRecordsComponent } from './records/search-records/search-records-
 import { MyOrgUsersComponent } from './my-org-users/my-org-users.component'
 import { MyOrgRecordsComponent } from './records/my-org-records/my-org-records.component'
 import { NewRecordResolver } from './new-record.resolver'
+import { DuplicateRecordResolver } from './duplicate-record.resolver'
 
 export const appRoutes: Route[] = [
   { path: '', redirectTo: 'catalog/search', pathMatch: 'prefix' },
@@ -100,6 +101,11 @@ export const appRoutes: Route[] = [
     path: 'create',
     component: EditPageComponent,
     resolve: { record: NewRecordResolver },
+  },
+  {
+    path: 'duplicate/:uuid',
+    component: EditPageComponent,
+    resolve: { record: DuplicateRecordResolver },
   },
   {
     path: 'edit/:uuid',

--- a/apps/metadata-editor/src/app/duplicate-record.resolver.spec.ts
+++ b/apps/metadata-editor/src/app/duplicate-record.resolver.spec.ts
@@ -1,0 +1,84 @@
+import { TestBed } from '@angular/core/testing'
+import { DuplicateRecordResolver } from './duplicate-record.resolver'
+import { HttpClientTestingModule } from '@angular/common/http/testing'
+import { NotificationsService } from '@geonetwork-ui/feature/notifications'
+import { of, throwError } from 'rxjs'
+import { DATASET_RECORDS } from '@geonetwork-ui/common/fixtures'
+import { ActivatedRouteSnapshot, convertToParamMap } from '@angular/router'
+import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
+import { TranslateModule } from '@ngx-translate/core'
+import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
+
+class NotificationsServiceMock {
+  showNotification = jest.fn()
+}
+class RecordsRepositoryMock {
+  openRecordForDuplication = jest.fn(() =>
+    of([DATASET_RECORDS[0], '<xml>blabla</xml>', false])
+  )
+}
+
+const activatedRoute = {
+  paramMap: convertToParamMap({ id: DATASET_RECORDS[0].uniqueIdentifier }),
+} as ActivatedRouteSnapshot
+
+describe('DuplicateRecordResolver', () => {
+  let resolver: DuplicateRecordResolver
+  let recordsRepository: RecordsRepositoryInterface
+  let notificationsService: NotificationsService
+  let resolvedData: [CatalogRecord, string, boolean]
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, TranslateModule.forRoot()],
+      providers: [
+        { provide: NotificationsService, useClass: NotificationsServiceMock },
+        {
+          provide: RecordsRepositoryInterface,
+          useClass: RecordsRepositoryMock,
+        },
+      ],
+    })
+    resolver = TestBed.inject(DuplicateRecordResolver)
+    recordsRepository = TestBed.inject(RecordsRepositoryInterface)
+    notificationsService = TestBed.inject(NotificationsService)
+  })
+
+  it('should be created', () => {
+    expect(resolver).toBeTruthy()
+  })
+
+  describe('load record success', () => {
+    beforeEach(() => {
+      resolvedData = undefined
+      resolver.resolve(activatedRoute).subscribe((r) => (resolvedData = r))
+    })
+    it('should load record by uuid', () => {
+      expect(resolvedData).toEqual([
+        DATASET_RECORDS[0],
+        '<xml>blabla</xml>',
+        false,
+      ])
+    })
+  })
+
+  describe('load record failure', () => {
+    beforeEach(() => {
+      recordsRepository.openRecordForDuplication = () =>
+        throwError(() => new Error('oopsie'))
+      resolvedData = undefined
+      resolver.resolve(activatedRoute).subscribe((r) => (resolvedData = r))
+    })
+    it('should not emit anything', () => {
+      expect(resolvedData).toBeUndefined()
+    })
+    it('should show error notification', () => {
+      expect(notificationsService.showNotification).toHaveBeenCalledWith({
+        type: 'error',
+        title: 'editor.record.loadError.title',
+        text: 'editor.record.loadError.body oopsie',
+        closeMessage: 'editor.record.loadError.closeMessage',
+      })
+    })
+  })
+})

--- a/apps/metadata-editor/src/app/duplicate-record.resolver.ts
+++ b/apps/metadata-editor/src/app/duplicate-record.resolver.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core'
+import { ActivatedRouteSnapshot } from '@angular/router'
+import { catchError, EMPTY, Observable } from 'rxjs'
+import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
+import { NotificationsService } from '@geonetwork-ui/feature/notifications'
+import { TranslateService } from '@ngx-translate/core'
+import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DuplicateRecordResolver {
+  constructor(
+    private recordsRepository: RecordsRepositoryInterface,
+    private notificationsService: NotificationsService,
+    private translateService: TranslateService
+  ) {}
+
+  resolve(
+    route: ActivatedRouteSnapshot
+  ): Observable<[CatalogRecord, string, boolean]> {
+    return this.recordsRepository
+      .openRecordForDuplication(route.paramMap.get('uuid'))
+      .pipe(
+        catchError((error) => {
+          this.notificationsService.showNotification({
+            type: 'error',
+            title: this.translateService.instant(
+              'editor.record.loadError.title'
+            ),
+            text: `${this.translateService.instant(
+              'editor.record.loadError.body'
+            )} ${error.message}`,
+            closeMessage: this.translateService.instant(
+              'editor.record.loadError.closeMessage'
+            ),
+          })
+          return EMPTY
+        })
+      )
+  }
+}

--- a/apps/metadata-editor/src/app/records/records-list.component.html
+++ b/apps/metadata-editor/src/app/records/records-list.component.html
@@ -53,6 +53,7 @@
   >
     <gn-ui-results-table-container
       (recordClick)="editRecord($event)"
+      (duplicateRecord)="duplicateRecord($event)"
     ></gn-ui-results-table-container>
     <div class="px-5 py-5 flex justify-center gap-8 items-baseline">
       <div class="grow">

--- a/apps/metadata-editor/src/app/records/records-list.component.spec.ts
+++ b/apps/metadata-editor/src/app/records/records-list.component.spec.ts
@@ -22,6 +22,7 @@ const totalPages = 25
 })
 export class ResultsTableContainerComponent {
   @Output() recordClick = new EventEmitter<CatalogRecord>()
+  @Output() duplicateRecord = new EventEmitter<CatalogRecord>()
 }
 
 @Component({
@@ -134,6 +135,19 @@ describe('RecordsListComponent', () => {
       })
       it('routes to record edition', () => {
         expect(router.navigate).toHaveBeenCalledWith(['/edit', 123])
+      })
+    })
+    describe('when asking for record duplication', () => {
+      const uniqueIdentifier = 123
+      const singleRecord = {
+        ...DATASET_RECORDS[0],
+        uniqueIdentifier,
+      }
+      beforeEach(() => {
+        table.duplicateRecord.emit(singleRecord)
+      })
+      it('routes to record duplication', () => {
+        expect(router.navigate).toHaveBeenCalledWith(['/duplicate', 123])
       })
     })
     describe('when click on pagination', () => {

--- a/apps/metadata-editor/src/app/records/records-list.component.ts
+++ b/apps/metadata-editor/src/app/records/records-list.component.ts
@@ -67,6 +67,10 @@ export class RecordsListComponent {
     this.router.navigate(['/edit', record.uniqueIdentifier])
   }
 
+  duplicateRecord(record: CatalogRecord) {
+    this.router.navigate(['/duplicate', record.uniqueIdentifier])
+  }
+
   showUsers() {
     this.router.navigate(['/users/my-org'])
   }

--- a/apps/metadata-editor/src/app/records/search-records/search-records-list.component.html
+++ b/apps/metadata-editor/src/app/records/search-records/search-records-list.component.html
@@ -43,6 +43,7 @@
     <gn-ui-results-table-container
       class="text-[14px]"
       (recordClick)="editRecord($event)"
+      (duplicateRecord)="duplicateRecord($event)"
     ></gn-ui-results-table-container>
 
     <div class="px-5 py-5 flex justify-center gap-8 items-baseline">

--- a/apps/metadata-editor/src/app/records/search-records/search-records-list.component.spec.ts
+++ b/apps/metadata-editor/src/app/records/search-records/search-records-list.component.spec.ts
@@ -30,6 +30,7 @@ const totalPages = 25
 })
 export class ResultsTableContainerComponent {
   @Output() recordClick = new EventEmitter<CatalogRecord>()
+  @Output() duplicateRecord = new EventEmitter<CatalogRecord>()
 }
 
 @Component({
@@ -150,6 +151,19 @@ describe('SearchRecordsComponent', () => {
       })
       it('routes to record edition', () => {
         expect(router.navigate).toHaveBeenCalledWith(['/edit', 123])
+      })
+    })
+    describe('when asking for record duplication', () => {
+      const uniqueIdentifier = 123
+      const singleRecord = {
+        ...DATASET_RECORDS[0],
+        uniqueIdentifier,
+      }
+      beforeEach(() => {
+        table.duplicateRecord.emit(singleRecord)
+      })
+      it('routes to record duplication', () => {
+        expect(router.navigate).toHaveBeenCalledWith(['/duplicate', 123])
       })
     })
     describe('when click on pagination', () => {

--- a/apps/metadata-editor/src/app/records/search-records/search-records-list.component.ts
+++ b/apps/metadata-editor/src/app/records/search-records/search-records-list.component.ts
@@ -48,6 +48,10 @@ export class SearchRecordsComponent {
     this.router.navigate(['/edit', record.uniqueIdentifier])
   }
 
+  duplicateRecord(record: CatalogRecord) {
+    this.router.navigate(['/duplicate', record.uniqueIdentifier])
+  }
+
   createRecord() {
     this.router.navigate(['/create'])
   }

--- a/libs/api/metadata-converter/src/index.ts
+++ b/libs/api/metadata-converter/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/base.converter'
 export * from './lib/iso19139'
 export * from './lib/iso19115-3'
 export * from './lib/find-converter'

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -235,15 +235,12 @@ export class Gn4Repository implements RecordsRepositoryInterface {
     uniqueIdentifier: string
   ): Observable<[CatalogRecord, string, false] | null> {
     return this.loadRecordAsXml(uniqueIdentifier).pipe(
-      switchMap(async (xml) => {
-        const converter = findConverterForDocument(xml)
-        const record = await converter.readRecord(xml)
-        return [record, converter] as [CatalogRecord, BaseConverter<string>]
-      }),
-      switchMap(async ([record, converter]) => {
+      switchMap(async (recordAsXml) => {
+        const converter = findConverterForDocument(recordAsXml)
+        const record = await converter.readRecord(recordAsXml)
         record.uniqueIdentifier = `TEMP-ID-${Date.now()}`
         record.title = `${record.title} (Copy)`
-        const xml = await converter.writeRecord(record)
+        const xml = await converter.writeRecord(record, recordAsXml)
         window.localStorage.setItem(
           this.getLocalStorageKeyForRecord(record.uniqueIdentifier),
           xml

--- a/libs/common/domain/src/lib/repository/records-repository.interface.ts
+++ b/libs/common/domain/src/lib/repository/records-repository.interface.ts
@@ -31,6 +31,18 @@ export abstract class RecordsRepositoryInterface {
   ): Observable<[CatalogRecord, string, boolean] | null>
 
   /**
+   * This emits once:
+   * - record object with a new unique identifier and suffixed title
+   * - serialized representation of the record as text
+   * - false, as the duplicated record is always a draft
+   * @param uniqueIdentifier
+   * @returns Observable<[CatalogRecord, string, false] | null>
+   */
+  abstract openRecordForDuplication(
+    uniqueIdentifier: string
+  ): Observable<[CatalogRecord, string, false] | null>
+
+  /**
    * @param record
    * @param referenceRecordSource
    * @returns Observable<string> Returns the unique identifier of the record as it was when saved

--- a/libs/feature/search/src/lib/results-table/results-table-container.component.html
+++ b/libs/feature/search/src/lib/results-table/results-table-container.component.html
@@ -4,6 +4,7 @@
   [selectedRecordsIdentifiers]="selectedRecords$ | async"
   [sortOrder]="sortBy$ | async"
   (recordClick)="handleRecordClick($event)"
+  (duplicateRecord)="handleDuplicateRecord($event)"
   (recordsSelectedChange)="handleRecordsSelectedChange($event[0], $event[1])"
   (sortByChange)="handleSortByChange($event[0], $event[1])"
 ></gn-ui-results-table>

--- a/libs/feature/search/src/lib/results-table/results-table-container.component.spec.ts
+++ b/libs/feature/search/src/lib/results-table/results-table-container.component.spec.ts
@@ -107,7 +107,7 @@ describe('ResultsTableContainerComponent', () => {
     })
   })
 
-  describe('clicking on a title', () => {
+  describe('clicking on a dataset', () => {
     let clickedRecord: CatalogRecord
 
     beforeEach(() => {
@@ -116,10 +116,10 @@ describe('ResultsTableContainerComponent', () => {
     })
 
     it('emits a recordClick event', () => {
-      const titleCell = fixture.debugElement.query(
-        By.css('[data-test="record-title-cell"]')
-      ).nativeElement as HTMLDivElement
-      titleCell.click()
+      const tableRow = fixture.debugElement.queryAll(
+        By.css('.table-row-cell')
+      )[1].nativeElement as HTMLDivElement
+      tableRow.parentElement.click()
       expect(clickedRecord).toEqual(DATASET_RECORDS[0])
     })
   })

--- a/libs/feature/search/src/lib/results-table/results-table-container.component.spec.ts
+++ b/libs/feature/search/src/lib/results-table/results-table-container.component.spec.ts
@@ -1,14 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { DATASET_RECORDS } from '@geonetwork-ui/common/fixtures'
-import { ResultsTableContainerComponent } from './results-table-container.component'
-import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
 import { By } from '@angular/platform-browser'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
+import { SelectionService } from '@geonetwork-ui/api/repository'
+import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
+import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
+import { DATASET_RECORDS } from '@geonetwork-ui/common/fixtures'
+import { TranslateModule } from '@ngx-translate/core'
 import { BehaviorSubject } from 'rxjs'
 import { SearchFacade } from '../state/search.facade'
 import { SearchService } from '../utils/service/search.service'
-import { SelectionService } from '@geonetwork-ui/api/repository'
-import { TranslateModule } from '@ngx-translate/core'
-import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
+import { ResultsTableContainerComponent } from './results-table-container.component'
 
 class SearchFacadeMock {
   results$ = new BehaviorSubject(DATASET_RECORDS)
@@ -40,7 +41,7 @@ describe('ResultsTableContainerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot(), NoopAnimationsModule],
       providers: [
         {
           provide: SearchFacade,
@@ -106,7 +107,7 @@ describe('ResultsTableContainerComponent', () => {
     })
   })
 
-  describe('clicking on a dataset', () => {
+  describe('clicking on a title', () => {
     let clickedRecord: CatalogRecord
 
     beforeEach(() => {
@@ -115,11 +116,33 @@ describe('ResultsTableContainerComponent', () => {
     })
 
     it('emits a recordClick event', () => {
-      const tableRow = fixture.debugElement.queryAll(
-        By.css('.table-row-cell')
-      )[1].nativeElement as HTMLDivElement
-      tableRow.parentElement.click()
+      const titleCell = fixture.debugElement.query(
+        By.css('[data-test="record-title-cell"]')
+      ).nativeElement as HTMLDivElement
+      titleCell.click()
       expect(clickedRecord).toEqual(DATASET_RECORDS[0])
+    })
+  })
+
+  describe('duplicating a dataset', () => {
+    let recordToBeDuplicated: CatalogRecord
+
+    beforeEach(() => {
+      recordToBeDuplicated = null
+      component.duplicateRecord.subscribe((r) => (recordToBeDuplicated = r))
+    })
+
+    it('emits a duplicateRecord event', () => {
+      const menuButton = fixture.debugElement.query(
+        By.css('[data-test="record-menu-button"]')
+      ).nativeElement as HTMLButtonElement
+      menuButton.click()
+      fixture.detectChanges()
+      const duplicateButton = fixture.debugElement.query(
+        By.css('[data-test="record-menu-duplicate-button"]')
+      ).nativeElement as HTMLButtonElement
+      duplicateButton.click()
+      expect(recordToBeDuplicated).toEqual(DATASET_RECORDS[0])
     })
   })
 

--- a/libs/feature/search/src/lib/results-table/results-table-container.component.ts
+++ b/libs/feature/search/src/lib/results-table/results-table-container.component.ts
@@ -16,6 +16,7 @@ import { CommonModule } from '@angular/common'
 })
 export class ResultsTableContainerComponent {
   @Output() recordClick = new EventEmitter<CatalogRecord>()
+  @Output() duplicateRecord = new EventEmitter<CatalogRecord>()
 
   records$ = this.searchFacade.results$
   selectedRecords$ = this.selectionService.selectedRecordsIdentifiers$
@@ -33,6 +34,10 @@ export class ResultsTableContainerComponent {
 
   handleRecordClick(item: unknown) {
     this.recordClick.emit(item as CatalogRecord)
+  }
+
+  handleDuplicateRecord(item: unknown) {
+    this.duplicateRecord.emit(item as CatalogRecord)
   }
 
   handleSortByChange(col: string, order: 'asc' | 'desc') {

--- a/libs/ui/search/src/lib/results-table/action-menu/action-menu.component.html
+++ b/libs/ui/search/src/lib/results-table/action-menu/action-menu.component.html
@@ -1,0 +1,17 @@
+<gn-ui-button
+  type="outline"
+  [matMenuTriggerFor]="menu"
+  (buttonClick)="openMenu()"
+  data-test="record-menu-button"
+>
+  <mat-icon class="material-symbols-outlined">more_vert</mat-icon>
+</gn-ui-button>
+<mat-menu #menu="matMenu">
+  <button
+    mat-menu-item
+    (click)="duplicate.emit()"
+    data-test="record-menu-duplicate-button"
+  >
+    <span translate>record.action.duplicate</span>
+  </button>
+</mat-menu>

--- a/libs/ui/search/src/lib/results-table/action-menu/action-menu.component.spec.ts
+++ b/libs/ui/search/src/lib/results-table/action-menu/action-menu.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { TranslateModule } from '@ngx-translate/core'
+import { ActionMenuComponent } from './action-menu.component'
+
+describe('ActionMenuComponent', () => {
+  let component: ActionMenuComponent
+  let fixture: ComponentFixture<ActionMenuComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(ActionMenuComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/ui/search/src/lib/results-table/action-menu/action-menu.component.ts
+++ b/libs/ui/search/src/lib/results-table/action-menu/action-menu.component.ts
@@ -1,0 +1,22 @@
+import { Component, EventEmitter, Output, ViewChild } from '@angular/core'
+import { MatIconModule } from '@angular/material/icon'
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu'
+import { ButtonComponent } from '@geonetwork-ui/ui/inputs'
+import { TranslateModule } from '@ngx-translate/core'
+
+@Component({
+  selector: 'gn-ui-action-menu',
+  templateUrl: './action-menu.component.html',
+  styleUrls: ['./action-menu.component.css'],
+  standalone: true,
+  imports: [MatIconModule, ButtonComponent, MatMenuModule, TranslateModule],
+})
+export class ActionMenuComponent {
+  @Output() duplicate = new EventEmitter<void>()
+
+  @ViewChild(MatMenuTrigger) trigger: MatMenuTrigger
+
+  openMenu() {
+    this.trigger.openMenu()
+  }
+}

--- a/libs/ui/search/src/lib/results-table/results-table.component.html
+++ b/libs/ui/search/src/lib/results-table/results-table.component.html
@@ -1,4 +1,7 @@
-<gn-ui-interactive-table [items]="records">
+<gn-ui-interactive-table
+  [items]="records"
+  (itemClick)="handleRecordClick($event)"
+>
   <!-- SELECTED COLUMN -->
   <gn-ui-interactive-table-column>
     <ng-template #header>
@@ -31,11 +34,7 @@
       <span translate>record.metadata.title</span>
     </ng-template>
     <ng-template #cell let-item>
-      <div
-        class="flex flex-row items-center gap-2 max-w-full"
-        (click)="handleRecordClick(item)"
-        data-test="record-title-cell"
-      >
+      <div class="flex flex-row items-center gap-2 max-w-full">
         <span class="overflow-hidden text-ellipsis">{{ item.title }}</span>
         <gn-ui-badge
           *ngIf="recordHasDraft(item)"
@@ -126,22 +125,8 @@
   <gn-ui-interactive-table-column>
     <ng-template #header> </ng-template>
     <ng-template #cell let-item>
-      <button
-        [matMenuTriggerFor]="menu"
-        (click)="$event.stopPropagation()"
-        data-test="record-menu-button"
-      >
-        <mat-icon class="material-symbols-outlined">more_vert</mat-icon>
-      </button>
-      <mat-menu #menu="matMenu">
-        <button
-          mat-menu-item
-          (click)="handleDuplicateClick($event, item)"
-          data-test="record-menu-duplicate-button"
-        >
-          <span translate>record.action.duplicate</span>
-        </button>
-      </mat-menu>
+      <gn-ui-action-menu (duplicate)="handleDuplicate(item)">
+      </gn-ui-action-menu>
     </ng-template>
   </gn-ui-interactive-table-column>
 </gn-ui-interactive-table>

--- a/libs/ui/search/src/lib/results-table/results-table.component.html
+++ b/libs/ui/search/src/lib/results-table/results-table.component.html
@@ -1,7 +1,4 @@
-<gn-ui-interactive-table
-  [items]="records"
-  (itemClick)="handleRecordClick($event)"
->
+<gn-ui-interactive-table [items]="records">
   <!-- SELECTED COLUMN -->
   <gn-ui-interactive-table-column>
     <ng-template #header>
@@ -34,7 +31,11 @@
       <span translate>record.metadata.title</span>
     </ng-template>
     <ng-template #cell let-item>
-      <div class="flex flex-row items-center gap-2 max-w-full">
+      <div
+        class="flex flex-row items-center gap-2 max-w-full"
+        (click)="handleRecordClick(item)"
+        data-test="record-title-cell"
+      >
         <span class="overflow-hidden text-ellipsis">{{ item.title }}</span>
         <gn-ui-badge
           *ngIf="recordHasDraft(item)"
@@ -118,6 +119,29 @@
     </ng-template>
     <ng-template #cell let-item>
       {{ dateToString(item.recordUpdated) }}
+    </ng-template>
+  </gn-ui-interactive-table-column>
+
+  <!-- ACTION MENU COLUMN -->
+  <gn-ui-interactive-table-column>
+    <ng-template #header> </ng-template>
+    <ng-template #cell let-item>
+      <button
+        [matMenuTriggerFor]="menu"
+        (click)="$event.stopPropagation()"
+        data-test="record-menu-button"
+      >
+        <mat-icon class="material-symbols-outlined">more_vert</mat-icon>
+      </button>
+      <mat-menu #menu="matMenu">
+        <button
+          mat-menu-item
+          (click)="handleDuplicateClick($event, item)"
+          data-test="record-menu-duplicate-button"
+        >
+          <span translate>record.action.duplicate</span>
+        </button>
+      </mat-menu>
     </ng-template>
   </gn-ui-interactive-table-column>
 </gn-ui-interactive-table>

--- a/libs/ui/search/src/lib/results-table/results-table.component.spec.ts
+++ b/libs/ui/search/src/lib/results-table/results-table.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-import { DATASET_RECORDS } from '@geonetwork-ui/common/fixtures'
-import { ResultsTableComponent } from './results-table.component'
-import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
 import { By } from '@angular/platform-browser'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
+import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
+import { DATASET_RECORDS } from '@geonetwork-ui/common/fixtures'
 import { TranslateModule } from '@ngx-translate/core'
+import { ResultsTableComponent } from './results-table.component'
 
 describe('ResultsTableComponent', () => {
   let component: ResultsTableComponent
@@ -11,7 +12,7 @@ describe('ResultsTableComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
+      imports: [TranslateModule.forRoot(), NoopAnimationsModule],
     }).compileComponents()
 
     fixture = TestBed.createComponent(ResultsTableComponent)
@@ -133,7 +134,7 @@ describe('ResultsTableComponent', () => {
     })
   })
 
-  describe('clicking on a dataset', () => {
+  describe('clicking on a title', () => {
     let clickedRecord: CatalogRecord
 
     beforeEach(() => {
@@ -142,11 +143,33 @@ describe('ResultsTableComponent', () => {
     })
 
     it('emits a recordClick event', () => {
-      const tableRow = fixture.debugElement.queryAll(
-        By.css('.table-row-cell')
-      )[1].nativeElement as HTMLDivElement
-      tableRow.parentElement.click()
+      const tableRow = fixture.debugElement.query(
+        By.css('[data-test="record-title-cell"]')
+      ).nativeElement as HTMLDivElement
+      tableRow.click()
       expect(clickedRecord).toEqual(DATASET_RECORDS[0])
+    })
+  })
+
+  describe('duplicating a dataset', () => {
+    let recordToBeDuplicated: CatalogRecord
+
+    beforeEach(() => {
+      recordToBeDuplicated = null
+      component.duplicateRecord.subscribe((r) => (recordToBeDuplicated = r))
+    })
+
+    it('emits a duplicateRecord event', () => {
+      const menuButton = fixture.debugElement.query(
+        By.css('[data-test="record-menu-button"]')
+      ).nativeElement as HTMLButtonElement
+      menuButton.click()
+      fixture.detectChanges()
+      const duplicateButton = fixture.debugElement.query(
+        By.css('[data-test="record-menu-duplicate-button"]')
+      ).nativeElement as HTMLButtonElement
+      duplicateButton.click()
+      expect(recordToBeDuplicated).toEqual(DATASET_RECORDS[0])
     })
   })
 })

--- a/libs/ui/search/src/lib/results-table/results-table.component.spec.ts
+++ b/libs/ui/search/src/lib/results-table/results-table.component.spec.ts
@@ -134,7 +134,7 @@ describe('ResultsTableComponent', () => {
     })
   })
 
-  describe('clicking on a title', () => {
+  describe('clicking on a dataset', () => {
     let clickedRecord: CatalogRecord
 
     beforeEach(() => {
@@ -143,10 +143,10 @@ describe('ResultsTableComponent', () => {
     })
 
     it('emits a recordClick event', () => {
-      const tableRow = fixture.debugElement.query(
-        By.css('[data-test="record-title-cell"]')
-      ).nativeElement as HTMLDivElement
-      tableRow.click()
+      const tableRow = fixture.debugElement.queryAll(
+        By.css('.table-row-cell')
+      )[1].nativeElement as HTMLDivElement
+      tableRow.parentElement.click()
       expect(clickedRecord).toEqual(DATASET_RECORDS[0])
     })
   })

--- a/libs/ui/search/src/lib/results-table/results-table.component.ts
+++ b/libs/ui/search/src/lib/results-table/results-table.component.ts
@@ -1,23 +1,24 @@
+import { CommonModule } from '@angular/common'
 import { Component, EventEmitter, Input, Output } from '@angular/core'
+import { MatIconModule } from '@angular/material/icon'
+import { MatMenuModule } from '@angular/material/menu'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
+import {
+  FieldSort,
+  SortByField,
+} from '@geonetwork-ui/common/domain/model/search'
+import { BadgeComponent, UiInputsModule } from '@geonetwork-ui/ui/inputs'
+import {
+  InteractiveTableColumnComponent,
+  InteractiveTableComponent,
+} from '@geonetwork-ui/ui/layout'
 import {
   FileFormat,
   getBadgeColor,
   getFileFormat,
   getFormatPriority,
 } from '@geonetwork-ui/util/shared'
-import { BadgeComponent, UiInputsModule } from '@geonetwork-ui/ui/inputs'
-import {
-  InteractiveTableColumnComponent,
-  InteractiveTableComponent,
-} from '@geonetwork-ui/ui/layout'
-import { MatIconModule } from '@angular/material/icon'
 import { TranslateModule } from '@ngx-translate/core'
-import { CommonModule } from '@angular/common'
-import {
-  FieldSort,
-  SortByField,
-} from '@geonetwork-ui/common/domain/model/search'
 
 @Component({
   selector: 'gn-ui-results-table',
@@ -32,6 +33,7 @@ import {
     MatIconModule,
     TranslateModule,
     BadgeComponent,
+    MatMenuModule,
   ],
 })
 export class ResultsTableComponent {
@@ -43,6 +45,7 @@ export class ResultsTableComponent {
   // emits the column (field) as well as the order
   @Output() sortByChange = new EventEmitter<[string, 'asc' | 'desc']>()
   @Output() recordClick = new EventEmitter<CatalogRecord>()
+  @Output() duplicateRecord = new EventEmitter<CatalogRecord>()
   @Output() recordsSelectedChange = new EventEmitter<
     [CatalogRecord[], boolean]
   >()
@@ -87,6 +90,11 @@ export class ResultsTableComponent {
 
   handleRecordClick(item: unknown) {
     this.recordClick.emit(item as CatalogRecord)
+  }
+
+  handleDuplicateClick(event: Event, item: unknown) {
+    event.stopPropagation()
+    this.duplicateRecord.emit(item as CatalogRecord)
   }
 
   setSortBy(col: string, order: 'asc' | 'desc') {

--- a/libs/ui/search/src/lib/results-table/results-table.component.ts
+++ b/libs/ui/search/src/lib/results-table/results-table.component.ts
@@ -1,7 +1,13 @@
 import { CommonModule } from '@angular/common'
-import { Component, EventEmitter, Input, Output } from '@angular/core'
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core'
 import { MatIconModule } from '@angular/material/icon'
-import { MatMenuModule } from '@angular/material/menu'
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
 import {
   FieldSort,
@@ -19,6 +25,7 @@ import {
   getFormatPriority,
 } from '@geonetwork-ui/util/shared'
 import { TranslateModule } from '@ngx-translate/core'
+import { ActionMenuComponent } from './action-menu/action-menu.component'
 
 @Component({
   selector: 'gn-ui-results-table',
@@ -33,7 +40,7 @@ import { TranslateModule } from '@ngx-translate/core'
     MatIconModule,
     TranslateModule,
     BadgeComponent,
-    MatMenuModule,
+    ActionMenuComponent,
   ],
 })
 export class ResultsTableComponent {
@@ -92,8 +99,7 @@ export class ResultsTableComponent {
     this.recordClick.emit(item as CatalogRecord)
   }
 
-  handleDuplicateClick(event: Event, item: unknown) {
-    event.stopPropagation()
+  handleDuplicate(item: unknown) {
     this.duplicateRecord.emit(item as CatalogRecord)
   }
 

--- a/translations/de.json
+++ b/translations/de.json
@@ -306,6 +306,7 @@
   "pagination.pageOf": "von",
   "previous": "zurück",
   "record.action.download": "Herunterladen",
+  "record.action.duplicate": "",
   "record.action.view": "Anzeigen",
   "record.externalViewer.open": "In externem Kartenviewer öffnen",
   "record.metadata.about": "Beschreibung",

--- a/translations/en.json
+++ b/translations/en.json
@@ -306,6 +306,7 @@
   "pagination.pageOf": "of",
   "previous": "previous",
   "record.action.download": "Download",
+  "record.action.duplicate": "Duplicate",
   "record.action.view": "View",
   "record.externalViewer.open": "Open in the external map viewer",
   "record.metadata.about": "Description",

--- a/translations/es.json
+++ b/translations/es.json
@@ -306,6 +306,7 @@
   "pagination.pageOf": "",
   "previous": "",
   "record.action.download": "",
+  "record.action.duplicate": "",
   "record.action.view": "",
   "record.externalViewer.open": "",
   "record.metadata.about": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -306,6 +306,7 @@
   "pagination.pageOf": "sur",
   "previous": "précédent",
   "record.action.download": "Télécharger",
+  "record.action.duplicate": "Dupliquer",
   "record.action.view": "Voir",
   "record.externalViewer.open": "Ouvrir dans le visualiseur externe",
   "record.metadata.about": "Description",

--- a/translations/it.json
+++ b/translations/it.json
@@ -306,6 +306,7 @@
   "pagination.pageOf": "di",
   "previous": "precedente",
   "record.action.download": "Scarica",
+  "record.action.duplicate": "",
   "record.action.view": "Visualizza",
   "record.externalViewer.open": "Apri nell'visualizzatore esterno",
   "record.metadata.about": "Descrizione",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -306,6 +306,7 @@
   "pagination.pageOf": "",
   "previous": "",
   "record.action.download": "",
+  "record.action.duplicate": "",
   "record.action.view": "",
   "record.externalViewer.open": "",
   "record.metadata.about": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -306,6 +306,7 @@
   "pagination.pageOf": "",
   "previous": "",
   "record.action.download": "",
+  "record.action.duplicate": "",
   "record.action.view": "",
   "record.externalViewer.open": "",
   "record.metadata.about": "",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -306,6 +306,7 @@
   "pagination.pageOf": "z",
   "previous": "predchádzajúci",
   "record.action.download": "Stiahnuť",
+  "record.action.duplicate": "",
   "record.action.view": "Zobraziť",
   "record.externalViewer.open": "Otvoriť v externom mapovom prehliadači",
   "record.metadata.about": "O",


### PR DESCRIPTION
### Description

This PR introduces the local record duplication feature, from the action menu on each record, in all records tables.

The click interaction on a record to open it has been moved to only the title, to allow a click on the menu.

When clicking on the duplicate action, the app navigates to a new duplicate route, which take an UUID as parameter, to read a local record, save it as a copy draft, then enter edition mode.

### Architectural changes

The ui-search results-table component now depends on the MatMenuModule from Angular Material.

### Screenshots

![image](https://github.com/user-attachments/assets/21d1cf85-24d2-493c-ac93-a92c6c40d987)

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
