### PR TITLE
Editor: Display notifications always on top

### DIFF
--- a/apps/metadata-editor/src/app/dashboard/dashboard-page.component.html
+++ b/apps/metadata-editor/src/app/dashboard/dashboard-page.component.html
@@ -4,7 +4,7 @@
       <md-editor-sidebar></md-editor-sidebar>
     </aside>
     <div class="relative grow flex flex-col">
-      <div class="absolute top-0 left-0 w-2/3 z-10 pointer-events-none">
+      <div class="absolute top-0 left-0 w-2/3 z-50 pointer-events-none">
         <gn-ui-notifications-container></gn-ui-notifications-container>
       </div>
       <router-outlet></router-outlet>

--- a/apps/metadata-editor/src/app/edit/edit-page.component.html
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.html
@@ -5,7 +5,7 @@
   <div class="flex flex-col h-full w-full">
     <div class="w-full h-auto shrink-0 relative">
       <md-editor-top-toolbar></md-editor-top-toolbar>
-      <div class="absolute top-full left-0 w-2/3 z-10 pointer-events-none">
+      <div class="absolute top-full left-0 w-2/3 z-50 pointer-events-none">
         <gn-ui-notifications-container></gn-ui-notifications-container>
       </div>
     </div>


### PR DESCRIPTION


### Description

This PR raises z-index of div around `notifications-container` to make sure they are always displayed on top (including hovered buttons). 

Commit related to the issue (that may be needed for other cases?) : https://github.com/geonetwork/geonetwork-ui/commit/4ac94ad1d452ad5aa3425ea1d58498dd919e0236

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Screenshots

![image](https://github.com/user-attachments/assets/95594f49-33c8-4298-9036-42cba4646a91)

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
