### PR TITLE
[Datahub] Wfs pagination in data fetcher

### DIFF
--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -244,15 +244,13 @@ export class DataService {
 
   getDataset(link: DatasetOnlineResource): Observable<BaseReader> {
     if (link.type === 'service' && link.accessServiceProtocol === 'wfs') {
+      const wfsUrlEndpoint = this.proxy.getProxiedUrl(link.url.toString())
       return this.getDownloadUrlsFromWfs(link.url.toString(), link.name).pipe(
         switchMap((urls) => {
-          if (urls.geojson) return openDataset(urls.geojson, 'geojson')
-          if (urls.gml)
-            return openDataset(urls.gml.featureUrl, 'gml', {
-              namespace: urls.gml.namespace,
-              wfsVersion: urls.gml.wfsVersion,
-            })
-          return null
+          return openDataset(link.url.toString(), 'wfs', {
+            wfsUrlEndpoint,
+            namespace: link.name,
+          })
         }),
         tap((url) => {
           if (url === null) {

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -245,17 +245,9 @@ export class DataService {
   getDataset(link: DatasetOnlineResource): Observable<BaseReader> {
     if (link.type === 'service' && link.accessServiceProtocol === 'wfs') {
       const wfsUrlEndpoint = this.proxy.getProxiedUrl(link.url.toString())
-      return this.getDownloadUrlsFromWfs(link.url.toString(), link.name).pipe(
-        switchMap((urls) => {
-          return openDataset(link.url.toString(), 'wfs', {
-            wfsUrlEndpoint,
-            namespace: link.name,
-          })
-        }),
-        tap((url) => {
-          if (url === null) {
-            throw new Error('wfs.geojsongml.notsupported')
-          }
+      return from(
+        openDataset(wfsUrlEndpoint, 'wfs', {
+          wfsFeatureType: link.name,
         })
       )
     } else if (link.type === 'download') {

--- a/libs/util/data-fetcher/src/lib/data-fetcher.spec.ts
+++ b/libs/util/data-fetcher/src/lib/data-fetcher.spec.ts
@@ -449,7 +449,6 @@ describe('data-fetcher', () => {
           {
             namespace: 'ms:n_mat_eolien_p_r32',
             wfsVersion: '2.0.0',
-            wfsUrlEndpoint: 'http://localfile/fixtures/wfs-gml.xml',
           }
         )
         expect(wfs[0]).toEqual({

--- a/libs/util/data-fetcher/src/lib/data-fetcher.spec.ts
+++ b/libs/util/data-fetcher/src/lib/data-fetcher.spec.ts
@@ -7,13 +7,52 @@ import path from 'path'
 import { readDataset } from './data-fetcher'
 import { CsvReader } from './readers/csv'
 import { GeojsonReader } from './readers/geojson'
-import { sharedFetch, useCache } from '@camptocamp/ogc-client'
+import { sharedFetch, useCache, WfsEndpoint } from '@camptocamp/ogc-client'
 
 jest.mock('@camptocamp/ogc-client', () => ({
   useCache: jest.fn(async (factory) =>
     JSON.parse(JSON.stringify(await factory()))
   ),
   sharedFetch: jest.fn((url) => global.fetch(url)),
+  WfsEndpoint: class {
+    constructor(private url) {}
+    isReady() {
+      return Promise.resolve(this)
+    }
+    getVersion() {
+      return '2.0.0'
+    }
+    getFeatureTypes() {
+      return [
+        {
+          name: 'ms:n_mat_eolien_p_r32',
+          outputFormats: ['gml'],
+          defaultCrs: 'EPSG:4326',
+        },
+      ]
+    }
+    getFeatureTypeSummary() {
+      return {
+        name: 'ms:n_mat_eolien_p_r32',
+        outputFormats: ['gml'],
+        defaultCrs: 'EPSG:4326',
+      }
+    }
+    getFeatureUrl() {
+      return this.url
+    }
+    getFeatureTypeFull() {
+      return Promise.resolve({
+        objectCount: 442,
+      })
+    }
+    supportsJson() {
+      return false
+    }
+    supportsStartIndex() {
+      return true
+    }
+  },
 }))
 
 describe('data-fetcher', () => {
@@ -349,6 +388,71 @@ describe('data-fetcher', () => {
           { namespace: 'ms:n_mat_eolien_p_r32', wfsVersion: '2.0.0' }
         )
         expect(gml[0]).toEqual({
+          type: 'Feature',
+          geometry: {
+            type: 'Point',
+            coordinates: [1.548145, 50.054755, 0],
+          },
+          properties: {
+            boundedBy: [1.548145, 50.054755, 1.548145, 50.054755],
+            id_map: 1862,
+            id_mat: 1862,
+            nom_parc: 'PARC EOLIEN DE CHASSE MAREE II',
+            id_eolienn: 'L1.1',
+            x_rgf93: 595929,
+            y_rgf93: 6996108,
+            puissanc_2: 2,
+            code_com: 80360,
+            nom_commun: 'FRESSENNEVILLE',
+            code_arron: 801,
+            departemen: 'SO',
+            secteur: 'E - SECTEUR OUEST SOMME',
+            id_sre: 'E-P',
+            ht_max: 127,
+            ht_mat: 0,
+            type_proce: 'PC',
+            etat_proce: 'AB',
+            contentieu: 0,
+            etat_mat: 'NCO',
+            en_service: 'NON',
+            etat_eolie: 'AB',
+            alt_base: null,
+            code_icpe: undefined,
+            date_crea: undefined,
+            date_decis: null,
+            date_depot: undefined,
+            date_maj: null,
+            date_prod: undefined,
+            date_real: undefined,
+            diam_rotor: null,
+            exploitant: undefined,
+            gardesol: null,
+            ht_nacelle: null,
+            id_parc: undefined,
+            id_pc: undefined,
+            n_parcel: undefined,
+            operateur: undefined,
+            precis_pos: undefined,
+            srce_geom: undefined,
+            sys_coord: undefined,
+            x_pc: null,
+            y_pc: null,
+          },
+        })
+      })
+    })
+    describe('Wfs service', () => {
+      it('reads the content from the service', async () => {
+        const wfs = await readDataset(
+          'http://localfile/fixtures/wfs-gml.xml',
+          'wfs',
+          {
+            namespace: 'ms:n_mat_eolien_p_r32',
+            wfsVersion: '2.0.0',
+            wfsUrlEndpoint: 'http://localfile/fixtures/wfs-gml.xml',
+          }
+        )
+        expect(wfs[0]).toEqual({
           type: 'Feature',
           geometry: {
             type: 'Point',

--- a/libs/util/data-fetcher/src/lib/data-fetcher.ts
+++ b/libs/util/data-fetcher/src/lib/data-fetcher.ts
@@ -8,11 +8,16 @@ import { inferDatasetType } from './utils'
 import { BaseReader } from './readers/base'
 import { GmlReader } from './readers/gml'
 import { WfsVersion } from '@camptocamp/ogc-client'
+import { WfsReader } from './readers/wfs'
 
 export async function openDataset(
   url: string,
   typeHint?: SupportedType,
-  options?: { namespace: string; wfsVersion: WfsVersion }
+  options?: {
+    namespace?: string
+    wfsVersion?: WfsVersion
+    wfsUrlEndpoint?: string
+  }
 ): Promise<BaseReader> {
   const fileType = await inferDatasetType(url, typeHint)
   let reader: BaseReader
@@ -32,6 +37,13 @@ export async function openDataset(
         break
       case 'gml':
         reader = new GmlReader(url, options.namespace, options.wfsVersion)
+        break
+      case 'wfs':
+        reader = await WfsReader.createReader(
+          url,
+          options.wfsUrlEndpoint,
+          options.namespace
+        )
         break
     }
     reader.load()

--- a/libs/util/data-fetcher/src/lib/data-fetcher.ts
+++ b/libs/util/data-fetcher/src/lib/data-fetcher.ts
@@ -16,7 +16,7 @@ export async function openDataset(
   options?: {
     namespace?: string
     wfsVersion?: WfsVersion
-    wfsUrlEndpoint?: string
+    wfsFeatureType?: string
   }
 ): Promise<BaseReader> {
   const fileType = await inferDatasetType(url, typeHint)
@@ -39,11 +39,7 @@ export async function openDataset(
         reader = new GmlReader(url, options.namespace, options.wfsVersion)
         break
       case 'wfs':
-        reader = await WfsReader.createReader(
-          url,
-          options.wfsUrlEndpoint,
-          options.namespace
-        )
+        reader = await WfsReader.createReader(url, options.wfsFeatureType)
         break
     }
     reader.load()

--- a/libs/util/data-fetcher/src/lib/headers.ts
+++ b/libs/util/data-fetcher/src/lib/headers.ts
@@ -5,7 +5,7 @@ export function parseHeaders(httpHeaders: Headers): DatasetHeaders {
   if (httpHeaders.has('Content-Type')) {
     result.mimeType = httpHeaders.get('Content-Type').split(';')[0]
     const supported =
-      SupportedTypes.filter(
+      SupportedTypes.filter((type) => type !== 'wfs').filter(
         (type) => AllMimeTypes[type].indexOf(result.mimeType as never) > -1
       )[0] || null
     if (supported !== null) result.supportedType = supported

--- a/libs/util/data-fetcher/src/lib/headers.ts
+++ b/libs/util/data-fetcher/src/lib/headers.ts
@@ -5,9 +5,10 @@ export function parseHeaders(httpHeaders: Headers): DatasetHeaders {
   if (httpHeaders.has('Content-Type')) {
     result.mimeType = httpHeaders.get('Content-Type').split(';')[0]
     const supported =
-      SupportedTypes.filter((type) => type !== 'wfs').filter(
-        (type) => AllMimeTypes[type].indexOf(result.mimeType as never) > -1
-      )[0] || null
+      SupportedTypes.filter((type) => type !== 'wfs') // Ignore wfs type as it is not a file type
+        .filter(
+          (type) => AllMimeTypes[type].indexOf(result.mimeType as never) > -1
+        )[0] || null
     if (supported !== null) result.supportedType = supported
   }
   if (httpHeaders.has('Content-Length')) {

--- a/libs/util/data-fetcher/src/lib/model.ts
+++ b/libs/util/data-fetcher/src/lib/model.ts
@@ -60,6 +60,7 @@ export const SupportedTypes = [
   'geojson',
   'excel',
   'gml',
+  'wfs',
 ] as const
 export type SupportedType = (typeof SupportedTypes)[number]
 

--- a/libs/util/data-fetcher/src/lib/readers/wfs.spec.ts
+++ b/libs/util/data-fetcher/src/lib/readers/wfs.spec.ts
@@ -1,0 +1,334 @@
+/**
+ * @jest-environment jsdom
+ */
+import fetchMock from 'fetch-mock-jest'
+import path from 'path'
+import fs from 'fs/promises'
+import { WfsReader } from './wfs'
+import { WfsEndpoint } from '@camptocamp/ogc-client'
+import { GeojsonReader } from './geojson'
+import { GmlReader } from './gml'
+
+const urlGeojson =
+  'http://localfile/fixtures/perimetre-des-epci-concernes-par-un-contrat-de-ville.geojson'
+const urlGml = 'http://localfile/fixtures/wfs-gml.xml'
+const urlGeojsonLegacy = 'https://mygeojsonreader.edu'
+const urlGmlLegacy = 'https://mygmlreader.edu'
+
+jest.mock('@camptocamp/ogc-client', () => ({
+  useCache: jest.fn(async (factory) =>
+    JSON.parse(JSON.stringify(await factory()))
+  ),
+  sharedFetch: jest.fn((url) => global.fetch(url)),
+  WfsEndpoint: class {
+    constructor(private url) {}
+    isReady() {
+      return Promise.resolve(this)
+    }
+    getVersion() {
+      if (this.url === urlGeojson || this.url === urlGml) {
+        return '2.0.0'
+      } else {
+        return '1.0.0'
+      }
+    }
+    getFeatureTypes() {
+      return [
+        {
+          name: 'any',
+          outputFormats: ['gml'],
+          defaultCrs: 'EPSG:4326',
+        },
+      ]
+    }
+    getFeatureTypeSummary() {
+      return {
+        name: 'any',
+        outputFormats: ['gml'],
+        defaultCrs: 'EPSG:4326',
+      }
+    }
+    getFeatureUrl() {
+      return this.url
+    }
+    getFeatureTypeFull() {
+      return Promise.resolve({
+        objectCount: 442,
+      })
+    }
+    supportsJson() {
+      if (this.url === urlGeojson || this.url === urlGeojsonLegacy) {
+        return true
+      } else {
+        return false
+      }
+    }
+    supportsStartIndex() {
+      if (this.url === urlGeojson) {
+        return true
+      } else {
+        return false
+      }
+    }
+  },
+}))
+
+describe('WfsReader', () => {
+  describe('WfsReader - Wfs is version 2.0.0 geojson', () => {
+    let reader: WfsReader
+    const wfsEndpoint = new WfsEndpoint(urlGeojson)
+
+    beforeEach(() => {
+      fetchMock.get(
+        (url) => new URL(url).hostname === 'localfile',
+        async (url) => {
+          const filePath = path.join(__dirname, '../..', new URL(url).pathname)
+          return {
+            body: await fs.readFile(filePath, 'utf8'),
+            status: 200,
+            headers: {
+              'Content-Type': 'application/geo+json',
+            },
+          }
+        },
+        {
+          sendAsJson: false,
+        }
+      )
+      reader = new WfsReader(urlGeojson, wfsEndpoint, 'epci')
+      reader.load()
+    })
+    afterEach(() => {
+      fetchMock.reset()
+    })
+    describe('#info', () => {
+      it('returns dataset info', async () => {
+        await expect(reader.info).resolves.toEqual({
+          itemsCount: 442,
+        })
+      })
+    })
+    describe('#properties', () => {
+      it('returns properties info', async () => {
+        await expect(reader.properties).resolves.toEqual([
+          {
+            label: 'code_epci',
+            name: 'code_epci',
+            type: 'number',
+          },
+          {
+            label: 'code_region',
+            name: 'code_region',
+            type: 'string',
+          },
+          {
+            label: 'objectid',
+            name: 'objectid',
+            type: 'number',
+          },
+          {
+            label: 'nom_region',
+            name: 'nom_region',
+            type: 'string',
+          },
+          {
+            label: 'geo_point_2d',
+            name: 'geo_point_2d',
+            type: 'string',
+          },
+          {
+            label: 'nom_dep',
+            name: 'nom_dep',
+            type: 'string',
+          },
+          {
+            label: 'st_area_shape',
+            name: 'st_area_shape',
+            type: 'number',
+          },
+          {
+            label: 'st_perimeter_shape',
+            name: 'st_perimeter_shape',
+            type: 'number',
+          },
+          {
+            label: 'code_dep',
+            name: 'code_dep',
+            type: 'string',
+          },
+          {
+            label: 'nom_epci',
+            name: 'nom_epci',
+            type: 'string',
+          },
+        ])
+      })
+    })
+    describe('#read', () => {
+      it('reads data', async () => {
+        const start = performance.now()
+        const items = await reader.read()
+        console.log(`took ${(performance.now() - start).toFixed(1)}ms`)
+        expect(items[0]).toEqual({
+          geometry: {
+            coordinates: [3.37305747018, 43.7929180957],
+            type: 'Point',
+          },
+          properties: {
+            code_dep: '34',
+            code_epci: 200017341,
+            code_region: '76',
+            geo_point_2d: [43.7929180957, 3.37305747018],
+            nom_dep: 'HERAULT',
+            nom_epci: 'CC Lodévois et Larzac',
+            nom_region: 'OCCITANIE',
+            objectid: 25,
+            st_area_shape: 554841824.0549872,
+            st_perimeter_shape: 125726.64842881361,
+          },
+          type: 'Feature',
+        })
+      })
+
+      it('reads data with pagination (limits)', async () => {
+        const getFeatureUrlSpy = jest.spyOn(wfsEndpoint, 'getFeatureUrl')
+        reader.limit(2, 42)
+        await reader.read()
+        expect(getFeatureUrlSpy).toHaveBeenCalledWith('epci', {
+          asJson: true,
+          outputCrs: 'EPSG:4326',
+          startIndex: 2,
+          maxFeatures: 42,
+        })
+      })
+    })
+  })
+
+  describe('WfsReader - Wfs is version 2.0.0 gml', () => {
+    let reader: WfsReader
+    beforeEach(() => {
+      fetchMock.get(
+        (url) => new URL(url).hostname === 'localfile',
+        async (url) => {
+          const filePath = path.join(__dirname, '../..', new URL(url).pathname)
+          return {
+            body: await fs.readFile(filePath, 'utf8'),
+            status: 200,
+            headers: {
+              'Content-Type': 'text/csv',
+            },
+          }
+        },
+        {
+          sendAsJson: false,
+        }
+      )
+      const wfsEndpoint = new WfsEndpoint(urlGml)
+      reader = new WfsReader(urlGml, wfsEndpoint, 'ms:n_mat_eolien_p_r32')
+      reader.load()
+    })
+    afterEach(() => {
+      fetchMock.reset()
+    })
+    describe('#info', () => {
+      it('returns dataset info', async () => {
+        await expect(reader.info).resolves.toEqual({
+          itemsCount: 442,
+        })
+      })
+
+      describe('#properties', () => {
+        it('returns properties info', async () => {
+          await expect(reader.properties).resolves.toEqual([
+            { label: 'boundedBy', name: 'boundedBy', type: 'string' },
+            { label: 'id_map', name: 'id_map', type: 'number' },
+            { label: 'id_mat', name: 'id_mat', type: 'number' },
+            { label: 'code_icpe', name: 'code_icpe', type: 'string' },
+            { label: 'id_parc', name: 'id_parc', type: 'string' },
+            { label: 'nom_parc', name: 'nom_parc', type: 'string' },
+            { label: 'id_pc', name: 'id_pc', type: 'string' },
+            { label: 'operateur', name: 'operateur', type: 'string' },
+            { label: 'exploitant', name: 'exploitant', type: 'string' },
+            { label: 'date_crea', name: 'date_crea', type: 'string' },
+            { label: 'id_eolienn', name: 'id_eolienn', type: 'string' },
+            { label: 'x_rgf93', name: 'x_rgf93', type: 'number' },
+            { label: 'y_rgf93', name: 'y_rgf93', type: 'number' },
+            { label: 'x_pc', name: 'x_pc', type: 'number' },
+            { label: 'y_pc', name: 'y_pc', type: 'number' },
+            { label: 'sys_coord', name: 'sys_coord', type: 'string' },
+            { label: 'alt_base', name: 'alt_base', type: 'number' },
+            { label: 'n_parcel', name: 'n_parcel', type: 'string' },
+            { label: 'puissanc_2', name: 'puissanc_2', type: 'number' },
+            { label: 'code_com', name: 'code_com', type: 'number' },
+            { label: 'nom_commun', name: 'nom_commun', type: 'string' },
+            { label: 'code_arron', name: 'code_arron', type: 'number' },
+            { label: 'departemen', name: 'departemen', type: 'string' },
+            { label: 'secteur', name: 'secteur', type: 'string' },
+            { label: 'id_sre', name: 'id_sre', type: 'string' },
+            { label: 'ht_max', name: 'ht_max', type: 'number' },
+            { label: 'ht_mat', name: 'ht_mat', type: 'number' },
+            { label: 'ht_nacelle', name: 'ht_nacelle', type: 'number' },
+            { label: 'diam_rotor', name: 'diam_rotor', type: 'number' },
+            { label: 'gardesol', name: 'gardesol', type: 'number' },
+            { label: 'type_proce', name: 'type_proce', type: 'string' },
+            { label: 'etat_proce', name: 'etat_proce', type: 'string' },
+            { label: 'date_depot', name: 'date_depot', type: 'string' },
+            { label: 'date_decis', name: 'date_decis', type: 'date' },
+            { label: 'contentieu', name: 'contentieu', type: 'number' },
+            { label: 'etat_mat', name: 'etat_mat', type: 'string' },
+            { label: 'date_real', name: 'date_real', type: 'string' },
+            { label: 'date_prod', name: 'date_prod', type: 'string' },
+            { label: 'en_service', name: 'en_service', type: 'string' },
+            { label: 'etat_eolie', name: 'etat_eolie', type: 'string' },
+            { label: 'date_maj', name: 'date_maj', type: 'date' },
+            { label: 'srce_geom', name: 'srce_geom', type: 'string' },
+            { label: 'precis_pos', name: 'precis_pos', type: 'string' },
+          ])
+        })
+      })
+    })
+  })
+
+  describe('#createReader', () => {
+    let reader: WfsReader
+    beforeEach(() => {
+      fetchMock.get(
+        (url) => new URL(url).hostname === 'localfile',
+        async (url) => {
+          const filePath = path.join(__dirname, '../..', new URL(url).pathname)
+          return {
+            body: await fs.readFile(filePath, 'utf8'),
+            status: 200,
+            headers: {
+              'Content-Type': 'text/csv',
+            },
+          }
+        },
+        {
+          sendAsJson: false,
+        }
+      )
+      const wfsEndpoint = new WfsEndpoint(urlGml)
+      reader = new WfsReader(urlGml, wfsEndpoint, 'ms:n_mat_eolien_p_r32')
+      reader.load()
+    })
+    afterEach(() => {
+      fetchMock.reset()
+    })
+    it('returns an instance of WfsReader', async () => {
+      await expect(
+        WfsReader.createReader(urlGeojson, urlGeojson, 'epci')
+      ).resolves.toBeInstanceOf(WfsReader)
+    })
+    it('returns an instance of GeojsonReader', async () => {
+      await expect(
+        WfsReader.createReader(urlGeojsonLegacy, urlGeojsonLegacy)
+      ).resolves.toBeInstanceOf(GeojsonReader)
+    })
+    it('returns an instance of GmlReader', async () => {
+      await expect(
+        WfsReader.createReader(urlGmlLegacy, urlGmlLegacy)
+      ).resolves.toBeInstanceOf(GmlReader)
+    })
+  })
+})

--- a/libs/util/data-fetcher/src/lib/readers/wfs.ts
+++ b/libs/util/data-fetcher/src/lib/readers/wfs.ts
@@ -91,9 +91,8 @@ export class WfsReader extends BaseReader {
           (fieldSort) => `${fieldSort[1]}+${fieldSort[0] === 'asc' ? 'A' : 'D'}`
         )
         .join(',')
-
-      finalUrl.searchParams.append('SORTBY', sorts)
-      url = finalUrl.toString()
+      // Direct update on string url to prevent encoding of +A and +D
+      url = `${url}${finalUrl.search ? '&' : ''}SORTBY=${sorts}`
     }
 
     return fetchDataAsText(url).then((text) =>

--- a/libs/util/data-fetcher/src/lib/readers/wfs.ts
+++ b/libs/util/data-fetcher/src/lib/readers/wfs.ts
@@ -1,0 +1,117 @@
+import { WfsEndpoint, WfsVersion } from '@camptocamp/ogc-client'
+import { DataItem, DatasetInfo, PropertyInfo } from '../model'
+import { fetchDataAsText } from '../utils'
+import { BaseReader } from './base'
+import { GmlReader, parseGml } from './gml'
+import { GeojsonReader, parseGeojson } from './geojson'
+
+export class WfsReader extends BaseReader {
+  endpoint: WfsEndpoint
+  featureTypeName: string
+  version: WfsVersion
+
+  constructor(url: string, wfsEndpoint: WfsEndpoint, featureTypeName: string) {
+    super(url)
+    this.endpoint = wfsEndpoint
+    this.featureTypeName = featureTypeName
+    this.version = this.endpoint.getVersion()
+  }
+
+  get properties(): Promise<PropertyInfo[]> {
+    return this.getData().then((result) => result.properties)
+  }
+
+  get info(): Promise<DatasetInfo> {
+    return this.endpoint.getFeatureTypeFull(this.featureTypeName).then(
+      (result) =>
+        ({
+          itemsCount: result.objectCount,
+        }) as DatasetInfo
+    )
+  }
+
+  static async createReader(
+    url: string,
+    wfsUrlEndpoint: string,
+    featureTypeName?: string
+  ) {
+    const wfsEndpoint = await new WfsEndpoint(wfsUrlEndpoint).isReady()
+    const featureTypes = wfsEndpoint.getFeatureTypes()
+    const featureType = wfsEndpoint.getFeatureTypeSummary(
+      featureTypes.length === 1 && !featureTypeName
+        ? featureTypes[0].name
+        : featureTypeName
+    )
+    if (!featureType) {
+      throw new Error('wfs.featuretype.notfound')
+    }
+
+    if (wfsEndpoint.supportsStartIndex()) {
+      return new WfsReader(url, wfsEndpoint, featureType.name)
+    } else if (wfsEndpoint.supportsJson(featureType.name)) {
+      return new GeojsonReader(
+        wfsEndpoint.getFeatureUrl(featureType.name, {
+          asJson: true,
+          outputCrs: 'EPSG:4326',
+        })
+      )
+    } else {
+      if (
+        featureType.outputFormats.find((f) =>
+          f.toLowerCase().includes('gml')
+        ) &&
+        (featureType.defaultCrs === 'EPSG:4326' ||
+          featureType.otherCrs?.includes('EPSG:4326'))
+      ) {
+        return new GmlReader(
+          wfsEndpoint.getFeatureUrl(featureType.name, {
+            outputFormat: featureType.outputFormats.find((f) =>
+              f.toLowerCase().includes('gml')
+            ),
+            outputCrs: 'EPSG:4326',
+          }),
+          featureType.name,
+          wfsEndpoint.getVersion()
+        )
+      }
+      throw new Error('wfs.geojsongml.notsupported')
+    }
+  }
+
+  protected getData() {
+    const asJson = this.endpoint.supportsJson(this.featureTypeName)
+    let url = this.endpoint.getFeatureUrl(this.featureTypeName, {
+      ...(this.startIndex !== null && { startIndex: this.startIndex }),
+      ...(this.count !== null && { maxFeatures: this.count }),
+      asJson,
+      outputCrs: 'EPSG:4326',
+      // sortBy: this.sort // TODO: no sort in ogc-client?
+    })
+
+    if (Array.isArray(this.sort) && this.sort.length > 0) {
+      const finalUrl = new URL(url)
+      const sorts = this.sort
+        .map(
+          (fieldSort) => `${fieldSort[1]}+${fieldSort[0] === 'asc' ? 'A' : 'D'}`
+        )
+        .join(',')
+
+      finalUrl.searchParams.append('sortBy', sorts)
+      url = finalUrl.toString()
+    }
+
+    return fetchDataAsText(url).then((text) =>
+      asJson
+        ? parseGeojson(text)
+        : parseGml(text, this.featureTypeName, this.version)
+    )
+  }
+
+  load() {
+    // Nothing to load for Wfs
+  }
+
+  async read(): Promise<DataItem[]> {
+    return (await this.getData()).items
+  }
+}

--- a/libs/util/data-fetcher/src/lib/readers/wfs.ts
+++ b/libs/util/data-fetcher/src/lib/readers/wfs.ts
@@ -30,11 +30,7 @@ export class WfsReader extends BaseReader {
     )
   }
 
-  static async createReader(
-    url: string,
-    wfsUrlEndpoint: string,
-    featureTypeName?: string
-  ) {
+  static async createReader(wfsUrlEndpoint: string, featureTypeName?: string) {
     const wfsEndpoint = await new WfsEndpoint(wfsUrlEndpoint).isReady()
     const featureTypes = wfsEndpoint.getFeatureTypes()
     const featureType = wfsEndpoint.getFeatureTypeSummary(
@@ -47,7 +43,7 @@ export class WfsReader extends BaseReader {
     }
 
     if (wfsEndpoint.supportsStartIndex()) {
-      return new WfsReader(url, wfsEndpoint, featureType.name)
+      return new WfsReader(wfsUrlEndpoint, wfsEndpoint, featureType.name)
     } else if (wfsEndpoint.supportsJson(featureType.name)) {
       return new GeojsonReader(
         wfsEndpoint.getFeatureUrl(featureType.name, {

--- a/libs/util/data-fetcher/src/lib/readers/wfs.ts
+++ b/libs/util/data-fetcher/src/lib/readers/wfs.ts
@@ -96,7 +96,7 @@ export class WfsReader extends BaseReader {
         )
         .join(',')
 
-      finalUrl.searchParams.append('sortBy', sorts)
+      finalUrl.searchParams.append('SORTBY', sorts)
       url = finalUrl.toString()
     }
 


### PR DESCRIPTION
### Description

This PR introduces pagination when reading data through a WFS service. This feature is implemented in a new reader: the `WfsReader`.

If the service supports pagination, the WfsReader will handle pagination, fetching api at each read(). If service version is lower than 2.0.0 (does not handle pagination) the WfsReader returns GeoJsonReader or GmlReader (works as previously).

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

Added a new WfsReader.

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

None

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
