### PR TITLE
Possibility the alternative text when image not available 

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/edit/record-fields/header.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/edit/record-fields/header.cy.ts
@@ -120,11 +120,24 @@ describe('editor form', () => {
           cy.get('@saveStatus').should('eq', 'record_up_to_date')
           cy.get('gn-ui-image-input').find('img').should('have.length', 1)
         })
-        it('allows to add an alternate text', () => {
+        it('allows to add an alternative text', () => {
           cy.get('gn-ui-image-input').find('gn-ui-button').eq(2).click()
           cy.get('gn-ui-image-input')
             .find('gn-ui-text-input')
             .should('be.visible')
+        })
+        it('shows and modifies alternative text for an image', () => {
+          cy.editor_wrapPreviousDraft()
+          cy.get('gn-ui-image-input').find('gn-ui-button').eq(2).click()
+          cy.get('gn-ui-text-input input').type(
+            '{selectall}{backspace}This is an alternative text for the test image'
+          )
+          cy.editor_publishAndReload()
+          cy.get('@saveStatus').should('eq', 'record_up_to_date')
+          cy.get('gn-ui-image-input').find('gn-ui-button').eq(2).click()
+          cy.get('gn-ui-text-input input')
+            .invoke('val')
+            .should('eq', 'This is an alternative text for the test image')
         })
       })
 

--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.spec.ts
@@ -22,6 +22,7 @@ import {
 import { HttpClientTestingModule } from '@angular/common/http/testing'
 import { HttpClient, HttpEventType } from '@angular/common/http'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
+import { url } from 'inspector'
 
 let geonetworkVersion: string
 
@@ -794,17 +795,22 @@ describe('Gn4PlatformService', () => {
     it('should clean record attachments no longer used', (done) => {
       const record = { uniqueIdentifier: '123' } as CatalogRecord
       const associatedResources = {
-        onlines: [{ title: { en: 'doge.jpg' } }],
-        thumbnails: [{ title: { en: 'flower.jpg' } }],
+        onlines: [{ title: { en: 'doge.jpg' }, url: 'http://doge.jpg' }],
+        thumbnails: [
+          {
+            title: { en: 'my-beautiful-flower.jpg' },
+            url: 'http://flower.jpg',
+          },
+        ],
       }
       ;(recordsApiService.getAssociatedResources as jest.Mock).mockReturnValue(
         of(associatedResources)
       )
       ;(recordsApiService.getAllResources as jest.Mock).mockReturnValue(
         of([
-          { filename: 'doge.jpg' },
-          { filename: 'flower.jpg' },
-          { filename: 'remove1.jpg' },
+          { filename: 'doge.jpg', url: 'http://doge.jpg' },
+          { filename: 'flower.jpg', url: 'http://flower.jpg' },
+          { filename: 'remove1.jpg', url: 'http://remove1.jpg' },
         ])
       )
       ;(recordsApiService.delResource as jest.Mock).mockReturnValue(

--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.ts
@@ -312,33 +312,31 @@ export class Gn4PlatformService implements PlatformServiceInterface {
       this.recordsApiService.getAssociatedResources(record.uniqueIdentifier),
       this.recordsApiService.getAllResources(record.uniqueIdentifier),
     ]).pipe(
-      map(([associatedResources, recordResources]) => {
-        // Received object from API is not a RelatedResponseApiModel, so we need
-        // to cast it as any and do the bellow mappings to get the wanted values.
-        const resourceIdsToKeep = [
-          ...((associatedResources as any).onlines ?? []).map(
-            (o) => Object.values(o.title)[0]
-          ),
-          ...((associatedResources as any).thumbnails ?? []).map(
-            (o) => Object.values(o.title)[0]
-          ),
-        ]
+      map(([associated, attachments]) => {
+        const { onlines = [], thumbnails = [] } = associated
 
-        const resourceIdsToRemove = recordResources
-          .map((r) => r.filename)
-          .filter((resourceId) => !resourceIdsToKeep.includes(resourceId))
+        const urlsToKeep = [
+          ...(Array.isArray(onlines) ? onlines : []),
+          ...(Array.isArray(thumbnails) ? thumbnails : []),
+        ].map((resource) => Object.values(resource.url)[0])
 
-        return resourceIdsToRemove
+        const fileToDelete = attachments
+          .filter((attachment) => !urlsToKeep.includes(attachment.url))
+          .map((attachment) => attachment.filename)
+
+        return fileToDelete
       }),
-      mergeMap((resourceIdsToRemove) =>
-        forkJoin(
-          resourceIdsToRemove.map((attachementId) =>
-            this.recordsApiService.delResource(
-              record.uniqueIdentifier,
-              attachementId
-            )
-          )
-        ).pipe(map(() => undefined))
+      mergeMap((filesToDelete) =>
+        filesToDelete.length
+          ? forkJoin(
+              filesToDelete.map((filename) =>
+                this.recordsApiService.delResource(
+                  record.uniqueIdentifier,
+                  filename
+                )
+              )
+            ).pipe(map(() => undefined))
+          : of(undefined)
       ),
       catchError((error) => {
         console.error('Error while cleaning attachments:', error)

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.spec.ts
@@ -108,7 +108,7 @@ describe('FormFieldOverviewsComponent', () => {
       expect(component.uploadProgress).toBeUndefined()
       expect(valueChange).toEqual([
         {
-          description: 'test.png',
+          description: 'test',
           url: new URL('http://example.com/test.png'),
         },
       ])

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-overviews/form-field-overviews.component.ts
@@ -64,7 +64,7 @@ export class FormFieldOverviewsComponent {
             this.cd.detectChanges()
             this.emitOverview({
               url: event.attachment.url,
-              description: event.attachment.fileName,
+              description: event.attachment.fileName.replace(/\.[^/.]+$/, ''),
             })
           }
         },

--- a/libs/ui/elements/src/lib/image-input/image-input.component.html
+++ b/libs/ui/elements/src/lib/image-input/image-input.component.html
@@ -11,7 +11,6 @@
       [value]="altText ?? ''"
       (valueChange)="handleAltTextChange($event)"
       extraClass="gn-ui-editor-textarea"
-      [disabled]="true"
     ></gn-ui-text-input>
     <div class="flex flex-row gap-2 mt-2">
       <gn-ui-button

--- a/libs/ui/elements/src/lib/image-input/image-input.component.ts
+++ b/libs/ui/elements/src/lib/image-input/image-input.component.ts
@@ -82,6 +82,7 @@ export class ImageInputComponent {
   showUrlInput = false
   imageFileError = this.uploadError
   showAltTextInput = false
+  pendingAltText: string
 
   get isUploadInProgress() {
     return this.uploadProgress !== undefined
@@ -209,7 +210,6 @@ export class ImageInputComponent {
   handleAltTextChange(altText: string) {
     this.altTextChange.emit(altText)
   }
-
   private filterTypeImage(files: File[]) {
     return files.filter((file) => {
       return file.type.startsWith('image/')


### PR DESCRIPTION
### Description

This PR introduces the modification of the alternative text to the image. 
The previous behaviour don’t expect to modify this alternative text. Now it is possible. 
When the alternative text is changed, the image was delete and make a 404 error because the thumbnails doesn't exist anymore
In consequences, the behaviour of the cleanRecordAttachement was changed, and side effects on annexes and associated resources were tested, all is OK. 

### Architectural changes




### Screenshots

[...]

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

First open a Insee dataset. 
Upload an image if there is no image associated
Click on the alternative text button
Change the text and validate. 
Save the dataset


make a F5
the dataset, the picture and the description still here

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
