### PR TITLE
[Datahub]: Change external card icon size

### DIFF
--- a/libs/ui/elements/src/lib/api-card/api-card.component.ts
+++ b/libs/ui/elements/src/lib/api-card/api-card.component.ts
@@ -13,7 +13,7 @@ import { CommonModule } from '@angular/common'
 import { CopyTextButtonComponent } from '@geonetwork-ui/ui/inputs'
 import { TranslateModule } from '@ngx-translate/core'
 import { MatTooltipModule } from '@angular/material/tooltip'
-import { NgIcon, provideIcons } from '@ng-icons/core'
+import { NgIcon, provideIcons, provideNgIconsConfig } from '@ng-icons/core'
 import { iconoirSettings } from '@ng-icons/iconoir'
 
 type CardSize = 'L' | 'M' | 'S' | 'XS'
@@ -35,6 +35,7 @@ type CardSize = 'L' | 'M' | 'S' | 'XS'
     provideIcons({
       iconoirSettings,
     }),
+    provideNgIconsConfig({ size: '1.5em' }),
   ],
 })
 export class ApiCardComponent implements OnInit, OnChanges {

--- a/libs/ui/elements/src/lib/download-item/download-item.component.ts
+++ b/libs/ui/elements/src/lib/download-item/download-item.component.ts
@@ -8,7 +8,7 @@ import {
 import { DatasetOnlineResource } from '@geonetwork-ui/common/domain/model/record'
 import { TranslateModule } from '@ngx-translate/core'
 import { CommonModule } from '@angular/common'
-import { NgIcon, provideIcons } from '@ng-icons/core'
+import { NgIcon, provideIcons, provideNgIconsConfig } from '@ng-icons/core'
 import { iconoirDownload } from '@ng-icons/iconoir'
 
 type CardSize = 'L' | 'M' | 'S' | 'XS'
@@ -24,6 +24,7 @@ type CardSize = 'L' | 'M' | 'S' | 'XS'
     provideIcons({
       iconoirDownload,
     }),
+    provideNgIconsConfig({ size: '1.5em' }),
   ],
 })
 export class DownloadItemComponent {


### PR DESCRIPTION
### Description

This PR increases the external card icon size for the downloads and API, to be 24x24px like the "Other links" cards.

### Architectural changes

none

### Screenshots

![image](https://github.com/user-attachments/assets/d9f1de5b-aae1-45ee-8ba3-b3e3072309d1)

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
