### PR TITLE
[Datahub] Quality score according to resource type (part. Elastic search)

### DIFF
--- a/tools/pipelines/register-es-pipelines.js
+++ b/tools/pipelines/register-es-pipelines.js
@@ -50,7 +50,7 @@ program
 
 program.parse(process.argv)
 
-const VERSION = 100 // increment on changes
+const VERSION = 101 // increment on changes
 
 const GEONETWORK_UI_PIPELINE = {
   description: 'GeoNetwork-UI pipeline',
@@ -61,8 +61,27 @@ const GEONETWORK_UI_PIPELINE = {
       script: {
         lang: 'painless',
         source: `
-int total=8;
+int total=0;
+int totalDataset=8;
+int totalService=6;
+int totalReuse=8;
 int ok=0;
+boolean isDataset=false;
+boolean isService=false;
+boolean isReuse=false;
+if (ctx.resourceType != null && ctx.resourceType.size() > 0) {
+  if (ctx.resourceType[0]=='dataset'||ctx.resourceType[0]=='series') {
+    isDataset = true;
+  }
+  if (ctx.resourceType[0]=='service') {
+    isService = true;
+  }
+  if (ctx.resourceType[0]=='interactiveMap'||ctx.resourceType[0]=='map'||ctx.resourceType[0]=='map/static'||ctx.resourceType[0]=='map/interactive'||ctx.resourceType[0]=='map-interactive'||ctx.resourceType[0]=='map-static'||ctx.resourceType[0]=='mapDigital'||ctx.resourceType[0]=='staticMap') {
+    isReuse = true;
+  }
+} else {
+ isDataset=true;
+}
 if(ctx.resourceTitleObject != null && ctx.resourceTitleObject.default != null && ctx.resourceTitleObject.default != '') {
   ok++
 }
@@ -70,27 +89,65 @@ if(ctx.resourceAbstractObject != null && ctx.resourceAbstractObject.default != n
   ok++
 }
 // this checks for single-language Organizations (GN 4.2.2)
-if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisation != null && ctx.contact[0].organisation != '') {
+if(!isService && ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisation != null && ctx.contact[0].organisation != '') {
   ok++
 }
 // this checks for multilingual Organizations (GN 4.2.3+)
-if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisationObject != null && ctx.contact[0].organisationObject.default != '') {
+if(!isService && ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisationObject != null && ctx.contact[0].organisationObject.default != '') {
   ok++
 }
 if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].email != null && ctx.contact[0].email != '') {
   ok++
 }
-if(ctx.cl_topic != null && ctx.cl_topic.length > 0) {
+if(!isService && ctx.cl_topic != null && ctx.cl_topic.length > 0) {
   ok++
 }
 if(ctx.tag != null && ctx.tag.length > 0) {
   ok++
 }
-if(ctx.cl_maintenanceAndUpdateFrequency != null && ctx.cl_maintenanceAndUpdateFrequency.length > 0) {
+if(isDataset && ctx.cl_maintenanceAndUpdateFrequency != null && ctx.cl_maintenanceAndUpdateFrequency.length > 0) {
   ok++
 }
 if(ctx.MD_LegalConstraintsUseLimitationObject != null && ctx.MD_LegalConstraintsUseLimitationObject.length > 0) {
   ok++
+}
+if(isService && ctx.link != null){
+  for (link in ctx.link) {
+    if (
+      link != null &&
+      link.urlObject != null &&
+      link.urlObject.default != null &&
+      link.urlObject.default.toLowerCase().contains('capabilities')
+    ) {
+      ok++;
+      break;
+    }
+  }
+}
+if(isReuse && ctx.recordLink != null){
+  for (link in ctx.recordLink) {
+    if (
+      link != null &&
+      link.origin != null &&
+      link.origin == 'catalog' &&
+      link.type != null &&
+      link.type == 'sources' &&
+      link.url != null &&
+      link.url != ''
+    ) {
+      ok++;
+      break;
+    }
+  }
+}
+if(isDataset) {
+  total=totalDataset;
+}
+if(isService) {
+  total=totalService;
+}
+if(isReuse) {
+  total=totalReuse;
 }
 ctx.qualityScore = ok * 100 / total;`,
       },


### PR DESCRIPTION
### Description

This PR introduces a custom quality score according to the resource type (on Elastic search pipeline).

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

The `geonetwork-ui` ES pipeline has been updated.

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

-

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Follow these instructions to confirm the quality score is correct, for each type of resource.
You can test the pipeline and es result directly in Kibana:
- launch Kibana (docker compose up Kibana)
- go to your local Kibana http://localhost:5601/app/dev_tools#/console
- before testing, register the pipeline with 
```
node pipelines/register-es-pipelines.js register --host=http://localhost:9200 --records-index=gn-records
```
- apply the pipeline in Kibana Dev Tools console
```
POST /gn-records/_update_by_query?pipeline=geonetwork-ui
{
  "query": {
    "match_all": {}
  }
}
```
- see result (check qualityScore value) with
```
GET /gn-records/_doc/e27e7006-fdf9-4004-b6c5-af2a5a5c025c
GET /gn-records/_doc/00b22798-ec8e-4500-89e8-90eeeda45919
```

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
