### PR TITLE
[Editor]: Fix cleanup attachments function 

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
@@ -186,6 +186,13 @@ describe('editor form', () => {
             'src/fixtures/sample.png'
           )
           cy.editor_publishAndReload()
+          cy.intercept({
+            method: 'GET',
+            url: '**/attachments/sample.png',
+          }).as('importUrlRequest')
+          cy.get('@importUrlRequest')
+            .its('response.statusCode')
+            .should('eq', 200)
           cy.get('@saveStatus').should('eq', 'record_up_to_date')
           cy.get('gn-ui-image-input').find('img').should('have.length', 1)
         })

--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.spec.ts
@@ -791,6 +791,37 @@ describe('Gn4PlatformService', () => {
         record.uniqueIdentifier
       )
     })
+    it('should clean record attachments no longer used', (done) => {
+      const record = { uniqueIdentifier: '123' } as CatalogRecord
+      const associatedResources = {
+        onlines: [{ title: { en: 'doge.jpg' } }],
+        thumbnails: [{ title: { en: 'flower.jpg' } }],
+      }
+      ;(recordsApiService.getAssociatedResources as jest.Mock).mockReturnValue(
+        of(associatedResources)
+      )
+      ;(recordsApiService.getAllResources as jest.Mock).mockReturnValue(
+        of([
+          { filename: 'doge.jpg' },
+          { filename: 'flower.jpg' },
+          { filename: 'remove1.jpg' },
+        ])
+      )
+      ;(recordsApiService.delResource as jest.Mock).mockReturnValue(
+        of(undefined)
+      )
+
+      service.cleanRecordAttachments(record).subscribe({
+        next: () => {
+          expect(recordsApiService.delResource).toHaveBeenCalledWith(
+            record.uniqueIdentifier,
+            'remove1.jpg'
+          )
+          done()
+        },
+        error: done.fail,
+      })
+    })
   })
 
   describe('attachFileToRecord', () => {

--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.ts
@@ -316,12 +316,12 @@ export class Gn4PlatformService implements PlatformServiceInterface {
         // Received object from API is not a RelatedResponseApiModel, so we need
         // to cast it as any and do the bellow mappings to get the wanted values.
         const resourceIdsToKeep = [
-          ...((associatedResources as any).onlines ?? [])
-            .map((o) => o.title)
-            .map((o) => o['']),
-          ...((associatedResources as any).thumbnails ?? [])
-            .map((o) => o.title)
-            .map((o) => o['']),
+          ...((associatedResources as any).onlines ?? []).map(
+            (o) => Object.values(o.title)[0]
+          ),
+          ...((associatedResources as any).thumbnails ?? []).map(
+            (o) => Object.values(o.title)[0]
+          ),
         ]
 
         const resourceIdsToRemove = recordResources


### PR DESCRIPTION
### Description

This PR fixes a wrong behavior in the editor's form, where the cleanup attachment function deletes the newly added attachments (eg : if an image is added, then the record saved, and then reloaded, the new image would be deleted).

This was because of a mapping that was not working : the names of the saved attachments were supposed to match the names of the new attachments, and the mapping was not taking into account that the name object had language keys in it, thus returning "undefined" for all attachment's names.

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
