### PR TITLE
Datahub: Get linked internal records

### DIFF
--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -294,12 +294,50 @@ export class Gn4FieldMapper {
         ) ?? {},
         '_source'
       )
-      const featureCatalogIdentifier = selectField(
+      const featureCatalogIdentifier: string = selectField(
         <SourceWithUnknownProps>fcatSource,
         'uuid'
       )
-      return featureCatalogIdentifier
-        ? this.addExtra({ featureCatalogIdentifier }, output)
+      const hasSourcesLinks = getAsArray(
+        selectField(
+          <SourceWithUnknownProps>selectField(source, 'related'),
+          'hassources'
+        )
+      )
+      const hasSourcesIdentifiers: string[] = hasSourcesLinks
+        .filter((link) => link['origin'] === 'catalog')
+        .map((link) => {
+          return selectField(
+            selectField(<SourceWithUnknownProps>link, '_source'),
+            'uuid'
+          )
+        })
+      const sourcesLinks = getAsArray(
+        selectField(
+          <SourceWithUnknownProps>selectField(source, 'related'),
+          'sources'
+        )
+      )
+      const sourcesIdentifiers: string[] = sourcesLinks
+        .filter((link) => link['origin'] === 'catalog')
+        .map((link) =>
+          selectField(
+            selectField(<SourceWithUnknownProps>link, '_source'),
+            'uuid'
+          )
+        )
+      const extraValues: Record<string, string | string[]> = {}
+      if (featureCatalogIdentifier) {
+        extraValues.featureCatalogIdentifier = featureCatalogIdentifier
+      }
+      if (hasSourcesIdentifiers && hasSourcesIdentifiers.length > 0) {
+        extraValues.hasSourcesIdentifiers = hasSourcesIdentifiers
+      }
+      if (sourcesIdentifiers && sourcesIdentifiers.length > 0) {
+        extraValues.sourcesIdentifiers = sourcesIdentifiers
+      }
+      return Object.keys(extraValues).length > 0
+        ? this.addExtra(extraValues, output)
         : output
     },
     isPublishedToAll: (output, source) =>

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -211,6 +211,16 @@ export class Gn4Repository implements RecordsRepositoryInterface {
     return of(null)
   }
 
