### PR TITLE
[Editor] : Save XML imports

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/record-actions.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/record-actions.cy.ts
@@ -1,5 +1,8 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { simpleDatasetRecordAsXmlFixture } from '@geonetwork-ui/common/fixtures'
+import {
+  duplicateDatasetRecordAsXmlFixture,
+  simpleDatasetRecordAsXmlFixture,
+} from '@geonetwork-ui/common/fixtures'
 
 describe('record-actions', () => {
   beforeEach(() => {
@@ -268,6 +271,15 @@ describe('record-actions', () => {
           .find('textarea')
           .invoke('val')
           .should('contain', 'Copy')
+        // imported record should be saved right away but not published
+        cy.url().should('not.include', 'TEMP')
+        cy.get('[data-cy="dashboard-drafts-count"]').should('not.exist')
+        cy.get('[data-cy="save-status"]')
+          .find('span')
+          .should('have.text', 'Saved - not published')
+        cy.get('md-editor-publish-button')
+          .find('gn-ui-button')
+          .should('have.attr', 'ng-reflect-message', 'Publish this dataset')
       })
 
       it('should be able to navigate back to the main section', () => {

--- a/apps/metadata-editor-e2e/src/e2e/record-actions.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/record-actions.cy.ts
@@ -1,8 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import {
-  duplicateDatasetRecordAsXmlFixture,
-  simpleDatasetRecordAsXmlFixture,
-} from '@geonetwork-ui/common/fixtures'
+import { importDatasetRecordAsXmlFixture } from '@geonetwork-ui/common/fixtures'
 
 describe('record-actions', () => {
   beforeEach(() => {
@@ -256,7 +253,7 @@ describe('record-actions', () => {
           },
           {
             statusCode: 200,
-            body: simpleDatasetRecordAsXmlFixture(),
+            body: importDatasetRecordAsXmlFixture(),
           }
         ).as('importUrlRequest')
 

--- a/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
@@ -738,13 +738,11 @@ describe('Gn4Repository', () => {
   describe('importRecordFromExternalFileUrlAsDraft', () => {
     const recordDownloadUrl = 'https://example.com/record/xml'
     const mockXml = simpleDatasetRecordAsXmlFixture()
-    let tempId: string
 
-    it('should fetch the external record and save it as a draft', fakeAsync(() => {
+    it('should fetch the external record and save it immediately', fakeAsync(() => {
       repository.duplicateExternalRecord(recordDownloadUrl).subscribe((id) => {
-        tempId = id
-
-        expect(tempId).toMatch(/^TEMP-ID-\d+$/)
+        expect(id).toMatch('my-dataset-001')
+        expect(repository.saveRecord).toHaveBeenCalled()
       })
 
       const req = httpTestingController.expectOne(recordDownloadUrl)

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -352,21 +352,13 @@ export class Gn4Repository implements RecordsRepositoryInterface {
       exhaustMap(async (fetchedRecordAsXml: string) => {
         const converter = findConverterForDocument(fetchedRecordAsXml)
         const record = await converter.readRecord(fetchedRecordAsXml)
-        const tempId = this.generateTemporaryId()
 
         record.title = `${record.title} (Copy)`
-        record.uniqueIdentifier = tempId
+        await converter.writeRecord(record, fetchedRecordAsXml)
 
-        const recordAsXml = await converter.writeRecord(
-          record,
-          fetchedRecordAsXml
-        )
-
-        this.saveRecordToLocalStorage(recordAsXml, record.uniqueIdentifier)
-        this._draftsChanged.next()
-
-        return tempId
+        return this.saveRecord(record, '', false)
       }),
+      exhaustMap((uuidObservable: Observable<string>) => uuidObservable),
       catchError((error: HttpErrorResponse) => {
         return throwError(() => error)
       })

--- a/libs/common/fixtures/src/lib/records.fixtures.ts
+++ b/libs/common/fixtures/src/lib/records.fixtures.ts
@@ -705,6 +705,96 @@ export const duplicateDatasetRecordAsXmlFixture =
     </mdb:resourceLineage>
 </mdb:MD_Metadata>`
 
+export const importDatasetRecordAsXmlFixture = (): string => `
+  <gmd:MD_Metadata
+	xmlns:gmd="http://www.isotc211.org/2005/gmd"
+	xmlns:gco="http://www.isotc211.org/2005/gco"
+	xmlns:srv="http://www.isotc211.org/2005/srv"
+	xmlns:gmx="http://www.isotc211.org/2005/gmx"
+	xmlns:gts="http://www.isotc211.org/2005/gts"
+	xmlns:gsr="http://www.isotc211.org/2005/gsr"
+	xmlns:gmi="http://www.isotc211.org/2005/gmi"
+	xmlns:gml="http://www.opengis.net/gml/3.2"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+	<gmd:language>
+		<gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
+	</gmd:language>
+	<gmd:characterSet>
+		<gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode"/>
+	</gmd:characterSet>
+	<gmd:contact>
+		<gmd:CI_ResponsibleParty>
+			<gmd:individualName gco:nilReason="missing">
+				<gco:CharacterString/>
+			</gmd:individualName>
+			<gmd:organisationName gco:nilReason="missing">
+				<gco:CharacterString/>
+			</gmd:organisationName>
+			<gmd:positionName gco:nilReason="missing">
+				<gco:CharacterString/>
+			</gmd:positionName>
+			<gmd:role>
+				<gmd:CI_RoleCode codeListValue="pointOfContact" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode"/>
+			</gmd:role>
+		</gmd:CI_ResponsibleParty>
+	</gmd:contact>
+	<gmd:dateStamp>
+		<gco:DateTime>2024-05-31T10:18:45.429Z</gco:DateTime>
+	</gmd:dateStamp>
+	<gmd:metadataStandardName>
+		<gco:CharacterString>ISO 19115:2003/19139</gco:CharacterString>
+	</gmd:metadataStandardName>
+	<gmd:metadataStandardVersion>
+		<gco:CharacterString>1.0</gco:CharacterString>
+	</gmd:metadataStandardVersion>
+	<gmd:identificationInfo>
+		<gmd:MD_DataIdentification>
+			<gmd:citation>
+				<gmd:CI_Citation>
+					<gmd:title>
+						<gco:CharacterString>Record with no link</gco:CharacterString>
+					</gmd:title>
+					<gmd:date>
+						<gmd:CI_Date>
+							<gmd:date>
+								<gco:DateTime>2024-05-31T11:00:00+00:00</gco:DateTime>
+							</gmd:date>
+							<gmd:dateType>
+								<gmd:CI_DateTypeCode codeListValue="publication" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"/>
+							</gmd:dateType>
+						</gmd:CI_Date>
+					</gmd:date>
+					<gmd:edition gco:nilReason="missing">
+						<gco:CharacterString/>
+					</gmd:edition>
+				</gmd:CI_Citation>
+			</gmd:citation>
+			<gmd:abstract>
+				<gco:CharacterString>Read the abstract and supplemental information provided in the Vector template for more details.</gco:CharacterString>
+			</gmd:abstract>
+			<gmd:purpose gco:nilReason="missing">
+				<gco:CharacterString/>
+			</gmd:purpose>
+			<gmd:status>
+				<gmd:MD_ProgressCode codeListValue="onGoing" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ProgressCode"/>
+			</gmd:status>
+			<gmd:language>
+				<gco:CharacterString>eng</gco:CharacterString>
+			</gmd:language>
+			<gmd:characterSet>
+				<gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode"/>
+			</gmd:characterSet>
+			<gmd:topicCategory>
+				<gmd:MD_TopicCategoryCode>boundaries</gmd:MD_TopicCategoryCode>
+			</gmd:topicCategory>
+			<gmd:supplementalInformation gco:nilReason="missing">
+				<gco:CharacterString/>
+			</gmd:supplementalInformation>
+		</gmd:MD_DataIdentification>
+	</gmd:identificationInfo>
+</gmd:MD_Metadata>`
+
 export const NATIONAL_KEYWORD = {
   key: 'http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/national',
   label: 'National',

--- a/libs/feature/editor/src/lib/components/import-record/import-record.component.ts
+++ b/libs/feature/editor/src/lib/components/import-record/import-record.component.ts
@@ -106,8 +106,8 @@ export class ImportRecordComponent {
     this.isRecordImportInProgress = true
 
     this.recordsRepository.duplicateExternalRecord(url).subscribe({
-      next: (recordTempId) => {
-        if (recordTempId) {
+      next: (uuid) => {
+        if (uuid) {
           this.notificationsService.showNotification(
             {
               type: 'success',
@@ -122,7 +122,7 @@ export class ImportRecordComponent {
           )
 
           this.router
-            .navigate(['/edit', recordTempId])
+            .navigate(['/edit', uuid])
             .catch((err) => console.error(err))
         }
         this.closeImportMenu.next()


### PR DESCRIPTION
### Description

This PR introduces automatic saving (but not published) for imported XML records. The behavior is the same as created and duplicated ones : 

- [x] New record is NOT saved as draft
- [x] Status is "saved - not published"
- [x] Option to publish is directly available
- [x] No temporary UUID is set, it's already the definitive one

### Architectural changes

none

### Screenshots

no UI change

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

### How to test

Import an XML file and check that the above list is true.
