### PR TITLE
[Editor]: Make first page default for record edition

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
@@ -83,6 +83,14 @@ describe('editor form', () => {
   })
 
   describe('form display', () => {
+    it('opens the first page by default', () => {
+      cy.get('@accessContactPageBtn').click()
+      cy.visit('/catalog/search')
+      cy.get('@recordUuid').then((recordUuid) => {
+        cy.visit(`/edit/${recordUuid}`)
+      })
+      cy.get('@abstractField').should('be.visible')
+    })
     it('form shows correctly', () => {
       cy.get('gn-ui-record-form').should('be.visible')
       cy.get('gn-ui-record-form gn-ui-form-field').should('have.length.gt', 0)

--- a/libs/feature/editor/src/lib/+state/editor.facade.spec.ts
+++ b/libs/feature/editor/src/lib/+state/editor.facade.spec.ts
@@ -49,13 +49,17 @@ describe('EditorFacade', () => {
       facade = TestBed.inject(EditorFacade)
     })
 
-    it('openRecord() should dispatch openRecord action', () => {
+    it('openRecord() should dispatch openRecord action and set the currentPage to 0', () => {
       const spy = jest.spyOn(store, 'dispatch')
-      facade.openRecord(datasetRecordsFixture()[0])
+      facade.openRecord(datasetRecordsFixture()[0], '', true)
       const action = EditorActions.openRecord({
         record: datasetRecordsFixture()[0],
+        recordSource: '',
+        alreadySavedOnce: true,
       })
+      const setPage = EditorActions.setCurrentPage({ page: 0 })
       expect(spy).toHaveBeenCalledWith(action)
+      expect(spy).toHaveBeenCalledWith(setPage)
     })
 
     it('saveRecord() should dispatch saveRecord action', () => {

--- a/libs/feature/editor/src/lib/+state/editor.facade.ts
+++ b/libs/feature/editor/src/lib/+state/editor.facade.ts
@@ -40,6 +40,7 @@ export class EditorFacade {
     this.store.dispatch(
       EditorActions.openRecord({ record, recordSource, alreadySavedOnce })
     )
+    this.setCurrentPage(0)
   }
 
   saveRecord() {


### PR DESCRIPTION
### Description

This PR defines the first page of the editor form as the default page when opening a record, 
instead of opening the record on the last page consulted.

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
