### PR TITLE
Exclude feature catalog records from the search - init

### DIFF
--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -183,7 +183,13 @@ describe('ElasticsearchService', () => {
           ],
           must_not: {
             terms: {
-              resourceType: ['service', 'map', 'map/static', 'mapDigital'],
+              resourceType: [
+                'service',
+                'map',
+                'map/static',
+                'mapDigital',
+                'featureCatalog',
+              ],
             },
           },
         },
@@ -251,7 +257,13 @@ describe('ElasticsearchService', () => {
           ],
           must_not: {
             terms: {
-              resourceType: ['service', 'map', 'map/static', 'mapDigital'],
+              resourceType: [
+                'service',
+                'map',
+                'map/static',
+                'mapDigital',
+                'featureCatalog',
+              ],
             },
           },
         },
@@ -317,7 +329,13 @@ describe('ElasticsearchService', () => {
           ],
           must_not: {
             terms: {
-              resourceType: ['service', 'map', 'map/static', 'mapDigital'],
+              resourceType: [
+                'service',
+                'map',
+                'map/static',
+                'mapDigital',
+                'featureCatalog',
+              ],
             },
           },
         },
@@ -376,7 +394,13 @@ describe('ElasticsearchService', () => {
           ],
           must_not: {
             terms: {
-              resourceType: ['service', 'map', 'map/static', 'mapDigital'],
+              resourceType: [
+                'service',
+                'map',
+                'map/static',
+                'mapDigital',
+                'featureCatalog',
+              ],
             },
           },
         },
@@ -417,7 +441,13 @@ describe('ElasticsearchService', () => {
           must: [],
           must_not: {
             terms: {
-              resourceType: ['service', 'map', 'map/static', 'mapDigital'],
+              resourceType: [
+                'service',
+                'map',
+                'map/static',
+                'mapDigital',
+                'featureCatalog',
+              ],
             },
           },
         },
@@ -470,7 +500,13 @@ describe('ElasticsearchService', () => {
           ],
           must_not: {
             terms: {
-              resourceType: ['service', 'map', 'map/static', 'mapDigital'],
+              resourceType: [
+                'service',
+                'map',
+                'map/static',
+                'mapDigital',
+                'featureCatalog',
+              ],
             },
           },
         },
@@ -581,7 +617,13 @@ describe('ElasticsearchService', () => {
             ],
             must_not: {
               terms: {
-                resourceType: ['service', 'map', 'map/static', 'mapDigital'],
+                resourceType: [
+                  'service',
+                  'map',
+                  'map/static',
+                  'mapDigital',
+                  'featureCatalog',
+                ],
               },
             },
             should: [
@@ -707,7 +749,13 @@ describe('ElasticsearchService', () => {
               ],
               must_not: {
                 terms: {
-                  resourceType: ['service', 'map', 'map/static', 'mapDigital'],
+                  resourceType: [
+                    'service',
+                    'map',
+                    'map/static',
+                    'mapDigital',
+                    'featureCatalog',
+                  ],
                 },
               },
             },

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -310,6 +310,7 @@ export class ElasticsearchService {
         'map',
         'map/static',
         'mapDigital',
+        'featureCatalog',
       ]),
     }
     const should = [] as Record<string, unknown>[]
@@ -419,6 +420,7 @@ export class ElasticsearchService {
               'map',
               'map/static',
               'mapDigital',
+              'featureCatalog',
             ]),
           },
         },

--- a/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.spec.ts
@@ -278,6 +278,7 @@ describe.each(['4.2.2-00', '4.2.3-xx', '4.2.5-xx'])(
                         'map',
                         'map/static',
                         'mapDigital',
+                        'featureCatalog',
                       ],
                     },
                   },


### PR DESCRIPTION
### Description

This PR introduces the exclusion of feature catalog records from the search. Currently, during a search, all datasets and feature catalog records are requested by the search ( elastic search to be precise). This PR aims to exclude this feature catalog records from the search in datahub and metadata editor. 

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

The following library now depends on [...]

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

[...]

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
