### PR TITLE
fix: add wrap to home buttons to avoid mobile horizontal scroll

### DIFF
--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -23,7 +23,10 @@
         (itemSelected)="onFuzzySearchSelection($event)"
         [autoFocus]="true"
       ></gn-ui-fuzzy-search>
-      <div class="flex flex-wrap h-0 py-5 gap-3" [style.opacity]="-0.6 + expandRatio * 2">
+      <div
+        class="flex flex-wrap h-0 py-5 gap-3"
+        [style.opacity]="-0.6 + expandRatio * 2"
+      >
         <datahub-header-badge-button
           [routerLink]="ROUTE_SEARCH"
           *ngIf="isAuthenticated$ | async"

--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -23,7 +23,7 @@
         (itemSelected)="onFuzzySearchSelection($event)"
         [autoFocus]="true"
       ></gn-ui-fuzzy-search>
-      <div class="flex h-0 py-5 gap-3" [style.opacity]="-0.6 + expandRatio * 2">
+      <div class="flex flex-wrap h-0 py-5 gap-3" [style.opacity]="-0.6 + expandRatio * 2">
         <datahub-header-badge-button
           [routerLink]="ROUTE_SEARCH"
           *ngIf="isAuthenticated$ | async"


### PR DESCRIPTION
### Description

This PR introduces flex wrap to home btns to avoid horizontal scrolling in mobile view

### Screenshots

From:
![image](https://github.com/user-attachments/assets/77da96dd-2265-4c4a-9a1b-2a73640bb39a)

To:
![image](https://github.com/user-attachments/assets/b9776980-1ff6-4bb8-adf6-90d2800e714b)


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews

