### PR TITLE
Fix converter on records with empty feature catalog

### DIFF
--- a/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
@@ -1028,6 +1028,20 @@ describe('Gn4Converter', () => {
             'related-metadata-with-fcats'
           )
         })
+
+        it('supports empty fcats array', async () => {
+          const record = await service.readRecord({
+            ...hit,
+            _source: {
+              ...hit._source,
+              related: {
+                fcats: [],
+              },
+            },
+          })
+
+          expect(record.extras['featureCatalogIdentifier']).toBeUndefined()
+        })
       })
 
       describe('full record', () => {

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -291,7 +291,7 @@ export class Gn4FieldMapper {
             <SourceWithUnknownProps>selectField(source, 'related'),
             'fcats'
           )
-        ),
+        ) ?? {},
         '_source'
       )
       const featureCatalogIdentifier = selectField(


### PR DESCRIPTION
### Description

This PR fixes the converter when a record has an empty related feature catalog array.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Import this record:

https://dev.geo2france.fr/datahub/dataset/fr-120066022-jdd-0b0138ad-46f1-41d5-9725-67f917de260d

The record page should not display this error message:

![image](https://github.com/user-attachments/assets/f651cdcb-fdd8-4672-99f9-6c8ac07c1d11)

