### PR TITLE
chore: put max upload size in field config

### DIFF
--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-link-resources/form-field-online-link-resources.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-link-resources/form-field-online-link-resources.component.html
@@ -1,5 +1,5 @@
 <gn-ui-file-input
-  [maxSizeMB]="10"
+  [maxSizeMB]="MAX_UPLOAD_SIZE_MB"
   (fileChange)="handleFileChange($event)"
   (uploadCancel)="handleUploadCancel()"
   [uploadProgress]="uploadProgress"

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-link-resources/form-field-online-link-resources.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-link-resources/form-field-online-link-resources.component.ts
@@ -28,6 +28,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.service.interface'
 import { Subscription } from 'rxjs'
 import { MatDialog } from '@angular/material/dialog'
+import { MAX_UPLOAD_SIZE_MB } from '../../../../fields.config'
 
 @Component({
   selector: 'gn-ui-form-field-online-link-resources',
@@ -62,6 +63,8 @@ export class FormFieldOnlineLinkResourcesComponent {
   linkResources: OnlineLinkResource[] = []
   uploadProgress = undefined
   uploadSubscription: Subscription = null
+
+  protected MAX_UPLOAD_SIZE_MB = MAX_UPLOAD_SIZE_MB
 
   constructor(
     private notificationsService: NotificationsService,

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.html
@@ -1,5 +1,5 @@
 <gn-ui-image-input
-  [maxSizeMB]="5"
+  [maxSizeMB]="MAX_UPLOAD_SIZE_MB"
   [previewUrl]="firstOverview.url"
   [altText]="firstOverview.description"
   (fileChange)="handleFileChange($event)"

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.ts
@@ -13,6 +13,7 @@ import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.
 import { NotificationsService } from '@geonetwork-ui/feature/notifications'
 import { TranslateService } from '@ngx-translate/core'
 import { Subscription } from 'rxjs'
+import { MAX_UPLOAD_SIZE_MB } from '../../../../fields.config'
 
 @Component({
   selector: 'gn-ui-form-field-overviews',
@@ -30,6 +31,8 @@ export class FormFieldOverviewsComponent {
 
   uploadProgress = undefined
   uploadSubscription: Subscription = null
+
+  protected MAX_UPLOAD_SIZE_MB = MAX_UPLOAD_SIZE_MB
 
   get firstOverview() {
     return (

--- a/libs/feature/editor/src/lib/fields.config.ts
+++ b/libs/feature/editor/src/lib/fields.config.ts
@@ -228,3 +228,5 @@ export const OPEN_DATA_LICENSES: string[] = [
   'odc-by',
   'pddl',
 ]
+
+export const MAX_UPLOAD_SIZE_MB = 10


### PR DESCRIPTION
### Description

This PR introduces a MAX_UPLOAD_SIZE_MB parameter in the field config. For now it is fixed to 10 MB because we cannot read it from the GeoNetwork API.

### Architectural changes
-
### Screenshots
-
### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

