### PR TITLE
[Webcomponent] Fix wc search dropdown

### DIFF
--- a/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.component.html
+++ b/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.component.html
@@ -4,4 +4,5 @@
   (itemSelected)="select($event)"
   (inputSubmitted)="search($event)"
   [autoFocus]="true"
+  [forceTrackPosition]="forceTrackPosition === 'force'"
 ></gn-ui-fuzzy-search>

--- a/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.component.ts
+++ b/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.component.ts
@@ -20,6 +20,7 @@ import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
   providers: [SearchFacade, SearchService],
 })
 export class GnSearchInputComponent extends BaseComponent {
+  @Input() forceTrackPosition = ''
   @Input() openOnSearch: string
   @Input() openOnSelect: string
   @ViewChild('searchInput') searchInput: FuzzySearchComponent

--- a/apps/webcomponents/src/styles.css
+++ b/apps/webcomponents/src/styles.css
@@ -18,6 +18,7 @@
   src: url(https://fonts.gstatic.com/s/materialsymbolsoutlined/v138/kJEhBvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oFsLjBuVY.woff2)
     format('woff2');
 }
+
 .material-symbols-outlined {
   font-family: 'Material Symbols Outlined';
   font-weight: normal;
@@ -44,6 +45,7 @@
   max-width: 100%;
   max-height: 100%;
 }
+
 .cdk-overlay-connected-position-bounding-box {
   position: absolute;
   z-index: 1000;
@@ -52,6 +54,7 @@
   min-width: 1px;
   min-height: 1px;
 }
+
 .cdk-overlay-backdrop {
   position: absolute;
   top: 0;
@@ -63,9 +66,11 @@
   transition: opacity 400ms cubic-bezier(0.25, 0.8, 0.25, 1);
   opacity: 0;
 }
+
 .cdk-overlay-backdrop.cdk-overlay-backdrop-showing {
   opacity: 1;
 }
+
 .cdk-overlay-transparent-backdrop {
   transition:
     visibility 1ms linear,
@@ -73,13 +78,14 @@
   visibility: hidden;
   opacity: 1;
 }
+
 .cdk-overlay-transparent-backdrop.cdk-overlay-backdrop-showing {
   opacity: 0;
   visibility: visible;
 }
 
 .gn-ui-overlay-container {
-  position: absolute;
+  position: fixed;
   z-index: 1000;
   pointer-events: none;
   top: 0;
@@ -87,6 +93,7 @@
   height: 100%;
   width: 100%;
 }
+
 .gn-ui-overlay-container:empty {
   display: none;
 }
@@ -102,20 +109,24 @@
   ) {
   color: rgba(0, 0, 0, 0.87);
 }
+
 .mat-mdc-option:hover:not(.mat-option-disabled),
 .mat-mdc-option:focus:not(.mat-option-disabled) {
   background: rgba(0, 0, 0, 0.04);
 }
+
 /* TODO(mdc-migration): The following rule targets internal classes of option that may no longer apply for the MDC version. */
 .mat-mdc-option.mat-selected:not(.mat-mdc-option-multiple):not(
     .mat-option-disabled
   ) {
   background: rgba(0, 0, 0, 0.04);
 }
+
 .mat-mdc-select-panel
   .mat-mdc-option.mat-selected:not(.mat-mdc-option-multiple) {
   background: rgba(0, 0, 0, 0.12);
 }
