### PR TITLE
[Datahub] Allow disabled ogc-client cache per request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,14 @@ If the changes incur visual changes, please include screenshots or an animated s
 Please only check items relevant to your contribution. Thank you very much for your time and efforts!
 -->
 
+### How to test
+
+Follow these instructions to confirm [...]
+
+<!--
+Describe here the steps to confirm that the changes work as they should.
+-->
+
 ---
 
 <!--

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.spec.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.spec.ts
@@ -380,4 +380,21 @@ describe('ChartViewComponent', () => {
       ])
     })
   })
+  describe('when cache is deactivated', () => {
+    beforeEach(fakeAsync(() => {
+      jest.clearAllMocks()
+      component.cacheActive = false
+      component.link = aSetOfLinksFixture().dataCsv()
+      fixture.detectChanges()
+      tick(500)
+      flushMicrotasks()
+    }))
+
+    it('loads the data without the cache', () => {
+      expect(dataService.getDataset).toHaveBeenCalledWith(
+        aSetOfLinksFixture().dataCsv(),
+        false
+      )
+    })
+  })
 })

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.spec.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.spec.ts
@@ -126,7 +126,8 @@ describe('ChartViewComponent', () => {
     it('creates a dataset reader once from the link', () => {
       expect(dataService.getDataset).toHaveBeenCalledTimes(1)
       expect(dataService.getDataset).toHaveBeenCalledWith(
-        aSetOfLinksFixture().dataCsv()
+        aSetOfLinksFixture().dataCsv(),
+        true
       )
     })
     it('choses the first string property for X', () => {

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.ts
@@ -65,6 +65,7 @@ marker('chart.aggregation.count')
   standalone: true,
 })
 export class ChartViewComponent {
+  @Input() cacheActive = true
   @Input() set link(value: DatasetOnlineResource) {
     this.currentLink$.next(value)
   }
@@ -134,8 +135,7 @@ export class ChartViewComponent {
     switchMap((link) => {
       this.error = null
       this.loading = true
-      const cacheActive = true // TODO implement whether should be true or false
-      return this.dataService.getDataset(link, cacheActive).pipe(
+      return this.dataService.getDataset(link, this.cacheActive).pipe(
         catchError((error) => {
           this.handleError(error)
           return EMPTY

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.ts
@@ -134,7 +134,8 @@ export class ChartViewComponent {
     switchMap((link) => {
       this.error = null
       this.loading = true
-      return this.dataService.getDataset(link).pipe(
+      const cacheActive = true // TODO implement whether should be true or false
+      return this.dataService.getDataset(link, cacheActive).pipe(
         catchError((error) => {
           this.handleError(error)
           return EMPTY

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -180,6 +180,7 @@ jest.mock('@geonetwork-ui/data-fetcher', () => ({
 
 describe('DataService', () => {
   let service: DataService
+  const cacheActive = true
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -649,11 +650,14 @@ describe('DataService', () => {
         it('returns an observable that errors with a relevant error', async () => {
           try {
             await lastValueFrom(
-              service.getDataset({
-                url: new URL('http://error.parse/geojson'),
-                mimeType: 'application/geo+json',
-                type: 'download',
-              })
+              service.getDataset(
+                {
+                  url: new URL('http://error.parse/geojson'),
+                  mimeType: 'application/geo+json',
+                  type: 'download',
+                },
+                cacheActive
+              )
             )
           } catch (e) {
             expect(e).toStrictEqual({
@@ -667,11 +671,14 @@ describe('DataService', () => {
         it('returns an observable that errors with a relevant error', async () => {
           try {
             await lastValueFrom(
-              service.getDataset({
-                url: new URL('http://error.network/xls'),
-                mimeType: 'application/vnd.ms-excel',
-                type: 'download',
-              })
+              service.getDataset(
+                {
+                  url: new URL('http://error.network/xls'),
+                  mimeType: 'application/vnd.ms-excel',
+                  type: 'download',
+                },
+                cacheActive
+              )
             )
           } catch (e) {
             expect(e).toStrictEqual({
@@ -685,11 +692,14 @@ describe('DataService', () => {
         it('returns an observable that errors with a relevant error', async () => {
           try {
             await lastValueFrom(
-              service.getDataset({
-                url: new URL('http://error.http/csv'),
-                mimeType: 'text/csv',
-                type: 'download',
-              })
+              service.getDataset(
+                {
+                  url: new URL('http://error.http/csv'),
+                  mimeType: 'text/csv',
+                  type: 'download',
+                },
+                cacheActive
+              )
             )
           } catch (e) {
             expect(e).toStrictEqual({
@@ -704,11 +714,14 @@ describe('DataService', () => {
         it('returns an observable that errors with a relevant error', async () => {
           try {
             await lastValueFrom(
-              service.getDataset({
-                url: new URL('http://error/xls'),
-                mimeType: 'application/vnd.ms-excel',
-                type: 'download',
-              })
+              service.getDataset(
+                {
+                  url: new URL('http://error/xls'),
+                  mimeType: 'application/vnd.ms-excel',
+                  type: 'download',
+                },
+                cacheActive
+              )
             )
           } catch (e) {
             expect(e).toStrictEqual({
@@ -719,23 +732,31 @@ describe('DataService', () => {
       })
       describe('valid file', () => {
         it('calls DataFetcher.openDataset', () => {
-          service.getDataset({
-            url: new URL('http://sample/geojson'),
-            mimeType: 'text/csv',
-            type: 'download',
-          })
+          service.getDataset(
+            {
+              url: new URL('http://sample/geojson'),
+              mimeType: 'text/csv',
+              type: 'download',
+            },
+            cacheActive
+          )
           expect(openDataset).toHaveBeenCalledWith(
             'http://sample/geojson',
-            'csv'
+            'csv',
+            undefined,
+            true
           )
         })
         it('returns an observable that emits the array of features', async () => {
           const result = await lastValueFrom(
-            service.getDataset({
-              url: new URL('http://sample/csv'),
-              mimeType: 'text/csv',
-              type: 'download',
-            })
+            service.getDataset(
+              {
+                url: new URL('http://sample/csv'),
+                mimeType: 'text/csv',
+                type: 'download',
+              },
+              cacheActive
+            )
           )
           await expect(result.read()).resolves.toEqual(SAMPLE_GEOJSON.features)
         })
@@ -746,11 +767,14 @@ describe('DataService', () => {
       describe('valid file', () => {
         it('returns an observable that emits the feature collection', async () => {
           const result = await lastValueFrom(
-            service.readAsGeoJson({
-              url: new URL('http://sample/geojson'),
-              mimeType: 'application/geo+json',
-              type: 'download',
-            })
+            service.readAsGeoJson(
+              {
+                url: new URL('http://sample/geojson'),
+                mimeType: 'application/geo+json',
+                type: 'download',
+              },
+              cacheActive
+            )
           )
           expect(result).toEqual(SAMPLE_GEOJSON)
         })
@@ -803,39 +827,56 @@ describe('DataService', () => {
         )
       })
       it('calls DataFetcher.openDataset with a proxied url', () => {
-        service.getDataset({
-          url: new URL('http://esri.rest/local'),
-          accessServiceProtocol: 'esriRest',
-          type: 'service',
-        })
+        service.getDataset(
+          {
+            url: new URL('http://esri.rest/local'),
+            accessServiceProtocol: 'esriRest',
+            type: 'service',
+          },
+          cacheActive
+        )
         expect(openDataset).toHaveBeenCalledWith(
           'http://proxy.local/?url=http%3A%2F%2Fesri.rest%2Flocal%2Fquery%3Ff%3Dgeojson%26where%3D1%3D1%26outFields%3D*',
-          'geojson'
+          'geojson',
+          undefined,
+          true
         )
       })
     })
 
     describe('#readGeoJsonDataset', () => {
       it('calls DataFetcher.openDataset with a proxied url', () => {
-        service.getDataset({
-          url: new URL('http://sample/geojson'),
-          mimeType: 'text/csv',
-          type: 'download',
-        })
+        service.getDataset(
+          {
+            url: new URL('http://sample/geojson'),
+            mimeType: 'text/csv',
+            type: 'download',
+          },
+          cacheActive
+        )
         expect(openDataset).toHaveBeenCalledWith(
           'http://proxy.local/?url=http%3A%2F%2Fsample%2Fgeojson',
-          'csv'
+          'csv',
+          undefined,
+          true
         )
       })
       it('does not apply the proxy twice', () => {
-        service.getDataset({
-          url: new URL('http://proxy.local/?url=http%3A%2F%2Fsample%2Fgeojson'),
-          mimeType: 'text/csv',
-          type: 'download',
-        })
+        service.getDataset(
+          {
+            url: new URL(
+              'http://proxy.local/?url=http%3A%2F%2Fsample%2Fgeojson'
+            ),
+            mimeType: 'text/csv',
+            type: 'download',
+          },
+          cacheActive
+        )
         expect(openDataset).toHaveBeenCalledWith(
           'http://proxy.local/?url=http%3A%2F%2Fsample%2Fgeojson',
-          'csv'
+          'csv',
+          undefined,
+          true
         )
       })
     })

--- a/libs/feature/dataviz/src/lib/table-view/table-view.component.spec.ts
+++ b/libs/feature/dataviz/src/lib/table-view/table-view.component.spec.ts
@@ -85,7 +85,8 @@ describe('TableViewComponent', () => {
 
     it('loads the data from the first available link', () => {
       expect(dataService.getDataset).toHaveBeenCalledWith(
-        aSetOfLinksFixture().dataCsv()
+        aSetOfLinksFixture().dataCsv(),
+        true
       )
     })
 
@@ -144,7 +145,8 @@ describe('TableViewComponent', () => {
         }))
         it('loads data from selected link', () => {
           expect(dataService.getDataset).toHaveBeenCalledWith(
-            aSetOfLinksFixture().geodataJson()
+            aSetOfLinksFixture().geodataJson(),
+            true
           )
         })
         it('displays mocked data in the table', () => {

--- a/libs/feature/dataviz/src/lib/table-view/table-view.component.spec.ts
+++ b/libs/feature/dataviz/src/lib/table-view/table-view.component.spec.ts
@@ -189,4 +189,21 @@ describe('TableViewComponent', () => {
       expect(component.error).toEqual('dataset.error.unknown')
     })
   })
+  describe('when cache is deactivated', () => {
+    beforeEach(fakeAsync(() => {
+      jest.clearAllMocks()
+      component.cacheActive = false
+      component.link = aSetOfLinksFixture().dataCsv()
+      fixture.detectChanges()
+      tick(500)
+      flushMicrotasks()
+    }))
+
+    it('loads the data without the cache', () => {
+      expect(dataService.getDataset).toHaveBeenCalledWith(
+        aSetOfLinksFixture().dataCsv(),
+        false
+      )
+    })
+  })
 })

--- a/libs/feature/dataviz/src/lib/table-view/table-view.component.ts
+++ b/libs/feature/dataviz/src/lib/table-view/table-view.component.ts
@@ -33,6 +33,7 @@ import { CommonModule } from '@angular/common'
   standalone: true,
 })
 export class TableViewComponent {
+  @Input() cacheActive = true
   @Input() set link(value: DatasetOnlineResource) {
     this.currentLink$.next(value)
   }
@@ -66,8 +67,7 @@ export class TableViewComponent {
   ) {}
 
   getDatasetReader(link: DatasetOnlineResource): Observable<BaseReader> {
-    const cacheActive = true // TODO implement whether should be true or false
-    return this.dataService.getDataset(link, cacheActive)
+    return this.dataService.getDataset(link, this.cacheActive)
   }
 
   onTableSelect(event) {

--- a/libs/feature/dataviz/src/lib/table-view/table-view.component.ts
+++ b/libs/feature/dataviz/src/lib/table-view/table-view.component.ts
@@ -66,7 +66,8 @@ export class TableViewComponent {
   ) {}
 
   getDatasetReader(link: DatasetOnlineResource): Observable<BaseReader> {
-    return this.dataService.getDataset(link)
+    const cacheActive = true // TODO implement whether should be true or false
+    return this.dataService.getDataset(link, cacheActive)
   }
 
   onTableSelect(event) {

--- a/libs/feature/record/src/lib/data-view/data-view.component.html
+++ b/libs/feature/record/src/lib/data-view/data-view.component.html
@@ -11,11 +11,13 @@
   <div class="relative h-[460px]">
     <gn-ui-table-view
       *ngIf="mode === 'table'"
+      [cacheActive]="cacheActive$ | async"
       [link]="selectedLink$ | async"
     ></gn-ui-table-view>
     <gn-ui-chart-view
       *ngIf="mode === 'chart'"
       (chartConfig$)="setChartConfig($event)"
+      [cacheActive]="cacheActive$ | async"
       [link]="selectedLink$ | async"
     ></gn-ui-chart-view>
   </div>

--- a/libs/feature/record/src/lib/data-view/data-view.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view/data-view.component.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '@geonetwork-ui/feature/dataviz'
 
 class MdViewFacadeMock {
+  isHighUpdateFrequency$ = new Subject()
   dataLinks$ = new Subject()
   geoDataLinks$ = new Subject()
   setChartConfig = jest.fn()

--- a/libs/feature/record/src/lib/data-view/data-view.component.ts
+++ b/libs/feature/record/src/lib/data-view/data-view.component.ts
@@ -36,6 +36,9 @@ export class DataViewComponent {
   @Input() mode: 'table' | 'chart'
   @Input() displaySource = true
   @Output() chartConfig$ = new BehaviorSubject<DatavizConfigurationModel>(null)
+  cacheActive$ = this.mdViewFacade.isHighUpdateFrequency$.pipe(
+    map((highF) => !highF)
+  )
   compatibleDataLinks$ = combineLatest([
     this.mdViewFacade.dataLinks$,
     this.mdViewFacade.geoDataLinks$,

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -239,7 +239,8 @@ export class MapViewComponent implements AfterViewInit {
           link.accessServiceProtocol === 'ogcFeatures')) ||
       link.type === 'download'
     ) {
-      return this.dataService.readAsGeoJson(link).pipe(
+      const cacheActive = true // TODO implement whether should be true or false
+      return this.dataService.readAsGeoJson(link, cacheActive).pipe(
         map((data) => ({
           type: 'geojson',
           data,

--- a/libs/feature/record/src/lib/state/mdview.facade.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.spec.ts
@@ -149,6 +149,57 @@ describe('MdViewFacade', () => {
     })
   })
 
+  describe('isHighUpdateFrequency$', () => {
+    describe('When frequency is more than once a day', () => {
+      it('emits true', () => {
+        store.setState({
+          [METADATA_VIEW_FEATURE_STATE_KEY]: {
+            ...initialMetadataViewState,
+            metadata: { updateFrequency: { per: 'day', updatedTimes: 2 } },
+          },
+        })
+        const expected = hot('a', { a: true })
+        expect(facade.isHighUpdateFrequency$).toBeObservable(expected)
+      })
+    })
+    describe('When frequency is "continual"', () => {
+      it('emits true', () => {
+        store.setState({
+          [METADATA_VIEW_FEATURE_STATE_KEY]: {
+            ...initialMetadataViewState,
+            metadata: { updateFrequency: 'continual' },
+          },
+        })
+        const expected = hot('a', { a: true })
+        expect(facade.isHighUpdateFrequency$).toBeObservable(expected)
+      })
+    })
+    describe('When frequency is less than once a day', () => {
+      it('emits false', () => {
+        store.setState({
+          [METADATA_VIEW_FEATURE_STATE_KEY]: {
+            ...initialMetadataViewState,
+            metadata: { updateFrequency: { per: 'month', updatedTimes: 2 } },
+          },
+        })
+        const expected = hot('a', { a: false })
+        expect(facade.isHighUpdateFrequency$).toBeObservable(expected)
+      })
+    })
+    describe('When frequency is not continual', () => {
+      it('emits false', () => {
+        store.setState({
+          [METADATA_VIEW_FEATURE_STATE_KEY]: {
+            ...initialMetadataViewState,
+            metadata: { updateFrequency: 'weekly' },
+          },
+        })
+        const expected = hot('a', { a: false })
+        expect(facade.isHighUpdateFrequency$).toBeObservable(expected)
+      })
+    })
+  })
+
   describe('error$', () => {
     let values
 

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -57,6 +57,19 @@ export class MdViewFacade {
     filter((incomplete) => incomplete !== null)
   )
 
+  isHighUpdateFrequency$ = this.metadata$.pipe(
+    map((record) => {
+      if (record.updateFrequency instanceof Object) {
+        return (
+          record.updateFrequency.per === 'day' &&
+          record.updateFrequency.updatedTimes > 1
+        )
+      }
+
+      return record.updateFrequency === 'continual'
+    })
+  )
+
   error$ = this.store.pipe(select(MdViewSelectors.getMetadataError))
 
   related$ = this.store.pipe(select(MdViewSelectors.getRelated))

--- a/libs/util/data-fetcher/src/lib/data-fetcher.spec.ts
+++ b/libs/util/data-fetcher/src/lib/data-fetcher.spec.ts
@@ -542,11 +542,25 @@ describe('data-fetcher', () => {
           'geojson'
         )
       })
-      it('uses cache', () => {
+      it('uses cache by default', () => {
         expect(useCache).toHaveBeenCalledTimes(1)
       })
       it('avoids identical concurrent requests', () => {
         expect(sharedFetch).toHaveBeenCalledTimes(1)
+      })
+    })
+    describe('when no use of ogc-client cache', () => {
+      beforeEach(() => {
+        const cacheActive = false
+        readDataset(
+          'http://localfile/fixtures/perimetre-des-epci-concernes-par-un-contrat-de-ville.geojson',
+          'geojson',
+          undefined,
+          cacheActive
+        )
+      })
+      it('does not use ogc-client cache', () => {
+        expect(useCache).not.toHaveBeenCalled()
       })
     })
   })

--- a/libs/util/data-fetcher/src/lib/data-fetcher.ts
+++ b/libs/util/data-fetcher/src/lib/data-fetcher.ts
@@ -17,29 +17,39 @@ export async function openDataset(
     namespace?: string
     wfsVersion?: WfsVersion
     wfsFeatureType?: string
-  }
+  },
+  cacheActive?: boolean
 ): Promise<BaseReader> {
   const fileType = await inferDatasetType(url, typeHint)
   let reader: BaseReader
   try {
     switch (fileType) {
       case 'csv':
-        reader = new CsvReader(url)
+        reader = new CsvReader(url, cacheActive)
         break
       case 'json':
-        reader = new JsonReader(url)
+        reader = new JsonReader(url, cacheActive)
         break
       case 'geojson':
-        reader = new GeojsonReader(url)
+        reader = new GeojsonReader(url, cacheActive)
         break
       case 'excel':
-        reader = new ExcelReader(url)
+        reader = new ExcelReader(url, cacheActive)
         break
       case 'gml':
-        reader = new GmlReader(url, options.namespace, options.wfsVersion)
+        reader = new GmlReader(
+          url,
+          options.namespace,
+          options.wfsVersion,
+          cacheActive
+        )
         break
       case 'wfs':
-        reader = await WfsReader.createReader(url, options.wfsFeatureType)
+        reader = await WfsReader.createReader(
+          url,
+          options.wfsFeatureType,
+          cacheActive
+        )
         break
     }
     reader.load()
@@ -61,9 +71,10 @@ export async function openDataset(
 export async function readDataset(
   url: string,
   typeHint?: SupportedType,
-  options?: any
+  options?: any,
+  cacheActive = true
 ): Promise<DataItem[]> {
-  const reader = await openDataset(url, typeHint, options)
+  const reader = await openDataset(url, typeHint, options, cacheActive)
   try {
     return await reader.read()
   } catch (e: any) {

--- a/libs/util/data-fetcher/src/lib/data-fetcher.ts
+++ b/libs/util/data-fetcher/src/lib/data-fetcher.ts
@@ -21,37 +21,35 @@ export async function openDataset(
   cacheActive?: boolean
 ): Promise<BaseReader> {
   const fileType = await inferDatasetType(url, typeHint)
-  let reader: BaseReader
+  let reader:
+    | CsvReader
+    | JsonReader
+    | GeojsonReader
+    | ExcelReader
+    | GmlReader
+    | WfsReader
   try {
     switch (fileType) {
       case 'csv':
-        reader = new CsvReader(url, cacheActive)
+        reader = new CsvReader(url)
         break
       case 'json':
-        reader = new JsonReader(url, cacheActive)
+        reader = new JsonReader(url)
         break
       case 'geojson':
-        reader = new GeojsonReader(url, cacheActive)
+        reader = new GeojsonReader(url)
         break
       case 'excel':
-        reader = new ExcelReader(url, cacheActive)
+        reader = new ExcelReader(url)
         break
       case 'gml':
-        reader = new GmlReader(
-          url,
-          options.namespace,
-          options.wfsVersion,
-          cacheActive
-        )
+        reader = new GmlReader(url, options.namespace, options.wfsVersion)
         break
       case 'wfs':
-        reader = await WfsReader.createReader(
-          url,
-          options.wfsFeatureType,
-          cacheActive
-        )
+        reader = await WfsReader.createReader(url, options.wfsFeatureType)
         break
     }
+    reader.setCacheActive(cacheActive)
     reader.load()
     return reader
   } catch (e: any) {

--- a/libs/util/data-fetcher/src/lib/readers/base-cache.ts
+++ b/libs/util/data-fetcher/src/lib/readers/base-cache.ts
@@ -1,0 +1,10 @@
+import { BaseReader } from './base'
+
+export abstract class BaseCacheReader extends BaseReader {
+  constructor(
+    protected url: string,
+    protected cacheActive: boolean
+  ) {
+    super(url)
+  }
+}

--- a/libs/util/data-fetcher/src/lib/readers/base-cache.ts
+++ b/libs/util/data-fetcher/src/lib/readers/base-cache.ts
@@ -3,8 +3,12 @@ import { BaseReader } from './base'
 export abstract class BaseCacheReader extends BaseReader {
   constructor(
     protected url: string,
-    protected cacheActive: boolean
+    protected cacheActive = true
   ) {
     super(url)
+  }
+
+  setCacheActive(value: boolean) {
+    this.cacheActive = value
   }
 }

--- a/libs/util/data-fetcher/src/lib/readers/base-file.ts
+++ b/libs/util/data-fetcher/src/lib/readers/base-file.ts
@@ -2,13 +2,14 @@ import { BaseReader } from './base'
 import { DataItem, DatasetInfo, PropertyInfo } from '../model'
 import { getJsonDataItemsProxy, jsonToGeojsonFeature } from '../utils'
 import { generateSqlQuery } from '../sql-utils'
+import { BaseCacheReader } from './base-cache'
 
 type ParseResult = {
   items: DataItem[]
   properties: PropertyInfo[]
 }
 
-export class BaseFileReader extends BaseReader {
+export class BaseFileReader extends BaseCacheReader {
   private parseResult_: Promise<ParseResult>
 
   protected getData(): Promise<ParseResult> {

--- a/libs/util/data-fetcher/src/lib/readers/csv.ts
+++ b/libs/util/data-fetcher/src/lib/readers/csv.ts
@@ -47,6 +47,6 @@ export function parseCsv(text: string): {
 
 export class CsvReader extends BaseFileReader {
   getData() {
-    return fetchDataAsText(this.url).then(parseCsv)
+    return fetchDataAsText(this.url, this.cacheActive).then(parseCsv)
   }
 }

--- a/libs/util/data-fetcher/src/lib/readers/excel.ts
+++ b/libs/util/data-fetcher/src/lib/readers/excel.ts
@@ -28,6 +28,6 @@ export function parseExcel(buffer: ArrayBuffer): Promise<{
 
 export class ExcelReader extends BaseFileReader {
   getData() {
-    return fetchDataAsArrayBuffer(this.url).then(parseExcel)
+    return fetchDataAsArrayBuffer(this.url, this.cacheActive).then(parseExcel)
   }
 }

--- a/libs/util/data-fetcher/src/lib/readers/geojson.ts
+++ b/libs/util/data-fetcher/src/lib/readers/geojson.ts
@@ -24,6 +24,6 @@ export function parseGeojson(text: string): {
 
 export class GeojsonReader extends BaseFileReader {
   getData() {
-    return fetchDataAsText(this.url).then(parseGeojson)
+    return fetchDataAsText(this.url, this.cacheActive).then(parseGeojson)
   }
 }

--- a/libs/util/data-fetcher/src/lib/readers/gml.ts
+++ b/libs/util/data-fetcher/src/lib/readers/gml.ts
@@ -37,17 +37,17 @@ export function parseGml(
 }
 
 export class GmlReader extends BaseFileReader {
-  namespace: string
-  version: WfsVersion
-
-  constructor(url, namespace, version) {
-    super(url)
-    this.namespace = namespace
-    this.version = version
+  constructor(
+    protected url: string,
+    protected namespace: string,
+    protected version: WfsVersion,
+    protected cacheActive: boolean
+  ) {
+    super(url, cacheActive)
   }
 
   protected getData() {
-    return fetchDataAsText(this.url).then((text) =>
+    return fetchDataAsText(this.url, this.cacheActive).then((text) =>
       parseGml(text, this.namespace, this.version)
     )
   }

--- a/libs/util/data-fetcher/src/lib/readers/gml.ts
+++ b/libs/util/data-fetcher/src/lib/readers/gml.ts
@@ -41,9 +41,9 @@ export class GmlReader extends BaseFileReader {
     protected url: string,
     protected namespace: string,
     protected version: WfsVersion,
-    protected cacheActive: boolean
+    protected cacheActive = true
   ) {
-    super(url, cacheActive)
+    super(url)
   }
 
   protected getData() {

--- a/libs/util/data-fetcher/src/lib/readers/json.ts
+++ b/libs/util/data-fetcher/src/lib/readers/json.ts
@@ -23,6 +23,6 @@ export function parseJson(text: string): {
 
 export class JsonReader extends BaseFileReader {
   getData() {
-    return fetchDataAsText(this.url).then(parseJson)
+    return fetchDataAsText(this.url, this.cacheActive).then(parseJson)
   }
 }

--- a/libs/util/data-fetcher/src/lib/readers/wfs.spec.ts
+++ b/libs/util/data-fetcher/src/lib/readers/wfs.spec.ts
@@ -418,23 +418,17 @@ describe('WfsReader', () => {
       ).resolves.toBeInstanceOf(WfsReader)
     })
     it('returns an instance of GeojsonReader', async () => {
-      await WfsReader.createReader(
-        urlGeojsonLegacy,
-        urlGeojsonLegacy,
-        cacheActive
-      )
+      await WfsReader.createReader(urlGeojsonLegacy, urlGeojsonLegacy)
       expect(GeojsonReader).toHaveBeenCalledWith(
-        'https://mygeojsonreader.edu?1=1&STARTINDEX=undefined&MAXFEATURES=undefined',
-        true
+        'https://mygeojsonreader.edu?1=1&STARTINDEX=undefined&MAXFEATURES=undefined'
       )
     })
     it('returns an instance of GmlReader', async () => {
-      await WfsReader.createReader(urlGmlLegacy, urlGmlLegacy, cacheActive)
+      await WfsReader.createReader(urlGmlLegacy, urlGmlLegacy)
       expect(GmlReader).toHaveBeenCalledWith(
         'https://mygmlreader.edu?1=1&STARTINDEX=undefined&MAXFEATURES=undefined',
         'any',
-        '1.0.0',
-        true
+        '1.0.0'
       )
     })
 

--- a/libs/util/data-fetcher/src/lib/readers/wfs.ts
+++ b/libs/util/data-fetcher/src/lib/readers/wfs.ts
@@ -51,11 +51,7 @@ export class WfsReader extends BaseCacheReader {
     )
   }
 
-  static async createReader(
-    wfsUrlEndpoint: string,
-    featureTypeName?: string,
-    cacheActive?: boolean
-  ) {
+  static async createReader(wfsUrlEndpoint: string, featureTypeName?: string) {
     const wfsEndpoint = await new WfsEndpoint(wfsUrlEndpoint).isReady()
     const featureTypes = wfsEndpoint.getFeatureTypes()
     const featureType = wfsEndpoint.getFeatureTypeSummary(
@@ -74,8 +70,7 @@ export class WfsReader extends BaseCacheReader {
         wfsEndpoint.getFeatureUrl(featureType.name, {
           asJson: true,
           outputCrs: 'EPSG:4326',
-        }),
-        cacheActive
+        })
       )
     } else {
       if (
@@ -93,8 +88,7 @@ export class WfsReader extends BaseCacheReader {
             outputCrs: 'EPSG:4326',
           }),
           featureType.name,
-          wfsEndpoint.getVersion(),
-          cacheActive
+          wfsEndpoint.getVersion()
         )
       }
       throw new Error('wfs.geojsongml.notsupported')


### PR DESCRIPTION
### Description

This PR allows disabling the ogc cache per request.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### How to tests

This PR is a preparation work for the next PR where components will disable/enable cache according to dataset's update frequency when fetching data (eg. table and chart). So no manual testing.

### Architectural changes

A new BaseCacheReader has been introduced from which all other readers (Wfs, Csv, Gml, Geojson, Excel) inherits the `cacheActive` private property.

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

No UI

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
