### PR TITLE
[Datahub] API card: better json detection, keep crs for WFS only

### DIFF
--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.spec.ts
@@ -40,6 +40,8 @@ jest.mock('@camptocamp/ogc-client', () => ({
       if (options.limit !== undefined) queryParams.set('limit', options.limit)
       if (options.offset !== undefined)
         queryParams.set('offset', options.offset)
+      if (options.outputCrs !== undefined)
+        queryParams.set('crs', options.outputCrs)
       queryParams.set('f', options.outputFormat)
       return `${
         this.url
@@ -200,13 +202,28 @@ describe('RecordApiFormComponent', () => {
         `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"application/json","outputCrs":"EPSG:4326"}`
       )
     })
-
-    it('sets maxFeatures if a limit is set', async () => {
+    it('should set maxFeatures if a limit is set', async () => {
       component.setLimit('12')
       expect(component.limit$.getValue()).toBe('12')
       const url = await firstValueFrom(component.apiQueryUrl$)
       expect(url).toBe(
         `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"application/json","maxFeatures":12,"outputCrs":"EPSG:4326"}`
+      )
+    })
+    it('should set outputCrs if format is geojson', async () => {
+      const mockFormat = 'application/geo+json'
+      component.setFormat(mockFormat)
+      const url = await firstValueFrom(component.apiQueryUrl$)
+      expect(url).toBe(
+        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"application/geo+json","outputCrs":"EPSG:4326"}`
+      )
+    })
+    it('should not set outputCrs if not a json format', async () => {
+      const mockFormat = 'text/csv'
+      component.setFormat(mockFormat)
+      const url = await firstValueFrom(component.apiQueryUrl$)
+      expect(url).toBe(
+        `https://api.example.com/data?type=mockFeatureType&options={"outputFormat":"text/csv"}`
       )
     })
   })

--- a/libs/ui/elements/src/lib/record-api-form/record-api-form.component.ts
+++ b/libs/ui/elements/src/lib/record-api-form/record-api-form.component.ts
@@ -162,7 +162,7 @@ export class RecordApiFormComponent {
       limit: limit !== '-1' ? Number(limit) : -1,
       offset: offset !== '' ? Number(offset) : undefined,
       outputCrs:
-        format === ('application/json' || 'geojson') ? 'EPSG:4326' : undefined,
+        format.toLowerCase().indexOf('json') > -1 ? 'EPSG:4326' : undefined,
     }
 
     if (this.endpoint instanceof WfsEndpoint) {
@@ -170,6 +170,7 @@ export class RecordApiFormComponent {
       options.maxFeatures = limit !== '-1' ? Number(limit) : undefined
       return this.endpoint.getFeatureUrl(this.apiFeatureType, options)
     } else {
+      delete options.outputCrs
       return await this.endpoint.getCollectionItemsUrl(
         this.apiFeatureType,
         options


### PR DESCRIPTION
### Description

This PR fixes the detection of the JSON/GEOJSON format and removes the "EPSG:4326" ouput projection on OGC API Features ("EPSG:4326" is not the correct format for OGC API Features, won't support the correct format for now).

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

This record contains both OGC API Features and WFS: https://data.lillemetropole.fr/catalogue/dataset/bcc17c08-63db-4e63-8dba-f4f2ed6a800b
Once imported in the test/demo platform, navigate to the record and scroll to the API section.
The output projection "EPSG:4326" should be added only to WFS in JSON.
The output projection "EPSG:4326" should NOT be added to OGCFEATURES, whether for JSON or GEOJSON or any other.
