### PR TITLE
[Datahub]: Make the application-banner move down with potential header

### DIFF
--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -2,11 +2,16 @@
   <div
     class="container-lg relative h-full mx-auto flex flex-col-reverse justify-between sm:flex-col sm:justify-end"
   >
-    <gn-ui-application-banner
-      [message]="platformService.translateKey(bannerKey) | async"
-      class="container-sm"
-      type="secondary"
-    ></gn-ui-application-banner>
+    <div
+      class="mb-8 top-0"
+      *ngIf="translatedBannerMessage$ | async as bannerMessage"
+    >
+      <gn-ui-application-banner
+        [message]="bannerMessage"
+        class="container-sm absolute top-0 left-0 right-0"
+        type="secondary"
+      ></gn-ui-application-banner>
+    </div>
     <div
       class="py-8 relative z-40 mb-[184px] sm:mb-0"
       [ngClass]="{ 'pointer-events-none': expandRatio < 0.2 }"

--- a/apps/datahub/src/app/home/home-header/home-header.component.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.ts
@@ -50,12 +50,13 @@ export class HomeHeaderComponent {
   showLanguageSwitcher = getGlobalConfig().LANGUAGES?.length > 0
   foregroundColor = getThemeConfig().HEADER_FOREGROUND_COLOR || '#ffffff'
   bannerKey = 'application-banner'
+  translatedBannerMessage$ = this.platformService.translateKey(this.bannerKey)
 
   constructor(
     public routerFacade: RouterFacade,
     public searchFacade: SearchFacade,
     private searchService: SearchService,
-    protected platformService: PlatformServiceInterface,
+    private platformService: PlatformServiceInterface,
     private fieldsService: FieldsService
   ) {}
 

--- a/libs/ui/elements/src/lib/application-banner/application-banner.component.html
+++ b/libs/ui/elements/src/lib/application-banner/application-banner.component.html
@@ -6,7 +6,7 @@
     class="flex flex-row py-2.5 px-5 gap-5 justify-start border max-h-20"
     [ngClass]="classList"
   >
-    <div [ngClass]="{ 'pt-5': message.length > 200 }">
+    <div [ngClass]="message.length > 200 ? 'pt-5' : 'pt-1'">
       <ng-icon [name]="icon"></ng-icon>
     </div>
     <div class="flex flex-col justify-start gap-2.5">

--- a/libs/ui/elements/src/lib/application-banner/application-banner.component.html
+++ b/libs/ui/elements/src/lib/application-banner/application-banner.component.html
@@ -1,6 +1,6 @@
 <div
   *ngIf="message && bannerOpen"
-  class="absolute top-0 text-wrap bg-white mt-4 max-h-24"
+  class="absolute left-0 right-0 text-wrap bg-white mt-4 max-h-24"
 >
   <div
     class="flex flex-row py-2.5 px-5 gap-5 justify-start border max-h-20"


### PR DESCRIPTION
### Description

This PR makes sure the position of the application-banner is not fixed anymore and moves down when inserting the georchestra header (or any other header).
It also avoids exposing the platformService, like it was done in MEL.

### Please also review on MEL : https://github.com/camptocamp/mel-dataplatform/pull/136

### Architectural changes

none

### Screenshots

![image](https://github.com/user-attachments/assets/947b558c-167d-4f75-a5b1-818a91d65d2e)

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Same as https://github.com/geonetwork/geonetwork-ui/pull/1142
