### PR TITLE
Element ref wasn't working on ng-for wizard.component.html with multiple fields

### DIFF
--- a/libs/feature/editor/src/lib/components/wizard/wizard.component.html
+++ b/libs/feature/editor/src/lib/components/wizard/wizard.component.html
@@ -1,9 +1,5 @@
-<div class="pl-5 pt-24 flex flex-1 flex-col justify-between">
-  <div
-    #wizardFields
-    class="flex-1 flex"
-    *ngFor="let config of configuration; let i = index"
-  >
+<div class="pl-5 pt-24 flex flex-1 flex-col justify-between" #wizardFields>
+  <div class="flex-1 flex" *ngFor="let config of configuration; let i = index">
     <gn-ui-wizard-field [wizardFieldConfig]="config"></gn-ui-wizard-field>
   </div>
 </div>


### PR DESCRIPTION
### Description

This PR introduces a fix where fields weren't all verified because the ElementRef was checked only on the first element of the list.

On second step, we could hit "Next" button even if abstract wasn't filled.

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