+  getHasSources(record: CatalogRecord): Observable<CatalogRecord[]> {
+    const hasSourcesIdentifiers = record.extras?.[
+      'hasSourcesIdentifiers'
+    ] as string[]
+    if (hasSourcesIdentifiers && hasSourcesIdentifiers.length > 0) {
+      return forkJoin(hasSourcesIdentifiers.map((id) => this.getRecord(id)))
+    }
+    return of(null)
+  }
+
   aggregate(params: AggregationsParams): Observable<Aggregations> {
     // if aggregations are empty, return an empty object right away
     if (Object.keys(params).length === 0) return of({})

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -187,8 +187,6 @@ export class Gn4Repository implements RecordsRepositoryInterface {
     return of(null)
   }
 
-  //TODO: add getHasSources to be used in effect
-
   getSimilarRecords(similarTo: CatalogRecord): Observable<CatalogRecord[]> {
     return this.gn4SearchApi
       .search(
@@ -203,6 +201,14 @@ export class Gn4Repository implements RecordsRepositoryInterface {
           this.gn4Mapper.readRecords(results.hits.hits)
         )
       )
+  }
+
+  getSources(record: CatalogRecord): Observable<CatalogRecord[]> {
+    const sourcesIdentifiers = record.extras?.['sourcesIdentifiers'] as string[]
+    if (sourcesIdentifiers && sourcesIdentifiers.length > 0) {
+      return forkJoin(sourcesIdentifiers.map((id) => this.getRecord(id)))
+    }
+    return of(null)
   }
 
   aggregate(params: AggregationsParams): Observable<Aggregations> {

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -129,7 +129,7 @@ export class Gn4Repository implements RecordsRepositoryInterface {
     return this.gn4SearchApi
       .search(
         'bucket',
-        ['fcats'],
+        ['fcats', 'sources', 'hassources'],
         JSON.stringify(
           this.gn4SearchHelper.getMetadataByIdPayload(uniqueIdentifier)
         )
@@ -186,6 +186,8 @@ export class Gn4Repository implements RecordsRepositoryInterface {
 
     return of(null)
   }
+
+  //TODO: add getHasSources to be used in effect
 
   getSimilarRecords(similarTo: CatalogRecord): Observable<CatalogRecord[]> {
     return this.gn4SearchApi

--- a/libs/common/domain/src/lib/repository/records-repository.interface.ts
+++ b/libs/common/domain/src/lib/repository/records-repository.interface.ts
@@ -20,6 +20,7 @@ export abstract class RecordsRepositoryInterface {
     similarTo: CatalogRecord
   ): Observable<CatalogRecord[]>
   abstract getSources(record: CatalogRecord): Observable<CatalogRecord[]>
+  abstract getHasSources(record: CatalogRecord): Observable<CatalogRecord[]>
   abstract fuzzySearch(query: string): Observable<SearchResults>
   abstract canEditRecord(uniqueIdentifier: string): Observable<boolean>
   /**

--- a/libs/common/domain/src/lib/repository/records-repository.interface.ts
+++ b/libs/common/domain/src/lib/repository/records-repository.interface.ts
@@ -19,6 +19,7 @@ export abstract class RecordsRepositoryInterface {
   abstract getSimilarRecords(
     similarTo: CatalogRecord
   ): Observable<CatalogRecord[]>
+  abstract getSources(record: CatalogRecord): Observable<CatalogRecord[]>
   abstract fuzzySearch(query: string): Observable<SearchResults>
   abstract canEditRecord(uniqueIdentifier: string): Observable<boolean>
   /**

--- a/libs/feature/record/src/lib/state/mdview.actions.ts
+++ b/libs/feature/record/src/lib/state/mdview.actions.ts
@@ -54,6 +54,11 @@ export const setRelated = createAction(
   props<{ related: CatalogRecord[] }>()
 )
 
+export const setSources = createAction(
+  '[Metadata view] Set sources',
+  props<{ sources: CatalogRecord[] }>()
+)
+
 /*
   ChartConfig actions
  */

--- a/libs/feature/record/src/lib/state/mdview.actions.ts
+++ b/libs/feature/record/src/lib/state/mdview.actions.ts
@@ -59,6 +59,11 @@ export const setSources = createAction(
   props<{ sources: CatalogRecord[] }>()
 )
 
+export const setHasSources = createAction(
+  '[Metadata view] Set has sources',
+  props<{ hasSources: CatalogRecord[] }>()
+)
+
 /*
   ChartConfig actions
  */

--- a/libs/feature/record/src/lib/state/mdview.effects.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.ts
@@ -79,6 +79,17 @@ export class MdViewEffects {
     )
   )
 
+  loadHasSources$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(MdViewActions.loadFullMetadataSuccess),
+      switchMap(({ full }) => this.recordsRepository.getHasSources(full)),
+      map((hasSources) => {
+        return MdViewActions.setHasSources({ hasSources })
+      }),
+      catchError(() => of(MdViewActions.setHasSources({ hasSources: null })))
+    )
+  )
+
   /*
     UserFeedback effects
   */

--- a/libs/feature/record/src/lib/state/mdview.effects.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.ts
@@ -68,6 +68,17 @@ export class MdViewEffects {
     )
   )
 
+  loadSources$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(MdViewActions.loadFullMetadataSuccess),
+      switchMap(({ full }) => this.recordsRepository.getSources(full)),
+      map((sources) => {
+        return MdViewActions.setSources({ sources })
+      }),
+      catchError(() => of(MdViewActions.setSources({ sources: null })))
+    )
+  )
+
   /*
     UserFeedback effects
   */

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -78,6 +78,8 @@ export class MdViewFacade {
 
   sources$ = this.store.pipe(select(MdViewSelectors.getSources))
 
+  hasSources$ = this.sources$.pipe(select(MdViewSelectors.getHasSources))
+
   chartConfig$ = this.store.pipe(select(MdViewSelectors.getChartConfig))
 
   allLinks$ = this.metadata$.pipe(

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -76,6 +76,8 @@ export class MdViewFacade {
 
   related$ = this.store.pipe(select(MdViewSelectors.getRelated))
 
+  sources$ = this.store.pipe(select(MdViewSelectors.getSources))
+
   chartConfig$ = this.store.pipe(select(MdViewSelectors.getChartConfig))
 
   allLinks$ = this.metadata$.pipe(

--- a/libs/feature/record/src/lib/state/mdview.reducer.ts
+++ b/libs/feature/record/src/lib/state/mdview.reducer.ts
@@ -14,6 +14,7 @@ export interface MetadataViewState {
   error: { notFound?: boolean; otherError?: string } | null
   metadata?: Partial<CatalogRecord>
   related?: CatalogRecord[]
+  sources?: CatalogRecord[]
   userFeedbacks?: UserFeedback[]
   allUserFeedbacksLoading: boolean
   addUserFeedbackLoading: boolean
@@ -73,6 +74,11 @@ const metadataViewReducer = createReducer(
   on(MetadataViewActions.setRelated, (state, { related }) => ({
     ...state,
     related,
+  })),
+
+  on(MetadataViewActions.setSources, (state, { sources }) => ({
+    ...state,
+    sources,
   })),
 
   /*

--- a/libs/feature/record/src/lib/state/mdview.reducer.ts
+++ b/libs/feature/record/src/lib/state/mdview.reducer.ts
@@ -15,6 +15,7 @@ export interface MetadataViewState {
   metadata?: Partial<CatalogRecord>
   related?: CatalogRecord[]
   sources?: CatalogRecord[]
+  hasSources?: CatalogRecord[]
   userFeedbacks?: UserFeedback[]
   allUserFeedbacksLoading: boolean
   addUserFeedbackLoading: boolean
@@ -79,6 +80,11 @@ const metadataViewReducer = createReducer(
   on(MetadataViewActions.setSources, (state, { sources }) => ({
     ...state,
     sources,
+  })),
+
+  on(MetadataViewActions.setHasSources, (state, { hasSources }) => ({
+    ...state,
+    hasSources,
   })),
 
   /*

--- a/libs/feature/record/src/lib/state/mdview.selectors.ts
+++ b/libs/feature/record/src/lib/state/mdview.selectors.ts
@@ -41,6 +41,10 @@ export const getRelated = createSelector(
   (state: MetadataViewState) => state.related
 )
 
+export const getSources = createSelector(
+  getMdViewState,
+  (state: MetadataViewState) => state.sources
+)
 /*
   Metadata selectors
 */

--- a/libs/feature/record/src/lib/state/mdview.selectors.ts
+++ b/libs/feature/record/src/lib/state/mdview.selectors.ts
@@ -45,6 +45,11 @@ export const getSources = createSelector(
   getMdViewState,
   (state: MetadataViewState) => state.sources
 )
+
+export const getHasSources = createSelector(
+  getMdViewState,
+  (state: MetadataViewState) => state.hasSources
+)
 /*
   Metadata selectors
 */


### PR DESCRIPTION
### Description

This PR is still WIP. 

It gets internally linked records via the ES fields `sources` and `hasSources` to display these records on dataset, service and reuse pages.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

The following library now depends on [...]

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

[...]

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Follow these instructions to confirm [...]

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
