### PR TITLE
[Editor]: Bug first letter eaten

### DIFF
--- a/libs/ui/inputs/src/lib/url-input/url-input.component.ts
+++ b/libs/ui/inputs/src/lib/url-input/url-input.component.ts
@@ -31,7 +31,7 @@ import { iconoirArrowUp, iconoirLink } from '@ng-icons/iconoir'
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class UrlInputComponent implements OnChanges {
+export class UrlInputComponent {
   @Input() set value(v: string) {
     // we're making sure to only update the input if the URL representation of it has changed; otherwise we keep it identical
     // to avoid glitches when starting to write a URL and having some characters added/replaced automatically
@@ -58,12 +58,6 @@ export class UrlInputComponent implements OnChanges {
   inputValue = ''
 
   constructor(private cd: ChangeDetectorRef) {}
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['value']) {
-      this.inputValue = changes['value'].currentValue
-    }
-  }
 
   handleInput(event: Event) {
     const value = (event.target as HTMLInputElement).value


### PR DESCRIPTION
### Description

This PR fixes the behavior in the "Link to a service" input where the first letter was eaten and where http://example.com turned into  https://e/xample.com. 


### Architectural changes

none

### Screenshots

no UI changes

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Follow these instructions to confirm [...]

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
