### PR TITLE
Editor: prevent multiple duplication (FIX after demo)

### DIFF
--- a/apps/metadata-editor/src/app/records/records-list.component.html
+++ b/apps/metadata-editor/src/app/records/records-list.component.html
@@ -4,6 +4,7 @@
   <gn-ui-results-table-container
     (recordClick)="editRecord($event)"
     (duplicateRecord)="duplicateRecord($event)"
+    [isDuplicating]="isDuplicating"
   ></gn-ui-results-table-container>
 
   <div class="px-5 py-5 flex justify-center gap-8 items-baseline">

--- a/apps/metadata-editor/src/app/records/records-list.component.ts
+++ b/apps/metadata-editor/src/app/records/records-list.component.ts
@@ -46,6 +46,8 @@ export class RecordsListComponent implements OnInit, Paginable {
     private searchService: SearchService
   ) {}
 
+  isDuplicating = false
+
   ngOnInit(): void {
     this.searchFacade.setConfigRequestFields(allSearchFields)
     this.searchFacade.setPageSize(15)
@@ -63,6 +65,7 @@ export class RecordsListComponent implements OnInit, Paginable {
   }
 
   duplicateRecord(record: CatalogRecord) {
+    this.isDuplicating = true
     this.router.navigate(['/duplicate', record.uniqueIdentifier])
   }
 

--- a/libs/feature/search/src/lib/results-table/results-table-container.component.html
+++ b/libs/feature/search/src/lib/results-table/results-table-container.component.html
@@ -6,6 +6,7 @@
   [sortOrder]="sortBy$ | async"
   [canDelete]="canDelete"
   [canDuplicate]="canDuplicate"
+  [isDuplicating]="isDuplicating"
   (recordClick)="handleRecordClick($event)"
   (duplicateRecord)="handleDuplicateRecord($event)"
   (deleteRecord)="handleDeleteRecord($event)"

--- a/libs/feature/search/src/lib/results-table/results-table-container.component.ts
+++ b/libs/feature/search/src/lib/results-table/results-table-container.component.ts
@@ -26,6 +26,7 @@ import { TranslateService } from '@ngx-translate/core'
 export class ResultsTableContainerComponent implements OnDestroy {
   @Input() canDuplicate: (record: CatalogRecord) => boolean = () => true
   @Input() canDelete: (record: CatalogRecord) => boolean = () => true
+  @Input() isDuplicating: false
 
   @Output() recordClick = new EventEmitter<CatalogRecord>()
   @Output() duplicateRecord = new EventEmitter<CatalogRecord>()

--- a/libs/ui/search/src/lib/results-table/action-menu/action-menu.component.html
+++ b/libs/ui/search/src/lib/results-table/action-menu/action-menu.component.html
@@ -11,7 +11,11 @@
           (buttonClick)="duplicate.emit()"
           [disabled]="!canDuplicate"
           data-test="record-menu-duplicate-button"
-          ><span translate>record.action.duplicate</span></gn-ui-button
+        >
+          <span *ngIf="canDuplicate" translate>record.action.duplicate</span>
+          <span *ngIf="!canDuplicate" translate
+            >record.action.duplicating</span
+          ></gn-ui-button
         >
         <gn-ui-button
           type="light"

--- a/libs/ui/search/src/lib/results-table/results-table.component.html
+++ b/libs/ui/search/src/lib/results-table/results-table.component.html
@@ -160,7 +160,7 @@
       </gn-ui-button>
       <ng-template #template>
         <gn-ui-action-menu
-          [canDuplicate]="canDuplicate(item)"
+          [canDuplicate]="canDuplicate(item) && !isDuplicating"
           [canDelete]="canDelete(item)"
           (duplicate)="handleDuplicate(item)"
           (delete)="handleDelete(item)"

--- a/libs/ui/search/src/lib/results-table/results-table.component.ts
+++ b/libs/ui/search/src/lib/results-table/results-table.component.ts
@@ -66,6 +66,7 @@ export class ResultsTableComponent {
   @Input() canDuplicate: (record: CatalogRecord) => boolean = () => true
   @Input() canDelete: (record: CatalogRecord) => boolean = () => true
   @Input() isDraftPage = false
+  @Input() isDuplicating = false
 
   // emits the column (field) as well as the order
   @Output() sortByChange = new EventEmitter<[string, 'asc' | 'desc']>()

--- a/translations/de.json
+++ b/translations/de.json
@@ -419,6 +419,7 @@
   "record.action.delete": "Löschen",
   "record.action.download": "Herunterladen",
   "record.action.duplicate": "",
+  "record.action.duplicating": "",
   "record.action.view": "Anzeigen",
   "record.externalViewer.open": "In externem Kartenviewer öffnen",
   "record.feature.limit": "Die Ressource enthält mehr als {count} Features und kann hier nicht angezeigt werden.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -419,6 +419,7 @@
   "record.action.delete": "Delete",
   "record.action.download": "Download",
   "record.action.duplicate": "Duplicate",
+  "record.action.duplicating": "Duplicating...",
   "record.action.view": "View",
   "record.externalViewer.open": "Open in the external map viewer",
   "record.feature.limit": "The resource contains more than {count} features and cannot be displayed here.",

--- a/translations/es.json
+++ b/translations/es.json
@@ -419,6 +419,7 @@
   "record.action.delete": "",
   "record.action.download": "",
   "record.action.duplicate": "",
+  "record.action.duplicating": "",
   "record.action.view": "",
   "record.externalViewer.open": "",
   "record.feature.limit": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -419,6 +419,7 @@
   "record.action.delete": "Supprimer",
   "record.action.download": "Télécharger",
   "record.action.duplicate": "Dupliquer",
+  "record.action.duplicating": "Duplication...",
   "record.action.view": "Voir",
   "record.externalViewer.open": "Ouvrir dans le visualiseur externe",
   "record.feature.limit": "La ressource contient plus de {count} entités et ne peut pas être affichée ici.",

--- a/translations/it.json
+++ b/translations/it.json
@@ -421,6 +421,7 @@
   "record.action.delete": "Elimina",
   "record.action.download": "Scarica",
   "record.action.duplicate": "Duplicato",
+  "record.action.duplicating": "",
   "record.action.view": "Visualizza",
   "record.externalViewer.open": "Aprire nel visualizzatore esterno",
   "record.feature.limit": "La risorsa contiene più di {count} funzionalità e non può essere visualizzata qui.",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -419,6 +419,7 @@
   "record.action.delete": "",
   "record.action.download": "",
   "record.action.duplicate": "",
+  "record.action.duplicating": "",
   "record.action.view": "",
   "record.externalViewer.open": "",
   "record.feature.limit": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -419,6 +419,7 @@
   "record.action.delete": "",
   "record.action.download": "",
   "record.action.duplicate": "",
+  "record.action.duplicating": "",
   "record.action.view": "",
   "record.externalViewer.open": "",
   "record.feature.limit": "",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -419,6 +419,7 @@
   "record.action.delete": "",
   "record.action.download": "Stiahnuť",
   "record.action.duplicate": "",
+  "record.action.duplicating": "",
   "record.action.view": "Zobraziť",
   "record.externalViewer.open": "Otvoriť v externom mapovom prehliadači",
   "record.feature.limit": "",


### PR DESCRIPTION
### Description

This PR disables the "Duplicate" action when the app is duplicating the record (before the redirection).

This is the fastest way to fix this duplication issue for now, but maybe a rework on `@Input canEdit()` for records-list/results-table-container/results-table components would be best.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

None

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

![image](https://github.com/user-attachments/assets/4a09aba2-2949-40ab-9812-abad679b0366)

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
