### PR TITLE
[Backport 2.3.x] Datahub: fix some issues in query URL generation form

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -706,7 +706,7 @@ describe('api form', () => {
     cy.get('@secondInput').type('87')
 
     cy.get('@apiForm').find('gn-ui-dropdown-selector').as('dropdown')
-    cy.get('@dropdown').eq(0).selectDropdownOption('geojson')
+    cy.get('@dropdown').eq(0).selectDropdownOption('application/geo+json')
 
     cy.get('@apiForm')
       .find('gn-ui-copy-text-button')
@@ -727,7 +727,7 @@ describe('api form', () => {
       .find('gn-ui-copy-text-button')
       .find('input')
       .invoke('val')
-      .should('include', 'f=json&limit=-1')
+      .should('include', 'f=application%2Fjson&limit=-1')
   })
   it('should close the panel on click', () => {
     cy.get('gn-ui-record-api-form').prev().find('button').click()

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
@@ -114,7 +114,9 @@ describe('RecordApiFormComponent', () => {
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data/collections/uniqueCollection/items?limit=${mockLimit}&offset=${mockOffset}&f=${encodeURIComponent(mockFormat)}`
+        `https://api.example.com/data/collections/uniqueCollection/items?limit=${mockLimit}&offset=${mockOffset}&f=${encodeURIComponent(
+          mockFormat
+        )}`
       )
     })
     it('should remove the param in url if value is null', async () => {
@@ -126,7 +128,9 @@ describe('RecordApiFormComponent', () => {
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data/collections/uniqueCollection/items?limit=${mockLimit}&offset=${mockOffset}&f=${encodeURIComponent(mockFormat)}`
+        `https://api.example.com/data/collections/uniqueCollection/items?limit=${mockLimit}&offset=${mockOffset}&f=${encodeURIComponent(
+          mockFormat
+        )}`
       )
     })
     it('should remove the param in url if value is zero', async () => {
@@ -138,7 +142,9 @@ describe('RecordApiFormComponent', () => {
       component.setFormat(mockFormat)
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data/collections/uniqueCollection/items?limit=${mockLimit}&offset=${mockOffset}&f=${encodeURIComponent(mockFormat)}`
+        `https://api.example.com/data/collections/uniqueCollection/items?limit=${mockLimit}&offset=${mockOffset}&f=${encodeURIComponent(
+          mockFormat
+        )}`
       )
     })
 


### PR DESCRIPTION
Backport of #1106

Error on cherry picking:
Error on backporting to branch 2.3.x, error on cherry picking a2ff93f0d794ffcf1eb548014665dffdff8e14b2:



To continue do:
git fetch && git checkout backport/1106-to-2.3.x && git reset --hard HEAD^
git cherry-pick a2ff93f0d794ffcf1eb548014665dffdff8e14b2
git push origin backport/1106-to-2.3.x --force