### PR TITLE
Quality score keyword item wasn't checked

### DIFF
--- a/libs/feature/search/src/lib/constants.ts
+++ b/libs/feature/search/src/lib/constants.ts
@@ -19,7 +19,6 @@ export const FIELDS_SUMMARY: FieldName[] = [
   'userSavedCount',
   'cl_topic',
   'cl_maintenanceAndUpdateFrequency',
-  'tag',
   'MD_LegalConstraintsUseLimitationObject',
   'qualityScore',
   'allKeywords',

--- a/libs/feature/search/src/lib/constants.ts
+++ b/libs/feature/search/src/lib/constants.ts
@@ -22,6 +22,7 @@ export const FIELDS_SUMMARY: FieldName[] = [
   'tag',
   'MD_LegalConstraintsUseLimitationObject',
   'qualityScore',
+  'allKeywords',
 ]
 
 export const FIELDS_BRIEF: FieldName[] = [


### PR DESCRIPTION
### Description

This PR adds allKeywords to global search in order to have the quality score fully checked.


### Screenshots

This was resulting of having a quality score of 100% but keywords item unchecked :
![image](https://github.com/user-attachments/assets/41e17947-9151-4612-9cfa-c42efb5b633a)

=> 

![image](https://github.com/user-attachments/assets/4aec6d30-3004-4824-acf2-99a96dc3e468)


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews


---

<!--
Please give credit to the sponsor of this work if possible.
-->

 **This work is sponsored by [INRAE](https://geodata.inrae.fr/datahub/news)**. 
