### PR TITLE
[Datahub]: Use EPSG:4326 as a projection for JSON/GeoJSON

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -543,6 +543,7 @@ describe('dataset pages', () => {
               'csv',
               'excel',
               'json',
+              'geojson',
               'shp',
               'gml',
               'kml',

--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -543,7 +543,6 @@ describe('dataset pages', () => {
               'csv',
               'excel',
               'json',
-              'geojson',
               'shp',
               'gml',
               'kml',

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -310,6 +310,26 @@ describe('DataService', () => {
               type: 'download',
               accessServiceProtocol: 'wfs',
             },
+            {
+              accessServiceProtocol: 'wfs',
+              description: 'Lieu de surveillance (ligne)',
+              mimeType: 'application/json',
+              name: 'surval_parametre_ligne',
+              type: 'download',
+              url: new URL(
+                'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=json'
+              ),
+            },
+            {
+              accessServiceProtocol: 'wfs',
+              description: 'Lieu de surveillance (ligne)',
+              mimeType: 'application/geo+json',
+              name: 'surval_parametre_ligne',
+              type: 'download',
+              url: new URL(
+                'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=geojson'
+              ),
+            },
           ])
         })
       })
@@ -406,6 +426,26 @@ describe('DataService', () => {
               ),
               type: 'download',
               accessServiceProtocol: 'wfs',
+            },
+            {
+              accessServiceProtocol: 'wfs',
+              description: 'Lieu de surveillance (ligne)',
+              mimeType: 'application/json',
+              name: '',
+              type: 'download',
+              url: new URL(
+                'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=json'
+              ),
+            },
+            {
+              accessServiceProtocol: 'wfs',
+              description: 'Lieu de surveillance (ligne)',
+              mimeType: 'application/geo+json',
+              name: '',
+              type: 'download',
+              url: new URL(
+                'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=geojson'
+              ),
             },
           ])
         })

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -320,16 +320,6 @@ describe('DataService', () => {
                 'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=json'
               ),
             },
-            {
-              accessServiceProtocol: 'wfs',
-              description: 'Lieu de surveillance (ligne)',
-              mimeType: 'application/geo+json',
-              name: 'surval_parametre_ligne',
-              type: 'download',
-              url: new URL(
-                'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=geojson'
-              ),
-            },
           ])
         })
       })
@@ -435,16 +425,6 @@ describe('DataService', () => {
               type: 'download',
               url: new URL(
                 'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=json'
-              ),
-            },
-            {
-              accessServiceProtocol: 'wfs',
-              description: 'Lieu de surveillance (ligne)',
-              mimeType: 'application/geo+json',
-              name: '',
-              type: 'download',
-              url: new URL(
-                'http://local/wfs?GetFeature&FeatureType=surval_parametre_ligne&format=geojson'
               ),
             },
           ])

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -164,18 +164,36 @@ export class DataService {
       wfsLink.url.toString(),
       wfsLink.name
     ).pipe(
-      map((urls) => urls.all),
-      map((urls) =>
-        Object.keys(urls).map((format) => ({
-          ...wfsLink,
-          name: wfsLink.name,
-          type: 'download',
-          url: new URL(urls[format]),
-          mimeType: getMimeTypeForFormat(
-            getFileFormatFromServiceOutput(format)
-          ),
-        }))
-      )
+      map((urls) => {
+        if (urls.geojson) {
+          urls.all['application/json'] = urls.geojson
+        }
+        return urls
+      }),
+      map((urls) => {
+        const resources: DatasetOnlineResource[] = Object.keys(urls.all).map(
+          (format) => ({
+            ...wfsLink,
+            name: wfsLink.name,
+            type: 'download' as const,
+            url: new URL(urls.all[format]),
+            mimeType: getMimeTypeForFormat(
+              getFileFormatFromServiceOutput(format)
+            ),
+          })
+        )
+
+        if (urls.geojson) {
+          resources.push({
+            ...wfsLink,
+            name: wfsLink.name,
+            type: 'download' as const,
+            url: new URL(urls.geojson),
+            mimeType: getMimeTypeForFormat('geojson'),
+          })
+        }
+        return resources
+      })
     )
   }
 

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -182,16 +182,6 @@ export class DataService {
             ),
           })
         )
-
-        if (urls.geojson) {
-          resources.push({
-            ...wfsLink,
-            name: wfsLink.name,
-            type: 'download' as const,
-            url: new URL(urls.geojson),
-            mimeType: getMimeTypeForFormat('geojson'),
-          })
-        }
         return resources
       })
     )

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
@@ -197,7 +197,7 @@ describe('RecordApiFormComponent', () => {
       expect(component.format$.getValue()).toBe('application/json')
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"application/json"}`
+        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"application/json","outputCrs":"EPSG:4326"}`
       )
     })
 
@@ -206,7 +206,7 @@ describe('RecordApiFormComponent', () => {
       expect(component.limit$.getValue()).toBe('12')
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
-        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"application/json","maxFeatures":12}`
+        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"application/json","maxFeatures":12,"outputCrs":"EPSG:4326"}`
       )
     })
   })

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.ts
@@ -161,6 +161,8 @@ export class RecordApiFormComponent {
       maxFeatures: limit !== '-1' ? Number(limit) : undefined,
       limit: limit !== '-1' ? Number(limit) : -1,
       offset: offset !== '' ? Number(offset) : undefined,
+      outputCrs:
+        format === ('application/json' || 'geojson') ? 'EPSG:4326' : undefined,
     }
 
     if (this.endpoint instanceof WfsEndpoint) {


### PR DESCRIPTION
### Description

This PR makes sure the download and API links for json and geojson types are followed by a projection parameter in 4326.
This is done by using the geojson link for both json & geojson in the downloads (since a JSON with a geospatial extent is indeed, a geojson). It also displays the geojson download link if it exists, which was not done before.
In the api-form, the parameter is added to every link that has either the type geojson or json.

### Architectural changes

none

### Screenshots

no UI changes

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
