### PR TITLE
use altText to handle state error on image input

### DIFF
--- a/libs/api/metadata-converter/src/lib/iso19139/write-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/write-parts.ts
@@ -1184,25 +1184,27 @@ export function writeGraphicOverviews(
     findOrCreateIdentification(),
     removeChildrenByName('gmd:graphicOverview'),
     appendChildren(
-      ...record.overviews.map((overview) =>
-        pipe(
-          createNestedElement('gmd:graphicOverview', 'gmd:MD_BrowseGraphic'),
-          appendChildren(
-            pipe(
-              createElement('gmd:fileName'),
-              writeCharacterString(overview.url.toString())
-            )
-          ),
-          'description' in overview
-            ? appendChildren(
-                pipe(
-                  createElement('gmd:fileDescription'),
-                  writeCharacterString(overview.description)
-                )
+      ...record.overviews
+        .filter((overview) => overview.url)
+        .map((overview) =>
+          pipe(
+            createNestedElement('gmd:graphicOverview', 'gmd:MD_BrowseGraphic'),
+            appendChildren(
+              pipe(
+                createElement('gmd:fileName'),
+                writeCharacterString(overview.url.toString())
               )
-            : noop
+            ),
+            'description' in overview
+              ? appendChildren(
+                  pipe(
+                    createElement('gmd:fileDescription'),
+                    writeCharacterString(overview.description)
+                  )
+                )
+              : noop
+          )
         )
-      )
     )
   )(rootEl)
 }

--- a/libs/ui/elements/src/lib/image-input/image-input.component.spec.ts
+++ b/libs/ui/elements/src/lib/image-input/image-input.component.spec.ts
@@ -158,7 +158,7 @@ describe('ImageInputComponent', () => {
     }))
   })
 
-  describe('reinitialise errors at dataset rollback', () => {
+  describe('reinitialize errors at dataset rollback', () => {
     beforeEach(() => {
       component.maxSizeMB = 1
     })
@@ -199,7 +199,7 @@ describe('ImageInputComponent', () => {
         statusText: 'OK',
       })
 
-      await downloadPromise // Attend que la promesse soit résolue
+      await downloadPromise //Await download promise to be resolve and finish emits
 
       expect(component.altTextChange.emit).toHaveBeenCalledWith('KO')
       component.altText = 'KO' // Simulate setting altText to KO by the parent component

--- a/libs/ui/elements/src/lib/image-input/image-input.component.spec.ts
+++ b/libs/ui/elements/src/lib/image-input/image-input.component.spec.ts
@@ -157,4 +157,61 @@ describe('ImageInputComponent', () => {
       }, 0)
     }))
   })
+
+  describe('reinitialise errors at dataset rollback', () => {
+    beforeEach(() => {
+      component.maxSizeMB = 1
+    })
+
+    it('should emit KO as altText when downloading invalid url and reset errors when dataset is rollback', waitForAsync(() => {
+      jest.spyOn(component.altTextChange, 'emit')
+      const nonImageFile = new File([], 'test.txt', { type: 'text/plain' })
+      component.handleDropFiles([nonImageFile])
+      expect(component.altTextChange.emit).toHaveBeenCalledWith('KO')
+      component.altText = 'KO' // Simulate setting altText to KO by the parent component
+      expect(component.imageFileError).toBe(true)
+
+      // Simulate component reset ( dataset rollback )
+      component.altText = null
+
+      expect(component.uploadError).toBe(false)
+      expect(component.imageFileError).toBe(false)
+    }))
+
+    it('should emit KO as altText when downloading 404 url and reset errors when dataset is rollback', waitForAsync(async () => {
+      jest.spyOn(component.altTextChange, 'emit')
+
+      const downloadPromise = component.downloadUrl(
+        'http://test.com/invalid.png'
+      )
+
+      const reqHead = httpTestingController.expectOne(
+        'http://test.com/invalid.png'
+      )
+      expect(reqHead.request.method).toEqual('HEAD')
+
+      const responseHeaders = new HttpHeaders()
+        .set('content-type', 'image/png')
+        .set('content-length', '1048575')
+      reqHead.flush(null, {
+        headers: responseHeaders,
+        status: 404,
+        statusText: 'OK',
+      })
+
+      await downloadPromise // Attend que la promesse soit résolue
+
+      expect(component.altTextChange.emit).toHaveBeenCalledWith('KO')
+      component.altText = 'KO' // Simulate setting altText to KO by the parent component
+      expect(component.imageFileError).toBe(true)
+
+      // Simulate component reset ( dataset rollback )
+      component.altText = null
+
+      expect(component.uploadError).toBe(false)
+      expect(component.imageFileError).toBe(false)
+
+      httpTestingController.verify()
+    }))
+  })
 })

--- a/libs/ui/elements/src/lib/image-input/image-input.component.ts
+++ b/libs/ui/elements/src/lib/image-input/image-input.component.ts
@@ -74,7 +74,7 @@ export class ImageInputComponent {
     return this._altText
   }
   set altText(value: string | undefined) {
-    if (value != 'KO' && this._altText === 'KO') {
+    if (value !== 'KO' && this._altText === 'KO') {
       //This is a dataset rollback after upload error
       this.resetErrors()
     }

--- a/libs/ui/elements/src/lib/image-input/image-input.component.ts
+++ b/libs/ui/elements/src/lib/image-input/image-input.component.ts
@@ -66,9 +66,22 @@ import { ImageOverlayPreviewComponent } from '../image-overlay-preview/image-ove
   ],
 })
 export class ImageInputComponent {
-  @Input() maxSizeMB: number
+  private _altText?: string
+
   @Input() previewUrl?: string
-  @Input() altText?: string
+  @Input()
+  get altText(): string | undefined {
+    return this._altText
+  }
+  set altText(value: string | undefined) {
+    if (value != 'KO' && this._altText === 'KO') {
+      //This is a dataset rollback after upload error
+      this.resetErrors()
+    }
+    this._altText = value
+  }
+
+  @Input() maxSizeMB: number
   @Input() uploadProgress?: number
   @Input() uploadError?: boolean
   @Input() disabled?: boolean = false
@@ -132,6 +145,7 @@ export class ImageInputComponent {
       this.resizeAndEmit(validFiles[0])
     } else {
       this.imageFileError = true
+      this.handleAltTextChange('KO')
     }
   }
 
@@ -143,6 +157,7 @@ export class ImageInputComponent {
       this.resizeAndEmit(validFiles[0])
     } else {
       this.imageFileError = true
+      this.handleAltTextChange('KO')
     }
   }
 
@@ -171,6 +186,7 @@ export class ImageInputComponent {
           },
           error: () => {
             this.imageFileError = true
+            this.handleAltTextChange('KO')
             this.cd.markForCheck()
             this.urlChange.emit(url)
           },
@@ -178,6 +194,7 @@ export class ImageInputComponent {
       }
     } catch {
       this.imageFileError = true
+      this.handleAltTextChange('KO')
       this.cd.markForCheck()
       return
     }


### PR DESCRIPTION
### Description

This PR introduces a small fix. 

When the user unlocks the rollback on the dataset (by uploading an image for example) and then this user uploads a bad image, this displays the error. If he clicks on the rollback button the error remains on the component while it has returned to the initial state.


### Architectural changes

No change
<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

![image](https://github.com/user-attachments/assets/a69c47a6-b19d-4e2b-bfad-cd050415cac0)

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Enter in a dataset 
upload a correct image like a png in your computer
delete this image 
upload a file like zip , pdf or whatever incorrect format
you have an error that indicate you uplad an invalid file
rollback the dataset by using the button at the top left of the application
the error remains


---

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
