### PR TITLE
[Editor]: Search in the whole catalog from any dashboard

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/dashboard.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/dashboard.cy.ts
@@ -272,10 +272,6 @@ describe('dashboard (authenticated)', () => {
         cy.get('md-editor-dashboard-menu').find('a').eq(5).click()
         cy.get('gn-ui-autocomplete').should('have.value', '')
       })
-      it('should hide the search input when navigating to my drafts', () => {
-        cy.get('md-editor-dashboard-menu').find('a').eq(4).click()
-        cy.get('gn-ui-autocomplete').should('not.exist')
-      })
     })
     describe('myRecords search input', () => {
       beforeEach(() => {
@@ -292,6 +288,14 @@ describe('dashboard (authenticated)', () => {
         cy.get('gn-ui-autocomplete').type('velo')
         cy.get('md-editor-dashboard-menu').find('a').first().click()
         cy.get('gn-ui-autocomplete').should('have.value', '')
+      })
+      it('should allow to search in the entire catalog', () => {
+        cy.get('gn-ui-autocomplete').type('mat{enter}')
+        cy.get('gn-ui-interactive-table')
+          .find('[data-cy="table-row"]')
+          .should('have.length', '1')
+        cy.url().should('include', '/search?q=mat')
+        cy.url().should('not.include', 'owner')
       })
     })
   })

--- a/apps/metadata-editor/src/app/dashboard/dashboard-page.component.html
+++ b/apps/metadata-editor/src/app/dashboard/dashboard-page.component.html
@@ -7,6 +7,9 @@
       <div class="absolute top-0 left-0 w-2/3 z-50 pointer-events-none">
         <gn-ui-notifications-container></gn-ui-notifications-container>
       </div>
+      <header class="shrink-0 border-b border-gray-300">
+        <md-editor-search-header></md-editor-search-header>
+      </header>
       <router-outlet></router-outlet>
     </div>
   </div>

--- a/apps/metadata-editor/src/app/records/all-records/all-records.component.html
+++ b/apps/metadata-editor/src/app/records/all-records/all-records.component.html
@@ -1,6 +1,3 @@
-<header class="shrink-0 border-b border-gray-300">
-  <md-editor-search-header></md-editor-search-header>
-</header>
 <main class="bg-white overflow-y-auto">
   <div class="flex flex-row items-baseline gap-[8px] px-[32px] py-[20px]">
     <ng-container *ngIf="searchText$ | async as searchText; else allRecords">

--- a/apps/metadata-editor/src/app/records/my-draft/my-draft.component.html
+++ b/apps/metadata-editor/src/app/records/my-draft/my-draft.component.html
@@ -1,4 +1,3 @@
-<header class="h-[60px] border-b border-gray-300"></header>
 <main class="bg-white overflow-y-auto">
   <div class="flex flex-row items-baseline gap-[8px] px-[32px] py-[20px]">
     <h1 class="text-[16px] text-main font-bold" translate>

--- a/apps/metadata-editor/src/app/records/my-draft/my-draft.component.html
+++ b/apps/metadata-editor/src/app/records/my-draft/my-draft.component.html
@@ -1,7 +1,7 @@
 <header class="h-[60px] border-b border-gray-300"></header>
 <main class="bg-white overflow-y-auto">
   <div class="flex flex-row items-baseline gap-[8px] px-[32px] py-[20px]">
-    <h1 class="text-[16px] text-main font-title font-bold" translate>
+    <h1 class="text-[16px] text-main font-bold" translate>
       dashboard.records.myDraft
     </h1>
   </div>

