### PR TITLE
fix(icons): center icons from home page #1091

### DIFF
--- a/libs/ui/dataviz/src/lib/figure/figure.component.html
+++ b/libs/ui/dataviz/src/lib/figure/figure.component.html
@@ -9,14 +9,14 @@
     (title | translate: { count: figure })
   "
 >
-  <ng-icon
+  <div
     class="{{ bgClass }} {{
       textClass
-    }} text-[1.875em] rounded-full mr-[0.55em] p-[0.6em] w-[2.2em] h-[2.2em] shrink-0"
+    }} text-[1.875em] rounded-full mr-[0.55em] flex justify-center items-center w-[2.2em] h-[2.2em] shrink-0"
     style="width: 2.2em; height: 2.2em"
-    [name]="icon"
   >
-  </ng-icon>
+    <ng-icon class="text-[0.66em]" [name]="icon"> </ng-icon>
+  </div>
   <div class="shrink overflow-hidden">
     <div class="figure-block text-[1.5em] text-black">
       <span class="figure font-medium mr-[0.3em]" data-test="figure">{{


### PR DESCRIPTION
### Description

This PR pr fixe the icon home pages.

fixes #1091 



### Architectural changes


### Screenshots
![image](https://github.com/user-attachments/assets/0ab945b5-05d2-4850-bd07-4b3c17571e22)



### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
