### PR TITLE
[Backport 2.3.x] Fix MD quality score not being 100% while all items are checked

### DIFF
--- a/tools/pipelines/register-es-pipelines.js
+++ b/tools/pipelines/register-es-pipelines.js
@@ -69,7 +69,12 @@ if(ctx.resourceTitleObject != null && ctx.resourceTitleObject.default != null &&
 if(ctx.resourceAbstractObject != null && ctx.resourceAbstractObject.default != null && ctx.resourceAbstractObject.default != '') {
   ok++
 }
+// this checks for single-language Organizations (GN 4.2.2)
 if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisation != null && ctx.contact[0].organisation != '') {
+  ok++
+}
+// this checks for multilingual Organizations (GN 4.2.3+)
+if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisationObject != null && ctx.contact[0].organisationObject.default != '') {
   ok++
 }
 if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].email != null && ctx.contact[0].email != '') {


### PR DESCRIPTION
This is a backport of this commit: https://github.com/geonetwork/geonetwork-ui/pull/945/commits/9696425a9fc932d33b996ca0291861e1fb79de53 which was only done on 2.4.0.

Fixes https://github.com/geonetwork/geonetwork-ui/issues/935