--- a/apps/metadata-editor/src/app/records/my-draft/my-draft.component.ts
+++ b/apps/metadata-editor/src/app/records/my-draft/my-draft.component.ts
@@ -12,7 +12,7 @@ import { startWith, switchMap } from 'rxjs'
 import { RecordsCountComponent } from '../records-count/records-count.component'
 import { RecordsListComponent } from '../records-list.component'
 @Component({
-  selector: 'md-editor-my-my-draft',
+  selector: 'md-editor-my-draft',
   templateUrl: './my-draft.component.html',
   styleUrls: ['./my-draft.component.css'],
   standalone: true,

--- a/apps/metadata-editor/src/app/records/my-records/my-records.component.html
+++ b/apps/metadata-editor/src/app/records/my-records/my-records.component.html
@@ -1,11 +1,8 @@
-<header class="shrink-0 border-b border-gray-300">
-  <md-editor-search-header></md-editor-search-header>
-</header>
 <main class="bg-white overflow-y-auto">
   <div class="flex flex-row items-baseline gap-[8px] px-[32px] py-[20px]">
     <ng-container *ngIf="searchText$ | async as searchText; else myRecords">
       <h1
-        class="text-[16px] text-main font-title font-bold"
+        class="text-[16px] text-main font-bold"
         translate
         [translateParams]="{ searchText: searchText }"
       >
@@ -16,7 +13,7 @@
       </div>
     </ng-container>
     <ng-template #myRecords>
-      <h1 class="text-[16px] text-main font-title font-bold" translate>
+      <h1 class="text-[16px] text-main font-bold" translate>
         dashboard.records.myRecords
       </h1>
       <div class="text-[12px]">

--- a/apps/metadata-editor/src/app/records/my-records/my-records.component.html
+++ b/apps/metadata-editor/src/app/records/my-records/my-records.component.html
@@ -1,25 +1,13 @@
 <main class="bg-white overflow-y-auto">
   <div class="flex flex-row items-baseline gap-[8px] px-[32px] py-[20px]">
-    <ng-container *ngIf="searchText$ | async as searchText; else myRecords">
-      <h1
-        class="text-[16px] text-main font-bold"
-        translate
-        [translateParams]="{ searchText: searchText }"
-      >
-        dashboard.records.search
-      </h1>
-      <div class="text-[12px]">
-        <md-editor-records-count></md-editor-records-count>
-      </div>
-    </ng-container>
-    <ng-template #myRecords>
+    <ng-container *ngIf="searchFacade.searchFilters$ | async">
       <h1 class="text-[16px] text-main font-bold" translate>
         dashboard.records.myRecords
       </h1>
       <div class="text-[12px]">
         <md-editor-records-count></md-editor-records-count>
       </div>
-    </ng-template>
+    </ng-container>
   </div>
   <div
     class="flex flex-row items-center mx-[32px] my-[16px] py-[8px] gap-[16px]"

--- a/apps/metadata-editor/src/app/records/my-records/my-records.component.spec.ts
+++ b/apps/metadata-editor/src/app/records/my-records/my-records.component.spec.ts
@@ -112,12 +112,5 @@ describe('MyRecordsComponent', () => {
         owner: user.id,
       })
     })
-
-    it('should map search filters to searchText$', (done) => {
-      component.searchText$.subscribe((text) => {
-        expect(text).toBe('hello world')
-        done()
-      })
-    })
   })
 })

--- a/apps/metadata-editor/src/app/records/my-records/my-records.component.ts
+++ b/apps/metadata-editor/src/app/records/my-records/my-records.component.ts
@@ -24,8 +24,6 @@ import { TemplatePortal } from '@angular/cdk/portal'
 import { RecordsCountComponent } from '../records-count/records-count.component'
 import { ButtonComponent } from '@geonetwork-ui/ui/inputs'
 import { ImportRecordComponent } from '@geonetwork-ui/feature/editor'
-import { SearchHeaderComponent } from '../../dashboard/search-header/search-header.component'
-import { map, Observable } from 'rxjs'
 import { SearchFiltersComponent } from '../../dashboard/search-filters/search-filters.component'
 import {
   NgIconComponent,
@@ -54,7 +52,6 @@ const FILTER_OWNER = 'owner'
     ButtonComponent,
     ImportRecordComponent,
     FeatureSearchModule,
-    SearchHeaderComponent,
     SearchFiltersComponent,
     NgIconComponent,
   ],
@@ -76,7 +73,6 @@ export class MyRecordsComponent implements OnInit {
   @ViewChild('template') template!: TemplateRef<any>
   private overlayRef!: OverlayRef
   searchFields = ['changeDate']
-  searchText$: Observable<string | null>
 
   isImportMenuOpen = false
 
@@ -100,10 +96,6 @@ export class MyRecordsComponent implements OnInit {
           this.searchFacade.updateFilters(filters)
         })
     })
-
-    this.searchText$ = this.searchFacade.searchFilters$.pipe(
-      map((filters) => ('any' in filters ? (filters['any'] as string) : null))
-    )
   }
 
   createRecord() {


### PR DESCRIPTION
### Description

This PR makes sure the search through the search header is done throughout the whole catalog, from any dashboard. For instance, the user can find records that they don't own if they start a search from "My records" dashboard.
It also clarifies the search state process, to make sure the states for "myRecords" and "allRecords" stay distinct and are not reinitialized at every render.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
