### PR TITLE
ME: revert image input component

### DIFF
--- a/libs/feature/editor/src/lib/components/overview-upload/overview-upload.component.html
+++ b/libs/feature/editor/src/lib/components/overview-upload/overview-upload.component.html
@@ -2,7 +2,6 @@
   [maxSizeMB]="5"
   [previewUrl]="resourceUrl"
   [altText]="resourceAltText"
-  [formControl]="formControl"
   (fileChange)="handleFileChange($event)"
   (urlChange)="handleUrlChange($event)"
   (altTextChange)="handleAltTextChange($event)"

--- a/libs/feature/editor/src/lib/components/overview-upload/overview-upload.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/overview-upload/overview-upload.component.spec.ts
@@ -68,7 +68,7 @@ describe('OverviewUploadComponent', () => {
     expect(recordsApiService.getAllResources).toHaveBeenCalledWith(metadataUuid)
     expect(component.resourceAltText).toEqual(imageFileName)
     expect(component.resourceFileName).toEqual(imageFileName)
-    expect(component.resourceUrl.href).toEqual(imageUrl)
+    expect(component.resourceUrl).toEqual(imageUrl)
   })
 
   it('should put the file resource on file change', () => {
@@ -80,7 +80,7 @@ describe('OverviewUploadComponent', () => {
       'public'
     )
     expect(component.resourceAltText).toEqual(imageFileName)
-    expect(component.resourceUrl.href).toEqual(imageUrl)
+    expect(component.resourceUrl).toEqual(imageUrl)
   })
 
   it('should put the file resource on alt text change', () => {
@@ -105,7 +105,7 @@ describe('OverviewUploadComponent', () => {
       'public'
     )
     expect(component.resourceAltText).toEqual(imageFileName)
-    expect(component.resourceUrl.href).toEqual(imageUrl)
+    expect(component.resourceUrl).toEqual(imageUrl)
   })
 
   it('should delete the resource corresponding to the metadata UUID on delete', () => {
@@ -115,7 +115,7 @@ describe('OverviewUploadComponent', () => {
       metadataUuid,
       imageFileName
     )
-    expect(component.resourceAltText).toBeNull()
-    expect(component.resourceUrl).toBeNull()
+    expect(component.resourceAltText).toEqual('')
+    expect(component.resourceUrl).toEqual('')
   })
 })

--- a/libs/feature/editor/src/lib/components/record-form/record-form.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/record-form.component.ts
@@ -24,7 +24,6 @@ export class RecordFormComponent {
     if (!model) {
       return
     }
-    console.log(newValue)
     this.facade.updateRecordField(model, newValue)
   }
 

--- a/libs/ui/inputs/src/lib/image-input/image-input.component.html
+++ b/libs/ui/inputs/src/lib/image-input/image-input.component.html
@@ -51,7 +51,7 @@
   <div class="w-full h-full flex flex-col gap-2">
     <label
       gnUiFilesDrop
-      class="block flex-1 border-2 border-dashed border-gray-300 rounded-lg p-6 flex flex-col items-center justify-center gap-4 hover:cursor-pointer"
+      class="block flex-1 border-2 border-dashed border-gray-300 rounded-lg p-6 flex flex-col items-center justify-center gap-4"
       (dragFilesOver)="handleDragFilesOver($event)"
       (dropFiles)="handleDropFiles($event)"
     >

--- a/libs/ui/inputs/src/lib/image-input/image-input.component.ts
+++ b/libs/ui/inputs/src/lib/image-input/image-input.component.ts
@@ -16,7 +16,6 @@ import { ButtonComponent } from '../button/button.component'
 import { FilesDropDirective } from '../files-drop/files-drop.directive'
 import { TranslateModule } from '@ngx-translate/core'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
-import { FormControl, ReactiveFormsModule } from '@angular/forms'
 
 @Component({
   selector: 'gn-ui-image-input',
@@ -31,13 +30,11 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms'
     FilesDropDirective,
     MatProgressSpinnerModule,
     TranslateModule,
-    ReactiveFormsModule,
   ],
 })
 export class ImageInputComponent {
-  @Input() formControl!: FormControl
   @Input() maxSizeMB: number
-  @Input() previewUrl?: URL
+  @Input() previewUrl?: string
   @Input() altText?: string
   @Input() uploadProgress?: number
   @Input() uploadError?: boolean
@@ -130,8 +127,7 @@ export class ImageInputComponent {
             const file = new File([blob], name)
             this.fileChange.emit(file)
           },
-          error: (error) => {
-            console.error(error)
+          error: () => {
             this.downloadError = true
             this.cd.markForCheck()
             this.urlChange.emit(this.urlInputValue)
@@ -169,7 +165,6 @@ export class ImageInputComponent {
   }
 
   handleDelete() {
-    this.formControl.markAsDirty()
     this.delete.emit()
   }
 


### PR DESCRIPTION
### Description

This PR introduces reverts a few changes done in #909 that were breaking the Storybook build.


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->
