### PR TITLE
Datahub / fix some layout issues

### DIFF
--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -1,6 +1,6 @@
 <header class="h-full px-5" [style.background]="backgroundCss">
   <div
-    class="container-lg h-full mx-auto flex flex-col-reverse justify-between sm:flex-col sm:justify-end"
+    class="container-lg relative h-full mx-auto flex flex-col-reverse justify-between sm:flex-col sm:justify-end"
   >
     <div
       class="py-8 relative z-40 mb-[184px] sm:mb-0"
@@ -83,9 +83,13 @@
         class="tabs flex justify-between font-medium -mx-5 sm:mx-0 sm:mt-32 inset-x-0 bottom-0 z-50"
       ></datahub-navigation-menu>
     </div>
+    <gn-ui-language-switcher
+      *ngIf="showLanguageSwitcher"
+      class="language-switcher absolute top-3.5 right-6 text-[13px]"
+      [style.--color-main]="foregroundColor"
+      [style.--color-gray-300]="foregroundColor"
+      [style.--color-primary-darker]="foregroundColor"
+      [style.--color-primary-black]="foregroundColor"
+    ></gn-ui-language-switcher>
   </div>
-  <gn-ui-language-switcher
-    *ngIf="showLanguageSwitcher"
-    class="language-switcher absolute top-2.5 left-2.5 text-[13px]"
-  ></gn-ui-language-switcher>
 </header>

--- a/apps/datahub/src/app/home/home-header/home-header.component.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.ts
@@ -48,6 +48,7 @@ export class HomeHeaderComponent {
   SORT_BY_PARAMS = SortByEnum
   searchConfig: SearchConfig = getOptionalSearchConfig()
   showLanguageSwitcher = getGlobalConfig().LANGUAGES?.length > 0
+  foregroundColor = getThemeConfig().HEADER_FOREGROUND_COLOR || '#ffffff'
 
   constructor(
     public routerFacade: RouterFacade,

--- a/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
+++ b/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
@@ -91,7 +91,7 @@
     [ngClass]="{ 'sm:col-span-3 lg:col-span-2': !isOpen }"
   >
     <div
-      class="flex flex-row"
+      class="flex flex-row gap-7 sm:gap-4"
       [ngClass]="
         isOpen
           ? 'justify-start sm:justify-end'
@@ -122,6 +122,7 @@
         ></ng-icon>
       </button>
       <gn-ui-sort-by
+        class="overflow-hidden"
         [ngClass]="isOpen ? 'block text-white mb-1' : 'hidden sm:block'"
         [isQualitySortable]="isQualitySortable"
       ></gn-ui-sort-by>

--- a/apps/datahub/src/app/record/header-record/header-record.component.html
+++ b/apps/datahub/src/app/record/header-record/header-record.component.html
@@ -27,6 +27,8 @@
           class="language-switcher text-[13px] mt-0.5"
           [style.--color-main]="foregroundColor"
           [style.--color-gray-300]="foregroundColor"
+          [style.--color-primary-darker]="foregroundColor"
+          [style.--color-primary-black]="foregroundColor"
         ></gn-ui-language-switcher>
       </div>
     </div>

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.css
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.css
@@ -1,3 +1,8 @@
+/* TODO(mdc-migration): The following rule targets internal classes of tabs that may no longer apply for the MDC version. */
+::ng-deep .mat-mdc-tab-labels {
+  /* move tabs on the right to let the title show */
+  margin-left: 140px;
+}
 ::ng-deep .mat-mdc-tab.mdc-tab {
   letter-spacing: 0.88px;
 }
@@ -16,6 +21,9 @@
 }
 @media only screen and (max-width: 639px) {
   /* TODO(mdc-migration): The following rule targets internal classes of tabs that may no longer apply for the MDC version. */
+  ::ng-deep .mat-mdc-tab-labels {
+    margin-left: 0px;
+  }
   ::ng-deep .mat-mdc-tab.mdc-tab {
     padding: 0px !important;
     margin-right: 24px;

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
@@ -79,9 +79,7 @@
           >
             <mat-tab [disabled]="(displayMap$ | async) === false">
               <ng-template mat-tab-label>
-                <span class="tab-header-label sm:ml-32" translate
-                  >record.tab.map</span
-                >
+                <span class="tab-header-label" translate>record.tab.map</span>
               </ng-template>
               <div
                 class="block"

--- a/libs/feature/record/src/lib/data-view/data-view.component.html
+++ b/libs/feature/record/src/lib/data-view/data-view.component.html
@@ -2,7 +2,7 @@
   <gn-ui-dropdown-selector
     *ngIf="dropdownChoices$ | async as choices"
     [title]="'table.select.data' | translate"
-    class="truncate p-1 -mx-1"
+    class="truncate p-1 -mx-1 self-end mb-1"
     extraBtnClass="!text-primary font-sans font-medium"
     [choices]="choices"
     (selectValue)="selectLink($event)"

--- a/libs/feature/record/src/lib/map-view/map-view.component.html
+++ b/libs/feature/record/src/lib/map-view/map-view.component.html
@@ -1,7 +1,7 @@
 <div class="w-full h-full flex flex-col p-1">
-  <div class="w-full flex justify-end mb-7 mt-1">
+  <div class="w-full flex justify-end">
     <gn-ui-dropdown-selector
-      class="truncate p-1 -mx-1"
+      class="truncate p-1 -mx-1 mb-1"
       extraBtnClass="!text-primary font-sans font-medium"
       [title]="'map.select.layer' | translate"
       [choices]="dropdownChoices$ | async"

--- a/libs/ui/catalog/src/lib/language-switcher/language-switcher.component.html
+++ b/libs/ui/catalog/src/lib/language-switcher/language-switcher.component.html
@@ -1,6 +1,6 @@
 <gn-ui-dropdown-selector
   [title]="'languages'"
-  [choices]="languageList"
+  [choices]="languageChoices"
   (selectValue)="changeLanguage($event)"
   [selected]="currentLang"
   ariaName="languages"

--- a/libs/ui/catalog/src/lib/language-switcher/language-switcher.component.ts
+++ b/libs/ui/catalog/src/lib/language-switcher/language-switcher.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  Inject,
-  InjectionToken,
-  OnInit,
-  Optional,
-} from '@angular/core'
+import { Component, Inject, InjectionToken, Optional } from '@angular/core'
 import { LANGUAGE_STORAGE_KEY } from '@geonetwork-ui/util/i18n'
 import { TranslateService } from '@ngx-translate/core'
 
@@ -17,13 +11,18 @@ const DEFAULT_LANGUAGES = ['en', 'fr']
   templateUrl: './language-switcher.component.html',
   styleUrls: ['./language-switcher.component.css'],
 })
