### PR TITLE
[Backport 2.3.x] [DATAHUB]: Record has no link error displayed when loading

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -160,7 +160,7 @@ jobs:
         run: cd tools && docker build . -f pipelines/Dockerfile -t geonetwork/geonetwork-ui-tools-pipelines:latest
 
       - name: Build the backend
-        run: sudo docker-compose -f support-services/docker-compose.yml up -d init
+        run: docker compose -f support-services/docker-compose.yml up -d init
 
       - name: Install dependencies
         run: |

--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -93,6 +93,13 @@ describe('dataset pages', () => {
   })
 
   describe('GENERAL : display & functions', () => {
+    describe('no-link-error block', () => {
+      it("shouldn't be there until metadata is fully loaded", () => {
+        cy.visit('/dataset/a3774ef6-809d-4dd1-984f-9254f49cbd0a')
+        cy.get('[data-test=dataset-has-no-link-block]').should('not.exist')
+      })
+    })
+
     describe('header', () => {
       it('should display the title, favorite star group and arrow back', () => {
         cy.get('datahub-header-record')
@@ -576,11 +583,25 @@ describe('dataset pages', () => {
         })
       })
 
-      describe('When there is no link', () => {
-        beforeEach(() => {
-          cy.visit('/dataset/a3774ef6-809d-4dd1-984f-9254f49cbd0a')
-        })
+      describe.only('When there is no link', () => {
         it('display the error datasetHasNoLink error block', () => {
+          cy.login()
+
+          cy.intercept(
+            'GET',
+            '/geonetwork/srv/api/userfeedback?metadataUuid=a3774ef6-809d-4dd1-984f-9254f49cbd0a',
+            (req) => {
+              // Test if the error block is not shown before the metadata is fully loaded
+              cy.get('[data-test="dataset-has-no-link-block"]').should(
+                'not.exist'
+              )
+            }
+          ).as('getData')
+
+          cy.visit('/dataset/a3774ef6-809d-4dd1-984f-9254f49cbd0a')
+
+          cy.wait('@getData')
+
           cy.get('[data-test="dataset-has-no-link-block"]').should('exist')
         })
       })

--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -583,7 +583,7 @@ describe('dataset pages', () => {
         })
       })
 
-      describe.only('When there is no link', () => {
+      describe('When there is no link', () => {
         it('display the error datasetHasNoLink error block', () => {
           cy.login()
 

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
@@ -45,6 +45,7 @@ class MdViewFacadeMock {
   otherLinks$ = new BehaviorSubject([])
   related$ = new BehaviorSubject(null)
   error$ = new BehaviorSubject(null)
+  isMetadataLoading$ = new BehaviorSubject(false)
 }
 
 class SearchServiceMock {
@@ -659,20 +660,39 @@ describe('RecordMetadataComponent', () => {
     })
 
     describe('When there are no link (download, api or other links)', () => {
-      beforeEach(() => {
-        facade.apiLinks$.next([])
-        facade.downloadLinks$.next([])
-        facade.otherLinks$.next([])
-        fixture.detectChanges()
+      describe('When the metadata is not fully loaded', () => {
+        beforeEach(() => {
+          facade.isMetadataLoading$.next(true)
+          facade.apiLinks$.next([])
+          facade.downloadLinks$.next([])
+          facade.otherLinks$.next([])
+          fixture.detectChanges()
+        })
+        it("doesn' show the no link error block", () => {
+          const result = fixture.debugElement.query(
+            By.css('[data-test="dataset-has-no-link-block"]')
+          )
+          expect(result).toBeFalsy()
+        })
       })
-      it('shows the no link error block', () => {
-        const result = fixture.debugElement.query(
-          By.css('[data-test="dataset-has-no-link-block"]')
-        )
-        expect(result).toBeTruthy()
-        expect(result.componentInstance.type).toBe(
-          ErrorType.DATASET_HAS_NO_LINK
-        )
+
+      describe('When the metadata is not fully loaded', () => {
+        beforeEach(() => {
+          facade.isMetadataLoading$.next(false)
+          facade.apiLinks$.next([])
+          facade.downloadLinks$.next([])
+          facade.otherLinks$.next([])
+          fixture.detectChanges()
+        })
+        it('shows the no link error block', () => {
+          const result = fixture.debugElement.query(
+            By.css('[data-test="dataset-has-no-link-block"]')
+          )
+          expect(result).toBeTruthy()
+          expect(result.componentInstance.type).toBe(
+            ErrorType.DATASET_HAS_NO_LINK
+          )
+        })
       })
     })
   })

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -55,13 +55,17 @@ export class RecordMetadataComponent {
   )
 
   displayDatasetHasNoLinkBlock$ = combineLatest([
+    this.metadataViewFacade.isMetadataLoading$,
     this.displayDownload$,
     this.displayApi$,
     this.displayOtherLinks,
   ]).pipe(
     map(
-      ([displayDownload, displayApi, displayOtherLinks]) =>
-        !displayDownload && !displayApi && !displayOtherLinks
+      ([isMetadataLoading, displayDownload, displayApi, displayOtherLinks]) =>
+        !isMetadataLoading &&
+        !displayDownload &&
+        !displayApi &&
+        !displayOtherLinks
     )
   )
 


### PR DESCRIPTION
Backport of #947

Error on cherry picking:
Error on backporting to branch 2.3.x, error on cherry picking 0587e8a29bfaa21444b118047aa69b1d068414fc:



To continue do:
git fetch && git checkout backport/947-to-2.3.x && git reset --hard HEAD^
git cherry-pick 0587e8a29bfaa21444b118047aa69b1d068414fc
git push origin backport/947-to-2.3.x --force