### PR TITLE
[Datahub] Search input webcomponent placeholder customization

### DIFF
--- a/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.component.html
+++ b/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.component.html
@@ -5,4 +5,5 @@
   (inputSubmitted)="search($event)"
   [autoFocus]="true"
   [forceTrackPosition]="forceTrackPosition === 'force'"
+  [placeholder]="placeholder"
 ></gn-ui-fuzzy-search>

--- a/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.component.ts
+++ b/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.component.ts
@@ -1,5 +1,4 @@
 import {
-  AfterViewChecked,
   ChangeDetectionStrategy,
   Component,
   Input,
@@ -23,6 +22,7 @@ export class GnSearchInputComponent extends BaseComponent {
   @Input() forceTrackPosition = ''
   @Input() openOnSearch: string
   @Input() openOnSelect: string
+  @Input() placeholder?: string
   @ViewChild('searchInput') searchInput: FuzzySearchComponent
 
   search(any: string) {

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.html
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.html
@@ -1,5 +1,5 @@
 <gn-ui-autocomplete
-  [placeholder]="'search.field.any.placeholder' | translate"
+  [placeholder]="placeholder ?? ('search.field.any.placeholder' | translate)"
   [displayWithFn]="displayWithFn"
   [action]="autoCompleteAction"
   (itemSelected)="handleItemSelection($event)"

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.spec.ts
@@ -212,4 +212,22 @@ describe('FuzzySearchComponent', () => {
       })
     })
   })
+
+  describe('custom placeholder', () => {
+    beforeEach(() => {
+      fixture = TestBed.createComponent(FuzzySearchComponent);
+      component = fixture.componentInstance;
+      component.placeholder = 'Type your custom placeholder text here…';
+      fixture.detectChanges();
+    });
+
+    it('uses custom placeholder when provided', () => {
+      const autocomplete = fixture.debugElement
+        .query(By.directive(AutocompleteComponent))
+        .componentInstance as AutocompleteComponent;
+
+      expect(autocomplete.placeholder).toBe('Type your custom placeholder text here…');
+    });
+  });
+
 })

--- a/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
+++ b/libs/feature/search/src/lib/fuzzy-search/fuzzy-search.component.ts
@@ -30,6 +30,7 @@ export class FuzzySearchComponent implements OnInit {
   @Input() autoFocus = false
   @Input() forceTrackPosition = false
   @Input() enterButton = false
+  @Input() placeholder?: string
   @Output() itemSelected = new EventEmitter<CatalogRecord>()
   @Output() inputSubmitted = new EventEmitter<string>()
   @Output() isSearchActive = new EventEmitter<boolean>()


### PR DESCRIPTION
### Description

This PR introduces placeholder-text customisation for the `wc-gn-search-input` web-component

* adds an optional `@Input() placeholder?: string` to **`GnSearchInputComponent`** and **`FuzzySearchComponent`**
* propagates the input into the underlying `<gn-ui-autocomplete>` template, bypassing translation when a value is supplied
* preserves the previous behaviour when the input is *omitted* (fallback to the translated key `search.field.any.placeholder`)
* adds a unit-test ensuring the provided text appears verbatim in the autocomplete component

---

### Architectural changes

* **No new external libraries**
* No changes to inter-library dependencies – only two components receive a new optional input.

---

### Quality Assurance Checklist

* [x] Commit history is devoid of any *merge commits* and readable to facilitate reviews
* [x] **New logic** ⚙️ introduced: unit tests were added (`fuzzy-search.component.spec.ts`)
* [ ] **New user stories** 🤏 introduced: E2E tests were added
* [ ] **New UI components** 🕹️ introduced: corresponding stories in Storybook were created
* [ ] **Breaking changes** 🪚 introduced: add the `breaking change` label
* [ ] **Bugs** 🐞 fixed: add the `backport <release branch>` label
* [ ] The [[documentation website](https://chatgpt.com/c/docs)](docs) 📚 has received the love it deserves

---

### How to test

1. **Edit the sample page**

   Open
   `apps/webcomponents/src/app/components/gn-search-input/gn-search-input.sample.html`
   and add the new **`placeholder`** input with a custom value, e-g.:

   ```html
   <gn-search-input
     placeholder="My custom place holder text"
     api-url="https://www.geo2france.fr/geonetwork/srv/api"
     open-on-search="https://www.geo2france.fr/datahub/home/search/?q=${search}"
     open-on-select="https://www.geo2france.fr/datahub/dataset/${uuid}"
     primary-color="#0f4395"
     secondary-color="#8bc832"
     main-color="#555"
     background-color="#fdfbff"
     main-font="'Inter', sans-serif"
     title-font="'DM Serif Display', serif"
   ></gn-search-input>
   ```

2. **Build the demo bundle**

   ```bash
   npm run build:demo
   ```

3. **Serve the demo**

   ```bash
   npm run demo
   ```

4. **Navigate to the component demo**

   Open your browser at **[http://localhost:8001/webcomponents/gn-search-input.sample.html](http://localhost:8001/webcomponents/gn-search-input.sample.html)**
   (or start from [http://localhost:8001/](http://localhost:8001/) and follow the link).

5. **Verify the result**

   The search bar should display exactly **“My custom place holder text”** as its placeholder, with no translation applied.
   Remove the `placeholder` attribute, rebuild, and the component should fall back to the original translated text.
