### PR TITLE
[Editor] Multilingual indicator in table list

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasetDetailPage.cy.ts
@@ -256,7 +256,7 @@ describe('dataset pages', () => {
       .eq(2)
       .children('div')
       .as('aboutContent')
-    cy.get('@aboutContent').should('have.length', 5)
+    cy.get('@aboutContent').should('have.length', 4)
     cy.get('@aboutContent')
       .eq(0)
       .children('p')

--- a/apps/metadata-editor-e2e/src/e2e/dashboard/dashboard.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/dashboard/dashboard.cy.ts
@@ -39,6 +39,22 @@ describe('dashboard (landing page)', () => {
       .find('[data-cy="table-row"]')
       .should('have.length', '15')
 
+    // MULTILINGUAL
+
+    // it should show a multilingual icon when the record is multilingual
+    cy.get('gn-ui-results-table')
+      .find('[data-cy-title="Leitungskataster Fernwärme AEW Energie AG"]')
+      .find('[data-cy="multilingual-indicator"]')
+      .should('exist')
+
+    // it should NOT show a multilingual icon when the record is NOT multilingual
+    cy.get('gn-ui-results-table')
+      .find(
+        '[data-cy-title="Zones de collecte de déchets en porte à porte - par flux de collecte, jour et horaire de tournée"]'
+      )
+      .find('[data-cy="multilingual-indicator"]')
+      .should('not.exist')
+
     // PAGINATION
 
     // it should display different results on click on arrow

--- a/apps/metadata-editor/src/app/records/records-list.component.ts
+++ b/apps/metadata-editor/src/app/records/records-list.component.ts
@@ -24,6 +24,8 @@ export const allSearchFields = [
   'link',
   'owner',
   'resourceType',
+  'mainLanguage',
+  'otherLanguage',
 ]
 @Component({
   selector: 'md-editor-records-list',

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
@@ -108,7 +108,6 @@ describe('Gn4Converter', () => {
             lineage: null,
             recordPublished: null,
             recordUpdated: null,
-            resourceLanguage: [],
             onlineResources: [],
             licenses: [],
             legalConstraints: [],
@@ -159,7 +158,6 @@ describe('Gn4Converter', () => {
             lineage: null,
             recordPublished: null,
             recordUpdated: null,
-            resourceLanguage: [],
             onlineResources: [],
             contacts: [],
             contactsForResource: [],
@@ -1704,7 +1702,6 @@ describe('Gn4Converter', () => {
             resourceCreated: new Date('2012-01-01T00:00:00.000Z'),
             resourceUpdated: new Date('2021-12-13T00:00:00.000Z'),
             resourcePublished: new Date('2021-04-01T00:00:00.000Z'),
-            resourceLanguage: [],
             status: 'ongoing',
             topics: ['Installations de suivi environnemental', 'Océans'],
             title: 'Surval - Données par paramètre',
@@ -1981,7 +1978,6 @@ describe('Gn4Converter', () => {
             ),
             defaultLanguage: 'de',
             otherLanguages: ['fr', 'it', 'en', 'rm'],
-            resourceLanguage: ['fr', 'it'],
             legalConstraints: [
               {
                 text: 'Opendata BY: Freie Nutzung. Quellenangabe ist Pflicht.',
@@ -3265,7 +3261,6 @@ describe('Gn4Converter', () => {
             },
             recordCreated: new Date('2024-09-13T10:12:38.614Z'),
             resourceCreated: new Date('2024-05-27T00:00:00.000Z'),
-            resourceLanguage: [],
             reuseType: 'map',
             uniqueIdentifier: '7eb795c2-d612-4b5e-b15e-d985b0f4e697',
             landingPage: new URL(
@@ -3344,7 +3339,6 @@ describe('Gn4Converter', () => {
             recordPublished: null,
             recordCreated: new Date('2024-01-25T07:19:13.493Z'),
             resourcePublished: new Date('2023-12-20T14:23:54.000Z'),
-            resourceLanguage: ['de'],
             ownerOrganization: {
               name: 'My Organization',
               website: new URL('http://my.org/'),

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.converter.spec.ts
@@ -108,6 +108,7 @@ describe('Gn4Converter', () => {
             lineage: null,
             recordPublished: null,
             recordUpdated: null,
+            resourceLanguage: [],
             onlineResources: [],
             licenses: [],
             legalConstraints: [],
@@ -158,6 +159,7 @@ describe('Gn4Converter', () => {
             lineage: null,
             recordPublished: null,
             recordUpdated: null,
+            resourceLanguage: [],
             onlineResources: [],
             contacts: [],
             contactsForResource: [],
@@ -1702,6 +1704,7 @@ describe('Gn4Converter', () => {
             resourceCreated: new Date('2012-01-01T00:00:00.000Z'),
             resourceUpdated: new Date('2021-12-13T00:00:00.000Z'),
             resourcePublished: new Date('2021-04-01T00:00:00.000Z'),
+            resourceLanguage: [],
             status: 'ongoing',
             topics: ['Installations de suivi environnemental', 'Océans'],
             title: 'Surval - Données par paramètre',
@@ -1977,7 +1980,8 @@ describe('Gn4Converter', () => {
               'http://my.catalog.org/metadata/8698bf0b-fceb-4f0f-989b-111e7c4af0a4'
             ),
             defaultLanguage: 'de',
-            otherLanguages: ['fr', 'it'],
+            otherLanguages: ['fr', 'it', 'en', 'rm'],
+            resourceLanguage: ['fr', 'it'],
             legalConstraints: [
               {
                 text: 'Opendata BY: Freie Nutzung. Quellenangabe ist Pflicht.',
@@ -3261,6 +3265,7 @@ describe('Gn4Converter', () => {
             },
             recordCreated: new Date('2024-09-13T10:12:38.614Z'),
             resourceCreated: new Date('2024-05-27T00:00:00.000Z'),
+            resourceLanguage: [],
             reuseType: 'map',
             uniqueIdentifier: '7eb795c2-d612-4b5e-b15e-d985b0f4e697',
             landingPage: new URL(
@@ -3339,6 +3344,7 @@ describe('Gn4Converter', () => {
             recordPublished: null,
             recordCreated: new Date('2024-01-25T07:19:13.493Z'),
             resourcePublished: new Date('2023-12-20T14:23:54.000Z'),
+            resourceLanguage: ['de'],
             ownerOrganization: {
               name: 'My Organization',
               website: new URL('http://my.org/'),
@@ -3392,7 +3398,7 @@ describe('Gn4Converter', () => {
               },
             ],
             defaultLanguage: 'fr',
-            otherLanguages: ['de'],
+            otherLanguages: ['de', 'en'],
             reuseType: 'map',
             title:
               'Herstellung, Verwendung, Forschung und Verteilung von Wasserstoff am Oberrhein',

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -146,6 +146,18 @@ export class Gn4FieldMapper {
       ...output,
       recordPublished: toDate(selectField<string>(source, 'publicationDate')),
     }),
+    resourceLanguage: (output, source) => {
+      const langList = getAsArray(
+        selectField<string>(source, 'resourceLanguage')
+      )
+      const languages = langList.map((lang) => LANG_3_TO_2_MAPPER[lang])
+      const defaultLanguage = output.defaultLanguage ?? languages[0] ?? null // set the first language as main one as fallback
+
+      return {
+        ...output,
+        defaultLanguage,
+      }
+    },
     otherLanguage: (output, source) => {
       const langList = getAsArray(selectField<string>(source, 'otherLanguage'))
       const languages = langList.map((lang) => LANG_3_TO_2_MAPPER[lang])

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -146,32 +146,17 @@ export class Gn4FieldMapper {
       ...output,
       recordPublished: toDate(selectField<string>(source, 'publicationDate')),
     }),
-    resourceLanguage: (output, source) => {
-      const langList = getAsArray(
-        selectField<string>(source, 'resourceLanguage')
-      )
-      const languages = langList.map((lang) => LANG_3_TO_2_MAPPER[lang])
-      const defaultLanguage = output.defaultLanguage ?? languages[0] ?? null // set the first language as main one as fallback
-      const resourceLanguage = languages.filter(
-        (lang) => lang !== defaultLanguage
-      )
-
-      return {
-        ...output,
-        defaultLanguage,
-        resourceLanguage,
-      }
-    },
     otherLanguage: (output, source) => {
       const langList = getAsArray(selectField<string>(source, 'otherLanguage'))
       const languages = langList.map((lang) => LANG_3_TO_2_MAPPER[lang])
-      const defaultLanguage = output.defaultLanguage ?? languages[0] ?? null
+      const defaultLanguage = output.defaultLanguage ?? languages[0] ?? null // set the first language as main one as fallback
       const otherLanguages = languages.filter(
         (lang) => lang !== defaultLanguage
       )
 
       return {
         ...output,
+        defaultLanguage,
         otherLanguages,
       }
     },

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -152,12 +152,26 @@ export class Gn4FieldMapper {
       )
       const languages = langList.map((lang) => LANG_3_TO_2_MAPPER[lang])
       const defaultLanguage = output.defaultLanguage ?? languages[0] ?? null // set the first language as main one as fallback
-      const otherLanguages = languages.filter(
+      const resourceLanguage = languages.filter(
         (lang) => lang !== defaultLanguage
       )
+
       return {
         ...output,
         defaultLanguage,
+        resourceLanguage,
+      }
+    },
+    otherLanguage: (output, source) => {
+      const langList = getAsArray(selectField<string>(source, 'otherLanguage'))
+      const languages = langList.map((lang) => LANG_3_TO_2_MAPPER[lang])
+      const defaultLanguage = output.defaultLanguage ?? languages[0] ?? null
+      const otherLanguages = languages.filter(
+        (lang) => lang !== defaultLanguage
+      )
+
+      return {
+        ...output,
         otherLanguages,
       }
     },

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -161,14 +161,13 @@ export class Gn4FieldMapper {
     otherLanguage: (output, source) => {
       const langList = getAsArray(selectField<string>(source, 'otherLanguage'))
       const languages = langList.map((lang) => LANG_3_TO_2_MAPPER[lang])
-      const defaultLanguage = output.defaultLanguage ?? languages[0] ?? null // set the first language as main one as fallback
+      const defaultLanguage = output.defaultLanguage ?? languages[0] ?? null
       const otherLanguages = languages.filter(
         (lang) => lang !== defaultLanguage
       )
 
       return {
         ...output,
-        defaultLanguage,
         otherLanguages,
       }
     },

--- a/libs/api/metadata-converter/src/lib/gn4/types/metadata.model.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/types/metadata.model.ts
@@ -164,7 +164,6 @@ export type MetadataObject = Partial<{
   resourceDate: ResourceDate[]
   resourceEdition: string
   resourceIdentifier: ResourceIdentifier[]
-  resourceLanguage: string[]
   resourceTemporalDateRange: ResourceTemporalDateRange[]
   resourceTemporalExtentDateRange: ResourceTemporalDateRange[]
   resourceTitleObject: MultilingualField

--- a/libs/ui/layout/src/lib/interactive-table/interactive-table.component.html
+++ b/libs/ui/layout/src/lib/interactive-table/interactive-table.component.html
@@ -31,6 +31,7 @@
     *ngFor="let item of items"
     (click)="handleRowClick(item)"
     data-cy="table-row"
+    [attr.data-cy-title]="item.title"
     [title]="getItemTitle(item) | translate"
   >
     <div

--- a/libs/ui/search/src/lib/results-table/results-table.component.css
+++ b/libs/ui/search/src/lib/results-table/results-table.component.css
@@ -1,0 +1,4 @@
+:host {
+  --gn-ui-button-height: 40px;
+  --gn-ui-button-width: 40px;
+}

--- a/libs/ui/search/src/lib/results-table/results-table.component.html
+++ b/libs/ui/search/src/lib/results-table/results-table.component.html
@@ -143,24 +143,34 @@
   <gn-ui-interactive-table-column>
     <ng-template #header> </ng-template>
     <ng-template #cell let-item>
-      <gn-ui-button
-        cdkOverlayOrigin
-        #actionMenuButton
-        (buttonClick)="openActionMenu(item, template)"
-        type="light"
-        data-test="record-menu-button"
-        [disabled]="
-          (!item.extras?.edit && !isDraftPage) || item.kind !== 'dataset'
-        "
-      >
+      <div class="flex justify-end items-center gap-4 w-full">
+        <!-- IS MULTILINGUAL -->
         <ng-icon
-          [ngClass]="{
-            'text-purple-light':
-              (!item.extras?.edit && !isDraftPage) || item.kind !== 'dataset',
-          }"
-          name="matMoreVert"
+          *ngIf="isMultilingual(item)"
+          data-cy="i18n-menu-button"
+          name="iconoirTranslate"
+          [attr.title]="getTxtHoverMultilingual(item)"
         ></ng-icon>
-      </gn-ui-button>
+        <!-- MORE ACTIONS MENU BUTTON -->
+        <gn-ui-button
+          cdkOverlayOrigin
+          #actionMenuButton
+          (buttonClick)="openActionMenu(item, template)"
+          type="light"
+          data-test="record-menu-button"
+          [disabled]="
+            (!item.extras?.edit && !isDraftPage) || item.kind !== 'dataset'
+          "
+        >
+          <ng-icon
+            [ngClass]="{
+              'text-purple-light':
+                (!item.extras?.edit && !isDraftPage) || item.kind !== 'dataset',
+            }"
+            name="matMoreVert"
+          ></ng-icon>
+        </gn-ui-button>
+      </div>
       <ng-template #template>
         <gn-ui-action-menu
           [canDuplicate]="canDuplicate(item) && !isDuplicating"

--- a/libs/ui/search/src/lib/results-table/results-table.component.html
+++ b/libs/ui/search/src/lib/results-table/results-table.component.html
@@ -147,7 +147,7 @@
         <!-- IS MULTILINGUAL -->
         <ng-icon
           *ngIf="isMultilingual(item)"
-          data-cy="i18n-menu-button"
+          data-cy="multilingual-indicator"
           name="iconoirTranslate"
           [attr.title]="getTxtHoverMultilingual(item)"
         ></ng-icon>

--- a/libs/ui/search/src/lib/results-table/results-table.component.ts
+++ b/libs/ui/search/src/lib/results-table/results-table.component.ts
@@ -224,7 +224,9 @@ export class ResultsTableComponent {
 
   getTxtHoverMultilingual(record: CatalogRecord) {
     return this.translateService.instant('dashboard.records.isMultilingual', {
-      languages: record.otherLanguages.join(', '),
+      languages: [...[record.defaultLanguage], ...record.otherLanguages].join(
+        ', '
+      ),
     })
   }
 }

--- a/libs/ui/search/src/lib/results-table/results-table.component.ts
+++ b/libs/ui/search/src/lib/results-table/results-table.component.ts
@@ -28,16 +28,11 @@ import {
   getFileFormat,
   getFormatPriority,
 } from '@geonetwork-ui/util/shared'
-import { TranslateModule } from '@ngx-translate/core'
+import { TranslateModule, TranslateService } from '@ngx-translate/core'
 import { ActionMenuComponent } from './action-menu/action-menu.component'
 import { NgIconComponent, provideIcons } from '@ng-icons/core'
-import { iconoirUser, iconoirLock } from '@ng-icons/iconoir'
-import {
-  CdkConnectedOverlay,
-  CdkOverlayOrigin,
-  Overlay,
-  OverlayRef,
-} from '@angular/cdk/overlay'
+import { iconoirUser, iconoirLock, iconoirTranslate } from '@ng-icons/iconoir'
+import { CdkOverlayOrigin, Overlay, OverlayRef } from '@angular/cdk/overlay'
 import { TemplatePortal } from '@angular/cdk/portal'
 import { matMoreVert } from '@ng-icons/material-icons/baseline'
 
@@ -57,7 +52,9 @@ import { matMoreVert } from '@ng-icons/material-icons/baseline'
     NgIconComponent,
     CdkOverlayOrigin,
   ],
-  providers: [provideIcons({ iconoirUser, iconoirLock, matMoreVert })],
+  providers: [
+    provideIcons({ iconoirUser, iconoirLock, iconoirTranslate, matMoreVert }),
+  ],
 })
 export class ResultsTableComponent {
   @Input() records: CatalogRecord[] = []
@@ -89,7 +86,8 @@ export class ResultsTableComponent {
     private overlay: Overlay,
     private viewContainerRef: ViewContainerRef,
     private cdr: ChangeDetectorRef,
-    private dateService: DateService
+    private dateService: DateService,
+    private translateService: TranslateService
   ) {}
 
   openActionMenu(item, template) {
@@ -218,5 +216,15 @@ export class ResultsTableComponent {
 
   handleRecordSelectedChange(selected: boolean, record: CatalogRecord) {
     this.recordsSelectedChange.emit([[record], selected])
+  }
+
+  isMultilingual(record: CatalogRecord): boolean {
+    return record.otherLanguages.length > 0
+  }
+
+  getTxtHoverMultilingual(record: CatalogRecord) {
+    return this.translateService.instant('dashboard.records.isMultilingual', {
+      languages: record.otherLanguages.join(', '),
+    })
   }
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -30,6 +30,7 @@
   "dashboard.labels.mySpace": "Mein Bereich",
   "dashboard.records.all": "Metadatenkatalog",
   "dashboard.records.hasDraft": "",
+  "dashboard.records.isMultilingual": "Dieser Eintrag ist mehrsprachig ({languages})",
   "dashboard.records.myDraft": "Meine Entwürfe",
   "dashboard.records.myRecords": "Meine Datensätze",
   "dashboard.records.search": "Suche nach \"{searchText}\"",

--- a/translations/en.json
+++ b/translations/en.json
@@ -30,6 +30,7 @@
   "dashboard.labels.mySpace": "My space",
   "dashboard.records.all": "Datasets",
   "dashboard.records.hasDraft": "draft",
+  "dashboard.records.isMultilingual": "This record is multilingual ({languages})",
   "dashboard.records.myDraft": "My drafts",
   "dashboard.records.myRecords": "My datasets",
   "dashboard.records.search": "Search for \"{searchText}\"",

--- a/translations/es.json
+++ b/translations/es.json
@@ -30,6 +30,7 @@
   "dashboard.labels.mySpace": "Mi espacio",
   "dashboard.records.all": "Catálogo",
   "dashboard.records.hasDraft": "",
+  "dashboard.records.isMultilingual": "Este registro es multilingüe ({languages})",
   "dashboard.records.myDraft": "Mis borradores",
   "dashboard.records.myRecords": "Mis Registros",
   "dashboard.records.search": "Buscar \"{searchText}\"",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -30,6 +30,7 @@
   "dashboard.labels.mySpace": "Mon espace",
   "dashboard.records.all": "Jeux de données",
   "dashboard.records.hasDraft": "brouillon",
+  "dashboard.records.isMultilingual": "Cet enregistrement est multilingue ({languages})",
   "dashboard.records.myDraft": "Mes brouillons",
   "dashboard.records.myRecords": "Mes jeux de données",
   "dashboard.records.search": "Résultats pour \"{searchText}\"",

--- a/translations/it.json
+++ b/translations/it.json
@@ -30,6 +30,7 @@
   "dashboard.labels.mySpace": "Il mio spazio",
   "dashboard.records.all": "Catalogo",
   "dashboard.records.hasDraft": "Bozza",
+  "dashboard.records.isMultilingual": "Questo record è multilingue ({languages})",
   "dashboard.records.myDraft": "Le mie bozze",
   "dashboard.records.myRecords": "I miei dati",
   "dashboard.records.search": "Risultati per \"{searchText}\"",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -30,6 +30,7 @@
   "dashboard.labels.mySpace": "Mijn ruimte",
   "dashboard.records.all": "Catalogus",
   "dashboard.records.hasDraft": "",
+  "dashboard.records.isMultilingual": "Dit record is meertalig ({languages})",
   "dashboard.records.myDraft": "Mijn concepten",
   "dashboard.records.myRecords": "Mijn Records",
   "dashboard.records.search": "Zoeken naar \"{searchText}\"",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -30,6 +30,7 @@
   "dashboard.labels.mySpace": "Meu espaço",
   "dashboard.records.all": "Catálogo",
   "dashboard.records.hasDraft": "",
+  "dashboard.records.isMultilingual": "Este registro é multilíngue ({languages})",
   "dashboard.records.myDraft": "Meus rascunhos",
   "dashboard.records.myRecords": "Meus Registros",
   "dashboard.records.search": "Buscar por \"{searchText}\"",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -30,6 +30,7 @@
   "dashboard.labels.mySpace": "Môj priestor",
   "dashboard.records.all": "Katalóg",
   "dashboard.records.hasDraft": "",
+  "dashboard.records.isMultilingual": "Tento záznam je viacjazyčný ({languages})",
   "dashboard.records.myDraft": "Moje koncepty",
   "dashboard.records.myRecords": "Moje záznamy",
   "dashboard.records.search": "Hľadať \"{searchText}\"",


### PR DESCRIPTION
### Description

This PR introduces a visual indicator when the record is multilingual.

NB: the dot that must be displayed on the multilingual icon for the right panel is handled in PR #1229 

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

Updated behavior in `gn4.field.mapper`:
Previously, the `resourceLanguage` field from Elasticsearch was used to populate the `otherLanguages` property in the GN-UI record, leading to inconsistencies in multilingual data.

Now, the mapping has been corrected:
- The `resourceLanguage` field in ES is used to populate mainLanguage only, it **HAS BEEN REMOVED** from the gn4 model.
- The `otherLanguages` field in ES is mapped to the `otherLanguages` property in GN-UI.

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

![image](https://github.com/user-attachments/assets/30a74608-4d1c-4aaa-8f25-0ab3a9e2a712)

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

For records displaying the multilingual icon, verify that they indeed contain content in multiple languages. To do this, open the record in the GeoNetwork admin interface and check if fields such as the title exist in several languages.

For records without the multilingual icon, ensure that they are truly monolingual and do not contain values in multiple languages.

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
