### PR TITLE
Properly parse settings_url from global config

### DIFF
--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -134,6 +134,7 @@ describe('app config utils', () => {
           METADATA_LANGUAGE: 'fre',
           LOGIN_URL: '/cas/login?service=',
           LOGOUT_URL: '/geonetwork/signout',
+          SETTINGS_URL: '/geonetwork/settings',
           WEB_COMPONENT_EMBEDDER_URL: '/datahub/wc-embedder.html',
         })
       })

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -99,6 +99,7 @@ export function loadAppConfig() {
           'metadata_language',
           'login_url',
           'logout_url',
+          'settings_url',
           'web_component_embedder_url',
           'languages',
           'contact_email',

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -7,6 +7,7 @@ proxy_path = "/proxy/?url="
 metadata_language = "fre"
 login_url = "/cas/login?service="
 logout_url = "/geonetwork/signout"
+settings_url = "/geonetwork/settings"
 web_component_embedder_url = "/datahub/wc-embedder.html"
 
 [map]


### PR DESCRIPTION
### Description

This PR fixes the parsing of settings_url in the global config part of the default.toml file.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Uncomment and change the settings_url value in the default.toml. Load the metadata-editor app with this new config. Check the link on the user icon, down the left side bar.

![image](https://github.com/user-attachments/assets/f6b4ef8b-176c-4032-997d-5764548a6ddd)

