### PR TITLE
[Datahub] Fix dates

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -226,7 +226,7 @@ describe('dataset pages', () => {
             .children('div')
             .should('have.length', 4)
         })
-        it('should display the creation date, the publication date, the frequency, the languages and the temporal extent', () => {
+        it('should display the resource creation date (for resource), the publication date (for resource), the frequency, the languages and the temporal extent', () => {
           cy.get('datahub-record-metadata')
             .find('[id="about"]')
             .find('gn-ui-expandable-panel')
@@ -239,7 +239,18 @@ describe('dataset pages', () => {
             .children('div')
             .eq(2)
             .children('div')
-            .should('have.length', 5)
+            .as('aboutContent')
+          cy.get('@aboutContent').should('have.length', 5)
+          cy.get('@aboutContent')
+            .eq(0)
+            .children('p')
+            .eq(1)
+            .should('contain.text', '22/09/2020')
+          cy.get('@aboutContent')
+            .eq(1)
+            .children('p')
+            .eq(1)
+            .should('contain.text', '17/03/2024')
         })
         it('should not display the same text twice in the constraints', () => {
           // this dataset has the same text for the license and the legal constraints

--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -245,12 +245,12 @@ describe('dataset pages', () => {
             .eq(0)
             .children('p')
             .eq(1)
-            .should('contain.text', '22/09/2020')
+            .should('contain.text', '9/22/2020')
           cy.get('@aboutContent')
             .eq(1)
             .children('p')
             .eq(1)
-            .should('contain.text', '17/03/2024')
+            .should('contain.text', '3/17/2024')
         })
         it('should not display the same text twice in the constraints', () => {
           // this dataset has the same text for the license and the legal constraints

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
@@ -1649,7 +1649,7 @@ describe('Gn4Converter', () => {
             ],
             recordCreated: new Date('2021-10-05T12:48:57.678Z'),
             recordUpdated: new Date('2021-10-05T12:48:57.678Z'),
-            recordPublished: new Date('2021-04-01T00:00:00.000Z'),
+            recordPublished: new Date('2021-11-05T12:48:57.678Z'),
             resourceCreated: new Date('2012-01-01T00:00:00.000Z'),
             resourceUpdated: new Date('2021-12-13T00:00:00.000Z'),
             resourcePublished: new Date('2021-04-01T00:00:00.000Z'),
@@ -2093,7 +2093,7 @@ describe('Gn4Converter', () => {
             status: null,
             lineage: null,
             recordUpdated: new Date('2024-10-15T07:37:39.350Z'),
-            recordPublished: new Date('2023-12-17T23:00:00.000Z'),
+            recordPublished: null,
             ownerOrganization: {
               name: 'My Organization',
               website: new URL('http://my.org/'),
@@ -2976,7 +2976,7 @@ describe('Gn4Converter', () => {
               website: new URL('http://my.org/'),
             },
             recordCreated: new Date('2013-07-29T11:33:08.000Z'),
-            recordPublished: new Date('2018-03-31T22:00:00.000Z'),
+            recordPublished: null,
             recordUpdated: new Date('2024-07-22T11:52:39.049Z'),
             resourceCreated: new Date('2017-05-31T22:00:00.000Z'),
             reuseType: 'application',
@@ -3279,7 +3279,9 @@ describe('Gn4Converter', () => {
             status: 'completed',
             lineage: null,
             recordUpdated: new Date('2024-01-25T07:45:05.215Z'),
-            recordPublished: new Date('2023-12-20T14:23:54.000Z'),
+            recordPublished: null,
+            recordCreated: new Date('2024-01-25T07:19:13.493Z'),
+            resourcePublished: new Date('2023-12-20T14:23:54.000Z'),
             ownerOrganization: {
               name: 'My Organization',
               website: new URL('http://my.org/'),
@@ -3367,7 +3369,6 @@ describe('Gn4Converter', () => {
             landingPage: new URL(
               'http://my.catalog.org/metadata/be209d24-586f-48f5-b944-e284079b7823'
             ),
-            recordCreated: new Date('2024-01-25T07:19:13.493Z'),
           })
         })
       })

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
@@ -1652,6 +1652,7 @@ describe('Gn4Converter', () => {
             recordPublished: new Date('2021-04-01T00:00:00.000Z'),
             resourceCreated: new Date('2012-01-01T00:00:00.000Z'),
             resourceUpdated: new Date('2021-12-13T00:00:00.000Z'),
+            resourcePublished: new Date('2021-04-01T00:00:00.000Z'),
             status: 'ongoing',
             topics: ['Installations de suivi environnemental', 'Océans'],
             title: 'Surval - Données par paramètre',
@@ -2350,6 +2351,7 @@ describe('Gn4Converter', () => {
             otherLanguages: [],
             title: 'Service OGC API Records du catalogue NAP-ITS-Wallonia',
             resourceUpdated: new Date('2023-12-17T23:00:00.000Z'),
+            resourcePublished: new Date('2023-12-17T23:00:00.000Z'),
             abstract:
               "Point d'accès OGC API Records du catalogue NAP-ITS-Wallonia contenant la description des données régionales de mobilité telles que demandé par la législation sur les systèmes de transport intelligents.",
             extras: {

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
@@ -2979,6 +2979,7 @@ describe('Gn4Converter', () => {
             recordPublished: null,
             recordUpdated: new Date('2024-07-22T11:52:39.049Z'),
             resourceCreated: new Date('2017-05-31T22:00:00.000Z'),
+            resourcePublished: new Date('2018-03-31T22:00:00.000Z'),
             reuseType: 'application',
             securityConstraints: [],
             spatialExtents: [

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -136,12 +136,16 @@ export class Gn4FieldMapper {
       ...output,
       recordUpdated: toDate(selectField<string>(source, 'changeDate')),
     }),
-    publicationDateForResource: (output, source) => ({
-      ...output,
-      recordPublished: toDate(
+    publicationDateForResource: (output, source) => {
+      const datePublished = toDate(
         selectField<string>(source, 'publicationDateForResource')
-      ),
-    }),
+      )
+      return {
+        ...output,
+        recordPublished: datePublished,
+        resourcePublished: datePublished,
+      }
+    },
     resourceLanguage: (output, source) => {
       const langList = getAsArray(
         selectField<string>(source, 'resourceLanguage')

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -128,6 +128,12 @@ export class Gn4FieldMapper {
         getFirstValue(selectField<string>(source, 'revisionDateForResource'))
       ),
     }),
+    publicationDateForResource: (output, source) => ({
+      ...output,
+      resourcePublished: toDate(
+        selectField<string>(source, 'publicationDateForResource')
+      ),
+    }),
     createDate: (output, source) => ({
       ...output,
       recordCreated: toDate(selectField<string>(source, 'createDate')),
@@ -136,16 +142,10 @@ export class Gn4FieldMapper {
       ...output,
       recordUpdated: toDate(selectField<string>(source, 'changeDate')),
     }),
-    publicationDateForResource: (output, source) => {
-      const datePublished = toDate(
-        selectField<string>(source, 'publicationDateForResource')
-      )
-      return {
-        ...output,
-        recordPublished: datePublished,
-        resourcePublished: datePublished,
-      }
-    },
+    publicationDate: (output, source) => ({
+      ...output,
+      recordPublished: toDate(selectField<string>(source, 'publicationDate')),
+    }),
     resourceLanguage: (output, source) => {
       const langList = getAsArray(
         selectField<string>(source, 'resourceLanguage')

--- a/libs/common/fixtures/src/lib/elasticsearch/full-response.fixtures.ts
+++ b/libs/common/fixtures/src/lib/elasticsearch/full-response.fixtures.ts
@@ -1502,6 +1502,7 @@ export const elasticFullResponseFixture = () => ({
           changeDate: '2021-10-05T12:48:57.678Z',
           id: '11700',
           createDate: '2021-10-05T12:48:57.678Z',
+          publicationDate: '2021-11-05T12:48:57.678Z',
           owner: '100',
           groupOwner: '2',
           logo: '/images/logos/81e8a591-7815-4d2f-a7da-5673192e74c9.png',

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -97,7 +97,7 @@
 <gn-ui-expandable-panel
   *ngIf="
     metadata.lineage ||
-    metadata.recordUpdated ||
+    metadata.resourceUpdated ||
     metadata.updateFrequency ||
     metadata.status
   "
@@ -160,16 +160,16 @@
   <div
     class="py-6 px-6 rounded bg-gray-100 grid grid-cols-2 gap-y-6 gap-x-[20px] text-gray-700"
   >
-    <div *ngIf="metadata.recordCreated">
+    <div *ngIf="metadata.resourceCreated">
       <p class="text-sm" translate>record.metadata.creation</p>
       <p class="text-primary font-medium mt-1">
-        {{ metadata.recordCreated.toLocaleDateString() }}
+        {{ metadata.resourceCreated.toLocaleDateString() }}
       </p>
     </div>
-    <div *ngIf="metadata.recordPublished">
+    <div *ngIf="metadata.resourcePublished">
       <p class="text-sm" translate>record.metadata.publication</p>
       <p class="text-primary font-medium mt-1">
-        {{ metadata.recordPublished.toLocaleDateString() }}
+        {{ metadata.resourcePublished.toLocaleDateString() }}
       </p>
     </div>
     <div *ngIf="updateFrequency">


### PR DESCRIPTION
### Description

This PR fixes the content of the "About the data" section regarding the dates: instead of displaying the metadata dates, we now display the resource related dates (`recordUpdated`, `resourceCreated`, and `resourcePublished` instead of `recordCreated` and `recordPublished`).

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

Breaking change:

- `publicationDateForResource` now becomes `resourcePublished` after conversion (instead of `recordPublished`)
- `publicationDate` becomes `recordPublished` after conversion (new)

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

No change in the UI.

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
