### PR TITLE
fix(ME): do not return null on text fields for new records

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -179,7 +179,7 @@ jobs:
         if: always()
         id: upload-screenshots
         with:
-          name: cypress-screenshots-gn-${{ matrix.gn_version }}
+          name: cypress-screenshots
           path: |
             apps/datahub-e2e/cypress/screenshots/**/*
             apps/metadata-editor-e2e/cypress/screenshots/**/*

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -179,7 +179,7 @@ jobs:
         if: always()
         id: upload-screenshots
         with:
-          name: cypress-screenshots
+          name: cypress-screenshots-gn-${{ matrix.gn_version }}
           path: |
             apps/datahub-e2e/cypress/screenshots/**/*
             apps/metadata-editor-e2e/cypress/screenshots/**/*

--- a/apps/metadata-editor-e2e/src/e2e/create.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/create.cy.ts
@@ -1,0 +1,34 @@
+describe('create', () => {
+  beforeEach(() => {
+    cy.login('admin', 'admin', false)
+    cy.visit('/catalog/search')
+  })
+
+  describe('create new record', () => {
+    it('should create the record without error', () => {
+      // First create a record and its draft
+      cy.get('[data-cy="create-record"]').click()
+
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(1200) // waiting for draft saving to kick in
+
+      // Check that the record is correctly displayed
+      cy.get('gn-ui-record-form').should('be.visible')
+
+      cy.get('gn-ui-record-form')
+        .children()
+        .eq(0)
+        .children()
+        .should('have.length', 3)
+
+      cy.get('[data-test="previousNextPageButtons"]')
+        .children()
+        .eq(0)
+        .should('contain.text', 'Come back later')
+      cy.get('[data-test="previousNextPageButtons"]')
+        .children()
+        .eq(1)
+        .should('contain.text', 'Next')
+    })
+  })
+})

--- a/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
@@ -43,7 +43,7 @@ describe('editor form', () => {
     cy.get('@abstractField').clear()
     cy.get('@abstractField').type('modified abstract')
     // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(1000) // waiting for draft saving to kick in
+    cy.wait(1200) // waiting for draft saving to kick in
     cy.reload()
     cy.get('@abstractField').invoke('val').should('eq', 'modified abstract')
     cy.get('@saveStatus').should('eq', 'draft_changes_pending')

--- a/apps/metadata-editor/src/app/edit/edit-page.component.html
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.html
@@ -9,7 +9,10 @@
     </div>
     <gn-ui-record-form></gn-ui-record-form>
   </div>
-  <div class="p-8 mt-auto flex flex-row justify-between">
+  <div
+    data-test="previousNextPageButtons"
+    class="p-8 mt-auto flex flex-row justify-between"
+  >
     <gn-ui-button
       type="secondary"
       (buttonClick)="previousPageButtonHandler()"

--- a/libs/api/metadata-converter/src/lib/xml-utils.spec.ts
+++ b/libs/api/metadata-converter/src/lib/xml-utils.spec.ts
@@ -2,6 +2,7 @@ import { XmlElement } from '@rgrove/parse-xml'
 import {
   getRootElement,
   parseXmlString,
+  readText,
   renameElements,
   xmlToString,
 } from './xml-utils'
@@ -142,6 +143,23 @@ end.
     </mdb:identificationInfo>
 </mdb:MD_Metadata>
 `)
+    })
+  })
+
+  describe('readText', () => {
+    it('returns the text node in an element', () => {
+      const input = parseXmlString(`
+<root>hello
+world</root>
+`).root
+      expect(readText()(input)).toEqual('hello\nworld')
+    })
+    it('returns an empty string if no text node', () => {
+      const input = parseXmlString(`<root/>`).root
+      expect(readText()(input)).toEqual('')
+    })
+    it('returns null if applied to a falsy element', () => {
+      expect(readText()(null)).toEqual(null)
     })
   })
 })

--- a/libs/api/metadata-converter/src/lib/xml-utils.ts
+++ b/libs/api/metadata-converter/src/lib/xml-utils.ts
@@ -180,11 +180,11 @@ export function findParent(
 
 export function readText(): ChainableFunction<XmlElement, string> {
   return (el) => {
-    const textNode =
-      el && Array.isArray(el.children)
-        ? (el.children.find((node) => node.type === 'text') as XmlText)
-        : null
-    return textNode ? textNode.text : null
+    if (!el) return null
+    const textNode = Array.isArray(el.children)
+      ? (el.children.find((node) => node.type === 'text') as XmlText)
+      : null
+    return textNode ? textNode.text : ''
   }
 }
 


### PR DESCRIPTION
This was causing some mandatory text fields (abstract and lineage) to become null after a draft was saved for the first time.