### PR TITLE
Force open panel when results in autocomplete

### DIFF
--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
@@ -147,6 +147,12 @@ export class AutocompleteComponent
         this.error = null
       }),
       switchMap((value) => this.action(value)),
+      tap((suggestions) => {
+        // forcing the panel to open if there are suggestions
+        if (suggestions.length > 0) {
+          this.triggerRef?.openPanel()
+        }
+      }),
       catchError((error: Error) => {
         this.error = error.message
         return of([])


### PR DESCRIPTION
Sometimes, Angular Material autocomplete doesn't open the suggestion panel even when suggestions are provided (due to some weird async behavior most probably). Force opening the panel when we know suggestions are not empty fixes that.

### How to test
- build the webcomponents `npm run build:demo`
- launch the demo app `npm run demo`
- go to `http://localhost:8001/webcomponents/gn-search-input.sample.html`
- type various inputs (at least 10 different)

The same test on the current [demo](https://geonetwork.github.io/geonetwork-ui/main/demo/webcomponents/gn-search-input.sample.html) page would show the wrong behaviour of sometimes not opening the suggestions panel.