### PR TITLE
[ME]: Clean up attachments on publishing

### DIFF
--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.spec.ts
@@ -15,11 +15,13 @@ import { AvatarServiceInterface } from '../auth/avatar.service.interface'
 import { Gn4PlatformMapper } from './gn4-platform.mapper'
 import { LangService } from '@geonetwork-ui/util/i18n'
 import {
+  datasetRecordsFixture,
   someUserFeedbacksFixture,
   userFeedbackFixture,
 } from '@geonetwork-ui/common/fixtures'
 import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { HttpClient, HttpEventType } from '@angular/common/http'
+import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
 
 let geonetworkVersion: string
 
@@ -171,6 +173,11 @@ class LangServiceMock {
   iso3 = 'fre'
 }
 
+const associatedResources = {
+  onlines: [],
+  thumbnails: [],
+}
+
 class RecordsApiServiceMock {
   getAllResources = jest.fn(() =>
     of([
@@ -184,6 +191,8 @@ class RecordsApiServiceMock {
       },
     ])
   )
+  getAssociatedResources = jest.fn(() => of(associatedResources))
+  delResource = jest.fn(() => of(undefined))
   putResource = jest.fn(() =>
     of({
       type: HttpEventType.UploadProgress,
@@ -766,6 +775,21 @@ describe('Gn4PlatformService', () => {
           ),
         },
       ])
+    })
+  })
+
+  describe('cleanRecordAttachments', () => {
+    it('calls api service', async () => {
+      const record = datasetRecordsFixture() as unknown as CatalogRecord
+
+      service.cleanRecordAttachments(record)
+
+      expect(recordsApiService.getAssociatedResources).toHaveBeenCalledWith(
+        record.uniqueIdentifier
+      )
+      expect(recordsApiService.getAllResources).toHaveBeenCalledWith(
+        record.uniqueIdentifier
+      )
     })
   })
 

--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.ts
@@ -1,14 +1,12 @@
 import { Injectable } from '@angular/core'
-import { combineLatest, Observable, of, switchMap, throwError } from 'rxjs'
 import {
-  combineLatest,
-  forkJoin,
+  catchError,
+  filter,
+  map,
   mergeMap,
-  Observable,
-  of,
-  switchMap,
-} from 'rxjs'
-import { catchError, filter, map, shareReplay, tap } from 'rxjs/operators'
+  shareReplay,
+  tap,
+} from 'rxjs/operators'
 import {
   MeApiService,
   RecordsApiService,
@@ -39,6 +37,14 @@ import {
 } from '@geonetwork-ui/api/metadata-converter'
 import { KeywordType } from '@geonetwork-ui/common/domain/model/thesaurus'
 import { noDuplicateFileName } from '@geonetwork-ui/util/shared'
+import {
+  combineLatest,
+  forkJoin,
+  Observable,
+  of,
+  switchMap,
+  throwError,
+} from 'rxjs'
 
 const minApiVersion = '4.2.2'
 
@@ -341,7 +347,6 @@ export class Gn4PlatformService implements PlatformServiceInterface {
     )
   }
 
-  attachFileToRecord(recordUuid: string, file: File) {
   attachFileToRecord(recordUuid: string, file: File): Observable<UploadEvent> {
     let sizeBytes = -1
 

--- a/libs/common/domain/src/lib/platform.service.interface.ts
+++ b/libs/common/domain/src/lib/platform.service.interface.ts
@@ -1,7 +1,7 @@
 import type { Observable } from 'rxjs'
 import type { UserModel } from './model/user/user.model'
 import type { Organization } from './model/record/organization.model'
-import { Keyword, UserFeedback } from './model/record'
+import { CatalogRecord, Keyword, UserFeedback } from './model/record'
 import { KeywordType } from './model/thesaurus'
 
 export interface RecordAttachment {
@@ -49,6 +49,7 @@ export abstract class PlatformServiceInterface {
   abstract getRecordAttachments(
     recordUuid: string
   ): Observable<RecordAttachment[]>
+  abstract cleanRecordAttachments(recordUuid: CatalogRecord): Observable<void>
   abstract attachFileToRecord(
     recordUuid: string,
     file: File

--- a/libs/feature/editor/src/lib/+state/editor.effects.spec.ts
+++ b/libs/feature/editor/src/lib/+state/editor.effects.spec.ts
@@ -172,16 +172,6 @@ describe('EditorEffects', () => {
     })
   })
 
-  describe('cleanRecordAttachments$', () => {
-    it('dispatch markRecordAsChanged', () => {
-      actions = hot('-a-|', {
-        a: EditorActions.saveRecordSuccess(),
-      })
-      const expected = hot('---|')
-      expect(effects.cleanRecordAttachments$).toBeObservable(expected)
-    })
-  })
-
   describe('checkHasChangesOnOpen$', () => {
     describe('if the record has a draft', () => {
       it('dispatch markRecordAsChanged', () => {

--- a/libs/feature/editor/src/lib/+state/editor.effects.spec.ts
+++ b/libs/feature/editor/src/lib/+state/editor.effects.spec.ts
@@ -10,6 +10,8 @@ import { datasetRecordsFixture } from '@geonetwork-ui/common/fixtures'
 import { EditorService } from '../services/editor.service'
 import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
 import { EditorPartialState } from './editor.reducer'
+import { MockProvider } from 'ng-mocks'
+import { Gn4PlatformService } from '@geonetwork-ui/api/repository'
 
 class EditorServiceMock {
   saveRecord = jest.fn((record) => of([record, '<xml>blabla</xml>']))
@@ -54,6 +56,9 @@ describe('EditorEffects', () => {
           provide: RecordsRepositoryInterface,
           useClass: RecordsRepositoryMock,
         },
+        MockProvider(Gn4PlatformService, {
+          cleanRecordAttachments: jest.fn(() => of(undefined)),
+        }),
       ],
     })
 
@@ -164,6 +169,16 @@ describe('EditorEffects', () => {
           '<xml>blabla</xml>'
         )
       })
+    })
+  })
+
+  describe('cleanRecordAttachments$', () => {
+    it('dispatch markRecordAsChanged', () => {
+      actions = hot('-a-|', {
+        a: EditorActions.saveRecordSuccess(),
+      })
+      const expected = hot('---|')
+      expect(effects.cleanRecordAttachments$).toBeObservable(expected)
     })
   })
 


### PR DESCRIPTION
This PR add an effect cleanRecordAttachments on saveRecordSuccess action that delete all ressources that are not used in the record.

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves


**This work is sponsored by**.
