### PR TITLE
[Backport 2.4.x] [Datahub]: Make analysis tab of preview work with WFS

### DIFF
--- a/BACKPORT_TODO
+++ b/BACKPORT_TODO
@@ -1,0 +1,10 @@
+Error on backporting to branch 2.4.x, error on cherry picking 6ec79251c880dbda21fb3f4ea1c5dda1bde4002b:
+
+
+
+To continue do:
+git fetch && git checkout backport/1158-to-2.4.x && git reset --hard HEAD^
+git cherry-pick 6ec79251c880dbda21fb3f4ea1c5dda1bde4002b
+git cherry-pick ee6dd6bc1f8e9bfa511d54d12adba09be69d29ec
+git cherry-pick e53e0165af831f36c011efa54ca78a9450ca17b2
+git push origin backport/1158-to-2.4.x --force


### PR DESCRIPTION
Backport of #1158

Error on cherry picking:
Error on backporting to branch 2.4.x, error on cherry picking 6ec79251c880dbda21fb3f4ea1c5dda1bde4002b:



To continue do:
git fetch && git checkout backport/1158-to-2.4.x && git reset --hard HEAD^
git cherry-pick 6ec79251c880dbda21fb3f4ea1c5dda1bde4002b
git cherry-pick ee6dd6bc1f8e9bfa511d54d12adba09be69d29ec
git cherry-pick e53e0165af831f36c011efa54ca78a9450ca17b2
git push origin backport/1158-to-2.4.x --force