### PR TITLE
[Datahub] Improve spatial extent preview visibility with transparent fill

### DIFF
--- a/libs/ui/map/src/lib/components/spatial-extent/spatial-extent.component.ts
+++ b/libs/ui/map/src/lib/components/spatial-extent/spatial-extent.component.ts
@@ -57,6 +57,7 @@ export class SpatialExtentComponent {
         style: {
           'stroke-color': 'black',
           'stroke-width': 2,
+          'fill-color': 'rgba(153, 153, 153, 0.3)',
         },
       }
       const view = await createViewFromLayer(layer)


### PR DESCRIPTION
### Description

This PR  makes bounding box spatial extents easier to visualize, especially when covering large areas like the whole Earth, by using a semi-transparent light grey fill.

### Screenshots

![BeforeAfterLandscape](https://github.com/user-attachments/assets/58a7a028-ed69-4aa2-bcef-c0a18fe78779)

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Import: https://www.geo2france.fr/geonetwork/srv/eng/catalog.search#/metadata/7eb795c2-d612-4b5e-b15e-d985b0f4e697
2. Open the imported record and open the spatial extend expansion panel.

