### PR TITLE
Deploy Metadata Converter app on gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
   gh-pages:
     needs: checks
     if: github.event_name != 'issue_comment' || needs.checks.outputs.shouldRun
-    name: Deploy Storybook to GitHub Pages
+    name: Deploy docs, apps, Storybook to GitHub Pages
     runs-on: ubuntu-latest
     env:
       BRANCH_NAME: ${{needs.checks.outputs.ref || 'main'}}
@@ -78,6 +78,10 @@ jobs:
       - name: Build demo & web components
         run: npm run build:demo
 
+      - name: Build metadata-converter app
+        if: github.event_name != 'issue_comment' # This is not done on PR, only on main branch
+        run: npx nx build metadata-converter --prod --base-href=./
+
       - name: Build docs
         run: npm run docs:build -- --base=/geonetwork-ui/${{env.BRANCH_NAME}}/docs/ && mkdir -p dist/docs && mv docs/.vitepress/dist/* dist/docs
 
@@ -99,39 +103,9 @@ jobs:
 
             * (Documentation)[https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}/docs/]
 
-            * (Demo & web components)[https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}/demo/]
+            * (Web components demo)[https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}/demo/webcomponents/]
 
             * (UI components storybook)[https://geonetwork.github.io/geonetwork-ui/${{env.BRANCH_NAME}}/storybook/demo/]'
           comment_tag: github-links
           pr_number: ${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  apps:
-    needs: checks
-    if: github.event_name != 'issue_comment'
-    name: Deploy Apps to GitHub Pages
-    runs-on: ubuntu-latest
-    env:
-      BRANCH_NAME: main
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-
-      - name: Install
-        run: npm ci
-
-      - name: Build metadata-converter
-        run: npx nx build metadata-converter --prod
-
-      - name: Deploy to directory ${{ env.BRANCH_NAME }}
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          npx gh-pages --dist dist/apps/ --dest ${{env.BRANCH_NAME}} --remove "${{env.BRANCH_NAME}}/**" --no-history --repo "https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ You can start it with `npm run storybook`.
 You can either try complete applications or showcases of components using the following links:
 
 - [Storybook of UI components](https://geonetwork.github.io/geonetwork-ui/main/storybook/demo/)
-- [Storybook of Web components](https://geonetwork.github.io/geonetwork-ui/main/storybook-wc/)
-- [Demo](https://geonetwork.github.io/geonetwork-ui/main/demo/)
+- [Metadata Converter app](https://geonetwork.github.io/geonetwork-ui/main/metadata-converter/)
+- [Web Components demo](https://geonetwork.github.io/geonetwork-ui/main/demo/webcomponents/)
 
 ## More information
 


### PR DESCRIPTION
### Description

This PR fixes the deployment of the MD Converter app on GitHub Pages, and adds a link in the readme.

### Architectural changes

none

### Screenshots

![image](https://github.com/user-attachments/assets/1de7c0fb-441a-497f-84c1-859c1d0c8d1c)

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->
