### PR TITLE
CI: Fix backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   backport:
     name: Backport PR
-    if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
+    if: github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ','), 'backport')
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action


### PR DESCRIPTION


### Description

Currently, the backport workflow is triggered on every merge on `main` (for both PRs with and without labels containing "backport"). This PR inverts the logic for the label check. It also converts the array to a string as the current condition does not seem to be taken account.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->