### PR TITLE
[Backport 2.3.x] Quality score keyword item wasn't checked

### DIFF
--- a/libs/feature/search/src/lib/constants.ts
+++ b/libs/feature/search/src/lib/constants.ts
@@ -19,7 +19,6 @@ export const FIELDS_SUMMARY: FieldName[] = [
   'userSavedCount',
   'cl_topic',
   'cl_maintenanceAndUpdateFrequency',
-  'tag',
   'MD_LegalConstraintsUseLimitationObject',
   'qualityScore',
   'allKeywords',

--- a/libs/feature/search/src/lib/constants.ts
+++ b/libs/feature/search/src/lib/constants.ts
@@ -22,6 +22,7 @@ export const FIELDS_SUMMARY: FieldName[] = [
   'tag',
   'MD_LegalConstraintsUseLimitationObject',
   'qualityScore',
+  'allKeywords',
 ]
 
 export const FIELDS_BRIEF: FieldName[] = [


### PR DESCRIPTION
Backport of #1054