### PR TITLE
Datahub: Make record kind quick filter optional

### DIFF
--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -6,7 +6,7 @@
     <gn-ui-application-banner
       [message]="bannerMessage"
       [closeEnabled]="true"
-      type="secondary"
+      type="light"
     ></gn-ui-application-banner>
   </div>
   <div

--- a/apps/datahub/src/app/home/search/search-page/search-page.component.html
+++ b/apps/datahub/src/app/home/search/search-page/search-page.component.html
@@ -3,7 +3,9 @@
     [isQualitySortable]="metadataQualityDisplay"
   ></datahub-search-filters>
   <div class="mt-6 rounded-lg text-gray-800 p-4 bg-slate-100">
-    <gn-ui-results-hits></gn-ui-results-hits>
+    <gn-ui-results-hits
+      [displayRecordKindFilter]="displayRecordKindFilter"
+    ></gn-ui-results-hits>
   </div>
   <div class="mt-8">
     <gn-ui-results-list-container

--- a/apps/datahub/src/app/home/search/search-page/search-page.component.spec.ts
+++ b/apps/datahub/src/app/home/search/search-page/search-page.component.spec.ts
@@ -57,4 +57,21 @@ describe('SearchPageComponent', () => {
       )
     })
   })
+  it('should display record kind filter by default (without searchConfig)', () => {
+    expect(component.displayRecordKindFilter).toBe(true)
+  })
+  it('should display record kind filter when RECORD_KIND_QUICK_FILTER is true', () => {
+    const searchConfig = {
+      RECORD_KIND_QUICK_FILTER: true,
+    }
+    component.displayRecordKindFilter = searchConfig.RECORD_KIND_QUICK_FILTER
+    expect(component.displayRecordKindFilter).toBe(true)
+  })
+  it('should not display record kind filter when RECORD_KIND_QUICK_FILTER is false', () => {
+    const searchConfig = {
+      RECORD_KIND_QUICK_FILTER: false,
+    }
+    component.displayRecordKindFilter = searchConfig.RECORD_KIND_QUICK_FILTER
+    expect(component.displayRecordKindFilter).toBe(false)
+  })
 })

