### PR TITLE
Force start align on suggestions to prevent herited center align

### DIFF
--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
@@ -79,7 +79,7 @@
   <mat-option
     *ngFor="let suggestion of suggestions$ | async"
     [value]="suggestion"
-    class="p-2 suggestion"
+    class="p-2 suggestion text-start"
   >
     {{ displayWithFnInternal(suggestion) }}
   </mat-option>


### PR DESCRIPTION
### Description

This PR fixes the autocomplete suggestions alignment when a parent element has set text alignment to center.
Now it's always forced to start for the fuzzy search results.

### Screenshots

Before
![image](https://github.com/user-attachments/assets/f8729e77-cb03-4464-bd7a-2537c14aafc6)

After
![image](https://github.com/user-attachments/assets/4e46fb7b-175f-4da8-bfdf-57054b2faec6)


<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

In `apps/webcomponents/src/app/components/gn-search-input/gn-search-input.sample.html`, edit the style of the container div like this:
```ts
<div class="container" style="text-align: center">
```
Then build and run the webcomponent demo app:
```bash
npm run build:demo
npm run demo
```
Navigate to http://localhost:8001/webcomponents/gn-search-input.sample.html, search for the word "vélo", and reduce your screensize to make the second result "Implantation des stations de vélo en libre service - GrandSoissons Agglomération" not fit on one line.
You can then inspect the `mat-option` element and activate/deactivate the `text-align` rule in the devtools to check the fix.
