### PR TITLE
[backport 2.4.3] [Datahub] Fix Links Section Display in record

### DIFF
--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -67,7 +67,7 @@ export class MdViewFacade {
 
   allLinks$ = this.metadata$.pipe(
     map((record) =>
-      record.kind === 'dataset' && 'onlineResources' in record
+      (record.kind === 'dataset' || record.kind === 'reuse') && 'onlineResources' in record
         ? record.onlineResources
         : []
     )

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -67,7 +67,8 @@ export class MdViewFacade {
 
   allLinks$ = this.metadata$.pipe(
     map((record) =>
-      (record.kind === 'dataset' || record.kind === 'reuse') && 'onlineResources' in record
+      (record.kind === 'dataset' || record.kind === 'reuse') &&
+      'onlineResources' in record
         ? record.onlineResources
         : []
     )


### PR DESCRIPTION
### Description

This PR fix the filter of links section disply in record "reuse".
The application should display the links if they exist in the record, reuse or not, as it worked before v2.4
Linked to [issue-1169](https://github.com/geonetwork/geonetwork-ui/issues/1169#issuecomment-2732312341)

### Architectural changes

Filter modified in mdview-facade.ts to get links in reuse record.
If needed, the filter can be remove but this implies a change in the typing of the elements returned, and therefore deeper changes in the code.

### Screenshots

Before

![image](https://github.com/user-attachments/assets/fc5e853f-7ec2-4695-89cd-5a30b486d9fa)

After

![image](https://github.com/user-attachments/assets/0a23b16a-814c-4424-a8a4-b3851d4cddf7)


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [x] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

### How to test

Open a interactiveMap or map record, see the links displayed in the right section

---

