### PR TITLE
ME: fix a bug when clicking "back" after creating a record would cause an error

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/create.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/create.cy.ts
@@ -30,5 +30,14 @@ describe('create', () => {
         .eq(1)
         .should('contain.text', 'Next')
     })
+
+    it('back navigation should go to search after creating a record', () => {
+      // First create a record and its draft
+      cy.get('[data-cy="create-record"]').click()
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(1200) // waiting for draft saving to kick in
+      cy.go('back')
+      cy.url().should('include', '/catalog/search')
+    })
   })
 })

--- a/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
@@ -133,7 +133,9 @@ describe('EditPageComponent', () => {
       const router = TestBed.inject(Router)
       const navigateSpy = jest.spyOn(router, 'navigate')
       ;(facade.draftSaveSuccess$ as any).next()
-      expect(navigateSpy).toHaveBeenCalledWith(['edit', 'my-dataset-001'])
+      expect(navigateSpy).toHaveBeenCalledWith(['edit', 'my-dataset-001'], {
+        replaceUrl: true,
+      })
     })
   })
 

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -102,7 +102,9 @@ export class EditPageComponent implements OnInit, OnDestroy {
     // if we're on the /create route, go to /edit/{uuid} on first change
     if (this.route.snapshot.routeConfig?.path.includes('create')) {
       this.facade.draftSaveSuccess$.pipe(take(1)).subscribe(() => {
-        this.router.navigate(['edit', currentRecord.uniqueIdentifier])
+        this.router.navigate(['edit', currentRecord.uniqueIdentifier], {
+          replaceUrl: true,
+        })
       })
     }
 


### PR DESCRIPTION
### Description

This PR fixes a bug where navigating back after creating a record would take the user back to the `/create` url, which tried creating _another_ record and caused an error.

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

