### PR TITLE
[Editor] : Multilingual demo feedback

### DIFF
--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -160,7 +160,7 @@ export class Gn4FieldMapper {
     },
     otherLanguage: (output, source) => {
       const langList = getAsArray(selectField<string>(source, 'otherLanguage'))
-      const languages = langList.map((lang) => LANG_3_TO_2_MAPPER[lang])
+      const languages = langList.map((lang) => LANG_3_TO_2_MAPPER[lang] ?? lang)
       const defaultLanguage = output.defaultLanguage ?? languages[0] ?? null
       const otherLanguages = languages.filter(
         (lang) => lang !== defaultLanguage

--- a/libs/api/metadata-converter/src/lib/iso19139/iso19139.converter.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/iso19139.converter.ts
@@ -183,8 +183,10 @@ export class Iso19139Converter extends BaseConverter<string> {
         }
         // add languages that have translations to the root language list
         for (const lang in fieldTranslations) {
-          if (!record.otherLanguages.includes(lang)) {
-            record.otherLanguages.push(lang)
+          if (!record.otherLanguages.length) {
+            if (!record.otherLanguages.includes(lang)) {
+              record.otherLanguages.push(lang)
+            }
           }
         }
       }

--- a/libs/feature/editor/src/lib/components/multilingual-panel/multilingual-panel.component.ts
+++ b/libs/feature/editor/src/lib/components/multilingual-panel/multilingual-panel.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ElementRef,
   Input,
+  OnChanges,
   OnDestroy,
   QueryList,
   ViewChildren,
@@ -189,11 +190,11 @@ export class MultilingualPanelComponent implements OnDestroy {
   }
 
   updateTranslations() {
-    this.facade.updateRecordField(
-      'otherLanguages',
-      this.selectedLanguages.filter((lang) => lang !== this.formLanguage)
+    const newLanguageSelection = this.selectedLanguages.filter(
+      (lang) => lang !== this.formLanguage
     )
-    this.recordLanguages = this.selectedLanguages
+    this.facade.updateRecordField('otherLanguages', newLanguageSelection)
+    this.recordLanguages = newLanguageSelection
     this.editTranslations = false
   }
 
@@ -226,6 +227,7 @@ export class MultilingualPanelComponent implements OnDestroy {
         cancelText: this.translateService.instant(
           'editor.record.multilingual.confirmation.cancelText'
         ),
+        focusCancel: true,
       },
       restoreFocus: true,
     })

--- a/libs/ui/elements/src/lib/confirmation-dialog/confirmation-dialog.component.html
+++ b/libs/ui/elements/src/lib/confirmation-dialog/confirmation-dialog.component.html
@@ -1,10 +1,14 @@
 <h1 mat-dialog-title>{{ data.title }}</h1>
 <div mat-dialog-content>{{ data.message }}</div>
 <div mat-dialog-actions>
-  <gn-ui-button (buttonClick)="onCancel()">{{ data.cancelText }}</gn-ui-button>
+  <gn-ui-button
+    [attr.cdkFocusInitial]="focusCancel"
+    (buttonClick)="onCancel()"
+    >{{ data.cancelText }}</gn-ui-button
+  >
   <gn-ui-button
     (buttonClick)="onConfirm()"
-    cdkFocusInitial
+    [attr.cdkFocusInitial]="!focusCancel"
     class="ml-2"
     data-cy="confirm-button"
     >{{ data.confirmText }}</gn-ui-button

--- a/libs/ui/elements/src/lib/confirmation-dialog/confirmation-dialog.component.ts
+++ b/libs/ui/elements/src/lib/confirmation-dialog/confirmation-dialog.component.ts
@@ -7,6 +7,7 @@ import {
 import { ButtonComponent } from '@geonetwork-ui/ui/inputs'
 
 export interface ConfirmationDialogData {
+  focusCancel: string
   title: string
   message: string
   confirmText: string
@@ -22,10 +23,13 @@ export interface ConfirmationDialogData {
   imports: [MatDialogModule, ButtonComponent],
 })
 export class ConfirmationDialogComponent {
+  focusCancel = null
   constructor(
     public dialogRef: MatDialogRef<ConfirmationDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: ConfirmationDialogData
-  ) {}
+  ) {
+    this.focusCancel = data.focusCancel ? true : null
+  }
 
   onConfirm() {
     this.dialogRef.close(true)

--- a/libs/ui/search/src/lib/results-table/results-table.component.ts
+++ b/libs/ui/search/src/lib/results-table/results-table.component.ts
@@ -223,10 +223,13 @@ export class ResultsTableComponent {
   }
 
   getTxtHoverMultilingual(record: CatalogRecord) {
+    const languages = [
+      ...[record.defaultLanguage],
+      ...record.otherLanguages,
+    ].sort((a, b) => a.localeCompare(b))
+
     return this.translateService.instant('dashboard.records.isMultilingual', {
-      languages: [...[record.defaultLanguage], ...record.otherLanguages].join(
-        ', '
-      ),
+      languages: languages.join(', '),
     })
   }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -245,7 +245,7 @@
   "editor.record.lock.reason": "You are not an editor of the allowed groups",
   "editor.record.multilingual.confirmation.cancelText": "Keep the language(s)",
   "editor.record.multilingual.confirmation.confirmText": "Remove the language(s)",
-  "editor.record.multilingual.confirmation.message": "You are about to remove one or several languages, which will delete all of the related translations and is irreversible. Do you want to proceed?",
+  "editor.record.multilingual.confirmation.message": "You are about to remove one or several languages, which will delete all of the related translations. Do you want to proceed?",
   "editor.record.multilingual.confirmation.title": "Remove languages",
   "editor.record.onlineResource.protocol.other": "Other",
   "editor.record.onlineResourceError.body": "An error happened while adding the resource:",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -245,7 +245,7 @@
   "editor.record.lock.reason": "Vous n'êtes pas éditeur d'un des groupes autorisés.",
   "editor.record.multilingual.confirmation.cancelText": "Garder le(s) language(s)",
   "editor.record.multilingual.confirmation.confirmText": "Supprimer le(s) language(s)",
-  "editor.record.multilingual.confirmation.message": "Vous allez supprimer un ou plusieurs languages, ce qui supprimera toutes les traductions qui y sont liées et est irréversible. Voulez-vous procéder ?",
+  "editor.record.multilingual.confirmation.message": "Vous allez supprimer un ou plusieurs languages, ce qui supprimera toutes les traductions qui y sont liées. Voulez-vous procéder ?",
   "editor.record.multilingual.confirmation.title": "Suppression de language(s)",
   "editor.record.onlineResource.protocol.other": "Autre",
   "editor.record.onlineResourceError.body": "Une erreur est survenue lors de l'ajout de la ressource :",


### PR DESCRIPTION
### Description

This PR does : 

- [ ] Change the confirmation dialog text to something less dramatic + focuses on the "delete" button
- [ ] Display unsupported languages in the dashboard tooltip for multilingual records
- [ ] Avoids having the newly-deleted languages show up in the panel in-between saving and reloading the page --> note that this was due to the isoConverter parsing the translations to `otherLanguages` all the time (loading the page, saving etc...) no matter if the list was already populated by the `gn4.field.mapper`. As far as I understand (and also with the time limit I had), this is only needed when `otherLanguages` has no languages already, so I added a check for that.

### Architectural changes

no

### Screenshots

no notable UI changes

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
