### PR TITLE
Add the latest tag without publishing again on release

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -145,9 +145,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish NPM package
+      - name: Set the latest tag on the released version
         if: github.event_name == 'release'
         working-directory: package/dist
-        run: npm publish --tag latest
+        run: npm dist-tag add '{{.Repository}}@{{.Tag}}' latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
With the current workflows, NPM packages are published twice, on tag and on release, and the second time fails due to the version already used. The package is thus correctly published when a tag is created, but never set to latest.

For the fix, we keep the publishing on all github events that are not a release, and on a release we just add the latest tag to the correct version.