### PR TITLE
ME: rework markdown parser display to be more generic

### DIFF
--- a/apps/datahub/src/app/organization/organization-details/organization-details.component.html
+++ b/apps/datahub/src/app/organization/organization-details/organization-details.component.html
@@ -6,7 +6,7 @@
           <div id="organization-details-left" class="w-2/3 mt-14">
             <div class="flex flex-col gap-11">
               <gn-ui-max-lines [maxLines]="2" *ngIf="organization.description">
-                <div>
+                <div class="mb-6">
                   <gn-ui-markdown-parser
                     data-test="organizationDescription"
                     [textContent]="organization.description"

--- a/libs/ui/elements/src/lib/markdown-editor/markdown-editor.component.html
+++ b/libs/ui/elements/src/lib/markdown-editor/markdown-editor.component.html
@@ -1,5 +1,8 @@
 <div class="h-full flex flex-col">
-  <p class="flex-none mb-2 font-medium text-sm text-gray-900">
+  <p
+    *ngIf="helperText"
+    class="flex-none mb-2 font-medium text-sm text-gray-900"
+  >
     {{ helperText }}
   </p>
   <div class="flex-1" [hidden]="preview">

--- a/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.css
+++ b/libs/ui/elements/src/lib/markdown-parser/markdown-parser.component.css
@@ -2,9 +2,10 @@
 :host ::ng-deep .markdown-body {
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
-  margin: 0px 0px 1.5rem 0px;
+  margin: 0;
   line-height: 1.5;
   word-wrap: break-word;
+  height: 100%;
 }
 
 /** Emphasis **/

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -1,7 +1,7 @@
 <div class="mb-6 md-description sm:mb-4 sm:pr-16">
   <gn-ui-content-ghost ghostClass="h-32" [showContent]="fieldReady('abstract')">
     <gn-ui-max-lines [maxLines]="6" *ngIf="metadata.abstract">
-      <div>
+      <div class="mb-6">
         <gn-ui-markdown-parser
           [textContent]="metadata.abstract"
         ></gn-ui-markdown-parser>
@@ -47,19 +47,23 @@
       </ng-template>
     </ng-container>
     <ng-container *ngIf="legalConstraints.length">
-      <gn-ui-markdown-parser
-        *ngFor="let constraint of legalConstraints"
-        [textContent]="constraint"
-      >
-      </gn-ui-markdown-parser>
+      <div class="mb-6">
+        <gn-ui-markdown-parser
+          *ngFor="let constraint of legalConstraints"
+          [textContent]="constraint"
+        >
+        </gn-ui-markdown-parser>
+      </div>
     </ng-container>
     <ng-container *ngIf="otherConstraints.length">
       <div gnUiLinkify *ngFor="let constraint of otherConstraints">
         <h5 translate class="font-medium text-black text-sm mb-[2px] mt-[16px]">
           record.metadata.otherConstraints
         </h5>
-        <gn-ui-markdown-parser [textContent]="constraint">
-        </gn-ui-markdown-parser>
+        <div class="mb-6">
+          <gn-ui-markdown-parser [textContent]="constraint">
+          </gn-ui-markdown-parser>
+        </div>
       </div>
     </ng-container>
 

--- a/libs/ui/layout/src/lib/form-field-wrapper/form-field-wrapper.component.html
+++ b/libs/ui/layout/src/lib/form-field-wrapper/form-field-wrapper.component.html
@@ -12,7 +12,7 @@
       </span>
     </div>
   </div>
-  <div class="flex-1">
+  <div class="flex-1 overflow-y-auto">
     <ng-content></ng-content>
   </div>
 </div>


### PR DESCRIPTION
### Description

This PR makes the markdown parser display more generic, and fixes the height in the rich text form field of the metadata editor.

### Screenshots

![image](https://github.com/user-attachments/assets/8711ab2e-e222-446f-9a2c-e97cffd4869a)

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves