### PR TITLE
Datahub: Fix quick access menu for firefox

### DIFF
--- a/apps/datahub/src/app/record/navigation-bar/navigation-bar.component.html
+++ b/apps/datahub/src/app/record/navigation-bar/navigation-bar.component.html
@@ -1,5 +1,5 @@
 <nav
-  class="text-xs text-black bg-primary-white shadow-[0px_0px_5.1px_0px] shadow-primary-darkest relative"
+  class="z-20 sticky block h-[60px] top-0 text-xs text-black bg-primary-white shadow-[0px_0px_5.1px_0px] shadow-primary-darkest"
 >
   <div
     class="h-full container-lg mx-auto flex justify-between overflow-hidden"

--- a/apps/datahub/src/app/record/record-page/record-page.component.html
+++ b/apps/datahub/src/app/record/record-page/record-page.component.html
@@ -1,7 +1,6 @@
 <div id="record-page">
   <datahub-navigation-bar
-    class="z-20 sticky"
-    style="top: 0"
+    class="z-20 sticky block h-[60px] top-0"
     [metadata]="mdViewFacade.metadata$ | async"
   ></datahub-navigation-bar>
   <gn-ui-record-meta

--- a/apps/datahub/src/app/record/record-page/record-page.component.html
+++ b/apps/datahub/src/app/record/record-page/record-page.component.html
@@ -1,6 +1,5 @@
 <div id="record-page">
   <datahub-navigation-bar
-    class="z-20 sticky block h-[60px] top-0"
     [metadata]="mdViewFacade.metadata$ | async"
   ></datahub-navigation-bar>
   <gn-ui-record-meta


### PR DESCRIPTION
### Description

This PR fixes the navigation bar for firefox, where it currently flickers/disappears and does not keep its position properly, since firefox is stricter on the `sticky` position.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Open a record page in the datahub on firefox and scroll down. 
=> The navigation bar should not flicker and stay positioned at the top.

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
