### PR TITLE
[Editor]: Change tab name for metadata-record

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -33,7 +33,7 @@
   "dashboard.labels.mySpace": "Mein Bereich",
   "dashboard.myRecords.currentlyEdited": "",
   "dashboard.myRecords.publishedMetadatas": "",
-  "dashboard.records.all": "Katalog",
+  "dashboard.records.all": "Metadatenkatalog",
   "dashboard.records.hasDraft": "",
   "dashboard.records.myDraft": "Meine Entwürfe",
   "dashboard.records.myRecords": "Meine Datensätze",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -33,7 +33,7 @@
   "dashboard.labels.mySpace": "Mon espace",
   "dashboard.myRecords.currentlyEdited": "En cours d'édition",
   "dashboard.myRecords.publishedMetadatas": "Fiches publiées",
-  "dashboard.records.all": "Catalogue",
+  "dashboard.records.all": "Fiches de métadonnées",
   "dashboard.records.hasDraft": "brouillon",
   "dashboard.records.myDraft": "Mes brouillons",
   "dashboard.records.myRecords": "Mes fiches publiées",


### PR DESCRIPTION
### Description

This PR changes the translations for French and German languages (English was already ok) for the Metadata record tab page name, from "Catalogue" to "Fiches de métadonnées".

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
