### PR TITLE
editor: set default metadata contact on creation

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
@@ -671,7 +671,7 @@ describe('editor form', () => {
             .children('div')
             .first()
             .invoke('text')
-            .should('eq', ' Creative Commons CC-BY ')
+            .should('eq', ' Unknown or absent ')
           cy.editor_wrapPreviousDraft()
           cy.get('gn-ui-form-field-license')
             .find('gn-ui-dropdown-selector')

--- a/apps/metadata-editor/src/app/edit/edit-page.component.html
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.html
@@ -47,8 +47,8 @@
           </gn-ui-button>
           <gn-ui-button
             type="primary"
+            *ngIf="(isLastPage$ | async) === false"
             (buttonClick)="nextPageButtonHandler()"
-            [disabled]="isLastPage$ | async"
           >
             <span translate>editor.record.form.bottomButtons.next</span>
           </gn-ui-button>

--- a/apps/metadata-editor/src/app/new-record.resolver.spec.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.spec.ts
@@ -66,7 +66,7 @@ describe('NewRecordResolver', () => {
     })
 
     it('creates a new empty record with a pregenerated id and connected user information as contact for ressource with the point_of_contact role.', () => {
-      const expectedContactsForResource = [
+      const expectedContacts = [
         {
           firstName: user.name,
           lastName: user.surname,
@@ -81,15 +81,11 @@ describe('NewRecordResolver', () => {
           abstract: '',
           kind: 'dataset',
           recordUpdated: expect.any(Date),
-          contactsForResource: expectedContactsForResource,
-          contacts: expectedContactsForResource,
+          contactsForResource: expectedContacts,
+          contacts: expectedContacts,
           status: 'ongoing',
           temporalExtents: [],
-          licenses: [
-            {
-              text: 'cc-by',
-            },
-          ],
+          licenses: [],
           title: expect.stringMatching(/^My new record/),
           uniqueIdentifier: null,
         } as Partial<CatalogRecord>,

--- a/apps/metadata-editor/src/app/new-record.resolver.spec.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.spec.ts
@@ -85,6 +85,11 @@ describe('NewRecordResolver', () => {
           contacts: expectedContactsForResource,
           status: 'ongoing',
           temporalExtents: [],
+          licenses: [
+            {
+              text: 'cc-by',
+            },
+          ],
           title: expect.stringMatching(/^My new record/),
           uniqueIdentifier: null,
         } as Partial<CatalogRecord>,

--- a/apps/metadata-editor/src/app/new-record.resolver.spec.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.spec.ts
@@ -82,11 +82,12 @@ describe('NewRecordResolver', () => {
           kind: 'dataset',
           recordUpdated: expect.any(Date),
           contactsForResource: expectedContactsForResource,
+          contacts: expectedContactsForResource,
           status: 'ongoing',
           temporalExtents: [],
           title: expect.stringMatching(/^My new record/),
           uniqueIdentifier: null,
-        },
+        } as Partial<CatalogRecord>,
         null,
         false,
       ])

--- a/apps/metadata-editor/src/app/new-record.resolver.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.ts
@@ -30,7 +30,7 @@ export class NewRecordResolver {
           ownerOrganization: {
             name: 'Owner organization',
           },
-          contacts: [],
+          contacts: contactsForResource ? [contactsForResource] : [],
           recordUpdated: new Date(),
           updateFrequency: 'unknown',
           otherLanguages: [],

--- a/apps/metadata-editor/src/app/new-record.resolver.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.ts
@@ -37,7 +37,11 @@ export class NewRecordResolver {
           defaultLanguage: 'en',
           topics: [],
           keywords: [],
-          licenses: [],
+          licenses: [
+            {
+              text: 'cc-by',
+            },
+          ],
           legalConstraints: [],
           securityConstraints: [],
           otherConstraints: [],

--- a/apps/metadata-editor/src/app/new-record.resolver.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.ts
@@ -22,7 +22,7 @@ export class NewRecordResolver {
 
   resolve(): Observable<[CatalogRecord, string, boolean]> {
     return this.getCurrentUserAsPointOfContact().pipe(
-      map((contactsForResource) => {
+      map((userContact) => {
         const catalogRecord: CatalogRecord = {
           uniqueIdentifier: null,
           title: `My new record`,
@@ -30,23 +30,19 @@ export class NewRecordResolver {
           ownerOrganization: {
             name: 'Owner organization',
           },
-          contacts: contactsForResource ? [contactsForResource] : [],
+          contacts: userContact ? [userContact] : [],
           recordUpdated: new Date(),
           updateFrequency: 'unknown',
           otherLanguages: [],
           defaultLanguage: 'en',
           topics: [],
           keywords: [],
-          licenses: [
-            {
-              text: 'cc-by',
-            },
-          ],
+          licenses: [],
           legalConstraints: [],
           securityConstraints: [],
           otherConstraints: [],
           overviews: [],
-          contactsForResource: contactsForResource ? [contactsForResource] : [],
+          contactsForResource: userContact ? [userContact] : [],
           kind: 'dataset',
           status: 'ongoing',
           lineage: '',

--- a/libs/feature/editor/src/lib/+state/editor.selectors.ts
+++ b/libs/feature/editor/src/lib/+state/editor.selectors.ts
@@ -43,11 +43,11 @@ export const selectCurrentPage = createSelector(
 export const selectRecordSections = createSelector(
   selectEditorState,
   (state: EditorState) => {
-    const currentPage = state.editorConfig.pages[state.currentPage]
-    if (!currentPage) {
+    const currentPageConfig = state.editorConfig.pages[state.currentPage]
+    if (!currentPageConfig) {
       return [] as EditorSectionWithValues[]
     }
-    return currentPage.sections.map((section) => ({
+    return currentPageConfig.sections.map((section) => ({
       ...section,
       fieldsWithValues: section.fields.map((fieldConfig) => ({
         config: fieldConfig,

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.html
@@ -2,7 +2,7 @@
   <gn-ui-dropdown-selector
     [title]="label"
     [showTitle]="false"
-    [choices]="licenceOptions"
+    [choices]="choices"
     [selected]="selectedLicence"
     (selectValue)="handleLicenceSelection($event)"
     [extraBtnClass]="'input-as-button gn-ui-text-input'"

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.spec.ts
@@ -15,7 +15,7 @@ describe('FormFieldLicenseComponent', () => {
     fixture = TestBed.createComponent(FormFieldLicenseComponent)
     component = fixture.componentInstance
     component.label = 'License' // TODO: translate
-    component.recordConstraints = [{ text: 'cc-by' }]
+    component.recordLicences = [{ text: 'cc-by' }]
     fixture.detectChanges()
   })
 
@@ -29,7 +29,7 @@ describe('FormFieldLicenseComponent', () => {
   })
   describe('#onSelectValue', () => {
     it('should emit the selected value', () => {
-      const spy = jest.spyOn(component.recordConstraintsChange, 'emit')
+      const spy = jest.spyOn(component.recordLicencesChange, 'emit')
       component.handleLicenceSelection('cc-by-sa')
       expect(spy).toHaveBeenCalledWith([{ text: 'cc-by-sa' }])
     })

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.spec.ts
@@ -33,6 +33,12 @@ describe('FormFieldLicenseComponent', () => {
       component.handleLicenceSelection('cc-by-sa')
       expect(spy).toHaveBeenCalledWith([{ text: 'cc-by-sa' }])
     })
+
+    it('should emit no value when unknown was selected', () => {
+      const spy = jest.spyOn(component.recordLicencesChange, 'emit')
+      component.handleLicenceSelection('unknown')
+      expect(spy).toHaveBeenCalledWith([])
+    })
   })
   describe('#ngOnInit', () => {
     it('should set selectedLicence based on recordLicences', () => {
@@ -40,10 +46,17 @@ describe('FormFieldLicenseComponent', () => {
       expect(component.selectedLicence).toBe('cc-by')
     })
 
-    it('should add recordLicence to choices if not found', () => {
+    it('should add recordLicence to choices if not found in available licences, and select it', () => {
       component.recordLicences = [{ text: 'new-license' }]
       component.ngOnInit()
       expect(component.choices[0].value).toBe('new-license')
+      expect(component.selectedLicence).toBe('new-license')
+    })
+
+    it('should set selectedLicence to unknown if recordLicence is empty', () => {
+      component.recordLicences = []
+      component.ngOnInit()
+      expect(component.selectedLicence).toBe('unknown')
     })
   })
 })

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.spec.ts
@@ -34,4 +34,16 @@ describe('FormFieldLicenseComponent', () => {
       expect(spy).toHaveBeenCalledWith([{ text: 'cc-by-sa' }])
     })
   })
+  describe('#ngOnInit', () => {
+    it('should set selectedLicence based on recordLicences', () => {
+      component.ngOnInit()
+      expect(component.selectedLicence).toBe('cc-by')
+    })
+
+    it('should add recordLicence to choices if not found', () => {
+      component.recordLicences = [{ text: 'new-license' }]
+      component.ngOnInit()
+      expect(component.choices[0].value).toBe('new-license')
+    })
+  })
 })

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.ts
@@ -30,27 +30,29 @@ export class FormFieldLicenseComponent implements OnInit {
   @Output() recordLicencesChange: EventEmitter<Constraint[]> =
     new EventEmitter()
 
+  choices: Licence[] = AVAILABLE_LICENSES.map((license) => ({
+    label: marker(`editor.record.form.license.${license}`),
+    value: license,
+  }))
+
   selectedLicence: string
 
   ngOnInit(): void {
-    // get the licence from the record constraints if it is one of the open data licence list
     this.selectedLicence = this.recordLicences.find((constraint) => {
-      return this.licenceOptions.find((licence) => {
+      return this.choices.find((licence) => {
         return licence.value === constraint.text
       })
     })?.text
-    // otherwise pre-select the first licence option
-    if (this.selectedLicence === undefined) {
-      this.selectedLicence = this.licenceOptions[0].value // cannot select 'etalab' as default as this would toggle the OpenData Toggle
-      this.recordLicencesChange.emit([{ text: this.selectedLicence }])
-    }
-  }
 
-  get licenceOptions(): Licence[] {
-    return AVAILABLE_LICENSES.map((license) => ({
-      label: marker(`editor.record.form.license.${license}`),
-      value: license,
-    }))
+    if (this.selectedLicence === undefined) {
+      this.choices = [
+        {
+          value: this.recordLicences[0].text,
+          label: this.recordLicences[0].text,
+        },
+        ...this.choices,
+      ]
+    }
   }
 
   handleLicenceSelection(licenceValue: string) {

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.ts
@@ -38,11 +38,15 @@ export class FormFieldLicenseComponent implements OnInit {
   selectedLicence: string
 
   ngOnInit(): void {
-    this.selectedLicence = this.recordLicences.find((constraint) => {
-      return this.choices.find((licence) => {
-        return licence.value === constraint.text
-      })
-    })?.text
+    if (this.recordLicences.length === 0) {
+      this.selectedLicence = 'unknown'
+    } else {
+      this.selectedLicence = this.recordLicences.find((constraint) => {
+        return this.choices.find((licence) => {
+          return licence.value === constraint.text
+        })
+      })?.text
+    }
 
     if (this.selectedLicence === undefined) {
       this.choices = [
@@ -52,11 +56,17 @@ export class FormFieldLicenseComponent implements OnInit {
         },
         ...this.choices,
       ]
+      this.selectedLicence = this.recordLicences[0].text
     }
   }
 
   handleLicenceSelection(licenceValue: string) {
     this.selectedLicence = licenceValue
-    this.recordLicencesChange.emit([{ text: licenceValue }])
+    if (licenceValue === 'unknown') {
+      this.recordLicencesChange.emit([])
+      return
+    } else {
+      this.recordLicencesChange.emit([{ text: licenceValue }])
+    }
   }
 }

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-license/form-field-license.component.ts
@@ -26,15 +26,15 @@ type Licence = {
 })
 export class FormFieldLicenseComponent implements OnInit {
   @Input() label: string
-  @Input() recordConstraints: Constraint[] = []
-  @Output() recordConstraintsChange: EventEmitter<Constraint[]> =
+  @Input() recordLicences: Constraint[] = []
+  @Output() recordLicencesChange: EventEmitter<Constraint[]> =
     new EventEmitter()
 
   selectedLicence: string
 
   ngOnInit(): void {
     // get the licence from the record constraints if it is one of the open data licence list
-    this.selectedLicence = this.recordConstraints.find((constraint) => {
+    this.selectedLicence = this.recordLicences.find((constraint) => {
       return this.licenceOptions.find((licence) => {
         return licence.value === constraint.text
       })
@@ -42,7 +42,7 @@ export class FormFieldLicenseComponent implements OnInit {
     // otherwise pre-select the first licence option
     if (this.selectedLicence === undefined) {
       this.selectedLicence = this.licenceOptions[0].value // cannot select 'etalab' as default as this would toggle the OpenData Toggle
-      this.recordConstraintsChange.emit([{ text: this.selectedLicence }])
+      this.recordLicencesChange.emit([{ text: this.selectedLicence }])
     }
   }
 
@@ -55,6 +55,6 @@ export class FormFieldLicenseComponent implements OnInit {
 
   handleLicenceSelection(licenceValue: string) {
     this.selectedLicence = licenceValue
-    this.recordConstraintsChange.emit([{ text: licenceValue }])
+    this.recordLicencesChange.emit([{ text: licenceValue }])
   }
 }

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.html
@@ -112,8 +112,8 @@
     <ng-container *ngSwitchCase="'licenses'">
       <gn-ui-form-field-license
         [label]="config.labelKey! | translate"
-        [recordConstraints]="valueAsConstraints"
-        (recordConstraintsChange)="valueChange.emit($event)"
+        [recordLicences]="valueAsConstraints"
+        (recordLicencesChange)="valueChange.emit($event)"
       ></gn-ui-form-field-license>
     </ng-container>
 


### PR DESCRIPTION
### Description

- When creating a new record, the authenticated user is added as metadata contact (it was already added as resource contact).
- Fix licence form section. The licence section was forcing a licence value if the one in the metadata was not recognized. The form should not change the metadata automatically.