### PR TITLE
Fix CI: Align metadata model and fixture

### DIFF
--- a/libs/common/domain/src/lib/model/record/metadata.model.ts
+++ b/libs/common/domain/src/lib/model/record/metadata.model.ts
@@ -241,7 +241,11 @@ export interface ServiceEndpoint {
   translations?: OnlineResourceTranslations
 }
 
-export type ServiceOnlineResource = (ServiceEndpoint | OnlineLinkResource) & {
+export type ServiceOnlineResource = (
+  | ServiceEndpoint
+  | OnlineLinkResource
+  | DatasetServiceDistribution
+) & {
   type: OnlineResourceType
 }
 

--- a/libs/common/domain/src/lib/model/record/metadata.model.ts
+++ b/libs/common/domain/src/lib/model/record/metadata.model.ts
@@ -241,11 +241,7 @@ export interface ServiceEndpoint {
   translations?: OnlineResourceTranslations
 }
 
-export type ServiceOnlineResource = (
-  | ServiceEndpoint
-  | OnlineLinkResource
-  | DatasetServiceDistribution
-) & {
+export type ServiceOnlineResource = (ServiceEndpoint | OnlineLinkResource) & {
   type: OnlineResourceType
 }
 

--- a/libs/common/fixtures/src/lib/records.fixtures.ts
+++ b/libs/common/fixtures/src/lib/records.fixtures.ts
@@ -827,9 +827,8 @@ export const importDatasetRecordAsXmlFixture = (): string => `
 </gmd:MD_Metadata>`
 
 export const simpleServiceRecordFixture = (): ServiceRecord => ({
+  abstract: `Ce service de visualisation WMS permet de consulter la série de couches de données "Sites de gestion des déchets miniers - Série".`,
   kind: 'service',
-  status: null,
-  lineage: null,
   recordUpdated: new Date('2023-03-17T07:38:08.875Z'),
   recordPublished: null,
   ownerOrganization: null,
@@ -842,7 +841,6 @@ export const simpleServiceRecordFixture = (): ServiceRecord => ({
   keywords: [],
   topics: [],
   spatialExtents: [],
-  temporalExtents: [],
   overviews: [],
   defaultLanguage: null,
   otherLanguages: [],

--- a/libs/common/fixtures/src/lib/records.fixtures.ts
+++ b/libs/common/fixtures/src/lib/records.fixtures.ts
@@ -847,14 +847,14 @@ export const simpleServiceRecordFixture = (): ServiceRecord => ({
   title: 'Sites de gestion des déchets miniers - Service de visualisation WMS',
   onlineResources: [
     {
-      name: 'Service de visualisation WMS',
+      name: 'Rapport de disponibilité du service WMS',
       description:
-        'Adresse de connexion au service de visualisation WMS de la série de couches de données "Sites de gestion des déchets miniers"',
-      type: 'service',
+        'Ce service de visualisation WMS permet de consulter la série de couches de données "Sites de gestion des déchets miniers - Série".',
+      mimeType: 'text/html',
+      type: 'link',
       url: new URL(
-        'https://geoservices.wallonie.be/arcgis/services/SOL_SOUS_SOL/DECHETS_MINIERS/MapServer/WMSServer?request=GetCapabilities&service=WMS'
+        'https://geoservices.wallonie.be/rapportDisponibilite/wms/sites_de_gestion_des_dechets_miniers_srie.html'
       ),
-      accessServiceProtocol: 'wms',
       accessRestricted: false,
     },
   ],


### PR DESCRIPTION
### Description

This PR intents to fix the CI, that currently breaks on the storybook build due to a conflict between the `metadata.model` and a recently added fixture of a `ServiceRecord`.

Looking at the field mapper, it seems to make sense to add `DatasetServiceDistribution` in the model to `ServiceOnlineResource`.

`status` and `lineage` are removed from the fixture as they seem to make less sense for a service. `abstract` was missing.

I've seen values for `temporalExtents` in ES for a service, but I don't know if these are very meaningful. I decided to also remove this field from the fixture, as we do not support it for services in the reader/writer. 

