### PR TITLE
Fix E2E test failures

### DIFF
--- a/apps/metadata-editor-e2e/project.json
+++ b/apps/metadata-editor-e2e/project.json
@@ -13,6 +13,12 @@
         "browser": "chrome",
         "port": "cypress-auto"
       },
+      "dependsOn": [
+        {
+          "projects": ["datahub-e2e"],
+          "target": "e2e"
+        }
+      ],
       "configurations": {
         "production": {
           "devServerTarget": "metadata-editor:serve:production"

--- a/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
@@ -9,7 +9,6 @@ import Map from 'ol/Map'
 import ImageWMS from 'ol/source/ImageWMS'
 import TileWMS from 'ol/source/TileWMS'
 import XYZ from 'ol/source/XYZ'
-import { firstValueFrom } from 'rxjs'
 import {
   dragPanCondition,
   MapUtilsService,
@@ -22,15 +21,11 @@ import {
   MouseWheelZoom,
   PinchRotate,
 } from 'ol/interaction'
-import {
-  CatalogRecord,
-  DatasetServiceDistribution,
-} from '@geonetwork-ui/common/domain/model/record'
+import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
 import MapBrowserEvent from 'ol/MapBrowserEvent'
-import type { MapContextLayerWmtsModel } from '../map-context/map-context.model'
 import * as olProjProj4 from 'ol/proj/proj4'
 import * as olProj from 'ol/proj'
-import { get } from 'ol/proj'
+import { fromLonLat, get } from 'ol/proj'
 
 jest.mock('@camptocamp/ogc-client', () => ({
   WmsEndpoint: class {
@@ -249,6 +244,9 @@ describe('MapUtilsService', () => {
           .spyOn(olProj, 'transformExtent')
           .mockImplementation((extent) => extent)
       })
+      afterEach(() => {
+        jest.restoreAllMocks()
+      })
 
       describe('extent available in capabilities', () => {
         beforeEach(() => {
@@ -327,7 +325,7 @@ describe('MapUtilsService', () => {
     })
   })
 
-  describe('getRecordExtent', () => {
+  describe('#getRecordExtent', () => {
     it('should return null if spatialExtents is not present or is an empty array', () => {
       const record1: Partial<CatalogRecord> = {}
       const record2: Partial<CatalogRecord> = { spatialExtents: [] }
@@ -336,27 +334,39 @@ describe('MapUtilsService', () => {
       expect(service.getRecordExtent(record2)).toBeNull()
     })
 
-    // FIXME: working locally but not on CI
-    /* it('should return the projected extent of included extents', () => {
+    it('should return the projected extent of included extents', () => {
       const record: Partial<CatalogRecord> = {
         spatialExtents: [
           {
-            bbox: [6.43, 47.663, 7.263, 48.033],
+            bbox: [1, 5, 3, 7],
           },
           {
-            bbox: [7.56, 47.24, 7.86, 47.41],
+            bbox: [2, 3, 5, 6],
           },
           {
-            bbox: [8.2, 47.95, 8.72, 48.26],
+            bbox: [6, 3, 8, 5],
+          },
+          {
+            geometry: {
+              coordinates: [
+                [
+                  [4, 4],
+                  [7, 4],
+                  [7, 8],
+                  [4, 8],
+                  [4, 4],
+                ],
+              ],
+              type: 'Polygon',
+            },
           },
         ],
       }
-
       expect(service.getRecordExtent(record)).toEqual([
-        715784.3258007491, 5981336.544186428, 970705.9597173458,
-        6150219.0853063855,
+        ...fromLonLat([1, 3]),
+        ...fromLonLat([8, 8]),
       ])
-    }) */
+    })
   })
 
   describe('#prioritizePageScroll', () => {

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -32,7 +32,7 @@ import { ProxyService } from '@geonetwork-ui/util/shared'
 import { WmsEndpoint, WmtsEndpoint } from '@camptocamp/ogc-client'
 import { LONLAT_CRS_CODES } from '../constant/projections'
 import { fromEPSGCode, register } from 'ol/proj/proj4'
-import proj4 from 'proj4/dist/proj4'
+import proj4 from 'proj4'
 import { defaults as defaultControls } from 'ol/control/defaults'
 
 const FEATURE_PROJECTION = 'EPSG:3857'
@@ -220,10 +220,15 @@ export class MapUtilsService {
     if (!('spatialExtents' in record) || record.spatialExtents.length === 0) {
       return null
     }
-    // extend all the spatial extents bbox into an including bbox
+    // extend all the spatial extents into an including bbox
     const totalExtent = record.spatialExtents.reduce(
       (prev, curr) => {
-        return extend(prev, curr.bbox)
+        if ('bbox' in curr) return extend(prev, curr.bbox)
+        else if ('geometry' in curr) {
+          const geom = GEOJSON.readGeometry(curr.geometry)
+          return extend(prev, geom.getExtent())
+        }
+        return prev
       },
       [Infinity, Infinity, -Infinity, -Infinity]
     )

--- a/support-services/docker-entrypoint.d/04-upload-thesauri.sh
+++ b/support-services/docker-entrypoint.d/04-upload-thesauri.sh
@@ -6,6 +6,9 @@ xsrf_token=$(cat /xsrf_token)
 
 echo "Uploading thesauri to GeoNetwork..."
 
+# we're waiting a bit here for GN to be ready to accept thesauri (i.e. the default ones are set up)
+sleep 4
+
 for f in /docker-entrypoint.d/thesauri/*.rdf
 do
   curl -s "http://$host/geonetwork/srv/api/registries/vocabularies" \
@@ -19,12 +22,12 @@ do
 done
 
 # this shows the registered thesauri in GN
-#curl "http://$host/geonetwork/srv/fre/thesaurus?_content_type=json" \
-#  -H 'Accept: application/json, text/plain, */*' \
-#  -H 'Content-Type: multipart/form-data' \
-#  -H 'Accept: application/json, text/plain, */*' \
-#  -H "Cookie: JSESSIONID=$jsessionid; XSRF-TOKEN=$xsrf_token" \
-#  -H "X-XSRF-TOKEN: $xsrf_token"
-#echo ""
+curl -s --no-progress-meter "http://$host/geonetwork/srv/fre/thesaurus?_content_type=json" \
+  -H 'Accept: application/json, text/plain, */*' \
+  -H 'Content-Type: multipart/form-data' \
+  -H 'Accept: application/json, text/plain, */*' \
+  -H "Cookie: JSESSIONID=$jsessionid; XSRF-TOKEN=$xsrf_token" \
+  -H "X-XSRF-TOKEN: $xsrf_token"
+echo ""
 
 echo "Thesauri uploaded to GeoNetwork."

--- a/support-services/docker-entrypoint.d/04-upload-thesauri.sh
+++ b/support-services/docker-entrypoint.d/04-upload-thesauri.sh
@@ -18,12 +18,13 @@ do
   echo ""
 done
 
-curl "http://$host/geonetwork/srv/fre/thesaurus?_content_type=json" \
-  -H 'Accept: application/json, text/plain, */*' \
-  -H 'Content-Type: multipart/form-data' \
-  -H 'Accept: application/json, text/plain, */*' \
-  -H "Cookie: JSESSIONID=$jsessionid; XSRF-TOKEN=$xsrf_token" \
-  -H "X-XSRF-TOKEN: $xsrf_token"
+# this shows the registered thesauri in GN
+#curl "http://$host/geonetwork/srv/fre/thesaurus?_content_type=json" \
+#  -H 'Accept: application/json, text/plain, */*' \
+#  -H 'Content-Type: multipart/form-data' \
+#  -H 'Accept: application/json, text/plain, */*' \
+#  -H "Cookie: JSESSIONID=$jsessionid; XSRF-TOKEN=$xsrf_token" \
+#  -H "X-XSRF-TOKEN: $xsrf_token"
+#echo ""
 
-echo ""
 echo "Thesauri uploaded to GeoNetwork."

--- a/support-services/docker-entrypoint.d/10-index-records.sh
+++ b/support-services/docker-entrypoint.d/10-index-records.sh
@@ -21,7 +21,8 @@ if [ "$result" != '"CREATED"' ]; then
   exit 1
 fi
 
-# then wait for indexing to finish
+# then wait for indexing to start
+# NOTE: this is confusing but GeoNetwork returns indexing=false when indexing has actually started
 indexing=true
 until [ "$indexing" = 'false' ];
 do
@@ -31,9 +32,9 @@ do
       -H "Cookie: JSESSIONID=$jsessionid; XSRF-TOKEN=$xsrf_token" \
       -H "X-XSRF-TOKEN: $xsrf_token"
   )
-  echo "Currently indexing: $indexing"
   sleep 1
 done
+echo "Indexing has successfully started."
 
 # finally check that the index has records in it
 # and that the records count is stable (i.e. indexing is finished)

--- a/support-services/docker-entrypoint.d/11-show-indexation-errors.sh
+++ b/support-services/docker-entrypoint.d/11-show-indexation-errors.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+host=geonetwork:8080
+jsessionid=$(cat /jsessionid)
+xsrf_token=$(cat /xsrf_token)
+
+echo "Querying indexation warnings and errors..."
+
+response=$(
+  curl -s "http://$host/geonetwork/srv/api/search/records/_search" \
+  -H 'Accept: application/json, text/plain, */*' \
+  -H 'Content-Type: application/json;charset=UTF-8' \
+  -H "Cookie: JSESSIONID=$jsessionid; XSRF-TOKEN=$xsrf_token" \
+  -H "X-XSRF-TOKEN: $xsrf_token" \
+  --data-raw '{"size":0,"aggregations":{"errorMsg":{"terms":{"field":"indexingErrorMsg","size":1000}}}}'
+)
+echo "There are $(echo $response | grep -oE '"key":"[^"]+"' | wc -l) indexation errors:"
+echo $response | grep -oE '"key":"[^"]+"' | sed 's/"key":"\([^"]\+\).*"/  > \1/g'
+echo ""


### PR DESCRIPTION
### Description

This PR tweaks E2E tests further. Issues fixed are:
* sometimes the custom thesauri (GEMEt and INSPIRE themes) in the `init ` step were pushed to GN, but then the thesauri would be reset and the "regions" thesauri would be pushed instead; I added a delay before pushing the custom thesauri and it always works now!
* I also added a print of the indexation errors happening in the `init` step, so that we can make sure that indexation happens exactly like it does locally (it wasn't the case before the above change)
* I added a dependency from the metadata-editor E2E to datahub E2E because if the editor tests pass first they change the records so that the datahub tests will fail after that; obviously this is not ideal (it shows that the datahub tests are too sensitive) but we can live with that for now

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes
none

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->
