### PR TITLE
[Editor]: Display all supported types of contacts

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/edit.cy.ts
@@ -840,14 +840,14 @@ describe('editor form', () => {
           it('show the roles available to add', () => {
             cy.get('[data-test=rolesToPick]')
               .children()
-              .should('have.length', 5)
+              .should('have.length', 18)
           })
 
           it('click on a role adds it to the list of displayed role', () => {
             cy.get('[data-test="rolesToPick"]').children().eq(2).click()
             cy.get('[data-test=rolesToPick]')
               .children()
-              .should('have.length', 4)
+              .should('have.length', 17)
             cy.get('[data-test=displayedRoles]')
               .children()
               .should('have.length', 2)

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-contacts-for-resource/form-field-contacts-for-resource.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-contacts-for-resource/form-field-contacts-for-resource.component.html
@@ -31,6 +31,7 @@
       </div>
 
       <gn-ui-autocomplete
+        *ngIf="role !== 'unspecified' && role !== 'other'"
         [placeholder]="
           'editor.record.form.field.contactsForResource.placeholder' | translate
         "

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-contacts-for-resource/form-field-contacts-for-resource.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-contacts-for-resource/form-field-contacts-for-resource.component.ts
@@ -40,6 +40,7 @@ import {
   provideNgIconsConfig,
 } from '@ng-icons/core'
 import { iconoirPlus } from '@ng-icons/iconoir'
+import { RoleValues } from '@geonetwork-ui/common/domain/model/record'
 
 @Component({
   selector: 'gn-ui-form-field-contacts-for-resource',
@@ -72,15 +73,11 @@ export class FormFieldContactsForResourceComponent
   @Output() valueChange: EventEmitter<Individual[]> = new EventEmitter()
 
   contactsForRessourceByRole: Map<Role, Individual[]> = new Map()
+  roleValues = RoleValues
 
-  rolesToPick: Role[] = [
-    'resource_provider',
-    'custodian',
-    'owner',
-    'point_of_contact',
-    'author',
-    'publisher',
-  ]
+  rolesToPick: Role[] = this.roleValues.filter(
+    (role) => role !== 'other' && role !== 'unspecified'
+  )
 
   roleSectionsToDisplay: Role[] = []
 

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-contacts-for-resource/form-field-contacts-for-resource.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-contacts-for-resource/form-field-contacts-for-resource.component.ts
@@ -175,9 +175,11 @@ export class FormFieldContactsForResourceComponent
    * gn-ui-autocomplete
    */
   displayWithFn: (user: UserModel) => string = (user) =>
-    `${user.name} ${user.surname} ${
-      user.organisation ? `(${user.organisation})` : ''
-    }`
+    user.name
+      ? `${user.name} ${user.surname} ${
+          user.organisation ? `(${user.organisation})` : ''
+        }`
+      : ``
 
   /**
    * gn-ui-autocomplete


### PR DESCRIPTION
### Description

This PR adds all the supported types of contacts that the converter can handle.
However it does not propose to add the types "Other" and "Unspecified", but allows them to be displayed if pre-existing.

### Architectural changes

none

### Screenshots

![Screenshot from 2025-03-21 13-53-12](https://github.com/user-attachments/assets/9e56bf12-4739-4667-97c2-af42f15ca271)

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves


### How to test

If you wish to test that Other/Unspecified values are indeed displayed, add a point of contact in old gn-ui without selecting a type in the dropdown. It should appear as "Unspecified" point of contact in the editor. For the "Other" category, I guess it will only appear when importing external records because it's not even available in the list (I added the one in the screenshot before filtering the list).