### PR TITLE
Datahub: fix some issues in query URL generation form

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -773,7 +773,7 @@ describe('api form', () => {
       cy.get('@secondInput').type('87')
 
       cy.get('@apiForm').find('gn-ui-dropdown-selector').as('dropdown')
-      cy.get('@dropdown').eq(0).selectDropdownOption('geojson')
+      cy.get('@dropdown').eq(0).selectDropdownOption('application/geo+json')
 
       cy.get('@apiForm')
         .find('gn-ui-copy-text-button')
@@ -794,7 +794,7 @@ describe('api form', () => {
         .find('gn-ui-copy-text-button')
         .find('input')
         .invoke('val')
-        .should('include', 'f=json&limit=-1')
+        .should('include', 'f=application%2Fjson&limit=-1')
     })
     it('should close the panel on click', () => {
       cy.get('gn-ui-record-api-form').prev().find('button').click()

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
@@ -88,10 +88,10 @@ describe('RecordApiFormComponent', () => {
       expect(component.apiBaseUrl).toBe('https://api.example.com/data')
       expect(component.offset$.getValue()).toBe('')
       expect(component.limit$.getValue()).toBe('-1')
-      expect(component.format$.getValue()).toBe('json')
+      expect(component.format$.getValue()).toBe('application/json')
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        'https://api.example.com/data/collections/feature1/items?limit=-1&f=json'
+        'https://api.example.com/data/collections/feature1/items?limit=-1&f=application%2Fjson'
       )
     })
   })
@@ -99,37 +99,37 @@ describe('RecordApiFormComponent', () => {
     it('should update query URL correctly when setting offset, limit, and format', async () => {
       const mockOffset = '10'
       const mockLimit = '20'
-      const mockFormat = 'json'
+      const mockFormat = 'text/csv'
       component.setOffset(mockOffset)
       component.setLimit(mockLimit)
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data/collections/feature1/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
+        `https://api.example.com/data/collections/feature1/items?limit=${mockLimit}&offset=${mockOffset}&f=${encodeURIComponent(mockFormat)}`
       )
     })
     it('should remove the param in url if value is null', async () => {
       const mockOffset = '0'
       const mockLimit = '20'
-      const mockFormat = 'json'
+      const mockFormat = 'application/json'
       component.setOffset(mockOffset)
       component.setLimit(mockLimit)
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data/collections/feature1/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
+        `https://api.example.com/data/collections/feature1/items?limit=${mockLimit}&offset=${mockOffset}&f=${encodeURIComponent(mockFormat)}`
       )
     })
     it('should remove the param in url if value is zero', async () => {
       const mockOffset = '10'
       const mockLimit = '0'
-      const mockFormat = 'json'
+      const mockFormat = 'application/json'
       component.setOffset(mockOffset)
       component.setLimit(mockLimit)
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data/collections/feature1/items?limit=${mockLimit}&offset=${mockOffset}&f=${mockFormat}`
+        `https://api.example.com/data/collections/feature1/items?limit=${mockLimit}&offset=${mockOffset}&f=${encodeURIComponent(mockFormat)}`
       )
     })
   })
@@ -139,7 +139,7 @@ describe('RecordApiFormComponent', () => {
       component.resetUrl()
       expect(component.offset$.getValue()).toBe('')
       expect(component.limit$.getValue()).toBe('-1')
-      expect(component.format$.getValue()).toBe('json')
+      expect(component.format$.getValue()).toBe('application/json')
     })
   })
 
@@ -151,9 +151,9 @@ describe('RecordApiFormComponent', () => {
     it('should parse the returned formats', () => {
       component.parseOutputFormats()
       expect(component.outputFormats).toEqual([
-        { value: 'csv', label: 'CSV' },
-        { value: 'geojson', label: 'GEOJSON' },
-        { value: 'json', label: 'JSON' },
+        { value: 'text/csv', label: 'CSV' },
+        { value: 'application/geo+json', label: 'GEOJSON' },
+        { value: 'application/json', label: 'JSON' },
       ])
     })
   })
@@ -172,10 +172,10 @@ describe('RecordApiFormComponent', () => {
       expect(component.accessServiceProtocol).toBe('wfs')
       expect(component.offset$.getValue()).toBe('')
       expect(component.limit$.getValue()).toBe('-1')
-      expect(component.format$.getValue()).toBe('json')
+      expect(component.format$.getValue()).toBe('application/json')
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"json","limit":-1}`
+        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"application/json","limit":-1}`
       )
     })
   })


### PR DESCRIPTION
### Description

This PR fixes https://github.com/geonetwork/geonetwork-ui/issues/1067 to use the correct mime-type when generating an URL in the API form.

This also supports specifying a collection name alongside an OGC API link instead of having the URL already point to a specific collection.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

none

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

![image](https://github.com/user-attachments/assets/729e593e-f24a-4818-b0c1-fb9996021f68)

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [x] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->


