### PR TITLE
Datahub: Fix TMS display without style

### DIFF
--- a/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
@@ -561,14 +561,14 @@ describe('MapViewComponent', () => {
           tick(200)
           fixture.detectChanges()
         }))
-        it('emits a map context using mvt tile format with root url', () => {
+        it('emits a map context using mvt tile format with url including the layer name', () => {
           expect(mapComponent.context).toEqual({
             layers: [
               {
                 name: 'orthophoto',
                 type: 'xyz',
                 tileFormat: 'application/vnd.mapbox-vector-tile',
-                url: 'http://abcd.com/tms/{z}/{x}/{y}.pbf',
+                url: 'http://abcd.com/tms/orthophoto/{z}/{x}/{y}.pbf',
               },
             ],
             view: expect.any(Object),
@@ -589,14 +589,14 @@ describe('MapViewComponent', () => {
           tick(200)
           fixture.detectChanges()
         }))
-        it('still emits a map context using mvt tile format with root url', () => {
+        it('still emits a map context using mvt tile format with url including the layer name', () => {
           expect(mapComponent.context).toEqual({
             layers: [
               {
                 name: 'tmserror',
                 type: 'xyz',
                 tileFormat: 'application/vnd.mapbox-vector-tile',
-                url: 'http://error.com/tms/{z}/{x}/{y}.pbf',
+                url: 'http://error.com/tms/tmserror/{z}/{x}/{y}.pbf',
               },
             ],
             view: expect.any(Object),

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -389,7 +389,9 @@ export class MapViewComponent implements AfterViewInit {
     ) {
       // FIXME: here we're assuming that the TMS serves vector tiles only; should be checked with ogc-client first
       return of({
-        url: link.url.toString().replace(/\/?$/, '/{z}/{x}/{y}.pbf'),
+        url: link.url
+          .toString()
+          .replace(/\/?$/, `/${link.name}/{z}/{x}/{y}.pbf`),
         type: 'xyz',
         tileFormat: 'application/vnd.mapbox-vector-tile',
         name: link.name,


### PR DESCRIPTION
### Description

This PR adds the `layer.name` to the TMS URL to be displayed on the map, instead of using the root URL for TMS without a style. This assumes, that the URL in the metadata is the root URL for a TMS and does not contain the layer name.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

- Point the datahub to  `geonetwork4_api_url = "https://data-qua.priv.geopf.fr/catalog"` in the `default.toml`
- Check that TMS without style display correctly on map (and in API section)
  - http://localhost:4200/dataset/ia_gpkg_22-04-2024_wfs_050625
  - http://localhost:4200/dataset/IGNF_BD-TOPO_withFC_csw_newTMS
  - ...
- Check that TMS with style display correctly (and in API section)
  - http://localhost:4200/dataset/IGNF_PLAN-IGN
  - ...

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