--- a/apps/datahub/src/app/home/search/search-page/search-page.component.ts
+++ b/apps/datahub/src/app/home/search/search-page/search-page.component.ts
@@ -39,7 +39,7 @@ export class SearchPageComponent implements OnInit {
 
     const searchConfig: SearchConfig = getOptionalSearchConfig()
     this.displayRecordKindFilter =
-      searchConfig?.RECORD_KIND_QUICK_FILTER === false ? false : true
+      searchConfig?.RECORD_KIND_QUICK_FILTER !== false
   }
 
   onMetadataSelection(metadata: CatalogRecord): void {

--- a/apps/datahub/src/app/home/search/search-page/search-page.component.ts
+++ b/apps/datahub/src/app/home/search/search-page/search-page.component.ts
@@ -7,7 +7,9 @@ import {
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
 import {
   getMetadataQualityConfig,
+  getOptionalSearchConfig,
   MetadataQualityConfig,
+  SearchConfig,
 } from '@geonetwork-ui/util/app-config'
 import { SearchFiltersComponent } from '../search-filters/search-filters.component'
 
@@ -21,6 +23,7 @@ import { SearchFiltersComponent } from '../search-filters/search-filters.compone
 })
 export class SearchPageComponent implements OnInit {
   metadataQualityDisplay: boolean
+  displayRecordKindFilter
 
   constructor(
     private searchRouter: RouterFacade,
@@ -30,9 +33,13 @@ export class SearchPageComponent implements OnInit {
   ngOnInit() {
     this.searchFacade.setResultsLayout('ROW')
 
-    const cfg: MetadataQualityConfig =
+    const metadataQualityConfig: MetadataQualityConfig =
       getMetadataQualityConfig() || ({} as MetadataQualityConfig)
-    this.metadataQualityDisplay = cfg.ENABLED
+    this.metadataQualityDisplay = metadataQualityConfig.ENABLED
+
+    const searchConfig: SearchConfig = getOptionalSearchConfig()
+    this.displayRecordKindFilter =
+      searchConfig?.RECORD_KIND_QUICK_FILTER === false ? false : true
   }
 
   onMetadataSelection(metadata: CatalogRecord): void {

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -74,6 +74,9 @@ background_color = "#fdfbff"
 # This section contains settings used for fine-tuning the search experience
 [search]
 
+# Optional; Indicates whether the quick filter (by record kind dataset, service or reuse) below the search filters is displayed or not. Defaults to `true`.
+# record_kind_quick_filter = true
+
 # Optional; specify a GeoJSON object to be used as filter: all records contained inside the geometry will be boosted on top,
 # all records which do not intersect with the geometry will be shown with lower priority; can be specified as URL or inline
 # Note: if the GeoJSON object contains multiple features, only the geometry of the first one will be kept!

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -139,6 +139,10 @@ All parameters in this section are expressed using CSS formats; references:
 
 #### `[search]`
 
+- `record_kind_quick_filter` (optional)
+
+Indicates whether the quick filter (by record kind dataset, service or reuse) below the search filters is displayed or not. Defaults to `true`.
+
 - `filter_geometry_url` or `filter_geometry_data` (optional)
 
 Specify a GeoJSON object to be used as filter: all records contained inside the geometry will be **boosted on top**, all records which do not intersect with the geometry will be **shown with lower priority**.

--- a/libs/feature/search/src/lib/results-hits/results-hits.container.component.html
+++ b/libs/feature/search/src/lib/results-hits/results-hits.container.component.html
@@ -9,6 +9,7 @@
     [hits]="searchFacade.resultsHits$ | async"
   ></gn-ui-results-hits-number>
   <gn-ui-results-hits-search-kind
+    *ngIf="displayRecordKindFilter"
     (selectionChanged)="onSelectionChanged($event)"
     [choices]="filterChoices$ | async"
     [selected]="selected$ | async"

--- a/libs/feature/search/src/lib/results-hits/results-hits.container.component.spec.ts
+++ b/libs/feature/search/src/lib/results-hits/results-hits.container.component.spec.ts
@@ -8,6 +8,9 @@ import { FieldsService } from '../utils/service/fields.service'
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core'
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core'
 import { provideI18n } from '@geonetwork-ui/util/i18n'
+import { By } from '@angular/platform-browser'
+import { ResultsHitsSearchKindComponent } from '@geonetwork-ui/ui/search'
+import { MockComponent } from 'ng-mocks'
 
 describe('ResultsHitsContainerComponent', () => {
   let component: ResultsHitsContainerComponent
@@ -40,7 +43,10 @@ describe('ResultsHitsContainerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ResultsHitsContainerComponent],
+      declarations: [
+        ResultsHitsContainerComponent,
+        MockComponent(ResultsHitsSearchKindComponent),
+      ],
       providers: [
         provideI18n(),
         { provide: SearchFacade, useValue: searchFacadeMock },
@@ -82,6 +88,21 @@ describe('ResultsHitsContainerComponent', () => {
 
     expect(searchServiceMock.updateFilters).toHaveBeenCalledWith({
       recordKind: ['dataset'],
+    })
+  })
+  describe('displayRecordKindFilter', () => {
+    it('should display ResultsHitsSearchKindComponent by default', () => {
+      expect(
+        fixture.debugElement.query(By.directive(ResultsHitsSearchKindComponent))
+      ).toBeTruthy()
+    })
+
+    it('should not display ResultsHitsSearchKindComponent when RECORD_KIND_QUICK_FILTER is false in searchConfig', () => {
+      component.displayRecordKindFilter = false
+      fixture.detectChanges()
+      expect(
+        fixture.debugElement.query(By.directive(ResultsHitsSearchKindComponent))
+      ).toBeFalsy()
     })
   })
 })

--- a/libs/feature/search/src/lib/results-hits/results-hits.container.component.ts
+++ b/libs/feature/search/src/lib/results-hits/results-hits.container.component.ts
@@ -7,7 +7,7 @@ import {
   startWith,
   switchMap,
 } from 'rxjs'
-import { Component, OnInit } from '@angular/core'
+import { Component, Input, OnInit } from '@angular/core'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import { SearchFacade } from '../state/search.facade'
 import { FieldAvailableValue, FieldValue } from '../utils/service/fields'
@@ -25,6 +25,7 @@ marker('search.filters.recordKind.reuse')
   styleUrls: ['./results-hits.container.component.css'],
 })
 export class ResultsHitsContainerComponent implements OnInit {
+  @Input() displayRecordKindFilter = true
   fieldName = 'recordKind'
   filterChoices$: Observable<FieldAvailableValue[]>
   selected$: Observable<FieldValue[]>

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -159,6 +159,7 @@ describe('app config utils', () => {
     describe('getOptionalSearchConfig', () => {
       it('returns the search config', () => {
         expect(getOptionalSearchConfig()).toEqual({
+          RECORD_KIND_QUICK_FILTER: false,
           FILTER_GEOMETRY_URL: 'https://my.domain.org/geom.json',
           SEARCH_PRESET: [
             {

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -224,6 +224,7 @@ export function loadAppConfig() {
         'search',
         [],
         [
+          'record_kind_quick_filter',
           'filter_geometry_data',
           'filter_geometry_url',
           'search_preset',
@@ -244,6 +245,8 @@ export function loadAppConfig() {
         parsedSearchSection === null
           ? null
           : ({
+              RECORD_KIND_QUICK_FILTER:
+                parsedSearchSection.record_kind_quick_filter,
               FILTER_GEOMETRY_DATA: parsedSearchSection.filter_geometry_data,
               FILTER_GEOMETRY_URL: parsedSearchSection.filter_geometry_url,
               SEARCH_PRESET: parsedSearchParams.map((param) => ({

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -38,6 +38,7 @@ title_font = 'serif'
 fonts_stylesheet_url = "https://fonts.googleapis.com/css2?family=Open+Sans"
 
 [search]
+record_kind_quick_filter = false
 filter_geometry_url = 'https://my.domain.org/geom.json'
 advanced_filters = ['publicationYear', 'documentStandard', 'inspireKeyword', 'topic', 'license']
 

--- a/libs/util/app-config/src/lib/model.ts
+++ b/libs/util/app-config/src/lib/model.ts
@@ -54,6 +54,7 @@ export interface SearchPreset {
 }
 
 export interface SearchConfig {
+  RECORD_KIND_QUICK_FILTER?: boolean
   FILTER_GEOMETRY_URL?: string
   FILTER_GEOMETRY_DATA?: string
   SEARCH_PRESET?: SearchPreset[]


### PR DESCRIPTION
### Description

This PR adds a `record_kind_quick_filter` setting to the config which is read in the datahub and conditions `<gn-ui-results-hits-search-kind>` to display or not.

Also slips in a commit changing the application-banner to `light` (see last screenshot).

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

The following library now depends on [...]

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

`record_kind_quick_filter = true` (default)
![image](https://github.com/user-attachments/assets/abbdf0ec-7b21-42a7-be13-9748d7b42989)


`record_kind_quick_filter = false`
![image](https://github.com/user-attachments/assets/a0626eff-b547-41dd-810a-8dad8c35c5ce)

Application banner color change:

![image](https://github.com/user-attachments/assets/feba4402-6e87-4ce4-84e3-e1cabb81d27b)



<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

- Check if quick filter is visible by default on `/search`
- Set `record_kind_quick_filter = false` in `default.toml` and check if it displays well without
- Check if doc is clear

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
