### PR TITLE
[ME]: Add coverage field (toggle)

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
@@ -237,6 +237,28 @@ describe('editor form', () => {
         ).should('have.length', 7)
       })
     })
+
+    describe('Spatial coverage', () => {
+      it('toggle between national and regional spatial coverage', () => {
+        cy.get('gn-ui-switch-toggle').should('exist')
+
+        cy.get('gn-ui-switch-toggle').find('mat-button-toggle').eq(0).click()
+        cy.get('mat-button-toggle')
+          .eq(0)
+          .should('have.class', 'mat-button-toggle-checked')
+        cy.get('mat-button-toggle')
+          .eq(1)
+          .should('not.have.class', 'mat-button-toggle-checked')
+
+        cy.get('gn-ui-switch-toggle').find('mat-button-toggle').eq(1).click()
+        cy.get('mat-button-toggle')
+          .eq(1)
+          .should('have.class', 'mat-button-toggle-checked')
+        cy.get('mat-button-toggle')
+          .eq(0)
+          .should('not.have.class', 'mat-button-toggle-checked')
+      })
+    })
   })
 
   describe('date range in sortable list', () => {

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.html
@@ -1,4 +1,9 @@
-<div class="flex flex-col gap-3">
+<div class="flex flex-col gap-8">
+  <gn-ui-switch-toggle
+    [options]="switchToggleOptions$ | async"
+    (selectedValue)="onSpatialScopeChange($event)"
+    extraClasses="grow"
+  ></gn-ui-switch-toggle>
   <gn-ui-generic-keywords
     [placeholder]="'Search for place keywords'"
     [keywords]="shownKeywords$ | async"

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.spec.ts
@@ -16,15 +16,7 @@ const NATIONAL_KEYWORD = {
   key: 'http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/national',
   label: 'National',
   description: '',
-  type: 'place',
-  thesaurus: {
-    id: 'external.place.national.en',
-    name: 'National',
-    url: new URL(
-      'http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.place.national.en'
-    ),
-    type: 'place',
-  },
+  type: 'theme',
 }
 
 const SAMPLE_PLACE_KEYWORDS: Keyword[] = [
@@ -376,7 +368,6 @@ describe('FormFieldSpatialExtentComponent', () => {
         component = fixture.componentInstance
         fixture.detectChanges()
 
-        await component.ngOnInit()
         const results = await firstValueFrom(component.switchToggleOptions$)
         const nationalOption = results.filter(
           (result) => result.label === 'National'
@@ -394,7 +385,6 @@ describe('FormFieldSpatialExtentComponent', () => {
         component = fixture.componentInstance
         fixture.detectChanges()
 
-        await component.ngOnInit()
         const results = await firstValueFrom(component.switchToggleOptions$)
         const nationalOption = results.filter(
           (result) => result.label === 'National'
@@ -405,7 +395,7 @@ describe('FormFieldSpatialExtentComponent', () => {
     })
     describe('#onSpatialScopeChange', () => {
       it('removes all existing spatial scope keywords and add the selected one', async () => {
-        const spatialScopes = [{ label: 'national' }, { label: 'regional' }]
+        const spatialScopes = [{ label: 'National' }, { label: 'Regional' }]
 
         const allKeywords = await firstValueFrom(component.allKeywords$)
         const filteredKeywords = allKeywords.filter((keyword) => {
@@ -414,7 +404,7 @@ describe('FormFieldSpatialExtentComponent', () => {
         })
 
         const selectedOption = {
-          label: 'national',
+          label: 'National',
           value: NATIONAL_KEYWORD,
           checked: true,
         }

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.spec.ts
@@ -1,8 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { FormFieldSpatialExtentComponent } from './form-field-spatial-extent.component'
-import { BehaviorSubject, of } from 'rxjs'
+import { BehaviorSubject, firstValueFrom, from, of } from 'rxjs'
 import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.service.interface'
 import {
+  CatalogRecord,
   DatasetSpatialExtent,
   Keyword,
 } from '@geonetwork-ui/common/domain/model/record'
@@ -10,6 +11,21 @@ import { MockBuilder, MockProvider } from 'ng-mocks'
 import { EditorFacade } from '../../../../+state/editor.facade'
 import { datasetRecordsFixture } from '@geonetwork-ui/common/fixtures'
 import { TranslateModule } from '@ngx-translate/core'
+
+const NATIONAL_KEYWORD = {
+  key: 'http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/national',
+  label: 'National',
+  description: '',
+  type: 'place',
+  thesaurus: {
+    id: 'external.place.national.en',
+    name: 'National',
+    url: new URL(
+      'http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.place.national.en'
+    ),
+    type: 'place',
+  },
+}
 
 const SAMPLE_PLACE_KEYWORDS: Keyword[] = [
   // these keywords come from a thesaurus available locally
@@ -341,6 +357,72 @@ describe('FormFieldSpatialExtentComponent', () => {
         expect(editorFacade.updateRecordField).toHaveBeenCalledWith(
           'spatialExtents',
           SAMPLE_SPATIAL_EXTENTS
+        )
+      })
+    })
+  })
+  describe('spatial coverage', () => {
+    describe('switch toggle option is based on the keywords present in the record', () => {
+      it('should return true if the record has a national keyword', async () => {
+        const keywords = [
+          ...SAMPLE_PLACE_KEYWORDS,
+          NATIONAL_KEYWORD,
+        ] as Keyword[]
+        editorFacade = TestBed.inject(EditorFacade)
+        editorFacade.record$ = from([
+          { ...SAMPLE_RECORD, keywords } as CatalogRecord,
+        ])
+        fixture = TestBed.createComponent(FormFieldSpatialExtentComponent)
+        component = fixture.componentInstance
+        fixture.detectChanges()
+
+        await component.ngOnInit()
+        const results = await firstValueFrom(component.switchToggleOptions$)
+        const nationalOption = results.filter(
+          (result) => result.label === 'National'
+        )[0]
+
+        expect(nationalOption.checked).toBe(true)
+      })
+      it('should return false if the record does not have a national keyword', async () => {
+        const keywords2 = [...SAMPLE_PLACE_KEYWORDS] as Keyword[]
+        editorFacade = TestBed.inject(EditorFacade)
+        editorFacade.record$ = from([
+          { ...SAMPLE_RECORD, keywords: keywords2 } as CatalogRecord,
+        ])
+        fixture = TestBed.createComponent(FormFieldSpatialExtentComponent)
+        component = fixture.componentInstance
+        fixture.detectChanges()
+
+        await component.ngOnInit()
+        const results = await firstValueFrom(component.switchToggleOptions$)
+        const nationalOption = results.filter(
+          (result) => result.label === 'National'
+        )[0]
+
+        expect(nationalOption.checked).toBe(false)
+      })
+    })
+    describe('#onSpatialScopeChange', () => {
+      it('removes all existing spatial scope keywords and add the selected one', async () => {
+        const spatialScopes = [{ label: 'national' }, { label: 'regional' }]
+
+        const allKeywords = await firstValueFrom(component.allKeywords$)
+        const filteredKeywords = allKeywords.filter((keyword) => {
+          const spatialScopeLabels = spatialScopes.map((scope) => scope.label)
+          return !spatialScopeLabels.includes(keyword.label)
+        })
+
+        const selectedOption = {
+          label: 'national',
+          value: NATIONAL_KEYWORD,
+          checked: true,
+        }
+        await component.onSpatialScopeChange(selectedOption)
+
+        expect(editorFacade.updateRecordField).toHaveBeenCalledWith(
+          'keywords',
+          [...filteredKeywords, NATIONAL_KEYWORD]
         )
       })
     })

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.ts
@@ -48,9 +48,12 @@ export class FormFieldSpatialExtentComponent {
     map((record) => ('spatialExtents' in record ? record?.spatialExtents : []))
   )
 
+  allKeywords$ = this.editorFacade.record$.pipe(
+    map((record) => record?.keywords)
+  )
+
   switchToggleOptions$: Observable<SwitchToggleOption[]> =
-    this.editorFacade.record$.pipe(
-      map((record) => record?.keywords || []), // Safely access keywords
+    this.allKeywords$.pipe(
       map((keywords) =>
         SPATIAL_SCOPES.map((scope) => {
           const isChecked = keywords.some(
@@ -63,10 +66,6 @@ export class FormFieldSpatialExtentComponent {
         })
       )
     )
-
-  allKeywords$ = this.editorFacade.record$.pipe(
-    map((record) => record?.keywords)
-  )
 
   shownKeywords$ = this.editorFacade.record$.pipe(
     map((record) => record?.keywords.filter((k) => k.type === 'place')),

--- a/libs/feature/editor/src/lib/fields.config.ts
+++ b/libs/feature/editor/src/lib/fields.config.ts
@@ -4,6 +4,7 @@ import {
   EditorField,
   EditorSection,
 } from './models/editor-config.model'
+import { Keyword } from '@geonetwork-ui/common/domain/model/record'
 
 /**
  * This file contains the configuration of the fields that will be displayed in the editor.
@@ -218,7 +219,7 @@ export const DEFAULT_CONFIGURATION: EditorConfig = {
 }
 
 /************************************************************
- ***************           LICENSES            *****************
+ ***************           LICENSES            **************
  ************************************************************
  */
 export const OPEN_DATA_LICENSES: string[] = [
@@ -230,3 +231,38 @@ export const OPEN_DATA_LICENSES: string[] = [
 ]
 
 export const MAX_UPLOAD_SIZE_MB = 10
+/************************************************************
+ ***************        SPATIAL SCOPE            ************
+ ************************************************************
+ */
+
+export const SPATIAL_SCOPES: Keyword[] = [
+  {
+    key: 'http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/national',
+    label: 'National',
+    description: '',
+    type: 'place',
+    thesaurus: {
+      id: 'external.place.national.en',
+      name: 'National',
+      url: new URL(
+        'http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.place.national.en'
+      ),
+      type: 'place',
+    },
+  },
+  {
+    key: 'http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/regional',
+    label: 'Regional',
+    description: '',
+    type: 'place',
+    thesaurus: {
+      id: 'external.place.regional.en',
+      name: 'Regional',
+      url: new URL(
+        'http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.place.regional.en'
+      ),
+      type: 'place',
+    },
+  },
+]

--- a/libs/feature/editor/src/lib/fields.config.ts
+++ b/libs/feature/editor/src/lib/fields.config.ts
@@ -241,28 +241,12 @@ export const SPATIAL_SCOPES: Keyword[] = [
     key: 'http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/national',
     label: 'National',
     description: '',
-    type: 'place',
-    thesaurus: {
-      id: 'external.place.national.en',
-      name: 'National',
-      url: new URL(
-        'http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.place.national.en'
-      ),
-      type: 'place',
-    },
+    type: 'theme',
   },
   {
     key: 'http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/regional',
     label: 'Regional',
     description: '',
-    type: 'place',
-    thesaurus: {
-      id: 'external.place.regional.en',
-      name: 'Regional',
-      url: new URL(
-        'http://localhost:8080/geonetwork/srv/api/registries/vocabularies/external.place.regional.en'
-      ),
-      type: 'place',
-    },
+    type: 'theme',
   },
 ]

--- a/libs/ui/inputs/src/lib/switch-toggle/switch-toggle.component.html
+++ b/libs/ui/inputs/src/lib/switch-toggle/switch-toggle.component.html
@@ -6,7 +6,6 @@
   <mat-button-toggle
     *ngFor="let option of options"
     [aria-label]="option.label"
-    [value]="option.value"
     [checked]="option.checked"
     (change)="onChange(option)"
     [class]="extraClasses"

--- a/libs/ui/inputs/src/lib/switch-toggle/switch-toggle.component.ts
+++ b/libs/ui/inputs/src/lib/switch-toggle/switch-toggle.component.ts
@@ -10,7 +10,7 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle'
 
 export type SwitchToggleOption = {
   label: string
-  value: string
+  value: any
   checked: boolean
 }
 
@@ -30,7 +30,7 @@ export class SwitchToggleComponent {
 
   onChange(selectedOption: SwitchToggleOption) {
     this.options.find(
-      (option) => option.value === selectedOption.value
+      (option) => option.label === selectedOption.label
     ).checked = true
 
     this.selectedValue.emit(selectedOption)

--- a/libs/ui/inputs/src/lib/switch-toggle/switch-toggle.component.ts
+++ b/libs/ui/inputs/src/lib/switch-toggle/switch-toggle.component.ts
@@ -10,7 +10,6 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle'
 
 export type SwitchToggleOption = {
   label: string
-  value: any
   checked: boolean
 }
 

--- a/libs/ui/inputs/src/lib/switch-toggle/switch-toggle.stories.ts
+++ b/libs/ui/inputs/src/lib/switch-toggle/switch-toggle.stories.ts
@@ -17,9 +17,9 @@ export default {
 export const Primary: StoryObj<SwitchToggleComponent> = {
   args: {
     options: [
-      { label: 'city', value: 'city', checked: true },
-      { label: 'municipality', value: 'municipality', checked: false },
-      { label: 'state', value: 'state', checked: false },
+      { label: 'city', checked: true },
+      { label: 'municipality', checked: false },
+      { label: 'state', checked: false },
     ],
     extraClasses: 'grow',
   },


### PR DESCRIPTION
### Description

This PR introduces an addition to the spatial extent field which is the coverage field. This field can be toggled between predefined values (as Keywords). For now we have "national" and "regional" as options.
When a value is selected, the corresponding Keyword will be added to the list of Keywords in the record.

## Note
**Update**: No need to add the thesauri. Having the keywords in the fields config should be enough.
I'm not sure if this is testable without me changing the dump, or manually adding the two new thesauri in geonetwork.
The urls for them are:
https://inspire.ec.europa.eu/metadata-codelist/SpatialScope/regional
https://inspire.ec.europa.eu/metadata-codelist/SpatialScope/national

And for adding them in geonetwork you need to provide the url to the RDF/XML:
national: [RDF/XML](http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/national/national.en.rdf)
regional: [RDF/XML](http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/regional/regional.en.rdf)

### Screenshots
![image](https://github.com/user-attachments/assets/55898d7a-790c-49da-a589-f0a4546278a6)

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