+
 .mdc-menu-surface.mat-mdc-autocomplete-panel {
   margin-top: 10px !important;
   border-radius: 8px;

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.html
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.html
@@ -9,4 +9,5 @@
   [preventCompleteOnSelection]="true"
   [autoFocus]="autoFocus"
   [allowSubmit]="true"
+  [forceTrackPosition]="forceTrackPosition"
 ></gn-ui-autocomplete>

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
@@ -28,6 +28,7 @@ import { SearchFilters } from '@geonetwork-ui/api/metadata-converter'
 export class FuzzySearchComponent implements OnInit {
   @ViewChild(AutocompleteComponent) autocomplete: AutocompleteComponent
   @Input() autoFocus = false
+  @Input() forceTrackPosition = false
   @Output() itemSelected = new EventEmitter<CatalogRecord>()
   @Output() inputSubmitted = new EventEmitter<string>()
   searchInputValue$: Observable<{ title: string }>

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy } from '@angular/core'
+import { ChangeDetectionStrategy, ElementRef } from '@angular/core'
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
 import { of, Subscription, throwError } from 'rxjs'
@@ -8,6 +8,7 @@ import {
 } from './autocomplete.component'
 import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 import { TranslateModule } from '@ngx-translate/core'
+import { MatAutocompleteTrigger } from '@angular/material/autocomplete'
 
 describe('AutocompleteComponent', () => {
   let component: AutocompleteComponent
@@ -367,6 +368,56 @@ describe('AutocompleteComponent', () => {
     })
     it('emits an empty suggestions list', () => {
       expect(suggestions).toEqual([])
+    })
+  })
+
+  describe('when tracking is activated', () => {
+    beforeEach(() => {
+      component.inputRef = new ElementRef(document.createElement('input'))
+      component.triggerRef = {
+        panelOpen: true,
+        updatePosition: jest.fn(),
+      } as unknown as MatAutocompleteTrigger
+      fixture.detectChanges()
+    })
+
+    it('starts the tracking position and redraw', () => {
+      jest
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation(() => 1519211809934)
+      jest.spyOn(component.triggerRef, 'updatePosition')
+
+      component.forceTrackPosition = true
+      component.startTrackingPosition()
+
+      expect(window.requestAnimationFrame).toHaveBeenCalledWith(
+        expect.any(Function)
+      )
+      expect(component.triggerRef.updatePosition).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('when tracking is disabled', () => {
+    beforeEach(() => {
+      component.inputRef = new ElementRef(document.createElement('input'))
+      component.triggerRef = {
+        panelOpen: true,
+        updatePosition: jest.fn(),
+      } as unknown as MatAutocompleteTrigger
+      fixture.detectChanges()
+    })
+
+    it('tracking is not called', () => {
+      jest
+        .spyOn(window, 'requestAnimationFrame')
+        .mockImplementation(() => 1519211809934)
+      jest.spyOn(component.triggerRef, 'updatePosition')
+
+      component.forceTrackPosition = false
+      component.startTrackingPosition()
+
+      expect(window.requestAnimationFrame).not.toHaveBeenCalledWith()
+      expect(component.triggerRef.updatePosition).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
### Description

This PR fixes the issue with the search dropdown suggestions list. Previously, when the page content height was large (and the screen height too small), the dropdown was incorrectly positioned at the bottom of the page due to the WC overlay's "`absolute`" positioning. Now, the WC overlay is set to "`fixed`"—aligning with the original Material Design overlay—and a scroll strategy has been implemented to dynamically update the dropdown's position when scrolling.

Possible cause: The demo page appears to use Vuetify containers that manage scrolling in a custom way, preventing Angular Material’s Autocomplete from detecting and reacting to these scroll events. However, global window scroll events are still being detected successfully.

Tested different approch to fix the issue:
- Approach failed: 
Forcing `matAutocomplete` to anchor to the input container using `matAutocompleteConnectedTo` did not resolve the issue
- Observers tested but ineffective: 
`IntersectionObserver` only triggers when the input becomes visible in the viewport, but we need an event that fires on every scroll. `ResizeObserver` and `MutationObserver` only trigger once, making them unsuitable for continuous tracking
- Track position with intervals 
=> working but some latency is visible when scrolling => switching to requestAnimationFrame()

Imrpovement to be done:
Maybe move the position detection to a custom strategy? (I had not enough time to do this work)

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

Added new input param `forceTrackPosition` for Autocomplete component to track scrolling with position instead of the Angular scroll detection (as it is not triggered when used inside a Vuetify component with Vuetify custom scroll enabled).

This custom positioning is disabled by default to minimize impact on datahub and wc components. 

For users facing dropdown issue, use this new attribute (set value to `"force"` to activate):
```
<div>
<gn-search-input force-track-position="force" api-url="https://xxx/srv/api" ... />
</div>
```

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

![image](https://github.com/user-attachments/assets/0128afb7-fda5-4cc2-b061-a5b0d698e173)

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Follow these instructions to confirm the autocomplete dropdown opens right under the input, for  wc component in the wc component demo page (there must be no impact), in the datahub (there must be no impact), in the geo2france given web page (position should be fixed, even when scrolling down to the bottom of the page):

- [ ]  Web component in demo (same behavior as before): 
`npm run demo` and open the page with the search input, check if dropdown is well positioned http://127.0.0.1:8001/webcomponents/gn-search-input-and-results.sample.html
- [ ] Search component in DH (same behavior as before): 
`npx nx serve datahub` to run the datahub and check if dropdown is well positioned
- [ ] Component in Storybook (same behavior as before): 
`npm run storybook` and check if dropdown is well positioned http://localhost:4400/?path=/docs/inputs-autocompletecomponent--docs
- [ ] Web component in Geo2france page (dropdown positioning issue shoud be fixed): 
`npm run build:demo` and replace the gn-wc.js from the Geo2france given web page (see Jira ticket and attached zip file) by the newly generated gn-wc.js, in the html source, activate the new positioning by adding the new attribute `force-track-position` to the web component: `<gn-search-input force-track-position="force" api-url="https://xxx/srv/api" ... />`. Then, check if dropdown is well positioned, even after scrolling up and down

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
