### PR TITLE
Only set active state in table view when active id is set

### DIFF
--- a/libs/ui/dataviz/src/lib/data-table/data-table.component.html
+++ b/libs/ui/dataviz/src/lib/data-table/data-table.component.html
@@ -32,7 +32,9 @@
         mat-row
         *matRowDef="let row; columns: properties"
         (click)="selected.emit(row)"
-        [class.active]="row.id === activeId"
+        [class.active]="
+          activeId !== undefined && activeId !== null && row.id === activeId
+        "
       ></tr>
     </table>
     <gn-ui-loading-mask


### PR DESCRIPTION
### Description

This PR fixes the issue where all rows in a table where displayed as active when no active id was set and no id column is present in the table.

Now the active state is set only when the active id is defined and not null.

### Screenshots

Before:
![image](https://github.com/user-attachments/assets/c4753c33-278b-410e-88de-f25787141454)

After:
![image](https://github.com/user-attachments/assets/ce14048f-84e8-4d12-95a3-0b9fc4bdbced)

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

### How to test

Example record with no id column: https://data.lillemetropole.fr/catalogue/dataset/base-de-commerce-de-la-ville-de-lambersart
