### PR TITLE
Datahub: Display search filter topic label in plural

### DIFF
--- a/apps/datahub/src/app/record/header-record/header-record.component.html
+++ b/apps/datahub/src/app/record/header-record/header-record.component.html
@@ -43,14 +43,15 @@
     >
       <gn-ui-badge
         *ngIf="(isGeodata$ | async) === true"
-        [style.--gn-ui-badge-padding]="'0.4em 0.75em'"
+        [style.--gn-ui-badge-padding]="'0.5em 0.75em'"
         [style.--gn-ui-badge-background-color]="'var(--color-primary-darker)'"
         [style.--gn-ui-badge-opacity]="'1'"
+        [style.font-size]="'0.85em'"
       >
-        <mat-icon class="material-symbols-outlined mt-0.5 ml-2 text-[20px]">
+        <mat-icon class="material-symbols-outlined mr-2">
           my_location
         </mat-icon>
-        <span class="ml-2 mr-2" translate>record.metadata.type</span>
+        <span class="font-semibold" translate>record.metadata.type</span>
       </gn-ui-badge>
       <div *ngIf="metadata.recordUpdated">
         <p translate [translateParams]="{ date: lastUpdate }">

--- a/translations/de.json
+++ b/translations/de.json
@@ -438,7 +438,7 @@
   "search.filters.resourceType": "Ressourcentyp",
   "search.filters.standard": "Standard",
   "search.filters.title": "Ergebnisse filtern",
-  "search.filters.topic": "Thema",
+  "search.filters.topic": "Themen",
   "search.filters.useSpatialFilter": "Zuerst Datensätze im Interessenbereich anzeigen",
   "search.filters.useSpatialFilterHelp": "Wenn diese Option aktiviert ist, werden Datensätze im Bereich des Katalogs zuerst angezeigt. Datensätze außerhalb dieses Bereichs werden nicht angezeigt.",
   "share.tab.permalink": "Teilen",

--- a/translations/en.json
+++ b/translations/en.json
@@ -438,7 +438,7 @@
   "search.filters.resourceType": "Resource type",
   "search.filters.standard": "Standard",
   "search.filters.title": "Filter your results",
-  "search.filters.topic": "Topic",
+  "search.filters.topic": "Topics",
   "search.filters.useSpatialFilter": "Show records in the area of interest first",
   "search.filters.useSpatialFilterHelp": "When this is enabled, records situated in the catalog's area of interest are shown first; records outside of this area will not show up.",
   "share.tab.permalink": "Share",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -438,7 +438,7 @@
   "search.filters.resourceType": "Type de ressource",
   "search.filters.standard": "Standard",
   "search.filters.title": "Affiner votre recherche",
-  "search.filters.topic": "Thème",
+  "search.filters.topic": "Thèmes",
   "search.filters.useSpatialFilter": "Mettre en avant les résultats sur la zone d'intérêt",
   "search.filters.useSpatialFilterHelp": "Si cette option est activée, les fiches portant sur la zone d'intérêt du catalogue seront montrées en premier; les fiches en dehors de cette zone n'apparaîtront pas dans les résultats.",
   "share.tab.permalink": "Partager",

--- a/translations/it.json
+++ b/translations/it.json
@@ -438,7 +438,7 @@
   "search.filters.resourceType": "Tipo di risorsa",
   "search.filters.standard": "Standard",
   "search.filters.title": "Affina la sua ricerca",
-  "search.filters.topic": "Argomento",
+  "search.filters.topic": "Argomenti",
   "search.filters.useSpatialFilter": "Evidenzia i risultati nell'area di interesse",
   "search.filters.useSpatialFilterHelp": "Se attivata, le schede relative all'area di interesse del catalogo saranno mostrate per prime; le schede al di fuori di questa area non appariranno nei risultati.",
   "share.tab.permalink": "Condividere",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -438,7 +438,7 @@
   "search.filters.resourceType": "Typ zdroja",
   "search.filters.standard": "Štandard",
   "search.filters.title": "Filtrovanie výsledkov",
-  "search.filters.topic": "Téma",
+  "search.filters.topic": "Témy",
   "search.filters.useSpatialFilter": "Najskôr zobraziť záznamy v oblasti záujmu",
   "search.filters.useSpatialFilterHelp": "Keď je táto možnosť zapnutá, záznamy nachádzajúce sa v oblasti záujmu katalógu sa zobrazia ako prvé; záznamy mimo tejto oblasti sa nezobrazia.",
   "share.tab.permalink": "Zdieľať",


### PR DESCRIPTION
### Description

This PR introduces proposes to change `topic` to `topics` in the search filter labels (just like `formats`). It might be worth discussing if we should display all search filter labels rather in plural or singular.

Also adds a small refinement on the geo badge.

### Screenshot

![image](https://github.com/user-attachments/assets/b390ff44-f11c-4383-b650-a1a19f113161)


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [Organization ABC](xx)**.
