### PR TITLE
DateService for consistent locale-based date formatting

### DIFF
--- a/apps/datahub/src/app/record/header-record/header-record.component.ts
+++ b/apps/datahub/src/app/record/header-record/header-record.component.ts
@@ -17,6 +17,7 @@ import { CommonModule } from '@angular/common'
 import { NgIcon, provideIcons } from '@ng-icons/core'
 import { matLocationSearchingOutline } from '@ng-icons/material-icons/outline'
 import { matArrowBack } from '@ng-icons/material-icons/baseline'
+import { DateService } from '@geonetwork-ui/util/shared'
 
 @Component({
   selector: 'datahub-header-record',
@@ -46,7 +47,7 @@ export class HeaderRecordComponent {
   constructor(
     private searchService: SearchService,
     public facade: MdViewFacade,
-    private translateService: TranslateService
+    private dateService: DateService
   ) {}
 
   isGeodata$ = combineLatest([
@@ -60,9 +61,7 @@ export class HeaderRecordComponent {
   )
 
   get lastUpdate() {
-    return this.metadata.recordUpdated.toLocaleDateString(
-      this.translateService.currentLang
-    )
+    return this.dateService.formatDate(this.metadata.recordUpdated)
   }
 
   back() {

--- a/apps/metadata-editor/src/app/edit/components/publish-button/publish-button.component.ts
+++ b/apps/metadata-editor/src/app/edit/components/publish-button/publish-button.component.ts
@@ -41,6 +41,7 @@ import {
   take,
   withLatestFrom,
 } from 'rxjs/operators'
+import { DateService } from '@geonetwork-ui/util/shared'
 
 export type RecordSaveStatus = 'saving' | 'upToDate' | 'hasChanges'
 @Component({
@@ -103,7 +104,7 @@ export class PublishButtonComponent implements OnDestroy {
     private overlay: Overlay,
     private viewContainerRef: ViewContainerRef,
     private cdr: ChangeDetectorRef,
-    private translateService: TranslateService
+    private dateService: DateService
   ) {}
 
   ngOnDestroy() {
@@ -205,7 +206,7 @@ export class PublishButtonComponent implements OnDestroy {
   }
 
   formatDate(date: Date): string {
-    return date.toLocaleDateString(this.translateService.currentLang, {
+    return this.dateService.formatDate(date, {
       year: 'numeric',
       month: 'long',
       day: 'numeric',

--- a/apps/metadata-editor/src/app/edit/edit-page.component.ts
+++ b/apps/metadata-editor/src/app/edit/edit-page.component.ts
@@ -28,6 +28,7 @@ import { TopToolbarComponent } from './components/top-toolbar/top-toolbar.compon
 import { SpinningLoaderComponent } from '@geonetwork-ui/ui/widgets'
 import { SearchHeaderComponent } from '../dashboard/search-header/search-header.component'
 import { PageErrorComponent } from './components/page-error/page-error.component'
+import { DateService } from '@geonetwork-ui/util/shared'
 
 marker('editor.record.form.bottomButtons.comeBackLater')
 marker('editor.record.form.bottomButtons.previous')
@@ -75,7 +76,8 @@ export class EditPageComponent implements OnInit, OnDestroy {
     protected facade: EditorFacade,
     private notificationsService: NotificationsService,
     private translateService: TranslateService,
-    private router: Router
+    private router: Router,
+    private dateService: DateService
   ) {}
 
   ngOnInit(): void {
@@ -217,7 +219,7 @@ export class EditPageComponent implements OnInit, OnDestroy {
   }
 
   formatDate(date: Date): string {
-    return date.toLocaleDateString(this.translateService.currentLang, {
+    return this.dateService.formatDate(date, {
       year: 'numeric',
       month: 'long',
       day: 'numeric',

--- a/libs/feature/editor/src/lib/components/wizard-summarize/wizard-summarize.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/wizard-summarize/wizard-summarize.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-
 import { WizardSummarizeComponent } from './wizard-summarize.component'
 import { TranslateModule } from '@ngx-translate/core'
 import { BrowserModule, By } from '@angular/platform-browser'
@@ -7,11 +6,12 @@ import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { NO_ERRORS_SCHEMA } from '@angular/core'
 import { WizardService } from '../../services/wizard.service'
 import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
+import { DateService } from '@geonetwork-ui/util/shared'
 
 const TIME = new Date().getTime()
 
 const wizardServiceMock = {
-  getWizardFieldData: jest.fn((id) => {
+  getWizardFieldData: jest.fn((id: string) => {
     switch (id) {
       case 'title': {
         return 'title'
@@ -46,6 +46,16 @@ const wizardServiceMock = {
   }),
 }
 
+const dateServiceStub = {
+  formatDate: jest.fn(
+    (date: Date, options?: Intl.DateTimeFormatOptions): string => {
+      // For testing, we force the locale to 'en'
+      return date.toLocaleDateString('en', options)
+    }
+  ),
+  formatDateTime: jest.fn(),
+}
+
 describe('WizardSummarizeComponent', () => {
   let component: WizardSummarizeComponent
   let fixture: ComponentFixture<WizardSummarizeComponent>
@@ -65,6 +75,10 @@ describe('WizardSummarizeComponent', () => {
           provide: WizardService,
           useValue: wizardServiceMock,
         },
+        {
+          provide: DateService,
+          useValue: dateServiceStub,
+        },
       ],
     }).compileComponents()
   })
@@ -82,7 +96,6 @@ describe('WizardSummarizeComponent', () => {
   it('should display title', () => {
     const title = fixture.debugElement.query(By.css('.title')).nativeElement
       .textContent
-
     expect(title.trim()).toEqual(
       wizardServiceMock.getWizardFieldData('title').toUpperCase().trim()
     )
@@ -91,29 +104,31 @@ describe('WizardSummarizeComponent', () => {
   it('should display abstract', () => {
     const abstract = fixture.debugElement.query(By.css('.abstract'))
       .nativeElement.textContent
-
     expect(abstract.trim()).toEqual(
       wizardServiceMock.getWizardFieldData('abstract').trim()
     )
   })
 
-  it('should display date', () => {
-    const date = fixture.debugElement.query(By.css('.date')).nativeElement
+  it('should display date using DateService', () => {
+    const dateEl = fixture.debugElement.query(By.css('.date')).nativeElement
       .textContent
-
-    expect(date).toEqual(
-      new Date(TIME).toLocaleDateString(undefined, {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      })
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }
+    // Use the dateServiceStub to compute the expected formatted date.
+    const expectedDate = dateServiceStub.formatDate(new Date(TIME), options)
+    expect(dateEl.trim()).toEqual(expectedDate)
+    expect(dateServiceStub.formatDate).toHaveBeenCalledWith(
+      new Date(TIME),
+      options
     )
   })
 
   it('should display scale', () => {
     const scale = fixture.debugElement.query(By.css('.scale')).nativeElement
       .textContent
-
     expect(scale.trim()).toEqual(
       `1:${JSON.parse(wizardServiceMock.getWizardFieldData('dropdown'))}`
     )
@@ -122,7 +137,6 @@ describe('WizardSummarizeComponent', () => {
   it('should display description', () => {
     const description = fixture.debugElement.query(By.css('.description'))
       .nativeElement.textContent
-
     expect(description.trim()).toEqual(
       wizardServiceMock.getWizardFieldData('description').trim()
     )
@@ -131,13 +145,11 @@ describe('WizardSummarizeComponent', () => {
   it('should display tags', () => {
     const tags = fixture.debugElement.query(By.css('.tags')).nativeElement
       .textContent
-
     const expectedTags = JSON.parse(
       wizardServiceMock.getWizardFieldData('tags')
     )
       .map((t) => t.display)
       .join(' - ')
-
     expect(tags.trim()).toEqual(expectedTags.trim())
   })
 })

--- a/libs/feature/editor/src/lib/components/wizard-summarize/wizard-summarize.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/wizard-summarize/wizard-summarize.component.spec.ts
@@ -8,7 +8,7 @@ import { WizardService } from '../../services/wizard.service'
 import { UiInputsModule } from '@geonetwork-ui/ui/inputs'
 import { DateService } from '@geonetwork-ui/util/shared'
 
-const TIME = new Date().getTime()
+const TIME = new Date('2025-01-01T00:00:00Z').getTime()
 
 const wizardServiceMock = {
   getWizardFieldData: jest.fn((id: string) => {
@@ -112,18 +112,8 @@ describe('WizardSummarizeComponent', () => {
   it('should display date using DateService', () => {
     const dateEl = fixture.debugElement.query(By.css('.date')).nativeElement
       .textContent
-    const options: Intl.DateTimeFormatOptions = {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    }
-    // Use the dateServiceStub to compute the expected formatted date.
-    const expectedDate = dateServiceStub.formatDate(new Date(TIME), options)
+    const expectedDate = 'January 1, 2025'
     expect(dateEl.trim()).toEqual(expectedDate)
-    expect(dateServiceStub.formatDate).toHaveBeenCalledWith(
-      new Date(TIME),
-      options
-    )
   })
 
   it('should display scale', () => {

--- a/libs/feature/editor/src/lib/components/wizard-summarize/wizard-summarize.component.ts
+++ b/libs/feature/editor/src/lib/components/wizard-summarize/wizard-summarize.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core'
 import { WizardService } from '../../services/wizard.service'
-import { TranslateService } from '@ngx-translate/core'
+import { DateService } from '@geonetwork-ui/util/shared'
 
 @Component({
   selector: 'gn-ui-wizard-summarize',
@@ -28,9 +28,8 @@ export class WizardSummarizeComponent {
 
   get createdDate() {
     const time = this.wizardService.getWizardFieldData('datepicker')
-    const locale = this.translateService.currentLang
 
-    return new Date(Number(time)).toLocaleDateString(locale, {
+    return this.dateService.formatDate(new Date(Number(time)), {
       year: 'numeric',
       month: 'long',
       day: 'numeric',
@@ -54,6 +53,6 @@ export class WizardSummarizeComponent {
 
   constructor(
     private wizardService: WizardService,
-    private translateService: TranslateService
+    private dateService: DateService
   ) {}
 }

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -163,13 +163,13 @@
     <div *ngIf="metadata.resourceCreated">
       <p class="text-sm" translate>record.metadata.creation</p>
       <p class="text-primary font-medium mt-1">
-        {{ metadata.resourceCreated.toLocaleDateString() }}
+        {{ formatDate(metadata.resourceCreated) }}
       </p>
     </div>
     <div *ngIf="metadata.resourcePublished">
       <p class="text-sm" translate>record.metadata.publication</p>
       <p class="text-primary font-medium mt-1">
-        {{ metadata.resourcePublished.toLocaleDateString() }}
+        {{ formatDate(metadata.resourcePublished)}}
       </p>
     </div>
     <div *ngIf="updateFrequency">
@@ -233,7 +233,7 @@
     <div *ngIf="metadata.recordUpdated">
       <p class="text-sm" translate>record.metadata.updatedOn</p>
       <p class="text-primary font-medium">
-        {{ metadata.recordUpdated && metadata.recordUpdated.toLocaleString() }}
+        {{ metadata.recordUpdated && formatDateTime(metadata.recordUpdated) }}
       </p>
     </div>
     <div *ngIf="metadata.landingPage">

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -169,7 +169,7 @@
     <div *ngIf="metadata.resourcePublished">
       <p class="text-sm" translate>record.metadata.publication</p>
       <p class="text-primary font-medium mt-1">
-        {{ formatDate(metadata.resourcePublished)}}
+        {{ formatDate(metadata.resourcePublished) }}
       </p>
     </div>
     <div *ngIf="updateFrequency">

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
@@ -9,7 +9,7 @@ import {
   DatasetRecord,
   Keyword,
 } from '@geonetwork-ui/common/domain/model/record'
-import { getTemporalRangeUnion } from '@geonetwork-ui/util/shared'
+import { DateService, getTemporalRangeUnion } from '@geonetwork-ui/util/shared'
 import { MarkdownParserComponent } from '../markdown-parser/markdown-parser.component'
 import {
   ExpandablePanelComponent,
@@ -59,6 +59,8 @@ export class MetadataInfoComponent {
   @Input() incomplete: boolean
   @Output() keyword = new EventEmitter<Keyword>()
   updatedTimes: number
+
+  constructor(private dateService: DateService) {}
 
   get hasUsage() {
     return (
@@ -138,5 +140,13 @@ export class MetadataInfoComponent {
 
   onKeywordClick(keyword: Keyword) {
     this.keyword.emit(keyword)
+  }
+
+  formatDate(date: Date): string {
+    return this.dateService.formatDate(date)
+  }
+
+  formatDateTime(date: Date): string {
+    return this.dateService.formatDateTime(date)
   }
 }

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.ts
@@ -123,7 +123,7 @@ export class MetadataInfoComponent {
 
   get temporalExtent(): { start: string; end: string } {
     const temporalExtents = this.metadata.temporalExtents
-    return getTemporalRangeUnion(temporalExtents)
+    return getTemporalRangeUnion(temporalExtents, this.dateService)
   }
 
   get shownOrganization() {

--- a/libs/ui/search/src/lib/results-table/results-table.component.ts
+++ b/libs/ui/search/src/lib/results-table/results-table.component.ts
@@ -21,6 +21,7 @@ import {
   InteractiveTableComponent,
 } from '@geonetwork-ui/ui/layout'
 import {
+  DateService,
   FileFormat,
   formatUserInfo,
   getBadgeColor,
@@ -86,7 +87,8 @@ export class ResultsTableComponent {
   constructor(
     private overlay: Overlay,
     private viewContainerRef: ViewContainerRef,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private dateService: DateService
   ) {}
 
   openActionMenu(item, template) {
@@ -139,7 +141,7 @@ export class ResultsTableComponent {
   }
 
   dateToString(date: Date): string {
-    return date?.toLocaleDateString(undefined, {
+    return this.dateService.formatDate(date, {
       year: 'numeric',
       month: 'long',
       day: 'numeric',

--- a/libs/util/shared/src/lib/services/date.service.spec.ts
+++ b/libs/util/shared/src/lib/services/date.service.spec.ts
@@ -1,0 +1,96 @@
+import { TestBed } from '@angular/core/testing'
+import { DateService } from './date.service'
+import { TranslateService } from '@ngx-translate/core'
+
+describe('DateService', () => {
+  let service: DateService
+  let translateService: TranslateService
+
+  beforeEach(() => {
+    // Create a simple stub for TranslateService with currentLang set to 'en-US'
+    const translateServiceStub = { currentLang: 'en-US' }
+
+    TestBed.configureTestingModule({
+      providers: [
+        DateService,
+        { provide: TranslateService, useValue: translateServiceStub },
+      ],
+    })
+    service = TestBed.inject(DateService)
+    translateService = TestBed.inject(TranslateService)
+  })
+
+  describe('formatDate', () => {
+    it('should format a valid Date object with default options', () => {
+      const date = new Date('2020-01-01T00:00:00Z')
+      const expected = date.toLocaleDateString('en-US')
+      const result = service.formatDate(date)
+      expect(result).toEqual(expected)
+    })
+
+    it('should format a valid Date object with provided options', () => {
+      const date = new Date('2020-01-01T00:00:00Z')
+      const options: Intl.DateTimeFormatOptions = {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      }
+      const expected = date.toLocaleDateString('en-US', options)
+      const result = service.formatDate(date, options)
+      expect(result).toEqual(expected)
+    })
+
+    it('should format a valid date string with default options', () => {
+      const dateString = '2020-01-01T00:00:00Z'
+      const date = new Date(dateString)
+      const expected = date.toLocaleDateString('en-US')
+      const result = service.formatDate(dateString)
+      expect(result).toEqual(expected)
+    })
+
+    it('should throw an error for an invalid date string', () => {
+      const invalidDate = 'invalid-date'
+      expect(() => service.formatDate(invalidDate)).toThrowError(
+        'Invalid date string'
+      )
+    })
+  })
+
+  describe('formatDateTime', () => {
+    it('should format a valid Date object with default options', () => {
+      const date = new Date('2020-01-01T12:34:56Z')
+      const expected = date.toLocaleString('en-US')
+      const result = service.formatDateTime(date)
+      expect(result).toEqual(expected)
+    })
+
+    it('should format a valid Date object with provided options', () => {
+      const date = new Date('2020-01-01T12:34:56Z')
+      const options: Intl.DateTimeFormatOptions = {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+      }
+      const expected = date.toLocaleString('en-US', options)
+      const result = service.formatDateTime(date, options)
+      expect(result).toEqual(expected)
+    })
+
+    it('should format a valid date string with default options', () => {
+      const dateString = '2020-01-01T12:34:56Z'
+      const date = new Date(dateString)
+      const expected = date.toLocaleString('en-US')
+      const result = service.formatDateTime(dateString)
+      expect(result).toEqual(expected)
+    })
+
+    it('should throw an error for an invalid date string', () => {
+      const invalidDate = 'invalid-date'
+      expect(() => service.formatDateTime(invalidDate)).toThrowError(
+        'Invalid date string'
+      )
+    })
+  })
+})

--- a/libs/util/shared/src/lib/services/date.service.ts
+++ b/libs/util/shared/src/lib/services/date.service.ts
@@ -18,25 +18,28 @@ export class DateService {
     return date
   }
 
+  private getLocaleAndDate(date: Date | string): {
+    locale: string
+    dateObj: Date
+  } {
+    const locale = this.translateService.currentLang || 'en-US'
+    const dateObj = this.getDateObject(date)
+    return { locale, dateObj }
+  }
+
   formatDate(
     date: Date | string,
     options?: Intl.DateTimeFormatOptions
   ): string {
-    const currentLocale = this.translateService.currentLang || 'en-US'
-    const dateObj = this.getDateObject(date)
-    return options
-      ? dateObj.toLocaleDateString(currentLocale, options)
-      : dateObj.toLocaleDateString(currentLocale)
+    const { locale, dateObj } = this.getLocaleAndDate(date)
+    return dateObj.toLocaleDateString(locale, options)
   }
 
   formatDateTime(
     date: Date | string,
     options?: Intl.DateTimeFormatOptions
   ): string {
-    const currentLocale = this.translateService.currentLang || 'en-US'
-    const dateObj = this.getDateObject(date)
-    return options
-      ? dateObj.toLocaleString(currentLocale, options)
-      : dateObj.toLocaleString(currentLocale)
+    const { locale, dateObj } = this.getLocaleAndDate(date)
+    return dateObj.toLocaleString(locale, options)
   }
 }

--- a/libs/util/shared/src/lib/services/date.service.ts
+++ b/libs/util/shared/src/lib/services/date.service.ts
@@ -7,22 +7,23 @@ import { TranslateService } from '@ngx-translate/core'
 export class DateService {
   constructor(private translateService: TranslateService) {}
 
+  private getDateObject(date: Date | string): Date {
+    if (typeof date === 'string') {
+      const dateObj = new Date(date)
+      if (isNaN(dateObj.getTime())) {
+        throw new Error('Invalid date string')
+      }
+      return dateObj
+    }
+    return date
+  }
+
   formatDate(
     date: Date | string,
     options?: Intl.DateTimeFormatOptions
   ): string {
     const currentLocale = this.translateService.currentLang || 'en-US'
-    let dateObj: Date
-
-    if (typeof date === 'string') {
-      dateObj = new Date(date)
-      if (isNaN(dateObj.getTime())) {
-        throw new Error('Invalid date string')
-      }
-    } else {
-      dateObj = date
-    }
-
+    const dateObj = this.getDateObject(date)
     return options
       ? dateObj.toLocaleDateString(currentLocale, options)
       : dateObj.toLocaleDateString(currentLocale)
@@ -33,17 +34,7 @@ export class DateService {
     options?: Intl.DateTimeFormatOptions
   ): string {
     const currentLocale = this.translateService.currentLang || 'en-US'
-    let dateObj: Date
-
-    if (typeof date === 'string') {
-      dateObj = new Date(date)
-      if (isNaN(dateObj.getTime())) {
-        throw new Error('Invalid date string')
-      }
-    } else {
-      dateObj = date
-    }
-
+    const dateObj = this.getDateObject(date)
     return options
       ? dateObj.toLocaleString(currentLocale, options)
       : dateObj.toLocaleString(currentLocale)

--- a/libs/util/shared/src/lib/services/date.service.ts
+++ b/libs/util/shared/src/lib/services/date.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core'
+import { TranslateService } from '@ngx-translate/core'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DateService {
+  constructor(private translateService: TranslateService) {}
+
+  formatDate(
+    date: Date | string,
+    options?: Intl.DateTimeFormatOptions
+  ): string {
+    const currentLocale = this.translateService.currentLang || 'en-US'
+    let dateObj: Date
+
+    if (typeof date === 'string') {
+      dateObj = new Date(date)
+      if (isNaN(dateObj.getTime())) {
+        throw new Error('Invalid date string')
+      }
+    } else {
+      dateObj = date
+    }
+
+    return options
+      ? dateObj.toLocaleDateString(currentLocale, options)
+      : dateObj.toLocaleDateString(currentLocale)
+  }
+
+  formatDateTime(
+    date: Date | string,
+    options?: Intl.DateTimeFormatOptions
+  ): string {
+    const currentLocale = this.translateService.currentLang || 'en-US'
+    let dateObj: Date
+
+    if (typeof date === 'string') {
+      dateObj = new Date(date)
+      if (isNaN(dateObj.getTime())) {
+        throw new Error('Invalid date string')
+      }
+    } else {
+      dateObj = date
+    }
+
+    return options
+      ? dateObj.toLocaleString(currentLocale, options)
+      : dateObj.toLocaleString(currentLocale)
+  }
+}

--- a/libs/util/shared/src/lib/services/index.ts
+++ b/libs/util/shared/src/lib/services/index.ts
@@ -1,3 +1,4 @@
 export * from './theme.service'
 export * from './log.service'
 export * from './proxy.service'
+export * from './date.service'

--- a/libs/util/shared/src/lib/utils/temporal-extent-union.spec.ts
+++ b/libs/util/shared/src/lib/utils/temporal-extent-union.spec.ts
@@ -9,8 +9,8 @@ const dateServiceMock = {
   ): string => {
     const dateObj = typeof date === 'string' ? new Date(date) : date
     return options
-      ? dateObj.toLocaleDateString('en', options)
-      : dateObj.toLocaleDateString('en')
+      ? dateObj.toLocaleDateString('en-US', options)
+      : dateObj.toLocaleDateString('en-US')
   },
   formatDateTime: (
     date: Date | string,

--- a/libs/util/shared/src/lib/utils/temporal-extent-union.spec.ts
+++ b/libs/util/shared/src/lib/utils/temporal-extent-union.spec.ts
@@ -1,7 +1,30 @@
 import { getTemporalRangeUnion } from './temporal-extent-union'
+import { DateService } from '../services'
 
-// lock locale to en
+// Create a minimal DateService mock by casting
+const dateServiceMock = {
+  formatDate: (
+    date: Date | string,
+    options?: Intl.DateTimeFormatOptions
+  ): string => {
+    const dateObj = typeof date === 'string' ? new Date(date) : date
+    return options
+      ? dateObj.toLocaleDateString('en', options)
+      : dateObj.toLocaleDateString('en')
+  },
+  formatDateTime: (
+    date: Date | string,
+    options?: Intl.DateTimeFormatOptions
+  ): string => {
+    const dateObj = typeof date === 'string' ? new Date(date) : date
+    return options
+      ? dateObj.toLocaleString('en', options)
+      : dateObj.toLocaleString('en')
+  },
+} as unknown as DateService
+
 beforeAll(() => {
+  // Override the native toLocaleDateString to use 'en' locale if called as a fallback.
   const originalFn = Date.prototype.toLocaleDateString
   Date.prototype.toLocaleDateString = function () {
     return originalFn.call(this, 'en')
@@ -21,7 +44,7 @@ describe('getTemporalRangeUnion', () => {
       end: '1/20/2022',
     }
 
-    const union = getTemporalRangeUnion(ranges)
+    const union = getTemporalRangeUnion(ranges, dateServiceMock)
 
     expect(union).toEqual(expectedUnion)
   })
@@ -29,7 +52,7 @@ describe('getTemporalRangeUnion', () => {
   it('should return null if no ranges are provided', () => {
     const ranges = []
 
-    const union = getTemporalRangeUnion(ranges)
+    const union = getTemporalRangeUnion(ranges, dateServiceMock)
 
     expect(union).toBe(undefined)
   })
@@ -46,7 +69,7 @@ describe('getTemporalRangeUnion', () => {
       end: undefined,
     }
 
-    const union = getTemporalRangeUnion(ranges)
+    const union = getTemporalRangeUnion(ranges, dateServiceMock)
 
     expect(union).toEqual(expectedUnion)
   })
@@ -63,7 +86,7 @@ describe('getTemporalRangeUnion', () => {
       end: '1/20/2022',
     }
 
-    const union = getTemporalRangeUnion(ranges)
+    const union = getTemporalRangeUnion(ranges, dateServiceMock)
 
     expect(union).toEqual(expectedUnion)
   })

--- a/libs/util/shared/src/lib/utils/temporal-extent-union.ts
+++ b/libs/util/shared/src/lib/utils/temporal-extent-union.ts
@@ -1,8 +1,11 @@
+import { DateService } from '../services'
+
 export function getTemporalRangeUnion(
   ranges: {
     start?: Date
     end?: Date
-  }[]
+  }[],
+  dateService: DateService
 ) {
   let earliestStartDate = Infinity
   let latestEndDate = -Infinity
@@ -24,11 +27,11 @@ export function getTemporalRangeUnion(
     return {
       start:
         earliestStartDate !== -Infinity
-          ? new Date(earliestStartDate).toLocaleDateString()
+          ? dateService.formatDate(new Date(earliestStartDate))
           : undefined,
       end:
         latestEndDate !== Infinity
-          ? new Date(latestEndDate).toLocaleDateString()
+          ? dateService.formatDate(new Date(latestEndDate))
           : undefined,
     }
   } else {


### PR DESCRIPTION
### Description
 
This PR introduces a centralized `DateService` that standardizes date formatting throughout the application based on the current user locale. The new service wraps the native `toLocaleDateString()` and `toLocaleString()` functions to ensure consistency and maintainability. The changes include:

- **New DateService Implementation:**  
  - A new `DateService` located at `libs/util/shared/src/lib/services/date.service.ts` that provides two methods:
    - `formatDate(date: Date | string, options?: Intl.DateTimeFormatOptions): string`  
      Wraps `toLocaleDateString()`
    - `formatDateTime(date: Date | string, options?: Intl.DateTimeFormatOptions): string`  
      Wraps `toLocaleString()`
  - The service retrieves the current locale from the `TranslateService`, defaulting to `'en-US'` if not available.
  - Unit tests for the `DateService` have been added to ensure that it correctly formats both dates and date-times.

- **Component Updates:**  Direct calls to `toLocaleDateString()` and `toLocaleString()` have been replaced with helper methods that delegate to `DateService.formatDate()` and `DateService.formatDateTime()` for following component:

  - Header-Record Component
  - Metadata-Info Component
  - Edit-Page Component
  - Metadata-Info Component
  - Publish-Button Component
  - Result-Table Component
  - Temporal-Extent-Union Utility
  - Wizard-Summarize Component


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
