### PR TITLE
[Editor]: Clear input on protocol switch but don't eat up letters

### DIFF
--- a/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.html
+++ b/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.html
@@ -36,6 +36,7 @@
     [disabled]="disabled"
     [value]="_service.url?.toString()"
     [showValidateButton]="activeLayerSuggestion"
+    [resetUrl]="resetUrl"
   >
     <ng-content *ngIf="activeLayerSuggestion">
       <ng-icon name="iconoirRefresh"></ng-icon>

--- a/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.html
+++ b/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.html
@@ -36,7 +36,7 @@
     [disabled]="disabled"
     [value]="_service.url?.toString()"
     [showValidateButton]="activeLayerSuggestion"
-    [resetUrl]="resetUrl"
+    [resetUrlOnChange]="resetUrlOnChange"
   >
     <ng-content *ngIf="activeLayerSuggestion">
       <ng-icon name="iconoirRefresh"></ng-icon>

--- a/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.ts
+++ b/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.ts
@@ -79,7 +79,7 @@ export class OnlineServiceResourceInputComponent {
     new EventEmitter()
 
   errorMessage = false
-  resetUrl = false
+  resetUrlOnChange = Math.random()
 
   layersSubject = new BehaviorSubject<{ name: string; title: string }[]>([])
   layers$: Observable<{ name: string; title: string }[]> =
@@ -150,7 +150,7 @@ export class OnlineServiceResourceInputComponent {
   }
 
   resetAllFormFields() {
-    this.resetUrl = !this.resetUrl
+    this.resetUrlOnChange = Math.random()
     this._service.url = null
     this.resetLayersSuggestion()
   }

--- a/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.ts
+++ b/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.ts
@@ -79,6 +79,7 @@ export class OnlineServiceResourceInputComponent {
     new EventEmitter()
 
   errorMessage = false
+  resetUrl = false
 
   layersSubject = new BehaviorSubject<{ name: string; title: string }[]>([])
   layers$: Observable<{ name: string; title: string }[]> =
@@ -149,6 +150,7 @@ export class OnlineServiceResourceInputComponent {
   }
 
   resetAllFormFields() {
+    this.resetUrl = !this.resetUrl
     this._service.url = null
     this.resetLayersSuggestion()
   }

--- a/libs/ui/inputs/src/lib/url-input/url-input.component.ts
+++ b/libs/ui/inputs/src/lib/url-input/url-input.component.ts
@@ -31,7 +31,7 @@ import { iconoirArrowUp, iconoirLink } from '@ng-icons/iconoir'
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class UrlInputComponent {
+export class UrlInputComponent implements OnChanges {
   @Input() set value(v: string) {
     // we're making sure to only update the input if the URL representation of it has changed; otherwise we keep it identical
     // to avoid glitches when starting to write a URL and having some characters added/replaced automatically
@@ -48,6 +48,7 @@ export class UrlInputComponent {
   @Input() placeholder = 'https://'
   @Input() disabled: boolean
   @Input() showValidateButton = true
+  @Input() resetUrl = false
 
   /**
    * This will emit null if the field is emptied
@@ -58,6 +59,12 @@ export class UrlInputComponent {
   inputValue = ''
 
   constructor(private cd: ChangeDetectorRef) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['resetUrl']) {
+      this.inputValue = ''
+    }
+  }
 
   handleInput(event: Event) {
     const value = (event.target as HTMLInputElement).value

--- a/libs/ui/inputs/src/lib/url-input/url-input.component.ts
+++ b/libs/ui/inputs/src/lib/url-input/url-input.component.ts
@@ -48,7 +48,7 @@ export class UrlInputComponent implements OnChanges {
   @Input() placeholder = 'https://'
   @Input() disabled: boolean
   @Input() showValidateButton = true
-  @Input() resetUrl = false
+  @Input() resetUrlOnChange: number
 
   /**
    * This will emit null if the field is emptied
@@ -61,7 +61,7 @@ export class UrlInputComponent implements OnChanges {
   constructor(private cd: ChangeDetectorRef) {}
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['resetUrl']) {
+    if (changes['resetUrlOnChange']) {
       this.inputValue = ''
     }
   }


### PR DESCRIPTION
### Description

This PR makes sure the `url-input` of the "Link to a service" section allows to : 

- [x] Type an url without it being eaten up (cf https://github.com/geonetwork/geonetwork-ui/pull/1176)
- [x] URL being reset when switching protocols when a valid URL was entered (was a regression from aforementioned PR)
- [x] URL being reset when switching protocols even when a non-valid URL was entered (eg google.com instead of https://google.com) --> was not the case before

### Architectural changes

none

### Screenshots

no UI changes

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

- [ ] Try typing (no copy pasting because it was never an issue) a URL starting with https:// --> should not add a random slash or eat up any letter
- [ ] Try switching protocols --> should clear the input
- [ ] Try the same but starting with any text that's not https:// --> should not eat anything nor clear the input
