### PR TITLE
Datahub: Use url instead of proxy url for ogc api endpoint

### DIFF
--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -174,7 +174,7 @@ export class DataService {
   }
 
   async getDownloadUrlsFromOgcApi(url: string): Promise<OgcApiCollectionInfo> {
-    const endpoint = new OgcApiEndpoint(this.proxy.getProxiedUrl(url))
+    const endpoint = new OgcApiEndpoint(url)
     return await endpoint.allCollections
       .then((collections) => {
         return endpoint.getCollectionInfo(collections[0].name)
@@ -185,7 +185,7 @@ export class DataService {
   }
 
   async getItemsFromOgcApi(url: string): Promise<OgcApiRecord> {
-    const endpoint = new OgcApiEndpoint(this.proxy.getProxiedUrl(url))
+    const endpoint = new OgcApiEndpoint(url)
     return await endpoint.featureCollections
       .then((collections) => {
         return collections.length


### PR DESCRIPTION
### Description

This PR removes the call to `getProxiedUrl` because the ogc-client does not support proxying OGC API endpoints.
It should fix errors for xhr-calls on some datasets.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves