### PR TITLE
Editor: Fix error when creating new record

### DIFF
--- a/apps/metadata-editor/src/app/duplicate-record.resolver.spec.ts
+++ b/apps/metadata-editor/src/app/duplicate-record.resolver.spec.ts
@@ -75,12 +75,16 @@ describe('DuplicateRecordResolver', () => {
       expect(resolvedData).toBeUndefined()
     })
     it('should show error notification', () => {
-      expect(notificationsService.showNotification).toHaveBeenCalledWith({
-        type: 'error',
-        title: 'editor.record.loadError.title',
-        text: 'editor.record.loadError.body oopsie',
-        closeMessage: 'editor.record.loadError.closeMessage',
-      })
+      expect(notificationsService.showNotification).toHaveBeenCalledWith(
+        {
+          type: 'error',
+          title: 'editor.record.loadError.title',
+          text: 'editor.record.loadError.body oopsie',
+          closeMessage: 'editor.record.loadError.closeMessage',
+        },
+        undefined,
+        expect.any(Error)
+      )
     })
   })
 })

--- a/apps/metadata-editor/src/app/duplicate-record.resolver.ts
+++ b/apps/metadata-editor/src/app/duplicate-record.resolver.ts
@@ -23,18 +23,22 @@ export class DuplicateRecordResolver {
       .openRecordForDuplication(route.paramMap.get('uuid'))
       .pipe(
         catchError((error) => {
-          this.notificationsService.showNotification({
-            type: 'error',
-            title: this.translateService.instant(
-              'editor.record.loadError.title'
-            ),
-            text: `${this.translateService.instant(
-              'editor.record.loadError.body'
-            )} ${error.message}`,
-            closeMessage: this.translateService.instant(
-              'editor.record.loadError.closeMessage'
-            ),
-          })
+          this.notificationsService.showNotification(
+            {
+              type: 'error',
+              title: this.translateService.instant(
+                'editor.record.loadError.title'
+              ),
+              text: `${this.translateService.instant(
+                'editor.record.loadError.body'
+              )} ${error.message}`,
+              closeMessage: this.translateService.instant(
+                'editor.record.loadError.closeMessage'
+              ),
+            },
+            undefined,
+            error
+          )
           return EMPTY
         })
       )

--- a/apps/metadata-editor/src/app/edit-record.resolver.spec.ts
+++ b/apps/metadata-editor/src/app/edit-record.resolver.spec.ts
@@ -75,12 +75,16 @@ describe('EditRecordResolver', () => {
       expect(resolvedData).toBeUndefined()
     })
     it('should show error notification', () => {
-      expect(notificationsService.showNotification).toHaveBeenCalledWith({
-        type: 'error',
-        title: 'editor.record.loadError.title',
-        text: 'editor.record.loadError.body oopsie',
-        closeMessage: 'editor.record.loadError.closeMessage',
-      })
+      expect(notificationsService.showNotification).toHaveBeenCalledWith(
+        {
+          type: 'error',
+          title: 'editor.record.loadError.title',
+          text: 'editor.record.loadError.body oopsie',
+          closeMessage: 'editor.record.loadError.closeMessage',
+        },
+        undefined,
+        expect.any(Error)
+      )
     })
   })
 })

