### PR TITLE
fix(editor): header fixed height due to border

### DIFF
--- a/apps/metadata-editor/src/app/dashboard/dashboard-page.component.html
+++ b/apps/metadata-editor/src/app/dashboard/dashboard-page.component.html
@@ -7,7 +7,7 @@
       <div class="absolute top-0 left-0 w-2/3 z-50 pointer-events-none">
         <gn-ui-notifications-container></gn-ui-notifications-container>
       </div>
-      <header class="shrink-0 border-b border-gray-300">
+      <header class="h-[60px] shrink-0 border-b border-gray-300">
         <md-editor-search-header></md-editor-search-header>
       </header>
       <router-outlet></router-outlet>


### PR DESCRIPTION
Small fix to prevent header border to add a scrollbar to the main page.