### PR TITLE
Tools pipeline: Fix quality score calculation for GN 4.2.2

### DIFF
--- a/apps/datahub-e2e/src/e2e/service/serviceDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/service/serviceDetailPage.cy.ts
@@ -89,4 +89,17 @@ describe('service pages', () => {
       cy.get('gn-ui-error').should('be.visible')
     })
   })
+  it('metadata quality widget enabled', () => {
+    cy.intercept('GET', '/assets/configuration/default.toml', {
+      fixture: 'config-with-metadata-quality.toml',
+    })
+    cy.visit('/service/00b22798-ec8e-4500-89e8-90eeeda45919')
+
+    cy.get('gn-ui-metadata-quality gn-ui-progress-bar')
+      .eq(0)
+      .find('[data-cy=progressPercentage]')
+      .invoke('text')
+      .invoke('trim')
+      .should('eql', '100%')
+  })
 })

--- a/tools/pipelines/register-es-pipelines.js
+++ b/tools/pipelines/register-es-pipelines.js
@@ -112,6 +112,7 @@ if((ctx.MD_LegalConstraintsUseLimitationObject != null && ctx.MD_LegalConstraint
    (ctx.MD_LegalConstraintsOtherConstraintsObject != null && ctx.MD_LegalConstraintsOtherConstraintsObject.length > 0)) {
   ok++
 }
+// GN 4.2.3+
 if(type == 'service' && ctx.link != null){
   for (link in ctx.link) {
     if (
@@ -119,6 +120,19 @@ if(type == 'service' && ctx.link != null){
       link.urlObject != null &&
       link.urlObject.default != null &&
       link.urlObject.default.toLowerCase().contains('capabilities')
+    ) {
+      ok++;
+      break;
+    }
+  }
+}
+// GN 4.2.2 and earlier
+if(type == 'service' && ctx.link != null){
+  for (link in ctx.link) {
+    if (
+      link != null &&
+      link.url != null &&
+      link.url.toLowerCase().contains('capabilities')
     ) {
       ok++;
       break;

--- a/tools/pipelines/register-es-pipelines.js
+++ b/tools/pipelines/register-es-pipelines.js
@@ -81,21 +81,13 @@ if(ctx.resourceTitleObject != null && ctx.resourceTitleObject.default != null &&
 if(ctx.resourceAbstractObject != null && ctx.resourceAbstractObject.default != null && ctx.resourceAbstractObject.default != '') {
   ok++
 }
-// Check for both 4.2.2 and 4.2.3+ versions
-if (type != 'service' && ctx.contact != null && ctx.contact.length > 0) {
-  def firstContact = ctx.contact[0];
-  
-  def hasOrgName = firstContact.organisation != null &&
-                   firstContact.organisation.name != null &&
-                   firstContact.organisation.name != '';
-                   
-  def hasOrgObjDefault = firstContact.organisationObject != null &&
-                         firstContact.organisationObject.default != null &&
-                         firstContact.organisationObject.default != '';
-                         
-  if (hasOrgName || hasOrgObjDefault) {
-    ok++;
-  }
+// this checks for single-language Organizations (GN 4.2.2)
+if(!isService && ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisation != null && ctx.contact[0].organisation != '') {
+  ok++
+}
+// this checks for multilingual Organizations (GN 4.2.3+)
+if(!isService && ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisationObject != null && ctx.contact[0].organisationObject.default != null && ctx.contact[0].organisationObject.default != '') {
+  ok++
 }
 if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].email != null && ctx.contact[0].email != '') {
   ok++

--- a/tools/pipelines/register-es-pipelines.js
+++ b/tools/pipelines/register-es-pipelines.js
@@ -50,7 +50,7 @@ program
 
 program.parse(process.argv)
 
-const VERSION = 103 // increment on changes
+const VERSION = 104 // increment on changes
 
 const GEONETWORK_UI_PIPELINE = {
   description: 'GeoNetwork-UI pipeline',
@@ -82,11 +82,11 @@ if(ctx.resourceAbstractObject != null && ctx.resourceAbstractObject.default != n
   ok++
 }
 // this checks for single-language Organizations (GN 4.2.2)
-if(!isService && ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisation != null && ctx.contact[0].organisation != '') {
+if(type != 'service' && ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisation != null && ctx.contact[0].organisation != '') {
   ok++
 }
 // this checks for multilingual Organizations (GN 4.2.3+)
-if(!isService && ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisationObject != null && ctx.contact[0].organisationObject.default != null && ctx.contact[0].organisationObject.default != '') {
+if(type != 'service' && ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].organisationObject != null && ctx.contact[0].organisationObject.default != null && ctx.contact[0].organisationObject.default != '') {
   ok++
 }
 if(ctx.contact != null && ctx.contact.length > 0 && ctx.contact[0].email != null && ctx.contact[0].email != '') {


### PR DESCRIPTION
### Description

This PR is a follow-up of https://github.com/geonetwork/geonetwork-ui/pull/1288.

It reverts the check on `organisation.name` which breaks the pipeline in GN 4.2.2.

Also adds a commit (5cdf36806217c5a1f70305ca1f90696f4efe1495) to take the service capablities URL into account in the score calculation in GN 4.2.2.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

- Check if pipeline does not prooke error with GN 4.2.2.
- Check if quality score is correct (in particular service capabilities in GN 4.2.2)


<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
