### PR TITLE
Link card description instead of empty contact

### DIFF
--- a/libs/common/fixtures/src/lib/records.fixtures.ts
+++ b/libs/common/fixtures/src/lib/records.fixtures.ts
@@ -63,7 +63,15 @@ This dataset has been established for testing purposes.
 This is a section about details. Here is an HTML tag: <img src="http://google.com" />. And [a link](https://google.com).
 
 ## Informations intéressantes
-Cette section contient des *caractères internationaux* (ainsi que des "caractères spéciaux"). 'çàü^@/~^&`,
+Cette section contient des *caractères internationaux* (ainsi que des "caractères spéciaux"). 'çàü^@/~^&,
+
+### Autres informations
+ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet magna vel velit condimentum viverra ac in metus. Aenean fermentum molestie nulla, id dapibus dolor. Maecenas sodales erat in lectus viverra, eget mattis arcu malesuada. Nam nec orci sed libero sollicitudin sagittis. Sed in ex venenatis purus elementum lobortis. Nam fringilla eleifend metus vel vulputate. Duis faucibus egestas fringilla. Nam et sagittis nisl, et laoreet nulla. Duis ligula purus, molestie eu elit sed, mattis rhoncus lorem. Nam facilisis orci ut odio convallis efficitur.
+
+Etiam nec nisl vestibulum, rhoncus metus convallis, aliquet lacus. Pellentesque in nulla sed justo venenatis luctus non ac magna. Nullam nibh sapien, ullamcorper vel mi vitae, egestas congue enim. Donec congue nisi at lacinia elementum. Curabitur arcu sem, finibus at velit a, facilisis auctor ligula. Praesent vulputate lacus et dui posuere aliquet. Fusce nec mauris nec purus rutrum condimentum in tempus eros. Mauris ipsum leo, consectetur vitae mauris eget, mattis luctus ligula. Praesent sed lorem tempor, viverra nunc at, pharetra nulla. Aliquam sed pellentesque est. Mauris volutpat orci in purus dictum, vitae luctus dolor viverra. Sed suscipit ornare mollis. Sed lobortis sed enim at fringilla.
+
+Ut fringilla vestibulum eros, vel ultricies diam interdum nec. Fusce lobortis rutrum nibh, nec volutpat nisl sagittis nec. Donec posuere tortor sit amet dolor varius ultrices. Praesent vitae justo commodo, elementum quam et, sollicitudin libero. Fusce posuere non quam vitae sagittis. Mauris odio ipsum, fermentum ut vulputate id, auctor eu mauris. Pellentesque facilisis imperdiet nulla a scelerisque. Mauris dolor magna, scelerisque feugiat massa nec, placerat lacinia urna. Nulla viverra efficitur dignissim. Morbi euismod, turpis id pharetra fringilla, felis nunc varius nisl, eu pretium risus sapien eu massa. Aliquam a ligula sed tellus dapibus dapibus. In ullamcorper nibh ac interdum fringilla. `,
+
     overviews: [
       {
         url: new URL('http://my-org.net/one.png'),

--- a/libs/common/fixtures/src/lib/records.fixtures.ts
+++ b/libs/common/fixtures/src/lib/records.fixtures.ts
@@ -64,7 +64,6 @@ This is a section about details. Here is an HTML tag: <img src="http://google.co
 
 ## Informations intéressantes
 Cette section contient des *caractères internationaux* (ainsi que des "caractères spéciaux"). 'çàü^@/~^&`,
-
     overviews: [
       {
         url: new URL('http://my-org.net/one.png'),

--- a/libs/common/fixtures/src/lib/records.fixtures.ts
+++ b/libs/common/fixtures/src/lib/records.fixtures.ts
@@ -63,14 +63,7 @@ This dataset has been established for testing purposes.
 This is a section about details. Here is an HTML tag: <img src="http://google.com" />. And [a link](https://google.com).
 
 ## Informations intéressantes
-Cette section contient des *caractères internationaux* (ainsi que des "caractères spéciaux"). 'çàü^@/~^&,
-
-### Autres informations
- Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet magna vel velit condimentum viverra ac in metus. Aenean fermentum molestie nulla, id dapibus dolor. Maecenas sodales erat in lectus viverra, eget mattis arcu malesuada. Nam nec orci sed libero sollicitudin sagittis. Sed in ex venenatis purus elementum lobortis. Nam fringilla eleifend metus vel vulputate. Duis faucibus egestas fringilla. Nam et sagittis nisl, et laoreet nulla. Duis ligula purus, molestie eu elit sed, mattis rhoncus lorem. Nam facilisis orci ut odio convallis efficitur.
-
-Etiam nec nisl vestibulum, rhoncus metus convallis, aliquet lacus. Pellentesque in nulla sed justo venenatis luctus non ac magna. Nullam nibh sapien, ullamcorper vel mi vitae, egestas congue enim. Donec congue nisi at lacinia elementum. Curabitur arcu sem, finibus at velit a, facilisis auctor ligula. Praesent vulputate lacus et dui posuere aliquet. Fusce nec mauris nec purus rutrum condimentum in tempus eros. Mauris ipsum leo, consectetur vitae mauris eget, mattis luctus ligula. Praesent sed lorem tempor, viverra nunc at, pharetra nulla. Aliquam sed pellentesque est. Mauris volutpat orci in purus dictum, vitae luctus dolor viverra. Sed suscipit ornare mollis. Sed lobortis sed enim at fringilla.
-
-Ut fringilla vestibulum eros, vel ultricies diam interdum nec. Fusce lobortis rutrum nibh, nec volutpat nisl sagittis nec. Donec posuere tortor sit amet dolor varius ultrices. Praesent vitae justo commodo, elementum quam et, sollicitudin libero. Fusce posuere non quam vitae sagittis. Mauris odio ipsum, fermentum ut vulputate id, auctor eu mauris. Pellentesque facilisis imperdiet nulla a scelerisque. Mauris dolor magna, scelerisque feugiat massa nec, placerat lacinia urna. Nulla viverra efficitur dignissim. Morbi euismod, turpis id pharetra fringilla, felis nunc varius nisl, eu pretium risus sapien eu massa. Aliquam a ligula sed tellus dapibus dapibus. In ullamcorper nibh ac interdum fringilla. `,
+Cette section contient des *caractères internationaux* (ainsi que des "caractères spéciaux"). 'çàü^@/~^&`,
 
     overviews: [
       {

--- a/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.html
+++ b/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.html
@@ -1,6 +1,5 @@
 <div
   data-cy="recordOrg"
-  *ngIf="size !== 'XS' && record.ownerOrganization?.name"
   class="flex items-center justify-evenly bg-gray-50 rounded-lg h-[53px] px-2"
 >
   <div class="flex items-center flex-1 min-w-0">

--- a/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.html
+++ b/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.html
@@ -1,0 +1,70 @@
+<div
+  data-cy="recordOrg"
+  *ngIf="size !== 'XS' && record.ownerOrganization?.name"
+  class="flex items-center justify-evenly bg-gray-50 rounded-lg h-[53px] px-2"
+>
+  <div class="flex items-center flex-1 min-w-0">
+    <div class="w-[45px] h-[45px] rounded-lg overflow-hidden shrink-0 mr-3">
+      <gn-ui-thumbnail
+        [thumbnailUrl]="record.ownerOrganization?.logoUrl?.toString() || ''"
+        [fit]="'contain'"
+        class="w-full h-full rounded-lg"
+      ></gn-ui-thumbnail>
+    </div>
+    <div *ngIf="organization?.name" class="flex-1 w-0 overflow-hidden">
+      <div
+        class="text-xs text-black font-normal leading-tight truncate"
+        translate
+      >
+        record.card.metadata.contact
+      </div>
+      <div
+        data-cy="recordOrgName"
+        class="text-xl text-primary-black font-medium truncate"
+      >
+        {{ organization.name }}
+      </div>
+    </div>
+  </div>
+  <div *ngIf="size === 'L'" class="ml-2 flex space-x-2">
+    <div *ngIf="organization?.website" class="flex">
+      <button
+        [title]="organization.website"
+        class="w-[40px] h-[32px] flex items-center justify-center rounded-lg border border-[#D4D3D7] px-[8px] py-[4px] hover:bg-primary-lightest"
+        (click)="openExternalUrl($event, organization.website)"
+      >
+        <ng-icon name="iconoirInternet"></ng-icon>
+      </button>
+    </div>
+    <div *ngIf="contacts[0]?.email" class="flex">
+      <button
+        [title]="contacts[0].email"
+        class="w-[40px] h-[32px] flex items-center justify-center rounded-lg border border-[#D4D3D7] px-[8px] py-[4px] hover:bg-primary-lightest"
+        data-cy="contact-email"
+        (click)="openMailto($event, contacts[0].email)"
+      >
+        <ng-icon name="matEmailOutline"></ng-icon>
+      </button>
+    </div>
+    <div *ngIf="contacts[0]?.phone" class="flex">
+      <button
+        [title]="'Copy to clipboard'"
+        class="w-[40px] h-[32px] flex items-center justify-center rounded-lg border border-[#D4D3D7] px-[8px] py-[4px] hover:bg-primary-lightest relative group"
+        data-cy="contact-phone"
+        (click)="copyToClipboard($event, contacts[0].phone)"
+      >
+        <ng-icon name="matPhoneOutline"></ng-icon>
+      </button>
+    </div>
+    <div *ngIf="contacts[0]?.address" class="flex">
+      <button
+        [title]="'Copy to clipboard'"
+        class="w-[40px] h-[32px] flex items-center justify-center rounded-lg border border-[#D4D3D7] px-[8px] py-[4px] hover:bg-primary-lightest relative group"
+        data-cy="contact-phone"
+        (click)="copyToClipboard($event, contacts[0].address)"
+      >
+        <ng-icon name="matLocationOnOutline"></ng-icon>
+      </button>
+    </div>
+  </div>
+</div>

--- a/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.spec.ts
+++ b/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.spec.ts
@@ -45,8 +45,6 @@ const mockRecord = {
 const mockRecordWithoutContact = {
   ...mockRecord,
   ownerOrganization: null,
-  contactsForResource: [],
-  contacts: [],
 } as unknown as CatalogRecord
 
 describe('InternalLinkCardContactComponent', () => {

--- a/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.spec.ts
+++ b/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.spec.ts
@@ -89,23 +89,6 @@ describe('InternalLinkCardContactComponent', () => {
     })
   })
 
-  describe('contacts getter', () => {
-    it('returns contactsForResource for dataset records', () => {
-      component.record.kind = 'dataset'
-      expect(component.contacts).toEqual(mockRecord.contactsForResource)
-    })
-
-    it('returns contacts for non-dataset records', () => {
-      component.record.kind = 'service'
-      expect(component.contacts).toEqual(mockRecord.contacts)
-    })
-
-    it('returns empty array when no contacts available', () => {
-      component.record = mockRecordWithoutContact
-      expect(component.contacts).toEqual([])
-    })
-  })
-
   describe('event handlers', () => {
     let openSpy: jest.SpyInstance
     let writeSpy: jest.SpyInstance

--- a/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.spec.ts
+++ b/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.spec.ts
@@ -1,0 +1,156 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { InternalLinkCardContactComponent } from './internal-link-card-contact.component'
+import { NO_ERRORS_SCHEMA } from '@angular/core'
+import { provideIcons, provideNgIconsConfig } from '@ng-icons/core'
+import {
+  matEmailOutline,
+  matPhoneOutline,
+  matLocationOnOutline,
+} from '@ng-icons/material-icons/outline'
+import { iconoirInternet } from '@ng-icons/iconoir'
+import { TranslateModule } from '@ngx-translate/core'
+import {
+  CatalogRecord,
+  Organization,
+} from '@geonetwork-ui/common/domain/model/record'
+
+// Mock organization
+const mockOrganization: Organization = {
+  name: 'Test Organization',
+  website: new URL('https://test-org.com'),
+  description: 'Test organization description',
+  logoUrl: new URL('https://test-org.com/logo.png'),
+}
+
+// Mock catalog record
+const mockRecord = {
+  uniqueIdentifier: '123',
+  title: 'Test Record',
+  abstract: 'This is a test abstract for the record',
+  kind: 'dataset' as 'dataset' | 'reuse' | 'service',
+  ownerOrganization: mockOrganization,
+  contactsForResource: [
+    {
+      email: 'test@example.com',
+      organization: 'Test Org',
+      position: 'Tester',
+      role: 'pointOfContact',
+      phone: '+1234567890',
+      address: '123 Test Street',
+    },
+  ],
+  contacts: [],
+} as unknown as CatalogRecord
+
+const mockRecordWithoutContact = {
+  ...mockRecord,
+  ownerOrganization: null,
+  contactsForResource: [],
+  contacts: [],
+} as unknown as CatalogRecord
+
+describe('InternalLinkCardContactComponent', () => {
+  let component: InternalLinkCardContactComponent
+  let fixture: ComponentFixture<InternalLinkCardContactComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InternalLinkCardContactComponent, TranslateModule.forRoot()],
+      schemas: [NO_ERRORS_SCHEMA],
+      providers: [
+        provideIcons({
+          iconoirInternet,
+          matEmailOutline,
+          matPhoneOutline,
+          matLocationOnOutline,
+        }),
+        provideNgIconsConfig({
+          size: '1.2em',
+        }),
+      ],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(InternalLinkCardContactComponent)
+    component = fixture.componentInstance
+    component.record = mockRecord
+  })
+
+  it('should create', () => {
+    fixture.detectChanges()
+    expect(component).toBeTruthy()
+  })
+
+  describe('organization getter', () => {
+    it('returns ownerOrganization from record', () => {
+      expect(component.organization).toBe(mockRecord.ownerOrganization)
+    })
+
+    it('returns null when no ownerOrganization', () => {
+      component.record = mockRecordWithoutContact
+      expect(component.organization).toBeNull()
+    })
+  })
+
+  describe('contacts getter', () => {
+    it('returns contactsForResource for dataset records', () => {
+      component.record.kind = 'dataset'
+      expect(component.contacts).toEqual(mockRecord.contactsForResource)
+    })
+
+    it('returns contacts for non-dataset records', () => {
+      component.record.kind = 'service'
+      expect(component.contacts).toEqual(mockRecord.contacts)
+    })
+
+    it('returns empty array when no contacts available', () => {
+      component.record = mockRecordWithoutContact
+      expect(component.contacts).toEqual([])
+    })
+  })
+
+  describe('event handlers', () => {
+    let openSpy: jest.SpyInstance
+    let writeSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+      if (!navigator.clipboard) {
+        Object.defineProperty(navigator, 'clipboard', {
+          value: {
+            writeText: jest.fn().mockImplementation(() => Promise.resolve()),
+          },
+          writable: true,
+        })
+      }
+      writeSpy = jest.spyOn(navigator.clipboard, 'writeText')
+    })
+
+    afterEach(() => {
+      openSpy.mockRestore()
+      writeSpy.mockRestore()
+    })
+    it('should open external URL in new window', () => {
+      const url = new URL('https://test-url.com')
+      const mockEvent = new Event('click')
+      jest.spyOn(mockEvent, 'stopPropagation').mockImplementation()
+      component.openExternalUrl(mockEvent, url)
+      expect(openSpy).toHaveBeenCalledWith(url, '_blank')
+    })
+
+    it('should open mailto link', () => {
+      const email = 'test@example.com'
+      const mockEvent = new Event('click')
+      jest.spyOn(mockEvent, 'stopPropagation').mockImplementation()
+      component.openMailto(mockEvent, email)
+      expect(openSpy).toHaveBeenCalledWith(`mailto:${email}`, '_blank')
+    })
+
+    it('should copy text to clipboard', () => {
+      const text = '+1234567890'
+      const mockEvent = new Event('click')
+      jest.spyOn(mockEvent, 'stopPropagation').mockImplementation()
+      component.copyToClipboard(mockEvent, text)
+      expect(writeSpy).toHaveBeenCalledWith(text)
+    })
+  })
+})

--- a/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.ts
+++ b/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.ts
@@ -1,0 +1,67 @@
+import { Component, Input } from '@angular/core'
+import { NgClass, NgIf } from '@angular/common'
+import {
+  CatalogRecord,
+  Organization,
+} from '@geonetwork-ui/common/domain/model/record'
+import { ThumbnailComponent } from '../thumbnail/thumbnail.component'
+import { NgIconComponent, provideIcons } from '@ng-icons/core'
+import {
+  matEmailOutline,
+  matPhoneOutline,
+  matLocationOnOutline,
+} from '@ng-icons/material-icons/outline'
+import { iconoirInternet } from '@ng-icons/iconoir'
+import { TranslateModule } from '@ngx-translate/core'
+
+@Component({
+  selector: 'gn-ui-internal-link-card-contact',
+  standalone: true,
+  imports: [
+    NgClass,
+    NgIf,
+    ThumbnailComponent,
+    NgIconComponent,
+    TranslateModule,
+  ],
+  providers: [
+    provideIcons({
+      iconoirInternet,
+      matEmailOutline,
+      matPhoneOutline,
+      matLocationOnOutline,
+    }),
+  ],
+  templateUrl: './internal-link-card-contact.component.html',
+})
+export class InternalLinkCardContactComponent {
+  @Input() record: CatalogRecord
+  @Input() size: 'L' | 'M' | 'S' | 'XS' = 'M'
+
+  get organization(): Organization {
+    return this.record.ownerOrganization
+  }
+
+  get contacts() {
+    return (
+      (this.record.kind === 'dataset'
+        ? this.record.contactsForResource
+        : this.record.contacts) || []
+    )
+  }
+
+  openExternalUrl(event: Event, url: URL): void {
+    event.stopPropagation()
+    window.open(url, '_blank')
+  }
+
+  openMailto(event: Event, email: string): void {
+    event.stopPropagation()
+    window.open(`mailto:${email}`, '_blank')
+  }
+
+  copyToClipboard(event: Event, text: string): void {
+    event.stopPropagation()
+    navigator.clipboard.writeText(text)
+  }
+}

--- a/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.ts
+++ b/libs/ui/elements/src/lib/internal-link-card-contact/internal-link-card-contact.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core'
-import { NgClass, NgIf } from '@angular/common'
+import { NgIf } from '@angular/common'
 import {
   CatalogRecord,
   Organization,
@@ -17,13 +17,7 @@ import { TranslateModule } from '@ngx-translate/core'
 @Component({
   selector: 'gn-ui-internal-link-card-contact',
   standalone: true,
-  imports: [
-    NgClass,
-    NgIf,
-    ThumbnailComponent,
-    NgIconComponent,
-    TranslateModule,
-  ],
+  imports: [NgIf, ThumbnailComponent, NgIconComponent, TranslateModule],
   providers: [
     provideIcons({
       iconoirInternet,

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.html
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.html
@@ -71,80 +71,10 @@
           </div>
         </div>
 
-        <div
-          data-cy="recordOrg"
-          *ngIf="size !== 'XS' && record.ownerOrganization?.name"
-          class="flex items-center justify-evenly bg-gray-50 rounded-lg h-[53px] px-2"
-        >
-          <div class="flex items-center flex-1 min-w-0">
-            <div
-              class="w-[45px] h-[45px] rounded-lg overflow-hidden shrink-0 mr-3"
-            >
-              <gn-ui-thumbnail
-                [thumbnailUrl]="
-                  record.ownerOrganization?.logoUrl?.toString() || ''
-                "
-                [fit]="'contain'"
-                class="w-full h-full rounded-lg"
-              ></gn-ui-thumbnail>
-            </div>
-            <div *ngIf="organization?.name" class="flex-1 w-0 overflow-hidden">
-              <div
-                class="text-xs text-black font-normal leading-tight truncate"
-                translate
-              >
-                record.card.metadata.contact
-              </div>
-              <div
-                data-cy="recordOrgName"
-                class="text-xl text-primary-black font-medium truncate"
-              >
-                {{ organization.name }}
-              </div>
-            </div>
-          </div>
-          <div *ngIf="size === 'L'" class="ml-2 flex space-x-2">
-            <div *ngIf="organization?.website" class="flex">
-              <button
-                [title]="organization.website"
-                class="w-[40px] h-[32px] flex items-center justify-center rounded-lg border border-[#D4D3D7] px-[8px] py-[4px] hover:bg-primary-lightest"
-                (click)="openExternalUrl($event, organization.website)"
-              >
-                <ng-icon name="iconoirInternet"></ng-icon>
-              </button>
-            </div>
-            <div *ngIf="contacts[0]?.email" class="flex">
-              <button
-                [title]="contacts[0].email"
-                class="w-[40px] h-[32px] flex items-center justify-center rounded-lg border border-[#D4D3D7] px-[8px] py-[4px] hover:bg-primary-lightest"
-                data-cy="contact-email"
-                (click)="openMailto($event, contacts[0].email)"
-              >
-                <ng-icon name="matEmailOutline"></ng-icon>
-              </button>
-            </div>
-            <div *ngIf="contacts[0]?.phone" class="flex">
-              <button
-                [title]="'Copy to clipboard'"
-                class="w-[40px] h-[32px] flex items-center justify-center rounded-lg border border-[#D4D3D7] px-[8px] py-[4px] hover:bg-primary-lightest relative group"
-                data-cy="contact-phone"
-                (click)="copyToClipboard($event, contacts[0].phone)"
-              >
-                <ng-icon name="matPhoneOutline"></ng-icon>
-              </button>
-            </div>
-            <div *ngIf="contacts[0]?.address" class="flex">
-              <button
-                [title]="'Copy to clipboard'"
-                class="w-[40px] h-[32px] flex items-center justify-center rounded-lg border border-[#D4D3D7] px-[8px] py-[4px] hover:bg-primary-lightest relative group"
-                data-cy="contact-phone"
-                (click)="copyToClipboard($event, contacts[0].address)"
-              >
-                <ng-icon name="matLocationOnOutline"></ng-icon>
-              </button>
-            </div>
-          </div>
-        </div>
+        <gn-ui-internal-link-card-contact
+          [record]="record"
+          [size]="size"
+        ></gn-ui-internal-link-card-contact>
       </div>
     </div>
   </div>

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.html
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.html
@@ -60,8 +60,9 @@
             </h4>
           </div>
           <div
-            *ngIf="size === 'L'"
-            class="mr-6 text-xs text-gray-900 line-clamp-2 overflow-hidden"
+            *ngIf="displayAbstract()"
+            class="mr-6 text-xs text-gray-900 overflow-hidden"
+            [ngClass]="getAbstractLineClamp()"
             data-cy="recordAbstract"
           >
             <gn-ui-markdown-parser
@@ -72,6 +73,7 @@
         </div>
 
         <gn-ui-internal-link-card-contact
+          *ngIf="size !== 'XS' && record.ownerOrganization?.name"
           [record]="record"
           [size]="size"
         ></gn-ui-internal-link-card-contact>

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.html
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.html
@@ -62,7 +62,7 @@
           <div
             *ngIf="displayAbstract()"
             class="mr-6 text-xs text-gray-900 overflow-hidden"
-            [ngClass]="getAbstractLineClamp()"
+            [ngClass]="getAbstractClass()"
             data-cy="recordAbstract"
           >
             <gn-ui-markdown-parser

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.spec.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.spec.ts
@@ -225,15 +225,9 @@ describe('InternalLinkCardComponent', () => {
       component.record = mockRecord
     })
 
-    it('returns the right line-clamp for each size ', () => {
+    it('returns the right line-clamp for L size ', () => {
       component.size = 'L'
       expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
-      component.size = 'M'
-      expect(component.getAbstractLineClamp()).toBe('')
-      component.size = 'S'
-      expect(component.getAbstractLineClamp()).toBe('')
-      component.size = 'XS'
-      expect(component.getAbstractLineClamp()).toBe('')
     })
   })
 
@@ -249,8 +243,6 @@ describe('InternalLinkCardComponent', () => {
       expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
       component.size = 'S'
       expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
-      component.size = 'XS'
-      expect(component.getAbstractLineClamp()).toBe('')
     })
   })
 

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.spec.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.spec.ts
@@ -220,29 +220,29 @@ describe('InternalLinkCardComponent', () => {
     })
   })
 
-  describe('getAbstractLineClamp with owner organization', () => {
+  describe('getAbstractClass with owner organization', () => {
     beforeEach(() => {
       component.record = mockRecord
     })
 
     it('returns the right line-clamp for L size ', () => {
       component.size = 'L'
-      expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
+      expect(component.getAbstractClass()).toBe('line-clamp-2')
     })
   })
 
-  describe('getAbstractLineClamp without owner organization', () => {
+  describe('getAbstractClass without owner organization', () => {
     beforeEach(() => {
       component.record = mockRecordWithoutContact
     })
 
     it('returns the right line-clamp for each size', () => {
       component.size = 'L'
-      expect(component.getAbstractLineClamp()).toBe('line-clamp-6')
+      expect(component.getAbstractClass()).toBe('line-clamp-6')
       component.size = 'M'
-      expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
+      expect(component.getAbstractClass()).toBe('line-clamp-2')
       component.size = 'S'
-      expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
+      expect(component.getAbstractClass()).toBe('line-clamp-2 ml-2')
     })
   })
 

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.spec.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.spec.ts
@@ -202,17 +202,14 @@ describe('InternalLinkCardComponent', () => {
 
   describe('event handlers', () => {
     let openSpy: jest.SpyInstance
-    let consoleSpy: jest.SpyInstance
 
     beforeEach(() => {
       openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
-      consoleSpy = jest.spyOn(console, 'log').mockImplementation()
       fixture.detectChanges()
     })
 
     afterEach(() => {
       openSpy.mockRestore()
-      consoleSpy.mockRestore()
     })
 
     it('should emit mdSelect when card is clicked', () => {
@@ -223,111 +220,75 @@ describe('InternalLinkCardComponent', () => {
     })
   })
 
-  describe('getAbstractLineClamp', () => {
-    describe('with owner organization', () => {
-      beforeEach(() => {
-        component.record = mockRecord
-      })
-
-      it('returns line-clamp-2 for size L', () => {
-        component.size = 'L'
-        expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
-      })
-
-      it('returns empty string for size M', () => {
-        component.size = 'M'
-        expect(component.getAbstractLineClamp()).toBe('')
-      })
-
-      it('returns empty string for size S', () => {
-        component.size = 'S'
-        expect(component.getAbstractLineClamp()).toBe('')
-      })
-
-      it('returns empty string for size XS', () => {
-        component.size = 'XS'
-        expect(component.getAbstractLineClamp()).toBe('')
-      })
+  describe('getAbstractLineClamp with owner organization', () => {
+    beforeEach(() => {
+      component.record = mockRecord
     })
 
-    describe('without owner organization', () => {
-      beforeEach(() => {
-        component.record = mockRecordWithoutContact
-      })
-
-      it('returns line-clamp-6 for size L', () => {
-        component.size = 'L'
-        expect(component.getAbstractLineClamp()).toBe('line-clamp-6')
-      })
-
-      it('returns line-clamp-2 for size M', () => {
-        component.size = 'M'
-        expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
-      })
-
-      it('returns line-clamp-2 for size S', () => {
-        component.size = 'S'
-        expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
-      })
-
-      it('returns empty string for size XS', () => {
-        component.size = 'XS'
-        expect(component.getAbstractLineClamp()).toBe('')
-      })
+    it('returns the right line-clamp for each size ', () => {
+      component.size = 'L'
+      expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
+      component.size = 'M'
+      expect(component.getAbstractLineClamp()).toBe('')
+      component.size = 'S'
+      expect(component.getAbstractLineClamp()).toBe('')
+      component.size = 'XS'
+      expect(component.getAbstractLineClamp()).toBe('')
     })
   })
 
-  describe('displayAbstract', () => {
-    describe('with owner organization', () => {
-      beforeEach(() => {
-        component.record = mockRecord
-      })
-
-      it('returns true for size L', () => {
-        component.size = 'L'
-        expect(component.displayAbstract()).toBe(true)
-      })
-
-      it('returns false for size M', () => {
-        component.size = 'M'
-        expect(component.displayAbstract()).toBe(false)
-      })
-
-      it('returns false for size S', () => {
-        component.size = 'S'
-        expect(component.displayAbstract()).toBe(false)
-      })
-
-      it('returns false for size XS', () => {
-        component.size = 'XS'
-        expect(component.displayAbstract()).toBe(false)
-      })
+  describe('getAbstractLineClamp without owner organization', () => {
+    beforeEach(() => {
+      component.record = mockRecordWithoutContact
     })
 
-    describe('without owner organization', () => {
-      beforeEach(() => {
-        component.record = mockRecordWithoutContact
-      })
+    it('returns the right line-clamp for each size', () => {
+      component.size = 'L'
+      expect(component.getAbstractLineClamp()).toBe('line-clamp-6')
+      component.size = 'M'
+      expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
+      component.size = 'S'
+      expect(component.getAbstractLineClamp()).toBe('line-clamp-2')
+      component.size = 'XS'
+      expect(component.getAbstractLineClamp()).toBe('')
+    })
+  })
 
-      it('returns true for size L', () => {
-        component.size = 'L'
-        expect(component.displayAbstract()).toBe(true)
-      })
+  describe('displayAbstract with owner organization', () => {
+    beforeEach(() => {
+      component.record = mockRecord
+    })
 
-      it('returns true for size M', () => {
-        component.size = 'M'
-        expect(component.displayAbstract()).toBe(true)
-      })
+    it('returns true for size L', () => {
+      component.size = 'L'
+      expect(component.displayAbstract()).toBe(true)
+    })
 
-      it('returns true for size S', () => {
-        component.size = 'S'
-        expect(component.displayAbstract()).toBe(true)
-      })
+    it('returns false for all other size M', () => {
+      component.size = 'M'
+      expect(component.displayAbstract()).toBe(false)
+      component.size = 'S'
+      expect(component.displayAbstract()).toBe(false)
+      component.size = 'XS'
+      expect(component.displayAbstract()).toBe(false)
+    })
+  })
 
-      it('returns false for size XS', () => {
-        component.size = 'XS'
-        expect(component.displayAbstract()).toBe(false)
-      })
+  describe('displayAbstract without owner organization', () => {
+    beforeEach(() => {
+      component.record = mockRecordWithoutContact
+    })
+    it('returns false for size XS', () => {
+      component.size = 'XS'
+      expect(component.displayAbstract()).toBe(false)
+    })
+    it('returns true for all other size', () => {
+      component.size = 'L'
+      expect(component.displayAbstract()).toBe(true)
+      component.size = 'M'
+      expect(component.displayAbstract()).toBe(true)
+      component.size = 'S'
+      expect(component.displayAbstract()).toBe(true)
     })
   })
 })

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.stories.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.stories.ts
@@ -26,10 +26,11 @@ const mockRecordLong = datasetRecordsFixture()[1] as CatalogRecord
 const mockRecordWithoutContact = {
   ...mockRecord,
   ownerOrganization: null,
-  contactsForResource: [],
-  contacts: [],
 } as CatalogRecord
-
+const mockLongRecordWithoutContact = {
+  ...mockRecordLong,
+  ownerOrganization: null,
+} as CatalogRecord
 const interactiveFavoriteTemplate = `<div class="flex flex-row items-center">
   <span class="inline-flex items-center text-gray-700 font-medium" style="line-height: 1; margin-top: 1px;">{{record.extras?.favoriteCount || 42}}</span>
   <button type="button" class="ml-1 flex items-center justify-center text-secondary hover:scale-125 transition will-change-transform"
@@ -225,7 +226,7 @@ export const LargeCardWithoutContact: StoryObj<InternalLinkCardComponentWithFavo
     args: {
       ...Primary.args,
       size: 'L',
-      record: mockRecordWithoutContact,
+      record: mockLongRecordWithoutContact,
     },
     render: Primary.render,
   }

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.stories.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.stories.ts
@@ -23,6 +23,12 @@ import { CommonModule } from '@angular/common'
 
 const mockRecord = datasetRecordsFixture()[0] as CatalogRecord
 const mockRecordLong = datasetRecordsFixture()[1] as CatalogRecord
+const mockRecordWithoutContact = {
+  ...mockRecord,
+  ownerOrganization: null,
+  contactsForResource: [],
+  contacts: [],
+} as CatalogRecord
 
 const interactiveFavoriteTemplate = `<div class="flex flex-row items-center">
   <span class="inline-flex items-center text-gray-700 font-medium" style="line-height: 1; margin-top: 1px;">{{record.extras?.favoriteCount || 42}}</span>
@@ -212,4 +218,34 @@ export const MultipleMediumCards: StoryObj<InternalLinkCardComponentWithFavorite
       </ng-template>
     `,
     }),
+  }
+
+export const LargeCardWithoutContact: StoryObj<InternalLinkCardComponentWithFavoriteTemplate> =
+  {
+    args: {
+      ...Primary.args,
+      size: 'L',
+      record: mockRecordWithoutContact,
+    },
+    render: Primary.render,
+  }
+
+export const MediumCardWithoutContact: StoryObj<InternalLinkCardComponentWithFavoriteTemplate> =
+  {
+    args: {
+      ...Primary.args,
+      size: 'M',
+      record: mockRecordWithoutContact,
+    },
+    render: Primary.render,
+  }
+
+export const SmallCardWithoutContact: StoryObj<InternalLinkCardComponentWithFavoriteTemplate> =
+  {
+    args: {
+      ...Primary.args,
+      size: 'S',
+      record: mockRecordWithoutContact,
+    },
+    render: Primary.render,
   }

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
@@ -112,15 +112,17 @@ export class InternalLinkCardComponent implements OnInit {
   }
 
   getAbstractLineClamp(): string {
-    if (this.size === 'L') {
-      return this.record.ownerOrganization?.name
-        ? 'line-clamp-2'
-        : 'line-clamp-6'
+    if (this.record.ownerOrganization?.name) {
+      if (this.size === 'L') {
+        return 'line-clamp-2'
+      }
+      return ''
     }
-    if (
-      (this.size === 'M' || this.size === 'S') &&
-      !this.record.ownerOrganization?.name
-    ) {
+
+    if (this.size === 'L') {
+      return 'line-clamp-6'
+    }
+    if (this.size === 'M' || this.size === 'S') {
       return 'line-clamp-2'
     }
     return ''

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
@@ -110,29 +110,15 @@ export class InternalLinkCardComponent implements OnInit {
   getTitleClass() {
     return this.titleClassMap[this._size]
   }
-
   getAbstractLineClamp(): string {
-    if (this.record.ownerOrganization?.name) {
-      if (this.size === 'L') {
-        return 'line-clamp-2'
-      }
-      return ''
-    }
-
-    if (this.size === 'L') {
-      return 'line-clamp-6'
-    }
-    if (this.size === 'M' || this.size === 'S') {
-      return 'line-clamp-2'
-    }
-    return ''
+    return this.size === 'L' && !this.record.ownerOrganization?.name
+      ? 'line-clamp-6'
+      : 'line-clamp-2'
   }
-
   displayAbstract(): boolean {
     return (
       this.size === 'L' ||
-      ((this.size === 'M' || this.size === 'S') &&
-        !this.record.ownerOrganization?.name)
+      (['M', 'S'].includes(this.size) && !this.record.ownerOrganization?.name)
     )
   }
 

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
@@ -110,10 +110,13 @@ export class InternalLinkCardComponent implements OnInit {
   getTitleClass() {
     return this.titleClassMap[this._size]
   }
-  getAbstractLineClamp(): string {
-    return this.size === 'L' && !this.record.ownerOrganization?.name
-      ? 'line-clamp-6'
-      : 'line-clamp-2'
+  getAbstractClass(): string {
+    const marginClass = ['S', 'XS'].includes(this.size) ? 'ml-2' : ''
+    const clampClass =
+      this.size === 'L' && !this.record.ownerOrganization?.name
+        ? 'line-clamp-6'
+        : 'line-clamp-2'
+    return `${clampClass} ${marginClass}`.trim()
   }
   displayAbstract(): boolean {
     return (

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
@@ -7,32 +7,16 @@ import {
   EventEmitter,
   ElementRef,
 } from '@angular/core'
-import {
-  CatalogRecord,
-  Organization,
-} from '@geonetwork-ui/common/domain/model/record'
+import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
 import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common'
 import { GeoDataBadgeComponent } from '../geo-data-badge/geo-data-badge.component'
 import { KindBadgeComponent } from '../kind-badge/kind-badge.component'
 import { MarkdownParserComponent } from '../markdown-parser/markdown-parser.component'
 import { MetadataQualityComponent } from '../metadata-quality/metadata-quality.component'
-import { ThumbnailComponent } from '../thumbnail/thumbnail.component'
-import {
-  propagateToDocumentOnly,
-  removeWhitespace,
-  stripHtml,
-} from '@geonetwork-ui/util/shared'
-import {
-  NgIconComponent,
-  provideIcons,
-  provideNgIconsConfig,
-} from '@ng-icons/core'
-import {
-  matLocationSearchingOutline,
-  matEmailOutline,
-  matPhoneOutline,
-  matLocationOnOutline,
-} from '@ng-icons/material-icons/outline'
+import { InternalLinkCardContactComponent } from '../internal-link-card-contact/internal-link-card-contact.component'
+import { removeWhitespace, stripHtml } from '@geonetwork-ui/util/shared'
+import { provideIcons, provideNgIconsConfig } from '@ng-icons/core'
+import { matLocationSearchingOutline } from '@ng-icons/material-icons/outline'
 import { iconoirInternet } from '@ng-icons/iconoir'
 import { TranslateModule } from '@ngx-translate/core'
 import { fromEvent, Subscription } from 'rxjs'
@@ -45,22 +29,18 @@ type CardSize = 'L' | 'M' | 'S' | 'XS'
   imports: [
     NgClass,
     NgIf,
-    ThumbnailComponent,
     MetadataQualityComponent,
     NgTemplateOutlet,
-    NgIconComponent,
     TranslateModule,
     GeoDataBadgeComponent,
     KindBadgeComponent,
     MarkdownParserComponent,
+    InternalLinkCardContactComponent,
   ],
   providers: [
     provideIcons({
       iconoirInternet,
       matLocationSearchingOutline,
-      matEmailOutline,
-      matPhoneOutline,
-      matLocationOnOutline,
     }),
     provideNgIconsConfig({
       size: '1.2em',
@@ -125,35 +105,8 @@ export class InternalLinkCardComponent implements OnInit {
     )
   }
 
-  get organization(): Organization {
-    return this.record.ownerOrganization
-  }
-
-  get contacts() {
-    return (
-      (this.record.kind === 'dataset'
-        ? this.record.contactsForResource
-        : this.record.contacts) || []
-    )
-  }
-
   getTitleClass() {
     return this.titleClassMap[this._size]
-  }
-
-  openExternalUrl(event: Event, url: URL): void {
-    event.stopPropagation()
-    window.open(url, '_blank')
-  }
-
-  openMailto(event: Event, email: string): void {
-    event.stopPropagation()
-    window.open(`mailto:${email}`, '_blank')
-  }
-
-  copyToClipboard(event: Event, text: string): void {
-    event.stopPropagation()
-    navigator.clipboard.writeText(text)
   }
 
   get shouldShowThumbnail(): boolean {

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
@@ -20,6 +20,7 @@ import { matLocationSearchingOutline } from '@ng-icons/material-icons/outline'
 import { iconoirInternet } from '@ng-icons/iconoir'
 import { TranslateModule } from '@ngx-translate/core'
 import { fromEvent, Subscription } from 'rxjs'
+import { ThumbnailComponent } from '../thumbnail/thumbnail.component'
 
 type CardSize = 'L' | 'M' | 'S' | 'XS'
 
@@ -36,6 +37,7 @@ type CardSize = 'L' | 'M' | 'S' | 'XS'
     KindBadgeComponent,
     MarkdownParserComponent,
     InternalLinkCardContactComponent,
+    ThumbnailComponent,
   ],
   providers: [
     provideIcons({
@@ -107,6 +109,29 @@ export class InternalLinkCardComponent implements OnInit {
 
   getTitleClass() {
     return this.titleClassMap[this._size]
+  }
+
+  getAbstractLineClamp(): string {
+    if (this.size === 'L') {
+      return this.record.ownerOrganization?.name
+        ? 'line-clamp-2'
+        : 'line-clamp-6'
+    }
+    if (
+      (this.size === 'M' || this.size === 'S') &&
+      !this.record.ownerOrganization?.name
+    ) {
+      return 'line-clamp-2'
+    }
+    return ''
+  }
+
+  displayAbstract(): boolean {
+    return (
+      this.size === 'L' ||
+      ((this.size === 'M' || this.size === 'S') &&
+        !this.record.ownerOrganization?.name)
+    )
   }
 
   get shouldShowThumbnail(): boolean {


### PR DESCRIPTION
### Description

This PR introduce modification around the internal Link cards. When the contact is not defined, the description replace it for M and S size. If there is already a description like in L size, the maximum lines is raised from 2 to 6 lines. 

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

I splitted the component in two parts to separate the contact and the card

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots
For Large size : 
![image](https://github.com/user-attachments/assets/dcafba9c-3a90-41f0-abd5-34184991d6e5)
![image](https://github.com/user-attachments/assets/19dd987b-f07b-4d4a-982f-e877fc17262d)


For M / S size ( M size in example here)  
![image](https://github.com/user-attachments/assets/abb9bf04-0dd2-4e27-9e76-c4440199d7e7)
![image](https://github.com/user-attachments/assets/977c98ed-bb91-4c2b-85c2-5bc28f105479)


<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Find a dataset with contact
Empty the organisation name in the contacts 
you will have this display

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
