### PR TITLE
[Datahub] Update the UI for Metadata Quality Component

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -342,7 +342,7 @@ describe('dataset pages', () => {
           cy.screenshot({ capture: 'fullPage' })
         })
         it('should not check all the criteria', () => {
-          cy.get('gn-ui-metadata-quality').realHover()
+          cy.get('gn-ui-metadata-quality').find('ng-icon').realHover()
           cy.get('gn-ui-metadata-quality-item')
             .find('ng-icon')
             .eq(4)
@@ -359,7 +359,7 @@ describe('dataset pages', () => {
             .should('have.attr', 'ng-reflect-value', 100)
         })
         it('should check all the criteria if score is 100%', () => {
-          cy.get('gn-ui-metadata-quality').realHover()
+          cy.get('gn-ui-metadata-quality').find('ng-icon').realHover()
           cy.get('gn-ui-metadata-quality-item')
             .find('ng-icon')
             .eq(4)

--- a/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.html
+++ b/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.html
@@ -12,19 +12,28 @@
   </ng-container>
 
   <ng-template #lightTheme>
-    <div class="flex items-center" [class]="smaller ? 'leading-[8px] min-w-[120px]' : 'min-w-[200px]'">
+    <div
+      class="flex items-center"
+      [class]="smaller ? 'leading-[8px] min-w-[120px]' : 'min-w-[200px]'"
+    >
       <gn-ui-progress-bar
         tabindex="0"
         [value]="qualityScore"
         [type]="theme"
         class="flex-grow"
       ></gn-ui-progress-bar>
-      <gn-ui-popover [content]="popoverItems" theme="light-border" [class]="smaller ? 'ml-2' : 'ml-2 mt-1'">
-        <ng-icon name="matInfoOutline" class="flex-shrink-0 text-gray-600"></ng-icon>
+      <gn-ui-popover
+        [content]="popoverItems"
+        theme="light-border"
+        [class]="smaller ? 'ml-2' : 'ml-2 mt-1'"
+      >
+        <ng-icon
+          name="matInfoOutline"
+          class="flex-shrink-0 text-gray-600"
+        ></ng-icon>
       </gn-ui-popover>
     </div>
   </ng-template>
-
 </div>
 <ng-template #popoverItems>
   <div class="p-2 py-4">

--- a/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.html
+++ b/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.html
@@ -1,39 +1,25 @@
 <div *ngIf="metadataQualityDisplay" class="mb-6 metadata-quality">
-  <ng-container *ngIf="theme !== 'light'; else lightTheme">
-    <gn-ui-popover [content]="popoverItems" theme="light-border">
-      <div class="min-w-[200px]" [class]="smaller ? 'leading-[8px]' : ''">
-        <gn-ui-progress-bar
-          tabindex="0"
-          [value]="qualityScore"
-          [type]="theme"
-        ></gn-ui-progress-bar>
-      </div>
-    </gn-ui-popover>
-  </ng-container>
-
-  <ng-template #lightTheme>
-    <div
-      class="flex items-center"
-      [class]="smaller ? 'leading-[8px] min-w-[120px]' : 'min-w-[200px]'"
+  <div
+    class="flex items-center"
+    [class]="smaller ? 'leading-[8px] min-w-[120px]' : 'min-w-[200px]'"
+  >
+    <gn-ui-progress-bar
+      tabindex="0"
+      [value]="qualityScore"
+      [type]="'light'"
+      class="flex-grow"
+    ></gn-ui-progress-bar>
+    <gn-ui-popover
+      [content]="popoverItems"
+      theme="light-border"
+      [class]="smaller ? 'ml-2' : 'ml-2 mt-1'"
     >
-      <gn-ui-progress-bar
-        tabindex="0"
-        [value]="qualityScore"
-        [type]="theme"
-        class="flex-grow"
-      ></gn-ui-progress-bar>
-      <gn-ui-popover
-        [content]="popoverItems"
-        theme="light-border"
-        [class]="smaller ? 'ml-2' : 'ml-2 mt-1'"
-      >
-        <ng-icon
-          name="matInfoOutline"
-          class="flex-shrink-0 text-gray-600"
-        ></ng-icon>
-      </gn-ui-popover>
-    </div>
-  </ng-template>
+      <ng-icon
+        name="matInfoOutline"
+        class="flex-shrink-0 text-gray-600"
+      ></ng-icon>
+    </gn-ui-popover>
+  </div>
 </div>
 <ng-template #popoverItems>
   <div class="p-2 py-4">

--- a/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.html
+++ b/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.html
@@ -1,13 +1,30 @@
 <div *ngIf="metadataQualityDisplay" class="mb-6 metadata-quality">
-  <gn-ui-popover [content]="popoverItems" theme="light-border">
-    <div class="min-w-[200px]" [class]="smaller ? 'leading-[8px]' : ''">
+  <ng-container *ngIf="theme !== 'light'; else lightTheme">
+    <gn-ui-popover [content]="popoverItems" theme="light-border">
+      <div class="min-w-[200px]" [class]="smaller ? 'leading-[8px]' : ''">
+        <gn-ui-progress-bar
+          tabindex="0"
+          [value]="qualityScore"
+          [type]="theme"
+        ></gn-ui-progress-bar>
+      </div>
+    </gn-ui-popover>
+  </ng-container>
+
+  <ng-template #lightTheme>
+    <div class="flex items-center" [class]="smaller ? 'leading-[8px] min-w-[120px]' : 'min-w-[200px]'">
       <gn-ui-progress-bar
         tabindex="0"
         [value]="qualityScore"
-        type="primary"
+        [type]="theme"
+        class="flex-grow"
       ></gn-ui-progress-bar>
+      <gn-ui-popover [content]="popoverItems" theme="light-border" [class]="smaller ? 'ml-2' : 'ml-2 mt-1'">
+        <ng-icon name="matInfoOutline" class="flex-shrink-0 text-gray-600"></ng-icon>
+      </gn-ui-popover>
     </div>
-  </gn-ui-popover>
+  </ng-template>
+
 </div>
 <ng-template #popoverItems>
   <div class="p-2 py-4">

--- a/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.stories.ts
+++ b/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.stories.ts
@@ -28,7 +28,6 @@ export default {
 export const Primary: StoryObj<MetadataQualityComponent> = {
   args: {
     smaller: false,
-    theme: 'primary',
     metadata: datasetRecordsFixture()[0] as Partial<CatalogRecord>,
     metadataQualityDisplay: true,
   },

--- a/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.stories.ts
+++ b/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.stories.ts
@@ -28,6 +28,7 @@ export default {
 export const Primary: StoryObj<MetadataQualityComponent> = {
   args: {
     smaller: false,
+    theme: 'primary',
     metadata: datasetRecordsFixture()[0] as Partial<CatalogRecord>,
     metadataQualityDisplay: true,
   },

--- a/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.ts
+++ b/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.ts
@@ -16,6 +16,9 @@ import {
 } from '@geonetwork-ui/ui/widgets'
 import { CommonModule } from '@angular/common'
 import { TranslateModule } from '@ngx-translate/core'
+import { NgIcon } from '@ng-icons/core'
+import { matInfoOutline } from '@ng-icons/material-icons/outline'
+import { provideIcons, provideNgIconsConfig } from '@ng-icons/core'
 
 @Component({
   selector: 'gn-ui-metadata-quality',
@@ -29,12 +32,23 @@ import { TranslateModule } from '@ngx-translate/core'
     ProgressBarComponent,
     MetadataQualityItemComponent,
     TranslateModule,
+    NgIcon,
+  ],
+  providers: [
+    provideIcons({
+      matInfoOutline,
+    }),
+    provideNgIconsConfig({
+      size: '1.2em',
+      strokeWidth: '1.5px',
+    }),
   ],
 })
 export class MetadataQualityComponent implements OnChanges {
   @Input() metadata: Partial<CatalogRecord>
   @Input() smaller = false
   @Input() metadataQualityDisplay: boolean
+  @Input() theme: 'primary' | 'light' = 'primary'
 
   items: MetadataQualityItem[] = []
 

--- a/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.ts
+++ b/libs/ui/elements/src/lib/metadata-quality/metadata-quality.component.ts
@@ -48,7 +48,6 @@ export class MetadataQualityComponent implements OnChanges {
   @Input() metadata: Partial<CatalogRecord>
   @Input() smaller = false
   @Input() metadataQualityDisplay: boolean
-  @Input() theme: 'primary' | 'light' = 'primary'
 
   items: MetadataQualityItem[] = []
 

--- a/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.html
+++ b/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.html
@@ -64,7 +64,7 @@
       class="col-start-2 row-start-4 sm:row-start-3 absolute right-[4em] sm:right-[5em]"
     >
       <gn-ui-metadata-quality
-        smaller="true"
+        [smaller]="true"
         [metadata]="record"
         [metadataQualityDisplay]="metadataQualityDisplay"
       ></gn-ui-metadata-quality>

--- a/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.html
+++ b/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.html
@@ -28,7 +28,9 @@
         class="flex {{ color.innerBar }} my-1 mx-1 transition-width
                duration-500 ease-in-out rounded-t-md rounded-b-md shadow-xl"
       >
-        <div class="flex items-center pl-2 py-1 {{ color.text }} font-bold text-4">
+        <div
+          class="flex items-center pl-2 py-1 {{ color.text }} font-bold text-4"
+        >
           {{ progress }}%
         </div>
       </div>

--- a/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.html
+++ b/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.html
@@ -1,21 +1,19 @@
 <ng-container [ngSwitch]="type">
   <!-- Light Theme -->
   <ng-container *ngSwitchCase="'light'">
-    <div class="relative">
-      <div class="flex items-center">
+    <div class="flex items-center relative">
+      <div
+        class="flex-shrink-0 {{ color.text }} text-xs font-medium mr-2
+             text-opacity-100 !text-slate-800"
+      >
+        {{ progress }}%
+      </div>
+      <div class="flex-grow h-[6px] w-full {{ color.outerBar }} rounded-full">
         <div
-          class="flex-shrink-0 {{ color.text }} text-xs font-medium mr-2
-                 text-opacity-100 !text-slate-800"
-        >
-          {{ progress }}%
-        </div>
-        <div class="flex-grow h-[6px] w-full {{ color.outerBar }} rounded-full">
-          <div
-            [style.width.%]="progress"
-            class="{{ color.innerBar }} transition-width duration-500
-                   ease-in-out rounded-full shadow-sm h-full"
-          ></div>
-        </div>
+          [style.width.%]="progress"
+          class="{{ color.innerBar }} transition-width duration-500
+               ease-in-out rounded-full shadow-sm h-full"
+        ></div>
       </div>
     </div>
   </ng-container>

--- a/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.html
+++ b/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.html
@@ -1,12 +1,37 @@
-<div class="flex h-full {{ color.outerBar }} rounded-t-lg rounded-b-lg">
-  <div
-    [style.width.%]="progress"
-    class="flex {{
-      color.innerBar
-    }} my-1 mx-1 transition-width duration-500 ease-in-out rounded-t-md rounded-b-md shadow-xl"
-  >
-    <div class="flex items-center pl-2 py-1 {{ color.text }} font-bold text-4">
-      {{ progress }}%
+<ng-container [ngSwitch]="type">
+  <!-- Light Theme -->
+  <ng-container *ngSwitchCase="'light'">
+    <div class="relative">
+      <div class="flex items-center">
+        <div
+          class="flex-shrink-0 {{ color.text }} text-xs font-medium mr-2
+                 text-opacity-100 !text-slate-800"
+        >
+          {{ progress }}%
+        </div>
+        <div class="flex-grow h-[6px] w-full {{ color.outerBar }} rounded-full">
+          <div
+            [style.width.%]="progress"
+            class="{{ color.innerBar }} transition-width duration-500
+                   ease-in-out rounded-full shadow-sm h-full"
+          ></div>
+        </div>
+      </div>
     </div>
-  </div>
-</div>
+  </ng-container>
+
+  <!-- Default / Primary / Secondary Themes -->
+  <ng-container *ngSwitchDefault>
+    <div class="flex h-full {{ color.outerBar }} rounded-t-lg rounded-b-lg">
+      <div
+        [style.width.%]="progress"
+        class="flex {{ color.innerBar }} my-1 mx-1 transition-width
+               duration-500 ease-in-out rounded-t-md rounded-b-md shadow-xl"
+      >
+        <div class="flex items-center pl-2 py-1 {{ color.text }} font-bold text-4">
+          {{ progress }}%
+        </div>
+      </div>
+    </div>
+  </ng-container>
+</ng-container>

--- a/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.stories.ts
+++ b/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.stories.ts
@@ -21,7 +21,7 @@ export const Primary: StoryObj<ProgressBarComponent> = {
   argTypes: {
     type: {
       control: 'select',
-      options: ['primary', 'secondary', 'default'],
+      options: ['primary', 'secondary', 'light', 'default'],
     },
   },
 }

--- a/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.ts
+++ b/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core'
+import { NgSwitch, NgSwitchCase, NgSwitchDefault } from '@angular/common'
 
 interface ColorScheme {
   outerBar: string
@@ -11,10 +12,11 @@ interface ColorScheme {
   templateUrl: './progress-bar.component.html',
   styleUrls: ['./progress-bar.component.css'],
   standalone: true,
+  imports: [NgSwitch, NgSwitchCase, NgSwitchDefault],
 })
 export class ProgressBarComponent {
   @Input() value = 0
-  @Input() type: 'primary' | 'secondary' | 'default' = 'default'
+  @Input() type: 'primary' | 'secondary' | 'default' | 'light' = 'default'
 
   get progress() {
     return this.value > 0 ? (this.value < 100 ? this.value : 100) : 0
@@ -39,6 +41,12 @@ export class ProgressBarComponent {
           outerBar: 'bg-secondary',
           innerBar: 'bg-secondary-lighter',
           text: 'text-white',
+        }
+      case 'light':
+        return {
+          outerBar: 'bg-primary-lighter',
+          innerBar: 'bg-primary',
+          text: 'text-main',
         }
     }
   }

--- a/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.ts
+++ b/libs/ui/widgets/src/lib/progress-bar/progress-bar.component.ts
@@ -44,7 +44,7 @@ export class ProgressBarComponent {
         }
       case 'light':
         return {
-          outerBar: 'bg-primary-lighter',
+          outerBar: 'bg-primary-white',
           innerBar: 'bg-primary',
           text: 'text-main',
         }


### PR DESCRIPTION
### Description

This PR introduces a simplified and improved light theme layout for the `MetadataQualityComponent`, using the updated `ProgressBarComponent`. The updated layout features a slimmer progress bar and a popover that is triggered only by the info icon, instead of the entire bar.

### Changes

#### `MetadataQualityComponent`

- The component now always uses the light theme layout by default.
- Integrated the new light-style progress bar directly using:

  ```html
  <gn-ui-progress-bar [type]="'light'" />

- Updated layout to display the info icon on the right, which is now the only trigger for the popover.


#### `ProgressBarComponent`

- Introduced a new `type="light"` layout to support a more compact, modern progress bar:
- Switched layout dynamically using `*ngSwitchCase` on type.
- Ensured  compatibility with existing types (default, primary, secondary).

### Screenshots


![image](https://github.com/user-attachments/assets/b0caed7e-ac1e-434a-b7c6-468abc731991)

![image](https://github.com/user-attachments/assets/a5ec96a6-0ad8-4287-a660-55c1de2da4c7)



### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [x] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to Test

1. **Enable the Metadata Quality Component**

   - Open `conf/default.toml` and uncomment line 118:
     ```toml
     enable = true
     ```
   - This will activate the metadata quality component in the application.

2. **Test on the Dataset Tab (Smaller Version)**

   - Visit: `http://localhost:4200/search`
   - Confirm that the **smaller version** of the light-themed progress bar is displayed.
   - The progress bar should be slim, and the popover should appear when clicking the info icon.

3. **Test on the DataHub Record Page (Non-Smaller Version)**

   - Visit a record detail page in the DataHub application.
   - Confirm that the **non-smaller version** of the light-themed progress bar is displayed.
   - The layout should be properly aligned, and the popover should be triggered only by the info icon.

