### PR TITLE
fix duplicated links OGC API

### DIFF
--- a/apps/datahub/src/app/record/record-downloads/record-downloads.component.spec.ts
+++ b/apps/datahub/src/app/record/record-downloads/record-downloads.component.spec.ts
@@ -73,6 +73,18 @@ class DataServiceMock {
           },
         ])
   )
+  getDownloadUrlsFromOgcApi = jest.fn((url: string) =>
+    url.indexOf('error') > -1
+      ? Promise.reject(new Error('ogc.unreachable.unknown'))
+      : Promise.resolve({
+          name: 'collection1',
+          title: 'Collection 1',
+          bulkDownloadLinks: {
+            'application/geo+json': 'http://example.com/collection1.geojson',
+            'application/json': 'http://example.com/collection1.json',
+          },
+        })
+  )
 }
 
 describe('RecordDownloadsComponent', () => {
@@ -292,6 +304,7 @@ describe('RecordDownloadsComponent', () => {
             description: 'OGC API service',
             mimeType: 'application/geo+json',
             name: 'Surveillance littorale OGC',
+            title: 'collection1',
             url: newUrl(
               'https://demo.ldproxy.net/zoomstack/collections/airports/items'
             ),
@@ -302,6 +315,7 @@ describe('RecordDownloadsComponent', () => {
             description: 'OGC API service',
             mimeType: 'application/json',
             name: 'Surveillance littorale OGC',
+            title: 'collection2',
             url: newUrl(
               'https://demo.ldproxy.net/zoomstack/collections/airports/items'
             ),

--- a/apps/datahub/src/app/record/record-downloads/record-downloads.component.spec.ts
+++ b/apps/datahub/src/app/record/record-downloads/record-downloads.component.spec.ts
@@ -63,10 +63,12 @@ class DataServiceMock {
       : Promise.resolve([
           {
             ...link,
+            title: 'collection1',
             mimeType: 'application/geo+json',
           },
           {
             ...link,
+            title: 'collection2',
             mimeType: 'application/json',
           },
         ])

--- a/apps/datahub/src/app/record/record-downloads/record-downloads.component.spec.ts
+++ b/apps/datahub/src/app/record/record-downloads/record-downloads.component.spec.ts
@@ -73,18 +73,6 @@ class DataServiceMock {
           },
         ])
   )
-  getDownloadUrlsFromOgcApi = jest.fn((url: string) =>
-    url.indexOf('error') > -1
-      ? Promise.reject(new Error('ogc.unreachable.unknown'))
-      : Promise.resolve({
-          name: 'collection1',
-          title: 'Collection 1',
-          bulkDownloadLinks: {
-            'application/geo+json': 'http://example.com/collection1.geojson',
-            'application/json': 'http://example.com/collection1.json',
-          },
-        })
-  )
 }
 
 describe('RecordDownloadsComponent', () => {

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -87,9 +87,9 @@ jest.mock('@camptocamp/ogc-client', () => ({
   },
   OgcApiEndpoint: class {
     constructor(private url) {
-      newEndpointCall(url) // to track endpoint creation
+      newEndpointCall(url)
     }
-    getCollectionInfo() {
+    getCollectionInfo(collectionName) {
       if (this.url.indexOf('error.http') > -1) {
         return Promise.reject({
           type: 'http',
@@ -97,11 +97,22 @@ jest.mock('@camptocamp/ogc-client', () => ({
           httpStatus: 403,
         })
       }
+      if (this.url === 'https://my.ogc.api/features') {
+        return Promise.resolve({
+          name: collectionName,
+          title:
+            collectionName === 'collection1' ? 'collection1' : 'collection2',
+          bulkDownloadLinks: { json: 'http://json', csv: 'http://csv' },
+        })
+      }
       return Promise.resolve({
         bulkDownloadLinks: { json: 'http://json', csv: 'http://csv' },
       })
     }
-    allCollections = Promise.resolve([{ name: 'collection1' }])
+    allCollections = Promise.resolve([
+      { name: 'collection1' },
+      { name: 'collection2' },
+    ])
     featureCollections =
       this.url.indexOf('error.http') > -1
         ? Promise.reject(new Error())
@@ -575,7 +586,7 @@ describe('DataService', () => {
               accessServiceProtocol: 'ogcFeatures',
             },
             {
-              name: 'collection2',
+              name: 'collection1',
               mimeType: 'text/csv',
               url: new URL('http://csv'),
               type: 'download',
@@ -593,7 +604,7 @@ describe('DataService', () => {
             accessServiceProtocol: 'ogcFeatures',
           })
           expect(links[0].name).toBe('collection1')
-          expect(links[1].name).toBe('collection2')
+          expect(links[1].name).toBe('collection1')
         })
       })
 

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -400,6 +400,24 @@ describe('DataService', () => {
           ])
         })
       })
+      describe('WFS with forced collection name', () => {
+        it('should override the name with the provided collection name', async () => {
+          const link = {
+            description: 'Lieu de surveillance (ligne)',
+            name: 'collection_name_forced',
+            url: new URL('http://local/wfs'),
+            type: 'service',
+            accessServiceProtocol: 'wfs',
+          } as const
+
+          const urls = await lastValueFrom(
+            service.getDownloadLinksFromWfs(link)
+          )
+          urls.forEach((url) => {
+            expect(url.name).toBe('collection_name_forced')
+          })
+        })
+      })
     })
 
     describe('#getWfsFeatureCount', () => {
@@ -543,21 +561,21 @@ describe('DataService', () => {
         it('returns links with formats for link', async () => {
           const url = new URL('https://my.ogc.api/features')
           const links = await service.getDownloadLinksFromOgcApiFeatures({
-            name: 'mycollection',
+            name: undefined,
             url,
             type: 'service',
             accessServiceProtocol: 'ogcFeatures',
           })
           expect(links).toEqual([
             {
-              name: 'mycollection',
+              name: 'collection1',
               mimeType: 'application/json',
               url: new URL('http://json'),
               type: 'download',
               accessServiceProtocol: 'ogcFeatures',
             },
             {
-              name: 'mycollection',
+              name: 'collection2',
               mimeType: 'text/csv',
               url: new URL('http://csv'),
               type: 'download',
@@ -565,7 +583,20 @@ describe('DataService', () => {
             },
           ])
         })
+
+        it('should OGC override the collection title when it is wrong', async () => {
+          const url = new URL('https://my.ogc.api/features')
+          const links = await service.getDownloadLinksFromOgcApiFeatures({
+            name: 'myFakecollection',
+            url,
+            type: 'service',
+            accessServiceProtocol: 'ogcFeatures',
+          })
+          expect(links[0].name).toBe('collection1')
+          expect(links[1].name).toBe('collection2')
+        })
       })
+
       describe('calling getDownloadLinksFromOgcApiFeatures() with a erroneous URL', () => {
         it('returns an error', async () => {
           try {

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -100,8 +100,7 @@ jest.mock('@camptocamp/ogc-client', () => ({
       if (this.url === 'https://my.ogc.api/features') {
         return Promise.resolve({
           name: collectionName,
-          title:
-            collectionName === 'collection1' ? 'collection1' : 'collection2',
+          id: collectionName === 'collection1' ? 'collection1' : 'collection2',
           bulkDownloadLinks: { json: 'http://json', csv: 'http://csv' },
         })
       }

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -168,6 +168,7 @@ export class DataService {
       map((urls) =>
         Object.keys(urls).map((format) => ({
           ...wfsLink,
+          name: wfsLink.name,
           type: 'download',
           url: new URL(urls[format]),
           mimeType: getMimeTypeForFormat(
@@ -187,6 +188,7 @@ export class DataService {
     return Object.keys(collectionInfo.bulkDownloadLinks).map((downloadLink) => {
       return {
         ...ogcApiLink,
+        name: collectionInfo.title,
         type: 'download',
         url: new URL(collectionInfo.bulkDownloadLinks[downloadLink]),
         mimeType: getMimeTypeForFormat(

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -188,7 +188,7 @@ export class DataService {
     return Object.keys(collectionInfo.bulkDownloadLinks).map((downloadLink) => {
       return {
         ...ogcApiLink,
-        name: collectionInfo.title,
+        name: collectionInfo.id,
         type: 'download',
         url: new URL(collectionInfo.bulkDownloadLinks[downloadLink]),
         mimeType: getMimeTypeForFormat(


### PR DESCRIPTION
### Description

This PR is about a bug encontred at MEL. The OGC and WFS links where duplicated because the OGC api does not have a name property linkd to the dataset. So to avoid this, in both OGCApi and WFS services, i reset the collection name. Now both OGC and WFS collection will have the same name, and the duplication remover works.

### Architectural changes

The following library now depends on [...]

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

[...]

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [x] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [x] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [x] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [x] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
