### PR TITLE
Editor: Ignore search value in filter reset button

### DIFF
--- a/libs/feature/search/src/lib/search-filters-summary/search-filters-summary.component.spec.ts
+++ b/libs/feature/search/src/lib/search-filters-summary/search-filters-summary.component.spec.ts
@@ -13,6 +13,7 @@ import { FieldFilters } from '@geonetwork-ui/common/domain/model/search'
 
 class SearchFacadeMock {
   searchFilters$ = new BehaviorSubject<FieldFilters>({
+    any: 'search should be ignored',
     format: {},
     isSpatial: {},
     license: {},
@@ -94,7 +95,9 @@ describe('SearchFiltersSummaryComponent', () => {
 
     it('should clear filters', () => {
       component.clearFilters()
-      expect(searchService.setFilters).toHaveBeenCalledWith({})
+      expect(searchService.setFilters).toHaveBeenCalledWith({
+        any: 'search should be ignored',
+      })
     })
   })
 
@@ -139,6 +142,7 @@ describe('SearchFiltersSummaryComponent', () => {
     it('should clear filters except with keys from FILTER_SUMMARY_IGNORE_LIST', () => {
       const filters = {
         owner: { 1: true },
+        any: 'search should be ignored',
         format: {},
         isSpatial: {},
         license: {},
@@ -150,6 +154,7 @@ describe('SearchFiltersSummaryComponent', () => {
       component.clearFilters()
       expect(searchService.setFilters).toHaveBeenCalledWith({
         owner: { 1: true },
+        any: 'search should be ignored',
       })
     })
   })

--- a/libs/feature/search/src/lib/search-filters-summary/search-filters-summary.component.ts
+++ b/libs/feature/search/src/lib/search-filters-summary/search-filters-summary.component.ts
@@ -31,7 +31,11 @@ export class SearchFiltersSummaryComponent implements OnInit {
     @Inject(FILTER_SUMMARY_IGNORE_LIST)
     filterSummaryIgnoreList: string[]
   ) {
-    this.filterSummaryIgnoreList = filterSummaryIgnoreList || []
+    const defaultIgnoreList = ['any']
+    this.filterSummaryIgnoreList = [
+      ...defaultIgnoreList,
+      ...(filterSummaryIgnoreList ?? []),
+    ]
   }
 
   ngOnInit(): void {
@@ -47,7 +51,6 @@ export class SearchFiltersSummaryComponent implements OnInit {
         filteredFilters[key] = value
       }
     }
-    delete filteredFilters['any'] //ignore search field
     return Object.values(filteredFilters).some(
       (value) =>
         value !== undefined &&
@@ -63,7 +66,7 @@ export class SearchFiltersSummaryComponent implements OnInit {
         map((filters) => {
           const newFilters = { ...filters }
           Object.keys(newFilters).forEach((key) => {
-            if (!this.filterSummaryIgnoreList.includes(key) && key !== 'any') {
+            if (!this.filterSummaryIgnoreList.includes(key)) {
               delete newFilters[key]
             }
           })

--- a/libs/feature/search/src/lib/search-filters-summary/search-filters-summary.component.ts
+++ b/libs/feature/search/src/lib/search-filters-summary/search-filters-summary.component.ts
@@ -47,6 +47,7 @@ export class SearchFiltersSummaryComponent implements OnInit {
         filteredFilters[key] = value
       }
     }
+    delete filteredFilters['any'] //ignore search field
     return Object.values(filteredFilters).some(
       (value) =>
         value !== undefined &&
@@ -62,7 +63,7 @@ export class SearchFiltersSummaryComponent implements OnInit {
         map((filters) => {
           const newFilters = { ...filters }
           Object.keys(newFilters).forEach((key) => {
-            if (!this.filterSummaryIgnoreList.includes(key)) {
+            if (!this.filterSummaryIgnoreList.includes(key) && key !== 'any') {
               delete newFilters[key]
             }
           })


### PR DESCRIPTION
### Description

Small follow-up PR to #1030 and #1037 to prevent 
- displaying the filter reset button, when doing a textual search
- resetting the textual search when clicking the button

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->



### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
