### PR TITLE
[me]: Fix owner org handling in iso converter (writeRecord)

### DIFF
--- a/libs/api/metadata-converter/src/lib/iso19139/iso19139.converter.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/iso19139.converter.ts
@@ -53,7 +53,6 @@ import {
   writeLineage,
   writeOnlineResources,
   writeOtherConstraints,
-  writeOwnerOrganization,
   writeRecordUpdated,
   writeResourceCreated,
   writeResourcePublished,
@@ -113,7 +112,7 @@ export class Iso19139Converter extends BaseConverter<string> {
   > = {
     uniqueIdentifier: writeUniqueIdentifier,
     kind: writeKind,
-    ownerOrganization: writeOwnerOrganization,
+    ownerOrganization: () => undefined, // fixme: find a way to store this value properly
     recordUpdated: writeRecordUpdated,
     recordCreated: () => undefined, // not supported in ISO19139
     recordPublished: () => undefined, // not supported in ISO19139

--- a/libs/api/metadata-converter/src/lib/iso19139/write-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/write-parts.ts
@@ -745,33 +745,6 @@ export function writeKind(record: CatalogRecord, rootEl: XmlElement) {
   )(rootEl)
 }
 
-export function writeOwnerOrganization(
-  record: CatalogRecord,
-  rootEl: XmlElement
-) {
-  // if no contact matches the owner org, create an empty one
-  const ownerContact: Individual = record.contacts.find(
-    (contact) => contact.organization.name === record.ownerOrganization.name
-  )
-  pipe(
-    findChildOrCreate('gmd:contact'),
-    removeAllChildren(),
-    appendResponsibleParty(
-      ownerContact
-        ? {
-            ...ownerContact,
-            // owner responsible party is always point of contact
-            role: 'point_of_contact',
-          }
-        : {
-            organization: record.ownerOrganization,
-            email: '',
-            role: 'point_of_contact',
-          }
-    )
-  )(rootEl)
-}
-
 export function writeRecordUpdated(record: CatalogRecord, rootEl: XmlElement) {
   pipe(
     findChildOrCreate('gmd:dateStamp'),


### PR DESCRIPTION
This PR remove the writeOwnerOrganization method which was messing up the contacts array.

We will have to find another way to hangle this field later.


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves


**This work is sponsored by **.
