### PR TITLE
Metadata Editor: Converter read fixes

### DIFF
--- a/libs/api/metadata-converter/src/lib/iso19139/read-parts.spec.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/read-parts.spec.ts
@@ -765,7 +765,7 @@ describe('read parts', () => {
                     <gmd:URL/>
                 </gmd:linkage>
                 <gmd:protocol>
-                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                    <gmx:MimeFileType>WWW:LINK-1.0-http--link</gmx:MimeFileType>
                 </gmd:protocol>
                 <gmd:function>
                     <gmd:CI_OnLineFunctionCode codeListValue="information" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_OnLineFunctionCode" />

--- a/libs/api/metadata-converter/src/lib/iso19139/read-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/read-parts.ts
@@ -65,7 +65,8 @@ export function extractCharacterString(): ChainableFunction<
   return pipe(
     fallback(
       findChildElement('gco:CharacterString', false),
-      findChildElement('gmx:Anchor', false)
+      findChildElement('gmx:Anchor', false),
+      findChildElement('gmx:MimeFileType', false)
     ),
     readText()
   )

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -362,9 +362,12 @@ export class Gn4Repository implements RecordsRepositoryInterface {
         const record = await converter.readRecord(fetchedRecordAsXml)
 
         record.title = `${record.title} (Copy)`
-        await converter.writeRecord(record, fetchedRecordAsXml)
+        const recordAsXml = await converter.writeRecord(
+          record,
+          fetchedRecordAsXml
+        )
 
-        return this.saveRecord(record, '', false)
+        return this.saveRecord(record, recordAsXml, false)
       }),
       exhaustMap((uuidObservable: Observable<string>) => uuidObservable),
       catchError((error: HttpErrorResponse) => {


### PR DESCRIPTION
### Description

The PR fixes two issues on the converter read functionality: 
- read onlineResources in ISO 19115-3 (was reverted again as `<mrd:MD_DigitalTransferOptions>` is mandatory in `transferOptions`
- read protocol value inside a `MimeFileType` tag => added as a fallback to `extractCharacterString()`

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Import the following records with the metadata-editor and check if the online resources are present:
- https://dev.geo2france.fr/geonetwork/srv/fre/catalog.search#/metadata/annuaire-des-associations-inscrites-a-la-maison-des-associations => actually not valid, so missing OGC API is expected
- https://dev.geo2france.fr/geonetwork/srv/fre/catalog.search#/metadata/791b9687-7b77-4db1-a78e-61a517668c3b

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
