### PR TITLE
Datahub: Tms support for basemap

### DIFF
--- a/conf/default.toml
+++ b/conf/default.toml
@@ -160,6 +160,9 @@ background_color = "#fdfbff"
 # Each layer is defined in its own [[map_layer]] section.
 # Example:
 # [[map_layer]]
+# type = "maplibre-style"
+# styleUrl = "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/gris.json"
+# [[map_layer]]
 # type = "xyz"
 # url = "https://{a-c}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
 # [[map_layer]]

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -231,6 +231,8 @@ The map section lets you customize how maps appear and behave across GeoNetwork-
   - `url` (mandatory for "xyz", "wms" and "wfs" types): Layer endpoint URL.
   - `name` (mandatory for "wms" and "wfs" types): indicates the layer name or feature type.
   - `data` (for "geojson" type only): inline GeoJSON data as string.
+  - `styleUrl` (mandatory for "maplibre-style" type only): Maplibre style URL.
+  - `accessToken` (optional for "maplibre-style" type only): credential to access the basemap styles service
 
   Layer order in the config is the same as in the map, the foreground layer being the last defined one.
 
@@ -254,6 +256,11 @@ The map section lets you customize how maps appear and behave across GeoNetwork-
   "features": [{"type": "Feature", "geometry": {"type": "Point", "coordinates": [125.6, 10.1]}}]
   }
   """
+
+  [[map_layer]]
+  type = "maplibre-style"
+  styleUrl = "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/gris.json"
+  accessToken = "token_if_needed" # optional
   ```
 
 - `external_viewer_url_template` (optional)

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -278,7 +278,11 @@ describe('app config utils', () => {
             [[map_layer]]
             type = "wfs"
             url = "https://www.geo2france.fr/geoserver/cr_hdf/ows"
-            name = "masque_hdf_ign_carto_latin1"`
+            name = "masque_hdf_ign_carto_latin1"
+            [[map_layer]]
+            type = "maplibre-style"
+            styleUrl = "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/standard.json"
+            accessToken = "any_token"`
         )
         await loadAppConfig()
       })
@@ -302,6 +306,12 @@ describe('app config utils', () => {
               TYPE: 'wfs',
               URL: 'https://www.geo2france.fr/geoserver/cr_hdf/ows',
               NAME: 'masque_hdf_ign_carto_latin1',
+            },
+            {
+              TYPE: 'maplibre-style',
+              STYLE_URL:
+                'https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/standard.json',
+              ACCESS_TOKEN: 'any_token',
             },
           ],
         })

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -137,7 +137,7 @@ export function loadAppConfig() {
         parsed,
         'map_layer',
         ['type'],
-        ['name', 'url', 'data'],
+        ['name', 'url', 'data', 'styleUrl', 'accessToken'],
         warnings,
         errors
       )
@@ -177,6 +177,8 @@ export function loadAppConfig() {
                     URL: map_layer.url,
                     NAME: map_layer.name,
                     DATA: map_layer.data,
+                    STYLE_URL: map_layer.styleUrl,
+                    ACCESS_TOKEN: map_layer.accessToken,
                   } as LayerConfig)
               ),
             } as MapConfig)

--- a/libs/util/app-config/src/lib/map-layers.ts
+++ b/libs/util/app-config/src/lib/map-layers.ts
@@ -27,5 +27,11 @@ export function getMapContextLayerFromConfig(
         type: config.TYPE,
         ...(config.DATA ? { data: config.DATA } : { url: config.URL }),
       }
+    case 'maplibre-style':
+      return {
+        type: config.TYPE,
+        styleUrl: config.STYLE_URL,
+        accessToken: config.ACCESS_TOKEN,
+      }
   }
 }

--- a/libs/util/app-config/src/lib/model.ts
+++ b/libs/util/app-config/src/lib/model.ts
@@ -14,10 +14,12 @@ export interface GlobalConfig {
 }
 
 export interface LayerConfig {
-  TYPE: 'xyz' | 'wms' | 'wfs' | 'geojson'
+  TYPE: 'xyz' | 'wms' | 'wfs' | 'geojson' | 'maplibre-style'
   URL?: string
   NAME?: string
   DATA?: string
+  STYLE_URL?: string
+  ACCESS_TOKEN?: string
 }
 
 export interface MapConfig {


### PR DESCRIPTION
### Description

This PR adds TMS configuration support for basemap layer in the map preview.

``` toml
[[map_layer]]
type = "maplibre-style"
styleUrl = "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/gris.json"
accessToken = "mytoken" #optional
```

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

none

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

no UI evolution

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [x] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
