### PR TITLE
[Datahub]: Hide tabs for absent sections in quick access

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -113,9 +113,16 @@ describe('dataset pages', () => {
 
     // navigation bar
     // it should display the navigation bar, with favorite star and arrow back
+    // it should display only the dataset sections
     cy.get('datahub-record-page').find('datahub-navigation-bar').should('exist')
     cy.get('datahub-record-page').find('[data-cy="backButton"]').should('exist')
     cy.get('datahub-record-page').find('gn-ui-favorite-star').should('exist')
+    cy.get('datahub-navigation-bar')
+      .find('[data-cy="capabilities"]')
+      .should('not.exist')
+    cy.get('datahub-navigation-bar')
+      .find('[data-cy="data-preview"]')
+      .should('be.visible')
 
     // it should display the gnUiAnchorLinkInViewClass when scrolling to the anchor
     cy.get('#user-feedbacks').should('be.visible')

--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -119,7 +119,7 @@ describe('dataset pages', () => {
     cy.get('datahub-record-page').find('gn-ui-favorite-star').should('exist')
     cy.get('datahub-navigation-bar')
       .find('[data-cy="capabilities"]')
-      .should('not.exist')
+      .should('not.be.visible')
     cy.get('datahub-navigation-bar')
       .find('[data-cy="data-preview"]')
       .should('be.visible')

--- a/apps/datahub-e2e/src/e2e/reuseDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/reuseDetailPage.cy.ts
@@ -20,6 +20,16 @@ describe.skip('reuse pages', () => {
         .and('have.attr', 'target', '_blank')
     })
   })
+  describe('Navigation bar', () => {
+    it('should only display the service sections buttons', () => {
+      cy.get('datahub-navigation-bar')
+        .find('[data-cy="capabilities"]')
+        .should('not.exist')
+      cy.get('datahub-navigation-bar')
+        .find('[data-cy="data-preview"]')
+        .should('not.exist')
+    })
+  })
   describe('About', () => {
     it('should display the spatial extent', () => {
       cy.get('gn-ui-expandable-panel').eq(1).click()

--- a/apps/datahub-e2e/src/e2e/reuseDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/reuseDetailPage.cy.ts
@@ -24,10 +24,10 @@ describe.skip('reuse pages', () => {
     it('should only display the service sections buttons', () => {
       cy.get('datahub-navigation-bar')
         .find('[data-cy="capabilities"]')
-        .should('not.exist')
+        .should('not.be.visible')
       cy.get('datahub-navigation-bar')
         .find('[data-cy="data-preview"]')
-        .should('not.exist')
+        .should('not.be.visible')
     })
   })
   describe('About', () => {

--- a/apps/datahub-e2e/src/e2e/serviceDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/serviceDetailPage.cy.ts
@@ -30,7 +30,7 @@ describe('service pages', () => {
         .should('be.visible')
       cy.get('datahub-navigation-bar')
         .find('[data-cy="data-preview"]')
-        .should('not.exist')
+        .should('not.be.visible')
     })
   })
   describe('About', () => {

--- a/apps/datahub-e2e/src/e2e/serviceDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/serviceDetailPage.cy.ts
@@ -23,6 +23,16 @@ describe('service pages', () => {
   beforeEach(() => {
     cy.visit('/service/01ec6ec7-6454-4504-ac95-befb16bacb0e')
   })
+  describe('Navigation bar', () => {
+    it('should only display the service sections buttons', () => {
+      cy.get('datahub-navigation-bar')
+        .find('[data-cy="capabilities"]')
+        .should('be.visible')
+      cy.get('datahub-navigation-bar')
+        .find('[data-cy="data-preview"]')
+        .should('not.exist')
+    })
+  })
   describe('About', () => {
     it('should display the spatial extent', () => {
       cy.get('gn-ui-expandable-panel').eq(1).click()

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
@@ -61,12 +61,16 @@
     </div>
   </section>
 
-  <section id="data-preview" class="mb-6" *ngIf="kind === 'dataset'">
+  <section
+    id="data-preview"
+    class="mb-6"
+    *ngIf="(displayMap$ | async) || (displayData$ | async)"
+  >
     <datahub-record-data-preview></datahub-record-data-preview>
   </section>
-  <section id="capabilities" class="mb-16" *ngIf="kind === 'service'">
+  <section id="capabilities" class="mb-16" *ngIf="displayCapabilities$ | async">
     <gn-ui-service-capabilities
-      [apiLinks]="metadataViewFacade.apiLinks$ | async"
+      [apiLinks]="apiLinks$ | async"
     ></gn-ui-service-capabilities>
   </section>
 

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
@@ -398,6 +398,7 @@ describe('RecordMetadataComponent', () => {
 
       describe('When the metadata is not fully loaded', () => {
         beforeEach(() => {
+          component.kind = 'dataset'
           facade.isMetadataLoading$.next(false)
           facade.apiLinks$.next([])
           facade.downloadLinks$.next([])

--- a/docs/apps/datahub.md
+++ b/docs/apps/datahub.md
@@ -20,6 +20,17 @@ The **Datahub** application offers a very intuitive and easy-to-use search inter
 - Support both geo- and non-geo datasets
 - Ability to show a welcome or maintenance message to users, which can be configured as needed, see [configure guide](../guide/configure.md#application-banner)
 
+## Pages
+
+The **Datahub** includes record of three different types : datasets, services and reuses.
+Each type has its own 'page-type' with fixed sections (if the related data is available in the record) :
+
+- Common sections : General information about the record (abstract, keywords, licensing, update date...), Point of contact, Links, User feedbacks and Related datasets
+
+- Specificities by page :
+  - Dataset : Download, API links and Preview (Map, Table and Chart)
+  - Service : Capabilities
+
 ## Run & deploy
 
 The Metadata Editor application is available as a docker image or as a ZIP archive.


### PR DESCRIPTION
### Description

This PR makes sure the tabs of the quick access are hidden if their related section are not present. This applies to the "Preview" tab (for datasets) and "Capabilities" tab (for services).

### Architectural changes

none

### Screenshots

![image](https://github.com/user-attachments/assets/f887c1e9-e574-4b12-ae91-ab938d6dfb96)

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [x] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

SERVICES : Since the wallonie links are down and that the existing services in our compo are from wallonie, you will need to import https://www.geo2france.fr/geonetwork/srv/fre/catalog.search#/metadata/be052079-f1f6-4f6f-a722-cbf11deb40eb , which has capabilities, and then delete the link inside of it to check that the capabilities tab is hidden.
DATASET : `/dataset/a3774ef6-809d-4dd1-984f-9254f49cbd0a` doesn't have a preview section, so you can check that the preview tab is hidden