### PR TITLE
[MEL]: Make preview source selector optional

### DIFF
--- a/libs/feature/record/src/lib/data-view/data-view.component.html
+++ b/libs/feature/record/src/lib/data-view/data-view.component.html
@@ -1,6 +1,7 @@
 <div class="w-full h-full flex flex-col p-1">
   <gn-ui-dropdown-selector
     *ngIf="dropdownChoices$ | async as choices"
+    [ngClass]="{ hidden: !displaySource }"
     [title]="'table.select.data' | translate"
     class="truncate p-1 -mx-1 self-end mb-1"
     extraBtnClass="!text-primary font-sans font-medium"

--- a/libs/feature/record/src/lib/data-view/data-view.component.ts
+++ b/libs/feature/record/src/lib/data-view/data-view.component.ts
@@ -34,6 +34,7 @@ import { TranslateModule } from '@ngx-translate/core'
 })
 export class DataViewComponent {
   @Input() mode: 'table' | 'chart'
+  @Input() displaySource = true
   @Output() chartConfig$ = new BehaviorSubject<DatavizConfigurationModel>(null)
   compatibleDataLinks$ = combineLatest([
     this.mdViewFacade.dataLinks$,

--- a/libs/feature/record/src/lib/map-view/map-view.component.html
+++ b/libs/feature/record/src/lib/map-view/map-view.component.html
@@ -1,6 +1,7 @@
 <div class="w-full h-full flex flex-col p-1">
   <div class="w-full flex justify-end">
     <gn-ui-dropdown-selector
+      [ngClass]="{ hidden: !displaySource }"
       class="truncate p-1 -mx-1 mb-1"
       extraBtnClass="!text-primary font-sans font-medium"
       [title]="'map.select.layer' | translate"

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -85,6 +85,7 @@ export class MapViewComponent implements AfterViewInit {
   @Input() set excludeWfs(value: boolean) {
     this.excludeWfs$.next(value)
   }
+  @Input() displaySource = true
   @ViewChild('mapContainer') mapContainer: MapContainerComponent
 
   excludeWfs$ = new BehaviorSubject(false)


### PR DESCRIPTION
### Description

This PR makes the source selector for the preview (map & data) optional.
**This does not change anything in generic gn-ui visually**, but will allow the MEL instance to hide the selector once the latest version is upgraded there. If the external viewer is not present, the space automatically collapses.
Note that this could have been done directly in MEL but this feature could be used by other instances on gn-ui in the future.

### Architectural changes

none

### Screenshots

no UI changes in gn-ui

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves


 **This work is sponsored by MEL.**