--- a/apps/metadata-editor/src/app/edit-record.resolver.ts
+++ b/apps/metadata-editor/src/app/edit-record.resolver.ts
@@ -23,18 +23,22 @@ export class EditRecordResolver {
       .openRecordForEdition(route.paramMap.get('uuid'))
       .pipe(
         catchError((error) => {
-          this.notificationsService.showNotification({
-            type: 'error',
-            title: this.translateService.instant(
-              'editor.record.loadError.title'
-            ),
-            text: `${this.translateService.instant(
-              'editor.record.loadError.body'
-            )} ${error.message}`,
-            closeMessage: this.translateService.instant(
-              'editor.record.loadError.closeMessage'
-            ),
-          })
+          this.notificationsService.showNotification(
+            {
+              type: 'error',
+              title: this.translateService.instant(
+                'editor.record.loadError.title'
+              ),
+              text: `${this.translateService.instant(
+                'editor.record.loadError.body'
+              )} ${error.message}`,
+              closeMessage: this.translateService.instant(
+                'editor.record.loadError.closeMessage'
+              ),
+            },
+            undefined,
+            error
+          )
           return EMPTY
         })
       )

--- a/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
@@ -121,24 +121,32 @@ describe('EditPageComponent', () => {
     describe('publish version error', () => {
       it('shows notification', () => {
         ;(facade.saveError$ as any).next(new PublicationVersionError('1.0.0'))
-        expect(notificationsService.showNotification).toHaveBeenCalledWith({
-          type: 'error',
-          title: 'editor.record.publishVersionError.title',
-          text: 'editor.record.publishVersionError.body',
-          closeMessage: 'editor.record.publishVersionError.closeMessage',
-        })
+        expect(notificationsService.showNotification).toHaveBeenCalledWith(
+          {
+            type: 'error',
+            title: 'editor.record.publishVersionError.title',
+            text: 'editor.record.publishVersionError.body',
+            closeMessage: 'editor.record.publishVersionError.closeMessage',
+          },
+          undefined,
+          expect.any(PublicationVersionError)
+        )
       })
     })
 
     describe('publish error', () => {
       it('shows notification', () => {
         ;(facade.saveError$ as any).next(new Error('oopsie'))
-        expect(notificationsService.showNotification).toHaveBeenCalledWith({
-          type: 'error',
-          title: 'editor.record.publishError.title',
-          text: 'editor.record.publishError.body oopsie',
-          closeMessage: 'editor.record.publishError.closeMessage',
-        })
+        expect(notificationsService.showNotification).toHaveBeenCalledWith(
+          {
+            type: 'error',
+            title: 'editor.record.publishError.title',
+            text: 'editor.record.publishError.body oopsie',
+            closeMessage: 'editor.record.publishError.closeMessage',
+          },
+          undefined,
+          expect.any(Error)
+        )
       })
     })
 

--- a/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
@@ -212,4 +212,25 @@ describe('EditPageComponent', () => {
       expect(await firstValueFrom(component.isLastPage$)).toBe(false)
     })
   })
+
+  describe('subscriptions', () => {
+    it('should add 3 subscriptions to component.subscription', () => {
+      const addSpy = jest.spyOn(component.subscription, 'add')
+      component.ngOnInit()
+      expect(addSpy).toHaveBeenCalledTimes(3)
+    })
+    it('should add 4 subscriptions to component.subscription when on /create route', () => {
+      const activatedRoute = TestBed.inject(ActivatedRoute)
+      activatedRoute.snapshot.routeConfig.path = '/create'
+      fixture.detectChanges()
+      const addSpy = jest.spyOn(component.subscription, 'add')
+      component.ngOnInit()
+      expect(addSpy).toHaveBeenCalledTimes(4)
+    })
+    it('unsubscribes', () => {
+      const unsubscribeSpy = jest.spyOn(component.subscription, 'unsubscribe')
+      component.ngOnDestroy()
+      expect(unsubscribeSpy).toHaveBeenCalled()
+    })
+  })
 })

--- a/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
@@ -165,6 +165,21 @@ describe('EditPageComponent', () => {
     })
   })
 