-export class LanguageSwitcherComponent implements OnInit {
-  languageList = this.languagePlaceholder || DEFAULT_LANGUAGES
+export class LanguageSwitcherComponent {
+  languageChoices = (this.languagesList || DEFAULT_LANGUAGES).map(
+    (language) => ({
+      label: `${language}`.toUpperCase(),
+      value: language,
+    })
+  )
 
   constructor(
     @Optional()
     @Inject(LANGUAGES_LIST)
-    private languagePlaceholder,
+    private languagesList: string[],
     private translate: TranslateService
   ) {}
 
@@ -31,22 +30,14 @@ export class LanguageSwitcherComponent implements OnInit {
     return this.translate.currentLang
   }
 
-  ngOnInit(): void {
-    const languages = this.languagePlaceholder || DEFAULT_LANGUAGES
-    this.languageList = languages.map((language) => ({
-      label: `${language}`.toUpperCase(),
-      value: language,
-    }))
-  }
-
-  changeLanguage(value) {
+  changeLanguage(value: unknown) {
     try {
-      localStorage.setItem(LANGUAGE_STORAGE_KEY, value)
+      localStorage.setItem(LANGUAGE_STORAGE_KEY, value as string)
       location.reload()
     } catch (error) {
       console.warn(`Language choice could not be persisted`, error)
     }
 
-    this.translate.use(value)
+    this.translate.use(value as string)
   }
 }


### PR DESCRIPTION
### Description

This PR fixes the following issues:
* the language switcher now shows up in the same place on the record page and home page:
  ![image](https://github.com/user-attachments/assets/39d43684-cfe4-4c79-a391-155e521e2b82)

* the "map" button in the preview section of the record page now has a correct size:
  ![image](https://github.com/user-attachments/assets/6f537800-4a47-4404-a0e3-653fefed7638)

* the layout of the search filters block now correctly renders if the sort-by field is too big:
  ![image](https://github.com/user-attachments/assets/1d99f677-5fe3-44ab-9e4c-2029be99f037)



### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->
