### PR TITLE
Editor: Extract and remove national/regional toggle

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
@@ -441,27 +441,6 @@ describe('editor form', () => {
             .should('have.length', 1)
         })
       })
-      describe('spatial scope', () => {
-        it('toggle between national and regional spatial coverage', () => {
-          cy.get('gn-ui-switch-toggle').should('exist')
-
-          cy.get('gn-ui-switch-toggle').find('mat-button-toggle').eq(0).click()
-          cy.get('mat-button-toggle')
-            .eq(0)
-            .should('have.class', 'mat-button-toggle-checked')
-          cy.get('mat-button-toggle')
-            .eq(1)
-            .should('not.have.class', 'mat-button-toggle-checked')
-
-          cy.get('gn-ui-switch-toggle').find('mat-button-toggle').eq(1).click()
-          cy.get('mat-button-toggle')
-            .eq(1)
-            .should('have.class', 'mat-button-toggle-checked')
-          cy.get('mat-button-toggle')
-            .eq(0)
-            .should('not.have.class', 'mat-button-toggle-checked')
-        })
-      })
     })
     describe('distribution resources', () => {
       beforeEach(() => {

--- a/libs/common/fixtures/src/lib/records.fixtures.ts
+++ b/libs/common/fixtures/src/lib/records.fixtures.ts
@@ -1,6 +1,8 @@
 import {
   CatalogRecord,
   DatasetRecord,
+  DatasetSpatialExtent,
+  Keyword,
 } from '@geonetwork-ui/common/domain/model/record'
 
 export const datasetRecordsFixture: () => CatalogRecord[] = () => [
@@ -464,3 +466,102 @@ export const simpleDatasetRecordAsXmlFixture =
         </mrl:LI_Lineage>
     </mdb:resourceLineage>
 </mdb:MD_Metadata>`
+
+export const NATIONAL_KEYWORD = {
+  key: 'http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/national',
+  label: 'National',
+  description: '',
+  type: 'theme',
+}
+
+export const SAMPLE_PLACE_KEYWORDS: Keyword[] = [
+  // these keywords come from a thesaurus available locally
+  {
+    key: 'uri1',
+    label: 'Berlin',
+    thesaurus: {
+      id: '1',
+      name: 'places',
+    },
+    type: 'place',
+    bbox: [13.27, 52.63, 52.5, 13.14],
+  },
+  {
+    key: 'uri2',
+    label: 'Hamburg',
+    thesaurus: {
+      id: '1',
+      name: 'places',
+    },
+    type: 'place',
+    bbox: [10.5, 53.66, 53.53, 10],
+  },
+  // this keyword is available locally but has no extent linked to it
+  {
+    key: 'uri3',
+    label: 'Munich',
+    thesaurus: {
+      id: '1',
+      name: 'places',
+    },
+    type: 'place',
+    bbox: [11.64, 48.65, 48.51, 11.5],
+  },
+  // this keyword comes from a thesaurus not available locally
+  {
+    label: 'Europe',
+    thesaurus: {
+      id: '2',
+      name: 'otherPlaces',
+    },
+    type: 'place',
+  },
+  // this keyword has no thesaurus
+  {
+    label: 'Narnia',
+    type: 'place',
+  },
+]
+
+// records coming from XML do not have a key or a bbox in them
+export const SAMPLE_PLACE_KEYWORDS_FROM_XML = SAMPLE_PLACE_KEYWORDS.map(
+  ({ label, thesaurus, type }) => ({
+    label,
+    type,
+    ...(thesaurus && { thesaurus }),
+  })
+)
+
+export const SAMPLE_SPATIAL_EXTENTS: DatasetSpatialExtent[] = [
+  // these extents are linked to keywords known locally
+  {
+    description: 'uri1',
+    bbox: [13.5, 52.5, 14.5, 53.5],
+  },
+  {
+    description: 'uri2',
+    bbox: [10, 53.5, 11, 53.4],
+  },
+  {
+    description: 'uri4',
+    bbox: [11.5, 48.5, 11.5, 48.3],
+  },
+  // this extent is linked to a keyword not available locally
+  {
+    description: 'URI-Paris',
+    bbox: [1, 2, 3, 4],
+  },
+  // this extent is not linked to any keyword
+  {
+    bbox: [5, 6, 7, 8],
+  },
+]
+
+export const SAMPLE_RECORD = {
+  ...datasetRecordsFixture()[0],
+  spatialExtents: SAMPLE_SPATIAL_EXTENTS,
+  keywords: [
+    ...datasetRecordsFixture()[0].keywords,
+    ...SAMPLE_PLACE_KEYWORDS_FROM_XML,
+  ],
+}

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.html
@@ -1,9 +1,4 @@
 <div class="flex flex-col gap-8">
-  <gn-ui-switch-toggle
-    [options]="switchToggleOptions$ | async"
-    (selectedValue)="onSpatialScopeChange($event)"
-    extraClasses="grow text-sm"
-  ></gn-ui-switch-toggle>
   <gn-ui-generic-keywords
     [placeholder]="'Search for place keywords'"
     [keywords]="shownKeywords$ | async"

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-extent/form-field-spatial-extent.component.ts
@@ -6,15 +6,11 @@ import {
 } from '@geonetwork-ui/common/domain/model/record'
 import { GenericKeywordsComponent } from '../../../generic-keywords/generic-keywords.component'
 import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.service.interface'
-import { firstValueFrom, map, Observable, shareReplay } from 'rxjs'
+import { firstValueFrom, map, shareReplay } from 'rxjs'
 import { EditorFacade } from '../../../../+state/editor.facade'
 import { switchMap } from 'rxjs/operators'
 import { FormFieldMapContainerComponent } from '../form-field-map-container/form-field-map-container.component'
 import { TranslateService } from '@ngx-translate/core'
-import {
-  SwitchToggleComponent,
-  SwitchToggleOption,
-} from '@geonetwork-ui/ui/inputs'
 import { SPATIAL_SCOPES } from '../../../../fields.config'
 
 // This intermediary type will let us keep track of which keyword is bound to
@@ -40,7 +36,6 @@ type KeywordWithExtent = Keyword & {
     CommonModule,
     GenericKeywordsComponent,
     FormFieldMapContainerComponent,
-    SwitchToggleComponent,
   ],
 })
 export class FormFieldSpatialExtentComponent {
@@ -51,21 +46,6 @@ export class FormFieldSpatialExtentComponent {
   allKeywords$ = this.editorFacade.record$.pipe(
     map((record) => record?.keywords)
   )
-
-  switchToggleOptions$: Observable<SwitchToggleOption[]> =
-    this.allKeywords$.pipe(
-      map((keywords) =>
-        SPATIAL_SCOPES.map((scope) => {
-          const isChecked = keywords.some(
-            (keyword) => keyword.label === scope.label
-          )
-          return {
-            label: scope.label,
-            checked: isChecked,
-          }
-        })
-      )
-    )
 
   shownKeywords$ = this.editorFacade.record$.pipe(
     map((record) => record?.keywords.filter((k) => k.type === 'place')),
@@ -197,25 +177,5 @@ export class FormFieldSpatialExtentComponent {
 
     this.editorFacade.updateRecordField('keywords', allKeywords)
     this.editorFacade.updateRecordField('spatialExtents', spatialExtents)
-  }
-
-  async onSpatialScopeChange(selectedOption: SwitchToggleOption) {
-    // remove all existing spatial scope keywords
-    const allKeywords = await firstValueFrom(this.allKeywords$)
-    const filteredKeywords = allKeywords.filter((keyword) => {
-      const spatialScopeLabels = SPATIAL_SCOPES.map((scope) => scope.label)
-      return !spatialScopeLabels.includes(keyword.label)
-    })
-
-    const selectedOptionLabel = selectedOption.label
-    const selectedKeyword = SPATIAL_SCOPES.find(
-      (scopes) => scopes.label === selectedOptionLabel
-    )
-
-    // add the selected spatial scope keyword
-    this.editorFacade.updateRecordField('keywords', [
-      ...filteredKeywords,
-      { ...selectedKeyword },
-    ])
   }
 }

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.html
@@ -1,1 +1,5 @@
-<p>form-field-spatial-toggle works!</p>
+<gn-ui-switch-toggle
+  [options]="switchToggleOptions$ | async"
+  (selectedValue)="onSpatialScopeChange($event)"
+  extraClasses="grow text-sm"
+></gn-ui-switch-toggle>

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.html
@@ -1,0 +1,1 @@
+<p>form-field-spatial-toggle works!</p>

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.spec.ts
@@ -1,21 +1,28 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing'
 
-import { FormFieldSpatialToggleComponent } from './form-field-spatial-toggle.component';
+import { FormFieldSpatialToggleComponent } from './form-field-spatial-toggle.component'
+import { MockProvider } from 'ng-mocks'
+import { EditorFacade } from '../../../../+state/editor.facade'
+import { BehaviorSubject } from 'rxjs'
 
+class EditorFacadeMock {
+  record$ = new BehaviorSubject([])
+}
 describe('FormFieldSpatialToggleComponent', () => {
-  let component: FormFieldSpatialToggleComponent;
-  let fixture: ComponentFixture<FormFieldSpatialToggleComponent>;
+  let component: FormFieldSpatialToggleComponent
+  let fixture: ComponentFixture<FormFieldSpatialToggleComponent>
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [FormFieldSpatialToggleComponent]
-    });
-    fixture = TestBed.createComponent(FormFieldSpatialToggleComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+      imports: [FormFieldSpatialToggleComponent],
+      providers: [MockProvider(EditorFacade, EditorFacadeMock, 'useClass')],
+    })
+    fixture = TestBed.createComponent(FormFieldSpatialToggleComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
 
   it('should create', () => {
-    expect(component).toBeTruthy();
-  });
-});
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.spec.ts
@@ -3,20 +3,35 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { FormFieldSpatialToggleComponent } from './form-field-spatial-toggle.component'
 import { MockProvider } from 'ng-mocks'
 import { EditorFacade } from '../../../../+state/editor.facade'
-import { BehaviorSubject } from 'rxjs'
+import { BehaviorSubject, firstValueFrom, from } from 'rxjs'
+import {
+  datasetRecordsFixture,
+  NATIONAL_KEYWORD,
+  SAMPLE_PLACE_KEYWORDS,
+  SAMPLE_RECORD,
+} from '@geonetwork-ui/common/fixtures'
+import {
+  CatalogRecord,
+  Keyword,
+} from '@geonetwork-ui/common/domain/model/record'
+import { TranslateModule } from '@ngx-translate/core'
 
-class EditorFacadeMock {
-  record$ = new BehaviorSubject([])
-}
 describe('FormFieldSpatialToggleComponent', () => {
   let component: FormFieldSpatialToggleComponent
   let fixture: ComponentFixture<FormFieldSpatialToggleComponent>
+  let editorFacade: EditorFacade
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [FormFieldSpatialToggleComponent],
-      providers: [MockProvider(EditorFacade, EditorFacadeMock, 'useClass')],
+      imports: [FormFieldSpatialToggleComponent, TranslateModule.forRoot()],
+      providers: [
+        MockProvider(EditorFacade, {
+          record$: new BehaviorSubject(SAMPLE_RECORD),
+          updateRecordField: jest.fn(),
+        }),
+      ],
     })
+    editorFacade = TestBed.inject(EditorFacade)
     fixture = TestBed.createComponent(FormFieldSpatialToggleComponent)
     component = fixture.componentInstance
     fixture.detectChanges()
@@ -24,5 +39,65 @@ describe('FormFieldSpatialToggleComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  describe('switch toggle option is based on the keywords present in the record', () => {
+    it('should return true if the record has a national keyword', async () => {
+      const keywords = [...SAMPLE_PLACE_KEYWORDS, NATIONAL_KEYWORD] as Keyword[]
+      editorFacade = TestBed.inject(EditorFacade)
+      editorFacade.record$ = from([
+        { ...SAMPLE_RECORD, keywords } as CatalogRecord,
+      ])
+      fixture = TestBed.createComponent(FormFieldSpatialToggleComponent)
+      component = fixture.componentInstance
+      fixture.detectChanges()
+
+      const results = await firstValueFrom(component.switchToggleOptions$)
+      const nationalOption = results.filter(
+        (result) => result.label === 'National'
+      )[0]
+
+      expect(nationalOption.checked).toBe(true)
+    })
+    it('should return false if the record does not have a national keyword', async () => {
+      const keywords2 = [...SAMPLE_PLACE_KEYWORDS] as Keyword[]
+      editorFacade = TestBed.inject(EditorFacade)
+      editorFacade.record$ = from([
+        { ...SAMPLE_RECORD, keywords: keywords2 } as CatalogRecord,
+      ])
+      fixture = TestBed.createComponent(FormFieldSpatialToggleComponent)
+      component = fixture.componentInstance
+      fixture.detectChanges()
+
+      const results = await firstValueFrom(component.switchToggleOptions$)
+      const nationalOption = results.filter(
+        (result) => result.label === 'National'
+      )[0]
+
+      expect(nationalOption.checked).toBe(false)
+    })
+  })
+  describe('#onSpatialScopeChange', () => {
+    it('removes all existing spatial scope keywords and add the selected one', async () => {
+      const spatialScopes = [{ label: 'National' }, { label: 'Regional' }]
+
+      const allKeywords = await firstValueFrom(component.allKeywords$)
+      const filteredKeywords = allKeywords.filter((keyword) => {
+        const spatialScopeLabels = spatialScopes.map((scope) => scope.label)
+        return !spatialScopeLabels.includes(keyword.label)
+      })
+
+      const selectedOption = {
+        label: 'National',
+        value: NATIONAL_KEYWORD,
+        checked: true,
+      }
+      await component.onSpatialScopeChange(selectedOption)
+
+      expect(editorFacade.updateRecordField).toHaveBeenCalledWith('keywords', [
+        ...filteredKeywords,
+        NATIONAL_KEYWORD,
+      ])
+    })
   })
 })

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormFieldSpatialToggleComponent } from './form-field-spatial-toggle.component';
+
+describe('FormFieldSpatialToggleComponent', () => {
+  let component: FormFieldSpatialToggleComponent;
+  let fixture: ComponentFixture<FormFieldSpatialToggleComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FormFieldSpatialToggleComponent]
+    });
+    fixture = TestBed.createComponent(FormFieldSpatialToggleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.ts
@@ -1,14 +1,60 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { CommonModule } from '@angular/common'
+import {
+  SwitchToggleComponent,
+  SwitchToggleOption,
+} from '@geonetwork-ui/ui/inputs'
+import { EditorFacade } from '../../../../+state/editor.facade'
+import { firstValueFrom, map, Observable } from 'rxjs'
+import { SPATIAL_SCOPES } from '../../../../fields.config'
 
 @Component({
   selector: 'gn-ui-form-field-spatial-toggle',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, SwitchToggleComponent],
   templateUrl: './form-field-spatial-toggle.component.html',
   styleUrls: ['./form-field-spatial-toggle.component.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FormFieldSpatialToggleComponent {
+  allKeywords$ = this.editorFacade.record$.pipe(
+    map((record) => record?.keywords)
+  )
 
+  switchToggleOptions$: Observable<SwitchToggleOption[]> =
+    this.allKeywords$.pipe(
+      map((keywords) =>
+        SPATIAL_SCOPES.map((scope) => {
+          const isChecked = keywords.some(
+            (keyword) => keyword.label === scope.label
+          )
+          return {
+            label: scope.label,
+            checked: isChecked,
+          }
+        })
+      )
+    )
+
+  constructor(private editorFacade: EditorFacade) {}
+
+  async onSpatialScopeChange(selectedOption: SwitchToggleOption) {
+    // remove all existing spatial scope keywords
+    const allKeywords = await firstValueFrom(this.allKeywords$)
+    const filteredKeywords = allKeywords.filter((keyword) => {
+      const spatialScopeLabels = SPATIAL_SCOPES.map((scope) => scope.label)
+      return !spatialScopeLabels.includes(keyword.label)
+    })
+
+    const selectedOptionLabel = selectedOption.label
+    const selectedKeyword = SPATIAL_SCOPES.find(
+      (scopes) => scopes.label === selectedOptionLabel
+    )
+
+    // add the selected spatial scope keyword
+    this.editorFacade.updateRecordField('keywords', [
+      ...filteredKeywords,
+      { ...selectedKeyword },
+    ])
+  }
 }

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-spatial-toggle/form-field-spatial-toggle.component.ts
@@ -1,0 +1,14 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'gn-ui-form-field-spatial-toggle',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './form-field-spatial-toggle.component.html',
+  styleUrls: ['./form-field-spatial-toggle.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class FormFieldSpatialToggleComponent {
+
+}

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.html
@@ -167,6 +167,9 @@
       <ng-container *ngSwitchCase="'form-field-constraints-shortcuts'">
         <gn-ui-form-field-constraints-shortcuts></gn-ui-form-field-constraints-shortcuts>
       </ng-container>
+      <ng-container *ngSwitchCase="'form-field-spatial-toggle'">
+        <gn-ui-form-field-spatial-toggle></gn-ui-form-field-spatial-toggle>
+      </ng-container>
     </ng-container>
   </ng-container>
 </ng-template>

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.ts
@@ -52,6 +52,7 @@ import { FormFieldUpdateFrequencyComponent } from './form-field-update-frequency
 import { FormFieldConstraintsShortcutsComponent } from './form-field-constraints-shortcuts/form-field-constraints-shortcuts.component'
 import { FormFieldConstraintsComponent } from './form-field-constraints/form-field-constraints.component'
 import { TextFieldModule } from '@angular/cdk/text-field'
+import { FormFieldSpatialToggleComponent } from './form-field-spatial-toggle/form-field-spatial-toggle.component'
 
 @Component({
   selector: 'gn-ui-form-field',
@@ -84,6 +85,7 @@ import { TextFieldModule } from '@angular/cdk/text-field'
     FormFieldContactsComponent,
     FormFieldConstraintsComponent,
     FormFieldConstraintsShortcutsComponent,
+    FormFieldSpatialToggleComponent,
     TextFieldModule,
   ],
 })
@@ -116,6 +118,7 @@ export class FormFieldComponent {
       this.model === 'legalConstraints' ||
       this.model === 'securityConstraints' ||
       this.model === 'otherConstraints' ||
+      this.model === 'spatialExtents' ||
       this.componentName === 'form-field-constraints-shortcuts'
     )
   }

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.ts
@@ -118,7 +118,6 @@ export class FormFieldComponent {
       this.model === 'legalConstraints' ||
       this.model === 'securityConstraints' ||
       this.model === 'otherConstraints' ||
-      this.model === 'spatialExtents' ||
       this.componentName === 'form-field-constraints-shortcuts'
     )
   }

--- a/libs/feature/editor/src/lib/fields.config.ts
+++ b/libs/feature/editor/src/lib/fields.config.ts
@@ -149,11 +149,9 @@ export const RECORD_GRAPHICAL_OVERVIEW_FIELD: EditorField = {
 }
 
 export const RECORD_SPATIAL_TOGGLE_FIELD: EditorField = {
-  // model: 'keywords',
   componentName: 'form-field-spatial-toggle',
-  formFieldConfig: {
-    labelKey: marker('editor.record.form.field.spatialExtents'),
-  },
+  formFieldConfig: {},
+  hidden: true,
 }
 
 export const RECORD_SPATIAL_EXTENTS_FIELD: EditorField = {

--- a/libs/feature/editor/src/lib/fields.config.ts
+++ b/libs/feature/editor/src/lib/fields.config.ts
@@ -148,6 +148,14 @@ export const RECORD_GRAPHICAL_OVERVIEW_FIELD: EditorField = {
   },
 }
 
+export const RECORD_SPATIAL_TOGGLE_FIELD: EditorField = {
+  // model: 'keywords',
+  componentName: 'form-field-spatial-toggle',
+  formFieldConfig: {
+    labelKey: marker('editor.record.form.field.spatialExtents'),
+  },
+}
+
 export const RECORD_SPATIAL_EXTENTS_FIELD: EditorField = {
   model: 'spatialExtents',
   formFieldConfig: {
@@ -203,7 +211,7 @@ export const ABOUT_SECTION: EditorSection = {
 export const GEOGRAPHICAL_COVERAGE_SECTION: EditorSection = {
   labelKey: marker('editor.record.form.section.geographicalCoverage.label'),
   hidden: false,
-  fields: [RECORD_SPATIAL_EXTENTS_FIELD],
+  fields: [RECORD_SPATIAL_TOGGLE_FIELD, RECORD_SPATIAL_EXTENTS_FIELD],
 }
 
 export const ASSOCIATED_RESOURCES_SECTION: EditorSection = {

--- a/libs/feature/editor/src/lib/models/editor-config.model.ts
+++ b/libs/feature/editor/src/lib/models/editor-config.model.ts
@@ -23,7 +23,9 @@ export type FieldModelSpecifier =
   | OnlineLinkResourceSpecifier
   | DatasetDistributionsSpecifier
 
-export type FormFieldComponentName = 'form-field-constraints-shortcuts'
+export type FormFieldComponentName =
+  | 'form-field-constraints-shortcuts'
+  | 'form-field-spatial-toggle'
 
 export interface EditorFieldIdentification {
   // name of the target field in the record; will not change the record directly if not defined


### PR DESCRIPTION
### Description

This PR extracts and removes/hides the national/regional toggle.

In order to easily configure if the edit form should contain a national/regional toggle, the toggle was extracted out of the spatial extent field and became its own field.
Most of the logic was kept and just moved.
The approach for the form-field is similar to the `form-field-constraints-shortcuts`, meaning it does not have a `model` but a `componentName` in the config.

### Screenshots
This is the current state if the component is hidden:
![image](https://github.com/user-attachments/assets/c9fe4dc9-4bdb-4a8e-bf52-c86983894871)

This is how it looks if the component is visible:
![image](https://github.com/user-attachments/assets/3dab1ef0-eff0-4d25-b915-4bd548dc29ab)


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