+  describe('unique identifier of the current record changes', () => {
+    beforeEach(() => {
+      fixture.detectChanges()
+    })
+    it('navigates to /edit/newUuid', () => {
+      const router = TestBed.inject(Router)
+      const navigateSpy = jest.spyOn(router, 'navigate')
+      ;(facade.record$ as any).next({
+        ...datasetRecordsFixture()[0],
+        uniqueIdentifier: 'new-uuid',
+      })
+      expect(navigateSpy).toHaveBeenCalledWith(['edit', 'new-uuid'])
+    })
+  })
+
   describe('isLastPage$', () => {
     let editorFacade: EditorFacadeMock
     beforeEach(() => {

--- a/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
@@ -165,22 +165,6 @@ describe('EditPageComponent', () => {
     })
   })
 
-  describe('new record', () => {
-    beforeEach(() => {
-      const activatedRoute = TestBed.inject(ActivatedRoute)
-      activatedRoute.snapshot.routeConfig.path = '/create'
-      fixture.detectChanges()
-    })
-    it('navigate from /create to /edit/uuid on first change', () => {
-      const router = TestBed.inject(Router)
-      const navigateSpy = jest.spyOn(router, 'navigate')
-      ;(facade.draftSaveSuccess$ as any).next()
-      expect(navigateSpy).toHaveBeenCalledWith(['edit', 'my-dataset-001'], {
-        replaceUrl: true,
-      })
-    })
-  })
-
   describe('unique identifier of the current record changes', () => {
     beforeEach(() => {
       fixture.detectChanges()

--- a/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
@@ -165,6 +165,22 @@ describe('EditPageComponent', () => {
     })
   })
 
+  describe('new record', () => {
+    beforeEach(() => {
+      const activatedRoute = TestBed.inject(ActivatedRoute)
+      activatedRoute.snapshot.routeConfig.path = '/create'
+      fixture.detectChanges()
+    })
+    it('navigate from /create to /edit/uuid on first change', () => {
+      const router = TestBed.inject(Router)
+      const navigateSpy = jest.spyOn(router, 'navigate')
+      ;(facade.draftSaveSuccess$ as any).next()
+      expect(navigateSpy).toHaveBeenCalledWith(['edit', 'my-dataset-001'], {
+        replaceUrl: true,
+      })
+    })
+  })
+
   describe('unique identifier of the current record changes', () => {
     beforeEach(() => {
       fixture.detectChanges()

--- a/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.spec.ts
@@ -165,21 +165,6 @@ describe('EditPageComponent', () => {
     })
   })
 
-  describe('unique identifier of the current record changes', () => {
-    beforeEach(() => {
-      fixture.detectChanges()
-    })
-    it('navigates to /edit/newUuid', () => {
-      const router = TestBed.inject(Router)
-      const navigateSpy = jest.spyOn(router, 'navigate')
-      ;(facade.record$ as any).next({
-        ...datasetRecordsFixture()[0],
-        uniqueIdentifier: 'new-uuid',
-      })
-      expect(navigateSpy).toHaveBeenCalledWith(['edit', 'new-uuid'])
-    })
-  })
-
   describe('isLastPage$', () => {
     let editorFacade: EditorFacadeMock
     beforeEach(() => {

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -138,11 +138,13 @@ export class EditPageComponent implements OnInit, OnDestroy {
 
     // if we're on the /create route, go to /edit/{uuid} on first change
     if (this.route.snapshot.routeConfig?.path.includes('create')) {
-      this.facade.draftSaveSuccess$.pipe(take(1)).subscribe(() => {
-        this.router.navigate(['edit', currentRecord.uniqueIdentifier], {
-          replaceUrl: true,
+      this.subscription.add(
+        this.facade.draftSaveSuccess$.pipe(take(1)).subscribe(() => {
+          this.router.navigate(['edit', currentRecord.uniqueIdentifier], {
+            replaceUrl: true,
+          })
         })
-      })
+      )
     }
 
     // if the record unique identifier changes, navigate to /edit/newUuid

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -24,7 +24,6 @@ import { combineLatest, filter, firstValueFrom, Subscription, take } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { SidebarComponent } from '../dashboard/sidebar/sidebar.component'
 import { PageSelectorComponent } from './components/page-selector/page-selector.component'
-import { PublishButtonComponent } from './components/publish-button/publish-button.component'
 import { TopToolbarComponent } from './components/top-toolbar/top-toolbar.component'
 
 marker('editor.record.form.bottomButtons.comeBackLater')
@@ -41,7 +40,6 @@ marker('editor.record.form.bottomButtons.next')
     CommonModule,
     ButtonComponent,
     MatProgressSpinnerModule,
-    PublishButtonComponent,
     TopToolbarComponent,
     NotificationsContainerComponent,
     PageSelectorComponent,
@@ -148,17 +146,19 @@ export class EditPageComponent implements OnInit, OnDestroy {
     }
 
     // if the record unique identifier changes, navigate to /edit/newUuid
-    this.facade.record$
-      .pipe(
-        filter(
-          (record) =>
-            record?.uniqueIdentifier !== currentRecord.uniqueIdentifier
-        ),
-        take(1)
-      )
-      .subscribe((savedRecord) => {
-        this.router.navigate(['edit', savedRecord.uniqueIdentifier])
-      })
+    this.subscription.add(
+      this.facade.record$
+        .pipe(
+          filter(
+            (record) =>
+              record?.uniqueIdentifier !== currentRecord.uniqueIdentifier
+          ),
+          take(1)
+        )
+        .subscribe((savedRecord) => {
+          this.router.navigate(['edit', savedRecord.uniqueIdentifier])
+        })
+    )
   }
 
   ngOnDestroy() {

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -137,6 +137,16 @@ export class EditPageComponent implements OnInit, OnDestroy {
         )
       })
     )
+
+    // if we're on the /create route, go to /edit/{uuid} on first change
+    if (this.route.snapshot.routeConfig?.path.includes('create')) {
+      this.facade.draftSaveSuccess$.pipe(take(1)).subscribe(() => {
+        this.router.navigate(['edit', currentRecord.uniqueIdentifier], {
+          replaceUrl: true,
+        })
+      })
+    }
+
     // if the record unique identifier changes, navigate to /edit/newUuid
     this.facade.record$
       .pipe(

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -83,32 +83,40 @@ export class EditPageComponent implements OnInit, OnDestroy {
     this.subscription.add(
       this.facade.saveError$.subscribe((error) => {
         if (error instanceof PublicationVersionError) {
-          this.notificationsService.showNotification({
-            type: 'error',
-            title: this.translateService.instant(
-              'editor.record.publishVersionError.title'
-            ),
-            text: this.translateService.instant(
-              'editor.record.publishVersionError.body',
-              { currentVersion: error.detectedApiVersion }
-            ),
-            closeMessage: this.translateService.instant(
-              'editor.record.publishVersionError.closeMessage'
-            ),
-          })
+          this.notificationsService.showNotification(
+            {
+              type: 'error',
+              title: this.translateService.instant(
+                'editor.record.publishVersionError.title'
+              ),
+              text: this.translateService.instant(
+                'editor.record.publishVersionError.body',
+                { currentVersion: error.detectedApiVersion }
+              ),
+              closeMessage: this.translateService.instant(
+                'editor.record.publishVersionError.closeMessage'
+              ),
+            },
+            undefined,
+            error
+          )
         } else {
-          this.notificationsService.showNotification({
-            type: 'error',
-            title: this.translateService.instant(
-              'editor.record.publishError.title'
-            ),
-            text: `${this.translateService.instant(
-              'editor.record.publishError.body'
-            )} ${error.message}`,
-            closeMessage: this.translateService.instant(
-              'editor.record.publishError.closeMessage'
-            ),
-          })
+          this.notificationsService.showNotification(
+            {
+              type: 'error',
+              title: this.translateService.instant(
+                'editor.record.publishError.title'
+              ),
+              text: `${this.translateService.instant(
+                'editor.record.publishError.body'
+              )} ${error.message}`,
+              closeMessage: this.translateService.instant(
+                'editor.record.publishError.closeMessage'
+              ),
+            },
+            undefined,
+            error
+          )
         }
       })
     )

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -137,6 +137,18 @@ export class EditPageComponent implements OnInit, OnDestroy {
         )
       })
     )
+    // if the record unique identifier changes, navigate to /edit/newUuid
+    this.facade.record$
+      .pipe(
+        filter(
+          (record) =>
+            record?.uniqueIdentifier !== currentRecord.uniqueIdentifier
+        ),
+        take(1)
+      )
+      .subscribe((savedRecord) => {
+        this.router.navigate(['edit', savedRecord.uniqueIdentifier])
+      })
   }
 
   ngOnDestroy() {

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -137,16 +137,6 @@ export class EditPageComponent implements OnInit, OnDestroy {
         )
       })
     )
-
-    // if we're on the /create route, go to /edit/{uuid} on first change
-    if (this.route.snapshot.routeConfig?.path.includes('create')) {
-      this.facade.draftSaveSuccess$.pipe(take(1)).subscribe(() => {
-        this.router.navigate(['edit', currentRecord.uniqueIdentifier], {
-          replaceUrl: true,
-        })
-      })
-    }
-
     // if the record unique identifier changes, navigate to /edit/newUuid
     this.facade.record$
       .pipe(

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -137,18 +137,6 @@ export class EditPageComponent implements OnInit, OnDestroy {
         )
       })
     )
-    // if the record unique identifier changes, navigate to /edit/newUuid
-    this.facade.record$
-      .pipe(
-        filter(
-          (record) =>
-            record?.uniqueIdentifier !== currentRecord.uniqueIdentifier
-        ),
-        take(1)
-      )
-      .subscribe((savedRecord) => {
-        this.router.navigate(['edit', savedRecord.uniqueIdentifier])
-      })
   }
 
   ngOnDestroy() {

--- a/libs/feature/editor/src/lib/components/import-record/import-record.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/import-record/import-record.component.spec.ts
@@ -7,6 +7,7 @@ import { NotificationsService } from '@geonetwork-ui/feature/notifications'
 import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
 import { of, throwError } from 'rxjs'
 import { MockBuilder, MockComponent, MockModule, MockProviders } from 'ng-mocks'
+import exp from 'constants'
 
 describe('ImportRecordComponent', () => {
   let component: ImportRecordComponent
@@ -112,7 +113,8 @@ describe('ImportRecordComponent', () => {
         title: 'editor.record.importFromExternalFile.failure.title',
         text: `editor.record.importFromExternalFile.failure.body `,
       }),
-      2500
+      2500,
+      mockError
     )
 
     expect(component.isRecordImportInProgress).toBe(false)

--- a/libs/feature/editor/src/lib/components/import-record/import-record.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/import-record/import-record.component.spec.ts
@@ -7,7 +7,6 @@ import { NotificationsService } from '@geonetwork-ui/feature/notifications'
 import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
 import { of, throwError } from 'rxjs'
 import { MockBuilder, MockComponent, MockModule, MockProviders } from 'ng-mocks'
-import exp from 'constants'
 
 describe('ImportRecordComponent', () => {
   let component: ImportRecordComponent

--- a/libs/feature/editor/src/lib/components/import-record/import-record.component.ts
+++ b/libs/feature/editor/src/lib/components/import-record/import-record.component.ts
@@ -142,7 +142,8 @@ export class ImportRecordComponent {
               'editor.record.importFromExternalFile.failure.body'
             )} ${error.message ?? ''}`,
           },
-          2500
+          2500,
+          error
         )
         this.isRecordImportInProgress = false
         this.cdr.markForCheck()

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-link-resources/form-field-online-link-resources.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-link-resources/form-field-online-link-resources.component.spec.ts
@@ -143,12 +143,16 @@ describe('FormFieldOnlineLinkResourcesComponent', () => {
       expect(component.uploadProgress).toBeUndefined()
       component.handleFileChange(file)
       uploadSubject.error(new Error('something went wrong'))
-      expect(notificationsService.showNotification).toHaveBeenCalledWith({
-        type: 'error',
-        closeMessage: 'editor.record.onlineResourceError.closeMessage',
-        text: 'editor.record.onlineResourceError.body something went wrong',
-        title: 'editor.record.onlineResourceError.title',
-      })
+      expect(notificationsService.showNotification).toHaveBeenCalledWith(
+        {
+          type: 'error',
+          closeMessage: 'editor.record.onlineResourceError.closeMessage',
+          text: 'editor.record.onlineResourceError.body something went wrong',
+          title: 'editor.record.onlineResourceError.title',
+        },
+        undefined,
+        expect.any(Error)
+      )
     })
   })
   describe('handleUploadCancel', () => {

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-link-resources/form-field-online-link-resources.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-link-resources/form-field-online-link-resources.component.ts
@@ -137,18 +137,22 @@ export class FormFieldOnlineLinkResourcesComponent {
   private handleError(error: Error) {
     this.uploadProgress = undefined
     this.cd.detectChanges()
-    this.notificationsService.showNotification({
-      type: 'error',
-      title: this.translateService.instant(
-        'editor.record.onlineResourceError.title'
-      ),
-      text: `${this.translateService.instant(
-        'editor.record.onlineResourceError.body'
-      )} ${error.message}`,
-      closeMessage: this.translateService.instant(
-        'editor.record.onlineResourceError.closeMessage'
-      ),
-    })
+    this.notificationsService.showNotification(
+      {
+        type: 'error',
+        title: this.translateService.instant(
+          'editor.record.onlineResourceError.title'
+        ),
+        text: `${this.translateService.instant(
+          'editor.record.onlineResourceError.body'
+        )} ${error.message}`,
+        closeMessage: this.translateService.instant(
+          'editor.record.onlineResourceError.closeMessage'
+        ),
+      },
+      undefined,
+      error
+    )
   }
 
   private openEditDialog(resource: OnlineLinkResource, index: number) {

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-resources/form-field-online-resources.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-resources/form-field-online-resources.component.ts
@@ -192,18 +192,22 @@ export class FormFieldOnlineResourcesComponent {
 
   private handleError(error: Error) {
     this.uploadProgress = undefined
-    this.notificationsService.showNotification({
-      type: 'error',
-      title: this.translateService.instant(
-        'editor.record.onlineResourceError.title'
-      ),
-      text: `${this.translateService.instant(
-        'editor.record.onlineResourceError.body'
-      )} ${error.message}`,
-      closeMessage: this.translateService.instant(
-        'editor.record.onlineResourceError.closeMessage'
-      ),
-    })
+    this.notificationsService.showNotification(
+      {
+        type: 'error',
+        title: this.translateService.instant(
+          'editor.record.onlineResourceError.title'
+        ),
+        text: `${this.translateService.instant(
+          'editor.record.onlineResourceError.body'
+        )} ${error.message}`,
+        closeMessage: this.translateService.instant(
+          'editor.record.onlineResourceError.closeMessage'
+        ),
+      },
+      undefined,
+      error
+    )
   }
 
   private openEditDialog(resource: OnlineNotLinkResource, index: number) {

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.spec.ts
@@ -119,12 +119,16 @@ describe('FormFieldOverviewsComponent', () => {
       expect(component.uploadProgress).toBeUndefined()
       component.handleFileChange(file)
       uploadSubject.error(new Error('something went wrong'))
-      expect(notificationsService.showNotification).toHaveBeenCalledWith({
-        type: 'error',
-        closeMessage: 'editor.record.resourceError.closeMessage',
-        text: 'editor.record.resourceError.body something went wrong',
-        title: 'editor.record.resourceError.title',
-      })
+      expect(notificationsService.showNotification).toHaveBeenCalledWith(
+        {
+          type: 'error',
+          closeMessage: 'editor.record.resourceError.closeMessage',
+          text: 'editor.record.resourceError.body something went wrong',
+          title: 'editor.record.resourceError.title',
+        },
+        undefined,
+        expect.any(Error)
+      )
     })
   })
 

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.ts
@@ -109,15 +109,21 @@ export class FormFieldOverviewsComponent {
   private handleError = (error: Error) => {
     this.uploadProgress = undefined
     this.cd.markForCheck()
-    this.notificationsService.showNotification({
-      type: 'error',
-      title: this.translateService.instant('editor.record.resourceError.title'),
-      text: `${this.translateService.instant(
-        'editor.record.resourceError.body'
-      )} ${error.message}`,
-      closeMessage: this.translateService.instant(
-        'editor.record.resourceError.closeMessage'
-      ),
-    })
+    this.notificationsService.showNotification(
+      {
+        type: 'error',
+        title: this.translateService.instant(
+          'editor.record.resourceError.title'
+        ),
+        text: `${this.translateService.instant(
+          'editor.record.resourceError.body'
+        )} ${error.message}`,
+        closeMessage: this.translateService.instant(
+          'editor.record.resourceError.closeMessage'
+        ),
+      },
+      undefined,
+      error
+    )
   }
 }

--- a/libs/feature/notifications/src/lib/notifications.service.ts
+++ b/libs/feature/notifications/src/lib/notifications.service.ts
@@ -10,7 +10,12 @@ type NotificationWithIdentity = NotificationContent & { id: number }
 export class NotificationsService {
   notifications$ = new BehaviorSubject<NotificationWithIdentity[]>([])
 
-  showNotification(content: NotificationContent, timeoutMs?: number) {
+  showNotification(
+    content: NotificationContent,
+    timeoutMs?: number,
+    error?: Error
+  ) {
+    error && console.error(error)
     const id = Math.floor(Math.random() * 1000000)
     this.notifications$.next([...this.notifications$.value, { ...content, id }])
     if (typeof timeoutMs === 'undefined') return

--- a/libs/feature/search/src/lib/results-table/results-table-container.component.spec.ts
+++ b/libs/feature/search/src/lib/results-table/results-table-container.component.spec.ts
@@ -120,12 +120,16 @@ describe('ResultsTableContainerComponent', () => {
           throwError(() => 'oopsie')
         )
         component.handleDeleteRecord(datasetRecordsFixture()[0])
-        expect(notificationsService.showNotification).toHaveBeenCalledWith({
-          type: 'error',
-          title: 'editor.record.deleteError.title',
-          text: 'editor.record.deleteError.body oopsie',
-          closeMessage: 'editor.record.deleteError.closeMessage',
-        })
+        expect(notificationsService.showNotification).toHaveBeenCalledWith(
+          {
+            type: 'error',
+            title: 'editor.record.deleteError.title',
+            text: 'editor.record.deleteError.body oopsie',
+            closeMessage: 'editor.record.deleteError.closeMessage',
+          },
+          undefined,
+          'oopsie'
+        )
       })
     })
 

--- a/libs/feature/search/src/lib/results-table/results-table-container.component.ts
+++ b/libs/feature/search/src/lib/results-table/results-table-container.component.ts
@@ -79,18 +79,22 @@ export class ResultsTableContainerComponent implements OnDestroy {
           )
         },
         error: (error) => {
-          this.notificationsService.showNotification({
-            type: 'error',
-            title: this.translateService.instant(
-              'editor.record.deleteError.title'
-            ),
-            text: `${this.translateService.instant(
-              'editor.record.deleteError.body'
-            )} ${error}`,
-            closeMessage: this.translateService.instant(
-              'editor.record.deleteError.closeMessage'
-            ),
-          })
+          this.notificationsService.showNotification(
+            {
+              type: 'error',
+              title: this.translateService.instant(
+                'editor.record.deleteError.title'
+              ),
+              text: `${this.translateService.instant(
+                'editor.record.deleteError.body'
+              )} ${error}`,
+              closeMessage: this.translateService.instant(
+                'editor.record.deleteError.closeMessage'
+              ),
+            },
+            undefined,
+            error
+          )
         },
       })
     )


### PR DESCRIPTION
### Description

The goal of this PR is to fix the error when creating a new record. The same exception sometimes occurs when editing fields of a draft. A first commit ensures errors displayed via the `notifications.service` still to be logged to the console.

The actual error is caused by the fact that the `EditRecordResolver` is called even when routing to `/create`. This happens due to the `navigate['edit']` calls within the component. Both navigations have been removed:
- 07dcd58b154bf47f0bf0d5e76f001e703123cbef does not seem essential, but maybe I've missed something. Creating a new record now stays on `/create`. => This prevents the exception when creating a new record.
- a97b566ab19a4a98b0ef3831aa8da821642a4a49 does not seem to be used anymore, since we've replaced the `uniqueIdentifier` with the `resourceIdentifier ` in the form. => This prevents the exception when editing fields of a draft.

Note to reproduce: The issue occurs on the first access to `/create` after app reload. It starts with the second access to `/create` or accessing `/create` after `/edit`. 

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Screenshots

![image](https://github.com/user-attachments/assets/8559425e-f89d-4cce-b95a-a7ec8094e515)

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
