### PR TITLE
[DH][IGN] : Quality score widget stuck at 87%

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -241,6 +241,21 @@ describe('dataset pages', () => {
             .children('div')
             .should('have.length', 5)
         })
+        it('should not display the same text twice in the constraints', () => {
+          // this dataset has the same text for the license and the legal constraints
+          cy.visit('/dataset/9e1ea778-d0ce-4b49-90b7-37bc0e448300')
+          cy.get('datahub-record-metadata')
+            .find('gn-ui-expandable-panel')
+            .first()
+            .click()
+          cy.get('datahub-record-metadata')
+            .find('gn-ui-expandable-panel')
+            .first()
+            .children('div')
+            .eq(1)
+            .children('div')
+            .should('have.length', 1)
+        })
       })
     })
     describe('features', () => {
@@ -300,12 +315,37 @@ describe('dataset pages', () => {
         })
         cy.reload()
       })
-
-      it('should display quality widget', () => {
-        cy.get('gn-ui-metadata-quality gn-ui-progress-bar')
-          .eq(0)
-          .should('have.attr', 'ng-reflect-value', 87)
-        cy.screenshot({ capture: 'fullPage' })
+      describe('Score is less than 100%', () => {
+        it('should display the score', () => {
+          cy.get('gn-ui-metadata-quality gn-ui-progress-bar')
+            .eq(0)
+            .should('have.attr', 'ng-reflect-value', 87)
+          cy.screenshot({ capture: 'fullPage' })
+        })
+        it('should not check all the criteria', () => {
+          cy.get('gn-ui-metadata-quality').realHover()
+          cy.get('gn-ui-metadata-quality-item')
+            .find('ng-icon')
+            .eq(4)
+            .should('have.attr', 'ng-reflect-name', 'matWarningAmber')
+        })
+      })
+      describe('Score is 100%', () => {
+        beforeEach(() => {
+          cy.visit('/dataset/6d0bfdf4-4e94-48c6-9740-3f9facfd453c')
+        })
+        it('should display the score', () => {
+          cy.get('gn-ui-metadata-quality gn-ui-progress-bar')
+            .eq(0)
+            .should('have.attr', 'ng-reflect-value', 100)
+        })
+        it('should check all the criteria if score is 100%', () => {
+          cy.get('gn-ui-metadata-quality').realHover()
+          cy.get('gn-ui-metadata-quality-item')
+            .find('ng-icon')
+            .eq(4)
+            .should('have.attr', 'ng-reflect-name', 'matCheck')
+        })
       })
     })
   })

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
@@ -857,7 +857,15 @@ describe('Gn4Converter', () => {
 
         it('parses the legal constraints', async () => {
           const record = (await service.readRecord(hit)) as DatasetRecord
-          expect(record.legalConstraints).toEqual([])
+          expect(record.legalConstraints).toEqual([
+            {
+              text: 'Öffentlich zugängliche Geobasisdaten: Zugangsberechtigungsstufe A (nach GeoIV, Art. 21).',
+              url: new URL('https://registry.geocat.ch/use-limitation/levelA'),
+            },
+            {
+              text: 'Es gelten die Nutzungsbedingungen für Geodaten des Kantons Wallis (https://www.vs.ch/de/web/guest/rechtliches).',
+            },
+          ])
         })
 
         it('parses the security constraints', async () => {
@@ -1013,6 +1021,15 @@ describe('Gn4Converter', () => {
             legalConstraints: [
               {
                 text: "Restriction légale d'utilisation à préciser",
+              },
+              {
+                text: 'Pas de restriction d’accès public',
+                url: new URL(
+                  'http://inspire.ec.europa.eu/metadatacodelist/LimitationsOnPublicAccess/noLimitations'
+                ),
+              },
+              {
+                text: 'Licence Ouverte version 2.0  https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf',
               },
             ],
             securityConstraints: [],
@@ -1909,7 +1926,14 @@ describe('Gn4Converter', () => {
             ),
             defaultLanguage: 'de',
             otherLanguages: ['fr', 'it'],
-            legalConstraints: [],
+            legalConstraints: [
+              {
+                text: 'Opendata BY: Freie Nutzung. Quellenangabe ist Pflicht.',
+                url: new URL(
+                  'https://opendata.swiss/en/terms-of-use/#terms_by'
+                ),
+              },
+            ],
             licenses: [
               {
                 text: 'Opendata BY: Freie Nutzung. Quellenangabe ist Pflicht.',

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -378,16 +378,6 @@ export class Gn4FieldMapper {
       ...output,
       [outputField]: outputArray,
     }
-    // avoid legal constraints being duplicates of licenses
-    if (
-      'legalConstraints' in result &&
-      (type === 'legal' || type === 'license')
-    ) {
-      result.legalConstraints = result.legalConstraints.filter(
-        (constraint) =>
-          !output.licenses?.some((license) => license.text === constraint.text)
-      )
-    }
     return result
   }
 

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.spec.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.spec.ts
@@ -131,4 +131,35 @@ describe('MetadataInfoComponent', () => {
       })
     })
   })
+  describe('legalConstraints', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(MetadataInfoComponent)
+      component = fixture.componentInstance
+      component.metadata = datasetRecordsFixture()[0] as DatasetRecord
+      fixture.detectChanges()
+    })
+    it('should filter out the licenses from the legal constraints', () => {
+      component.metadata = {
+        ...datasetRecordsFixture()[0],
+        licenses: [
+          ...datasetRecordsFixture()[0].licenses,
+          {
+            text: 'Contains sensitive information related to national defense',
+            url: new URL('https:/google.com/pages/licence/'),
+          },
+        ],
+      } as DatasetRecord
+      expect(component.legalConstraints).toEqual([
+        "Dataset access isn't possible since it does not really exist",
+      ])
+    })
+    it('should not return anything if the license is the only legal constraint', () => {
+      component.metadata = {
+        ...datasetRecordsFixture()[0],
+        legalConstraints: datasetRecordsFixture()[0].licenses,
+      } as DatasetRecord
+      fixture.detectChanges()
+      expect(component.legalConstraints).toEqual([])
+    })
+  })
 })

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
@@ -74,8 +74,13 @@ export class MetadataInfoComponent {
   get legalConstraints() {
     let array = []
     if (this.metadata.legalConstraints?.length) {
+      const licensesTexts = this.metadata.licenses.map(
+        (license) => license.text
+      )
       array = array.concat(
-        this.metadata.legalConstraints.filter((c) => c.text).map((c) => c.text)
+        this.metadata.legalConstraints
+          .filter((c) => c.text && !licensesTexts.includes(c.text))
+          .map((c) => c.text)
       )
     }
     return array

--- a/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.ts
+++ b/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.ts
@@ -15,6 +15,7 @@ import {
   ProgressBarComponent,
 } from '@geonetwork-ui/ui/widgets'
 import { CommonModule } from '@angular/common'
+import { TranslateModule } from '@ngx-translate/core'
 
 @Component({
   selector: 'gn-ui-metadata-quality',
@@ -27,6 +28,7 @@ import { CommonModule } from '@angular/common'
     PopoverComponent,
     ProgressBarComponent,
     MetadataQualityItemComponent,
+    TranslateModule,
   ],
 })
 export class MetadataQualityComponent implements OnChanges {


### PR DESCRIPTION
### Description

#### What the issue was

The issue was that a filtering was done during the field mapping to remove any legal constraint that was also present in the licenses, to avoid having duplicates displayed. Since some records only have a legal constraint that happens to be a license, the array ends up empty.

#### Fix

The filtering was removed from the mapping and placed in a display component.

#### What issues remain


_**This PR fixes the behavior of the quality score widget specifically for IGN.**_

The backend still returns a wrong value for the quality score, which is taken instead of the one calculated by the front-end.
The IGN platform doesn't have a value returned for that field, which means that this fix will work on their platform (to test on our platform, we can simulate an empty value [here](https://github.com/geonetwork/geonetwork-ui/blob/17894ab49ccebf771ed6234174346f7360ce54e4/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.ts#L40)).

With this fix, all of our records that should be displaying a score of 100% will still show 87% with all indicators checked (like on the geo2france platform). 

### Screenshots

![Screenshot from 2025-01-09 12-27-40](https://github.com/user-attachments/assets/652a50c0-1728-434e-80a7-89feb10520bb)

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

-----

Thanks @AlitaBernachot for the help on this :slightly_smiling_face: 