### PR TITLE
Change layout for cards depending on content and screen size

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -567,7 +567,7 @@ describe('dataset pages', () => {
 
     // it should have a list of downloads based on the WFS capabilities
     cy.get('datahub-record-downloads')
-      .find('gn-ui-download-item [data-cy="download-format"]')
+      .find('gn-ui-block-list gn-ui-download-item [data-cy="download-format"]')
       .then((formatBadges) => {
         const formats = formatBadges
           .toArray()
@@ -599,7 +599,7 @@ describe('dataset pages', () => {
       })
 
     // it filters the download list on format filter click
-    cy.get('datahub-record-downloads')
+    cy.get('[data-cy="download-format-filters"]')
       .find('gn-ui-button')
       .children('button')
       .eq(1)
@@ -640,15 +640,17 @@ describe('dataset pages', () => {
     cy.get('datahub-record-downloads')
       .find('gn-ui-button')
       .children('button')
-      .eq(1)
+      .eq(3)
       .as('filterFormat')
     cy.get('@filterFormat').click()
-    cy.get('[data-cy="download-format"]')
+    cy.get('datahub-record-downloads')
+      .find('[data-cy="download-format"]')
       .filter(':visible')
       .its('length')
       .then((l1) => {
         cy.get('@filterFormat').click()
-        cy.get('[data-cy="download-format"]')
+        cy.get('datahub-record-downloads')
+          .find('[data-cy="download-format"]')
           .filter(':visible')
           .its('length')
           .then((l2) => expect(l2).to.not.equal(l1))
@@ -657,6 +659,48 @@ describe('dataset pages', () => {
 
   it('LINKS & APIs : display & functions', () => {
     cy.visit('/dataset/04bcec79-5b25-4b16-b635-73115f7456e4')
+    cy.get('datahub-record-otherlinks').as('otherLinks')
+
+    // display on desktop
+    //it should display links in a grid layout
+    cy.viewport(1200, 800)
+    cy.get('@otherLinks').find('gn-ui-block-list').should('be.visible')
+    cy.get('@otherLinks').find('gn-ui-carousel').should('not.be.visible')
+
+    //it should not show pagination when 4 links or less
+    cy.viewport(1200, 800)
+    cy.get('@otherLinks').find('gn-ui-pagination-dots').should('not.be.visible')
+    cy.get('@otherLinks')
+      .find('gn-ui-previous-next-buttons')
+      .should('not.exist')
+
+    //it should display links in a carousel
+    cy.viewport(375, 667)
+    cy.get('@otherLinks').find('gn-ui-carousel').should('be.visible')
+    cy.get('@otherLinks').find('gn-ui-block-list').should('not.be.visible')
+    //it should show pagination dots in carousel
+    cy.get('@otherLinks')
+      .find('gn-ui-carousel gn-ui-pagination-dots')
+      .should('be.visible')
+
+    //it should maintain link functionality in both layoutss
+    // Test on mobile
+    cy.viewport(375, 667)
+    cy.get('@otherLinks')
+      .find('gn-ui-link-card')
+      .first()
+      .find('a')
+      .should('have.attr', 'href')
+      .and('not.be.empty')
+
+    //Test on desktop
+    cy.viewport(1200, 800)
+    cy.get('@otherLinks')
+      .find('gn-ui-link-card')
+      .first()
+      .find('a')
+      .should('have.attr', 'href')
+      .and('not.be.empty')
 
     // it should have external, API and internal links with one option
     cy.get('datahub-record-otherlinks')
@@ -667,7 +711,9 @@ describe('dataset pages', () => {
       .should('have.length.gt', 0)
 
     // it should not display carousel dot button for 4 link cards
-    cy.get('datahub-record-otherlinks').find('.pagination-dot').should('exist')
+    cy.get('datahub-record-otherlinks')
+      .find('.pagination-dot')
+      .should('not.exist')
 
     // it should not display carousel dot button for 2 API cards
     cy.get('datahub-record-apis').find('.pagination-dot').should('not.exist')
@@ -702,7 +748,7 @@ describe('dataset pages', () => {
     })
 
     // API cards
-    cy.get('gn-ui-api-card').eq(1).as('firstCard')
+    cy.get('gn-ui-block-list gn-ui-api-card').eq(1).as('firstCard')
 
     // it should display the open panel button
     cy.get('@firstCard')
@@ -797,7 +843,7 @@ it('record with file distributions', () => {
 
 it('API query form', () => {
   cy.visit('/dataset/accroche_velos')
-  cy.get('gn-ui-api-card').first().find('button').eq(1).click()
+  cy.get('gn-ui-block-list gn-ui-api-card').first().find('button').eq(1).click()
   cy.get('gn-ui-record-api-form').children('div').as('apiForm')
   cy.get('@apiForm').find('gn-ui-text-input').first().as('firstInput')
   cy.get('@apiForm').find('gn-ui-text-input').eq(1).as('secondInput')
@@ -871,7 +917,11 @@ it('API query form', () => {
     .invoke('val')
     .then((url) => {
       cy.get('@firstInput').type('{selectAll}{backspace}54')
-      cy.get('gn-ui-api-card').eq(1).find('button').eq(1).click()
+      cy.get('gn-ui-block-list gn-ui-api-card')
+        .eq(1)
+        .find('button')
+        .eq(1)
+        .click()
       cy.get('@apiForm')
         .find('gn-ui-copy-text-button')
         .find('input')

--- a/apps/datahub/src/app/record/record-apis/record-apis.component.html
+++ b/apps/datahub/src/app/record/record-apis/record-apis.component.html
@@ -1,16 +1,26 @@
 <div class="flex flex-row gap-x-4 items-center justify-center md:justify-start">
-  <p
-    class="font-title text-xl font-medium text-title text-center sm:text-left"
-    translate
-  >
-    record.metadata.api
-  </p>
+  <div>
+    <span
+      class="font-title text-xl font-medium text-title text-center sm:text-left"
+      translate
+    >
+      record.metadata.api
+    </span>
+    <span class="px-3">({{ apiLinksCount$ | async }})</span>
+  </div>
   <gn-ui-previous-next-buttons
-    *ngIf="carousel.pagesCount > 1"
+    class="block md:hidden"
+    *ngIf="carousel?.pagesCount > 1"
     [listComponent]="carousel"
+  ></gn-ui-previous-next-buttons>
+  <gn-ui-previous-next-buttons
+    class="hidden md:block"
+    *ngIf="list?.pagesCount > 1"
+    [listComponent]="list"
   ></gn-ui-previous-next-buttons>
 </div>
 <gn-ui-carousel
+  class="block md:hidden"
   (currentStepChange)="updateView()"
   containerClass="gap-4 pt-5 pb-7"
   #carousel
@@ -21,14 +31,25 @@
     [link]="link"
     [currentLink]="selectedApiLink"
     size="S"
-    [ngClass]="{
-      'card-shadow': link !== selectedApiLink || !selectedApiLink,
-      'bg-neutral-100': link === selectedApiLink,
-    }"
     (openRecordApiForm)="openRecordApiForm($event)"
   >
   </gn-ui-api-card>
 </gn-ui-carousel>
+<gn-ui-block-list
+  #blockList
+  class="hidden md:block"
+  containerClass="gap-4 pt-5 pb-7"
+>
+  <gn-ui-api-card
+    #block
+    *ngFor="let link of apiLinks$ | async"
+    [title]="link.name"
+    [link]="link"
+    [currentLink]="selectedApiLink"
+    [size]="blockList.subComponentSize"
+    (openRecordApiForm)="openRecordApiForm($event)"
+  ></gn-ui-api-card>
+</gn-ui-block-list>
 <div
   class="content transition-all duration-300 w-screen mx-auto -ml-[calc(50vw-50%)] overflow-hidden"
   [ngClass]="selectedApiLink ? 'ease-in' : 'ease-out'"

--- a/apps/datahub/src/app/record/record-apis/record-apis.component.ts
+++ b/apps/datahub/src/app/record/record-apis/record-apis.component.ts
@@ -10,6 +10,7 @@ import { GpfApiDlComponent, MdViewFacade } from '@geonetwork-ui/feature/record'
 import {
   CarouselComponent,
   PreviousNextButtonsComponent,
+  BlockListComponent,
 } from '@geonetwork-ui/ui/layout'
 import {
   ApiCardComponent,
@@ -20,6 +21,7 @@ import { NgIcon, provideIcons } from '@ng-icons/core'
 import { matCloseOutline } from '@ng-icons/material-icons/outline'
 import { TranslateModule } from '@ngx-translate/core'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
+import { map } from 'rxjs/operators'
 
 marker('record.metadata.api.form.title.gpf')
 marker('record.metadata.api.form.title')
@@ -31,6 +33,7 @@ marker('record.metadata.api.form.title')
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
+    BlockListComponent,
     CommonModule,
     CarouselComponent,
     PreviousNextButtonsComponent,
@@ -48,12 +51,17 @@ marker('record.metadata.api.form.title')
 })
 export class RecordApisComponent implements OnInit {
   @ViewChild(CarouselComponent) carousel: CarouselComponent
+  @ViewChild(BlockListComponent) list: BlockListComponent
 
   maxHeight = '0px'
   opacity = 0
   selectedApiLink: DatasetServiceDistribution
 
   apiLinks$ = this.facade.apiLinks$
+
+  get apiLinksCount$() {
+    return this.apiLinks$?.pipe(map((links) => links.length))
+  }
 
   constructor(
     private facade: MdViewFacade,

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
@@ -87,16 +87,16 @@
     <div class="gn-ui-section-title container-lg px-4 lg:mx-auto" translate>
       record.metadata.ressources.and.links
     </div>
-    <div class="container-lg px-4 pb-10 lg:mx-auto mt-5">
-      <div id="downloads" class="pb-7" *ngIf="displayDownload$ | async">
+    <div class="container-lg px-4 lg:mx-auto mt-5">
+      <div id="downloads" *ngIf="displayDownload$ | async" class="pb-7">
         <datahub-record-downloads class="block"></datahub-record-downloads>
       </div>
 
-      <div *ngIf="displayOtherLinks | async" id="otherlinks">
+      <div *ngIf="displayOtherLinks | async" id="otherlinks" class="pb-7">
         <datahub-record-otherlinks class="block"></datahub-record-otherlinks>
       </div>
 
-      <div *ngIf="displayApi$ | async" id="apis" class="mt-5">
+      <div *ngIf="displayApi$ | async" id="apis" class="pb-7">
         <datahub-record-apis class="block"></datahub-record-apis>
       </div>
     </div>

--- a/apps/datahub/src/app/record/record-otherlinks/record-otherlinks.component.html
+++ b/apps/datahub/src/app/record/record-otherlinks/record-otherlinks.component.html
@@ -1,37 +1,47 @@
 <div class="flex flex-row gap-x-4 items-center justify-center md:justify-start">
-  <p
-    class="font-title text-xl font-medium text-title text-center sm:text-left"
-    translate
-  >
-    record.metadata.links
-  </p>
+  <div>
+    <span
+      class="font-title text-xl font-medium text-title text-center sm:text-left"
+      translate
+    >
+      record.metadata.links
+    </span>
+    <span class="px-3">({{ linksCount$ | async }})</span>
+  </div>
   <gn-ui-previous-next-buttons
-    *ngIf="paginableElement?.pagesCount > 1"
-    [listComponent]="paginableElement"
+    class="block md:hidden"
+    *ngIf="carousel?.pagesCount > 1"
+    [listComponent]="carousel"
+  ></gn-ui-previous-next-buttons>
+  <gn-ui-previous-next-buttons
+    class="hidden md:block"
+    *ngIf="list?.pagesCount > 1"
+    [listComponent]="list"
   ></gn-ui-previous-next-buttons>
 </div>
 <ng-container *ngrxLet="otherLinks$ as otherLinks">
+  <gn-ui-carousel
+    class="block md:hidden"
+    containerClass="gap-4 pt-5 pb-7"
+    (currentStepChange)="updateView()"
+  >
+    <gn-ui-link-card
+      *ngFor="let otherLink of otherLinks"
+      [link]="otherLink"
+      class="w-80"
+      size="S"
+    ></gn-ui-link-card>
+  </gn-ui-carousel>
   <gn-ui-block-list
-    containerClass="gap-4 pt-5"
-    *ngIf="otherLinks.length >= 10; else carouselTemplate"
+    #blockList
+    class="hidden md:block"
+    containerClass="gap-4 pt-5 pb-7"
   >
     <gn-ui-link-card
       #block
       *ngFor="let otherLink of otherLinks"
       [link]="otherLink"
-      size="S"
+      [size]="blockList.subComponentSize"
     ></gn-ui-link-card>
   </gn-ui-block-list>
-  <ng-template #carouselTemplate>
-    <gn-ui-carousel
-      containerClass="gap-4 pt-5 pb-7"
-      (currentStepChange)="updateView()"
-    >
-      <gn-ui-link-card
-        *ngFor="let otherLink of otherLinks; let first = first; let last = last"
-        [link]="otherLink"
-        size="S"
-      ></gn-ui-link-card>
-    </gn-ui-carousel>
-  </ng-template>
 </ng-container>

--- a/apps/datahub/src/app/record/record-otherlinks/record-otherlinks.component.ts
+++ b/apps/datahub/src/app/record/record-otherlinks/record-otherlinks.component.ts
@@ -9,13 +9,13 @@ import { MdViewFacade } from '@geonetwork-ui/feature/record'
 import {
   BlockListComponent,
   CarouselComponent,
-  Paginable,
   PreviousNextButtonsComponent,
 } from '@geonetwork-ui/ui/layout'
 import { CommonModule } from '@angular/common'
 import { LinkCardComponent } from '@geonetwork-ui/ui/elements'
 import { LetDirective } from '@ngrx/component'
 import { TranslateModule } from '@ngx-translate/core'
+import { map } from 'rxjs/operators'
 
 @Component({
   selector: 'datahub-record-otherlinks',
@@ -36,11 +36,12 @@ import { TranslateModule } from '@ngx-translate/core'
 export class RecordOtherlinksComponent implements AfterViewInit {
   otherLinks$ = this.facade.otherLinks$
 
+  get linksCount$() {
+    return this.otherLinks$?.pipe(map((links) => links.length))
+  }
+
   @ViewChild(CarouselComponent) carousel: CarouselComponent
   @ViewChild(BlockListComponent) list: BlockListComponent
-  get paginableElement(): Paginable {
-    return this.carousel || this.list
-  }
 
   constructor(
     public facade: MdViewFacade,
@@ -52,7 +53,6 @@ export class RecordOtherlinksComponent implements AfterViewInit {
   }
 
   ngAfterViewInit() {
-    // this is required to show the pagination correctly
     this.changeDetector.detectChanges()
   }
 }

--- a/libs/ui/elements/src/lib/api-card/api-card.component.html
+++ b/libs/ui/elements/src/lib/api-card/api-card.component.html
@@ -1,12 +1,12 @@
 <div
-  class="group flex justify-between rounded filter overflow-hidden"
+  class="group flex justify-between rounded filter overflow-hidden card-shadow"
   [ngClass]="cardClass"
 >
   <ng-container *ngIf="size !== 'S'">
-    <div>
+    <div class="flex-1 min-w-0">
       <ng-container *ngTemplateOutlet="content"></ng-container>
     </div>
-    <div class="flex items-center">
+    <div class="flex items-center min-w-[32px]">
       <ng-container *ngTemplateOutlet="buttons"></ng-container>
     </div>
   </ng-container>
@@ -51,7 +51,7 @@
 </ng-template>
 
 <ng-template #content>
-  <div>
+  <div class="flex-1 min-w-0">
     <div class="gn-ui-card-title">
       {{ link.description || link.name }}
     </div>

--- a/libs/ui/elements/src/lib/download-item/download-item.component.html
+++ b/libs/ui/elements/src/lib/download-item/download-item.component.html
@@ -1,20 +1,20 @@
 <a
   href="{{ link.url }}"
   target="_blank"
-  class="group flex flex-row justify-between card-shadow cursor-pointer rounded overflow-hidden"
+  class="group flex flex-row justify-between card-shadow cursor-pointer rounded overflow-hidden w-full"
   rel="noopener"
   [ngClass]="cardClass"
 >
-  <div class="flex flex-col justify-between">
+  <div class="flex flex-col flex-1 justify-between min-w-0">
     <div class="gn-ui-card-title" [title]="link.description || link.name">
       {{ link.description || link.name }}
     </div>
     <div class="gn-ui-card-detail">
       {{ link.name }}
     </div>
-    <div class="flex flex-row gap-2 items-center pt-1">
+    <div class="flex flex-row gap-2 items-center pt-1 min-w-0">
       <span
-        class="inline-flex items-center justify-center px-2 py-1 text-13 font-medium leading-none text-white rounded transition-opacity opacity-70 group-hover:opacity-100"
+        class="inline-flex items-center justify-center px-2 py-1 text-13 font-medium leading-none text-white rounded transition-opacity opacity-70 group-hover:opacity-100 whitespace-nowrap"
         [style.background-color]="color"
         data-cy="download-format"
         >{{ format || ('downloads.format.unknown' | translate) }}</span
@@ -24,7 +24,10 @@
       >
     </div>
   </div>
-  <div class="flex" [ngClass]="size === 'S' ? 'items-end' : 'items-center'">
+  <div
+    class="flex min-w-[32px] flex-shrink-0"
+    [ngClass]="size === 'S' ? 'items-end' : 'items-center'"
+  >
     <div class="gn-ui-card-icon">
       <ng-icon
         class="inline-block card-icon align-middle"

--- a/libs/ui/elements/src/lib/download-item/download-item.component.ts
+++ b/libs/ui/elements/src/lib/download-item/download-item.component.ts
@@ -27,7 +27,7 @@ type CardSize = 'L' | 'M' | 'S' | 'XS'
   ],
 })
 export class DownloadItemComponent {
-  private _size: 'L' | 'M' | 'S' | 'XS'
+  private _size: CardSize
   @Input() link: DatasetOnlineResource
   @Input() color: string
   @Input() format: string
@@ -43,7 +43,7 @@ export class DownloadItemComponent {
     this._size = value
     this.cardClass = this.sizeClassMap[value]
   }
-  get size(): 'L' | 'M' | 'S' | 'XS' {
+  get size(): CardSize {
     return this._size
   }
   cardClass = ''

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.html
@@ -2,12 +2,23 @@
   class="flex flex-wrap justify-between items-center pb-4"
   *ngIf="links && links.length > 0"
 >
-  <div
-    class="font-title text-xl text-title font-medium mr-4 text-center sm:text-left"
-    translate
-  >
-    record.metadata.download
+  <div class="flex flex-row items-center gap-x-4">
+    <div>
+      <span
+        class="font-title text-xl text-title font-medium text-center sm:text-left"
+        translate
+      >
+        record.metadata.download
+      </span>
+      <span class="px-3">({{ linksCount }})</span>
+    </div>
+    <gn-ui-previous-next-buttons
+      class="md:block hidden"
+      *ngIf="_list?.pagesCount > 1"
+      [listComponent]="_list"
+    ></gn-ui-previous-next-buttons>
   </div>
+
   <div
     class="flex flex-wrap justify-start sm:justify-end"
     data-cy="download-format-filters"
@@ -26,9 +37,29 @@
     </gn-ui-button>
   </div>
 </div>
-<div class="mb-2 sm:mb-3" *ngFor="let link of filteredLinks">
+
+<ng-container>
+  <gn-ui-block-list
+    class="md:block hidden"
+    #blockList
+    (listChanges)="updateList($event)"
+    containerClass="gap-4 pt-5 pb-7"
+  >
+    <gn-ui-download-item
+      #block
+      *ngFor="let link of filteredLinks"
+      [link]="link"
+      [color]="getLinkColor(link)"
+      [format]="getLinkFormat(link)"
+      [isFromApi]="isFromApi(link)"
+      [size]="blockList.subComponentSize"
+    ></gn-ui-download-item>
+  </gn-ui-block-list>
+</ng-container>
+
+<div class="mb-5 md:hidden block" *ngFor="let link of filteredLinks">
   <gn-ui-download-item
-    size="L"
+    size="M"
     [link]="link"
     [color]="getLinkColor(link)"
     [format]="getLinkFormat(link)"

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.spec.ts
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.spec.ts
@@ -59,7 +59,7 @@ describe('DownloadsListComponent', () => {
       items = de.queryAll(By.directive(DownloadItemComponent))
     })
     it('contains three links', () => {
-      expect(items.length).toBe(3)
+      expect(items.length).toBe(6) // 2 presentation (1 hidden) of 3 links
     })
   })
 
@@ -85,7 +85,7 @@ describe('DownloadsListComponent', () => {
       items = de.queryAll(By.directive(DownloadItemComponent))
     })
     it('contains one link in "others" section', () => {
-      expect(items.length).toBe(1)
+      expect(items.length).toBe(2) // 2 presentation (1 hidden) of 1 link
       expect(component.isLinkOfFormat(component.links[0], 'others')).toBe(true)
     })
   })
@@ -103,7 +103,7 @@ describe('DownloadsListComponent', () => {
       items = de.queryAll(By.directive(DownloadItemComponent))
     })
     it('contains one link and mime type is ignored', () => {
-      expect(items.length).toBe(1)
+      expect(items.length).toBe(2) // 2 presentation (1 hidden) of 1 link
       expect(component.isLinkOfFormat(component.links[0], 'json')).toBe(true)
     })
   })
@@ -116,7 +116,7 @@ describe('DownloadsListComponent', () => {
       items = de.queryAll(By.directive(DownloadItemComponent))
     })
     it('contains color, isAPI & format', () => {
-      expect(items.length).toBe(1)
+      expect(items.length).toBe(2) // 2 presentation (1 hidden) of 1 link
       expect(items[0].componentInstance.link).toEqual(
         aSetOfLinksFixture().geodataShpWithMimeType()
       )

--- a/libs/ui/elements/src/lib/downloads-list/downloads-list.component.ts
+++ b/libs/ui/elements/src/lib/downloads-list/downloads-list.component.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  ViewChild,
+} from '@angular/core'
 import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import { getBadgeColor, getFileFormat } from '@geonetwork-ui/util/shared'
@@ -6,6 +13,11 @@ import { DatasetDownloadDistribution } from '@geonetwork-ui/common/domain/model/
 import { CommonModule } from '@angular/common'
 import { ButtonComponent } from '@geonetwork-ui/ui/inputs'
 import { DownloadItemComponent } from '../download-item/download-item.component'
+import {
+  BlockListComponent,
+  Paginable,
+  PreviousNextButtonsComponent,
+} from '@geonetwork-ui/ui/layout'
 
 marker('datahub.search.filter.all')
 marker('datahub.search.filter.others')
@@ -22,16 +34,31 @@ type FilterFormat = (typeof FILTER_FORMATS)[number]
   imports: [
     CommonModule,
     ButtonComponent,
+    BlockListComponent,
     DownloadItemComponent,
     TranslateModule,
+    PreviousNextButtonsComponent,
   ],
 })
 export class DownloadsListComponent {
-  constructor(private translateService: TranslateService) {}
+  constructor(
+    private translateService: TranslateService,
+    private changeDetector: ChangeDetectorRef
+  ) {}
 
+  _list: BlockListComponent
   @Input() links: DatasetDownloadDistribution[]
 
+  get linksCount(): number {
+    return this.filteredLinks?.length || 0
+  }
+
   activeFilterFormats: FilterFormat[] = ['all']
+
+  updateList($event: BlockListComponent) {
+    this._list = $event
+    this.changeDetector.detectChanges()
+  }
 
   private removeDuplicateFormats(
     links: DatasetDownloadDistribution[]

--- a/libs/ui/elements/src/lib/link-card/link-card.component.html
+++ b/libs/ui/elements/src/lib/link-card/link-card.component.html
@@ -5,7 +5,7 @@
   [ngClass]="cardClass"
   [title]="title"
 >
-  <div class="flex flex-col justify-between">
+  <div class="flex flex-col justify-between flex-1 min-w-0">
     <div class="gn-ui-card-title">
       {{ link.description || link.name }}
     </div>
@@ -26,7 +26,10 @@
       >
     </div>
   </div>
-  <div class="flex" [ngClass]="size === 'S' ? 'items-end' : 'items-center'">
+  <div
+    class="flex min-w-[32px]"
+    [ngClass]="size === 'S' ? 'items-end' : 'items-center'"
+  >
     <div class="gn-ui-card-icon">
       <ng-icon
         class="inline-block card-icon align-middle"

--- a/libs/ui/elements/src/lib/link-card/link-card.component.ts
+++ b/libs/ui/elements/src/lib/link-card/link-card.component.ts
@@ -1,9 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core'
-import {
-  DatasetDownloadDistribution,
-  DatasetOnlineResource,
-  DatasetServiceDistribution,
-} from '@geonetwork-ui/common/domain/model/record'
+import { DatasetOnlineResource } from '@geonetwork-ui/common/domain/model/record'
 import { CommonModule } from '@angular/common'
 import {
   NgIconComponent,
@@ -30,7 +26,7 @@ type CardSize = 'L' | 'M' | 'S' | 'XS'
   ],
 })
 export class LinkCardComponent {
-  private _size: 'L' | 'M' | 'S' | 'XS'
+  private _size: CardSize
   @Input() link: DatasetOnlineResource
   private readonly sizeClassMap: Record<CardSize, string> = {
     L: 'gn-ui-card-l py-2 px-5',
@@ -43,7 +39,7 @@ export class LinkCardComponent {
     this._size = value
     this.cardClass = this.sizeClassMap[value]
   }
-  get size(): 'L' | 'M' | 'S' | 'XS' {
+  get size(): CardSize {
     return this._size
   }
   cardClass = ''

--- a/libs/ui/layout/src/lib/block-list/block-list.component.css
+++ b/libs/ui/layout/src/lib/block-list/block-list.component.css
@@ -5,3 +5,25 @@
 :host {
   position: relative;
 }
+
+@media screen and (min-width: 769px) {
+  .size-L {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+    grid-auto-rows: minmax(0, min-content);
+  }
+
+  .size-M {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-rows: minmax(0, min-content);
+  }
+
+  .size-S {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-auto-rows: minmax(0, min-content);
+  }
+
+  .size-XS {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-rows: minmax(0, min-content);
+  }
+}

--- a/libs/ui/layout/src/lib/block-list/block-list.component.html
+++ b/libs/ui/layout/src/lib/block-list/block-list.component.html
@@ -1,7 +1,7 @@
 <div
-  class="block-list-container flex flex-col"
+  class="grid gap-4 w-full md:grid-cols-2"
   #blockContainer
-  [ngClass]="containerClass"
+  [ngClass]="[containerClass, 'size-' + subComponentSize]"
   [ngStyle]="{ minHeight: minHeight + 'px' }"
 >
   <ng-content></ng-content>

--- a/libs/ui/layout/src/lib/block-list/block-list.component.ts
+++ b/libs/ui/layout/src/lib/block-list/block-list.component.ts
@@ -5,7 +5,9 @@ import {
   Component,
   ContentChildren,
   ElementRef,
+  EventEmitter,
   Input,
+  Output,
   QueryList,
   ViewChild,
 } from '@angular/core'
@@ -13,6 +15,7 @@ import { CommonModule } from '@angular/common'
 import { Paginable } from '../paginable.interface'
 import { PaginationDotsComponent } from '../pagination-dots/pagination-dots.component'
 
+type ComponentSize = 'L' | 'M' | 'S' | 'XS'
 @Component({
   selector: 'gn-ui-block-list',
   templateUrl: './block-list.component.html',
@@ -22,15 +25,16 @@ import { PaginationDotsComponent } from '../pagination-dots/pagination-dots.comp
   imports: [CommonModule, PaginationDotsComponent],
 })
 export class BlockListComponent implements AfterViewInit, Paginable {
-  @Input() pageSize = 5
+  pageSize = 4
   @Input() containerClass = ''
   @Input() paginationContainerClass = 'w-full bottom-0 top-auto'
   @ContentChildren('block', { read: ElementRef }) blocks: QueryList<
     ElementRef<HTMLElement>
   >
   @ViewChild('blockContainer') blockContainer: ElementRef<HTMLElement>
-
   protected minHeight = 0
+  @Output() listChanges = new EventEmitter<BlockListComponent>()
+  subComponentSize: ComponentSize = 'M'
 
   protected currentPage_ = 0
   protected get pages() {
@@ -47,18 +51,26 @@ export class BlockListComponent implements AfterViewInit, Paginable {
     return this.blocks ? Math.ceil(this.blocks.length / this.pageSize) : 1
   }
   get currentPage() {
-    return this.currentPage_ + 1 // this is 1-based
+    return this.currentPage_ + 1
   }
 
   constructor(private changeDetector: ChangeDetectorRef) {}
 
   ngAfterViewInit() {
-    this.blocks.changes.subscribe(this.refreshBlocksVisibility)
+    this.blocks.changes.subscribe(() => {
+      this.updateSizes()
+      this.refreshBlocksVisibility()
+      this.goToPage(1)
+      this.changeDetector.detectChanges()
+      this.listChanges.emit(this)
+    })
+    this.updateSizes()
     this.refreshBlocksVisibility()
 
     // we store the first height as the min-height of the list container
     this.minHeight = this.blockContainer.nativeElement.clientHeight
     this.changeDetector.detectChanges()
+    this.listChanges.emit(this)
   }
 
   protected refreshBlocksVisibility = () => {
@@ -71,7 +83,33 @@ export class BlockListComponent implements AfterViewInit, Paginable {
     })
   }
 
-  // pageIndex is 1-based
+  protected updateSizes() {
+    this.subComponentSize = this.computeSubComponentSize()
+    this.pageSize = this.computePageSize()
+  }
+
+  protected computeSubComponentSize(): ComponentSize {
+    if (!this.blocks) return 'M'
+    const subComponentsCount = this.blocks.length
+    if (subComponentsCount <= 3) return 'L'
+    if (subComponentsCount <= 12) return 'M'
+    if (subComponentsCount <= 18) return 'S'
+    return 'XS'
+  }
+
+  protected computePageSize(): number {
+    switch (this.subComponentSize) {
+      case 'L':
+        return 3
+      case 'S':
+        return 6
+      case 'XS':
+        return 8
+      default:
+        return 4
+    }
+  }
+
   public goToPage(pageIndex: number) {
     this.currentPage_ = Math.max(
       Math.min(pageIndex - 1, this.pagesCount - 1),

--- a/libs/ui/layout/src/lib/carousel/carousel.component.css
+++ b/libs/ui/layout/src/lib/carousel/carousel.component.css
@@ -1,4 +1,3 @@
 :host {
   position: relative;
-  display: block;
 }

--- a/libs/ui/layout/src/lib/carousel/carousel.component.html
+++ b/libs/ui/layout/src/lib/carousel/carousel.component.html
@@ -1,4 +1,4 @@
-<div #carouselOverflowContainer class="w-full">
+<div #carouselOverflowContainer class="w-full block">
   <div class="carousel-container flex" [ngClass]="containerClass">
     <ng-content></ng-content>
   </div>

--- a/libs/ui/layout/src/lib/previous-next-buttons/previous-next-buttons.component.html
+++ b/libs/ui/layout/src/lib/previous-next-buttons/previous-next-buttons.component.html
@@ -1,18 +1,30 @@
-<div class="flex flex-row gap-x-4 items-center">
+<div class="flex flex-row gap-x-1 items-center">
   <gn-ui-button
     data-test="previousButton"
-    type="outline"
+    type="light"
+    [extraClass]="
+      'w-10 h-8 px-2 py-1 rounded-lg ' +
+      (!listComponent.isFirstPage
+        ? 'border border-gray-300'
+        : 'border border-gray-100')
+    "
     [disabled]="listComponent.isFirstPage"
     (buttonClick)="listComponent.goToPrevPage()"
   >
-    <ng-icon name="matArrowBack"></ng-icon>
+    <ng-icon name="matArrowBackIos"></ng-icon>
   </gn-ui-button>
   <gn-ui-button
     data-test="nextButton"
-    type="outline"
+    type="light"
+    [extraClass]="
+      'w-10 h-8 px-2 py-1 rounded-lg ' +
+      (!listComponent.isLastPage
+        ? 'border border-gray-300'
+        : 'border border-gray-100')
+    "
     [disabled]="listComponent.isLastPage"
     (buttonClick)="listComponent.goToNextPage()"
   >
-    <ng-icon name="matArrowForward"></ng-icon>
+    <ng-icon name="matArrowForwardIos"></ng-icon>
   </gn-ui-button>
 </div>

--- a/libs/ui/layout/src/lib/previous-next-buttons/previous-next-buttons.component.ts
+++ b/libs/ui/layout/src/lib/previous-next-buttons/previous-next-buttons.component.ts
@@ -5,8 +5,8 @@ import {
   provideNgIconsConfig,
 } from '@ng-icons/core'
 import {
-  matArrowBack,
-  matArrowForward,
+  matArrowBackIos,
+  matArrowForwardIos,
 } from '@ng-icons/material-icons/baseline'
 import { Paginable } from '../paginable.interface'
 import { ButtonComponent } from '@geonetwork-ui/ui/inputs'
@@ -18,7 +18,7 @@ import { ButtonComponent } from '@geonetwork-ui/ui/inputs'
   standalone: true,
   imports: [ButtonComponent, NgIconComponent],
   providers: [
-    provideIcons({ matArrowForward, matArrowBack }),
+    provideIcons({ matArrowBackIos, matArrowForwardIos }),
     provideNgIconsConfig({
       size: '0.875em',
     }),

--- a/tailwind.base.config.js
+++ b/tailwind.base.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   theme: {
     extend: {
+      screens: {
+        xs: '320px',
+      },
       colors: {
         'primary-white': 'var(--color-primary-white)',
         'primary-lightest': 'var(--color-primary-lightest)',

--- a/tailwind.base.css
+++ b/tailwind.base.css
@@ -134,20 +134,8 @@
       border-white focus:ring-4 focus:ring-gray-300;
   }
 
-  .gn-ui-card-xs {
-    @apply min-h-[68px] md:w-[487px];
-  }
-
   .gn-ui-card-s {
-    @apply min-h-[135px] md:w-80;
-  }
-
-  .gn-ui-card-m {
-    @apply min-h-[68px] md:w-[487px];
-  }
-
-  .gn-ui-card-l {
-    @apply min-h-[68px] md:w-[992px];
+    @apply min-h-[64px] w-full xs:min-w-[260px] xs:max-w-[280px] sm:min-w-[300px] sm:max-w-[500px] md:min-w-[230px];
   }
 
   .gn-ui-card-title {

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -406,7 +406,7 @@
   "record.metadata.keywords": "Mots-clés",
   "record.metadata.languages": "Langues",
   "record.metadata.lastUpdate": "Mis à jour le {date}",
-  "record.metadata.links": "Ressources & liens",
+  "record.metadata.links": "Liens",
   "record.metadata.noUsage": "Aucune condition d'utilisation spécifiée pour ces données",
   "record.metadata.otherConstraints": "Limitations d'usage",
   "record.metadata.owner": "Catalogue d'origine",


### PR DESCRIPTION
### Description

This PR introduces a card list layout to make components use a harmonized grid layout. This Layout wrapper is in charge of the layout itself, the pagination of the cards ( the subcomponents) and also the size of its components ( to permit to show more information when there is few elements, and less when there is more elements). The layout is usable with mobile but use caroussel instead is preferable ( as the exemple in otherlink) 
The layout is also responsible of the number of elements per pages. 


### Architectural changes

The following library now depends on [...]

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots
Desktop view 
![image](https://github.com/user-attachments/assets/97a50073-d061-40ce-9d4c-12533cb4ccc6)
![image](https://github.com/user-attachments/assets/7837a4b1-6ca1-46c0-8199-1a2ca0a6a687)
![image](https://github.com/user-attachments/assets/74a97e7e-e1d1-4470-a41c-95bb543bfb1a)

Mobile view : 
![image](https://github.com/user-attachments/assets/56b7a0e1-daae-49b5-a398-a3cd5aa0567d)
![image](https://github.com/user-attachments/assets/581028b5-82a8-42fa-be9a-3bc095094d29)
![image](https://github.com/user-attachments/assets/d6639eda-b001-4fad-8286-fe1f5b2bf1ab)


<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

2 parts of testing. 

About Download part: 
- The component show download with a grid adapted
- in case of filtering, the grid and the pagination is adapted ( grid size can changes and pagination also) ,
- each filter action cause a go back to page 1 


About the link part : 
- in desktop and tablet, there is the layout with blocks elements 
- in mobile, there is a caroussel
- The destop layout has pagination if concerned, and the layout is adapt with the number of elements


I don't have a precise dataset to advise, but it is preferable to test this cases with 4 elements, between 4 and 12, 13 and 18 ( i don't have one) and more than 19. 

All of this cases are covered theorically by e2e and unit tests 

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
