### PR TITLE
[MEL]: Fix size of share links

### DIFF
--- a/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.html
+++ b/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.html
@@ -88,6 +88,7 @@
   </div>
 </div>
 <gn-ui-data-view-share
+  extraClass="container-lg lg:mx-auto"
   *ngIf="displayViewShare$ | async"
   [viewType]="selectedView$ | async"
 ></gn-ui-data-view-share>

--- a/libs/feature/record/src/lib/data-view-share/data-view-share.component.html
+++ b/libs/feature/record/src/lib/data-view-share/data-view-share.component.html
@@ -1,4 +1,4 @@
-<div class="container-lg px-5 my-1 lg:mx-auto">
+<div class="px-5 my-1" [ngClass]="extraClass">
   <mat-tab-group
     [selectedIndex]="0"
     animationDuration="0ms"

--- a/libs/feature/record/src/lib/data-view-share/data-view-share.component.ts
+++ b/libs/feature/record/src/lib/data-view-share/data-view-share.component.ts
@@ -30,6 +30,7 @@ import { TranslateModule } from '@ngx-translate/core'
 })
 export class DataViewShareComponent {
   private _viewType: string
+  @Input() extraClass: string
 
   @Input()
   set viewType(value: string) {


### PR DESCRIPTION
### Description

This PR adds an extraClass to the `gn-ui-data-view-share` component, which has no impact on the display of the component in gn-ui, but will allow the webcomponent on MEL to be stretched all the way across the preview square (see https://mel.integration.apps.gs-fr-prod.camptocamp.com/catalogue/dataset/ville-roubaix::activit%C3%A9-sportive-sport-pass-roubaix).
Removing the `container-lg` and `lg:mx-auto` for the MEL fixes that.

### Architectural changes

none

### Screenshots

none

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
