### PR TITLE
Better spatial query

### DIFF
--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -145,11 +145,33 @@ Indicates whether the quick filter (by record kind dataset, service or reuse) be
 
 - `filter_geometry_url` or `filter_geometry_data` (optional)
 
-Specify a GeoJSON object to be used as filter: all records contained inside the geometry will be **boosted on top**, all records which do not intersect with the geometry will be **shown with lower priority**.
+Specifies a GeoJSON geometry to be used as filter. The GeoJSON geometry can be specified either as URL or inline data.
 
-The GeoJSON geometry can be specified either as URL or inline data.
+The filter geometry does not actually exclude results from the search; instead, it simply "boosts" the relevancy of results in that geometry.
 
-Note: if the GeoJSON object contains multiple features, only the geometry of the first one will be kept!
+::: tip
+
+This parameter has no effect if results are not sorted by relevancy!
+
+:::
+
+The following logic is applied when a filter geometry is provided:
+
+| Location of the record relative to the filter geometry                | Relative boost |
+| --------------------------------------------------------------------- | -------------- |
+| **within the geometry** and **close to the geometry center**          | `+1`           |
+| **within the geometry** but **on the outskirt** of the geometry       | `+0.75`        |
+| **intersecting the geometry** and **on the outskirt** of the geometry | `+0.5`         |
+| **intersecting the geometry** but slightly further from the geometry  | `0`            |
+| not intersecting but **close to the geometry**                        | `-0.5`         |
+| **intersecting** but **located very far away**                        | `-0.75`        |
+| not intersecting and far away                                         | `-1`           |
+
+::: info
+
+If the GeoJSON object contains multiple features, only the geometry of the first one will be kept.
+
+:::
 
 - `advanced_filters` (optional)
 

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -615,7 +615,7 @@ describe('ElasticsearchService', () => {
                     shape: geojsonPolygon,
                     relation: 'within',
                   },
-                  boost: 10.0,
+                  boost: 5.0,
                 },
               },
               {
@@ -624,7 +624,15 @@ describe('ElasticsearchService', () => {
                     shape: geojsonPolygon,
                     relation: 'intersects',
                   },
-                  boost: 7.0,
+                  boost: 2.0,
+                },
+              },
+              {
+                distance_feature: {
+                  boost: 5,
+                  field: 'location',
+                  origin: [3.063904886799392, 50.635541344891436],
+                  pivot: '2848m',
                 },
               },
             ],

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -354,15 +354,11 @@ export class ElasticsearchService {
       })
     }
     if (geometry) {
-      // boosting will happen like so when a geometry is provided:
-      // * records completely within the geometry and close to the center will have a maximum boost of 10
-      // * records within the geometry but on the outskirt will have a boost of ~8
-      // * records intersecting the geometry and on the outskirt will have a boost of ~7
-      // * records intersecting the geometry but slightly further from the geometry will have a boost of ~4
-      // * records not intersecting but close to the geometry will have a boost of ~2
-      // * records intersecting but located very far away will have a boost of ~2
-      // * records not intersecting and far away will have a boost of ~0
-
+      // boosts applied using the filter geometry:
+      // * records completely within the geometry receive a boost of 5
+      // * records intersecting the geometry receive a boost of 2
+      // * records close to the geometry center receive a boost of 5 (based on the `location` field)
+      // * records on the outskirt of the geometry receive a boost of 2.5
       should.push(
         {
           geo_shape: {

--- a/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
@@ -45,7 +45,7 @@ describe('MapUtilsService', () => {
           },
         ],
       }
-      expect(service.getRecordExtent(record)).toEqual([...[1, 3], ...[8, 8]])
+      expect(service.getRecordExtent(record)).toEqual([1, 3, 8, 8])
     })
   })
 })

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -1,25 +1,25 @@
 import { Injectable } from '@angular/core'
-import { extend, Extent } from 'ol/extent'
-import GeoJSON from 'ol/format/GeoJSON'
+import { extend } from 'ol/extent'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
-
-const GEOJSON = new GeoJSON()
+import { BoundingBox, getGeometryBoundingBox } from '@geonetwork-ui/util/shared'
 
 @Injectable({
   providedIn: 'root',
 })
 export class MapUtilsService {
-  getRecordExtent(record: Partial<CatalogRecord>): Extent {
+  getRecordExtent(record: Partial<CatalogRecord>): BoundingBox {
     if (!('spatialExtents' in record) || record.spatialExtents.length === 0) {
       return null
     }
     // extend all the spatial extents into an including bbox
     return record.spatialExtents.reduce(
       (prev, curr) => {
-        if ('bbox' in curr) return extend(prev, curr.bbox)
+        if ('bbox' in curr) return extend(prev, curr.bbox) as BoundingBox
         else if ('geometry' in curr) {
-          const geom = GEOJSON.readGeometry(curr.geometry)
-          return extend(prev, geom.getExtent())
+          return extend(
+            prev,
+            getGeometryBoundingBox(curr.geometry)
+          ) as BoundingBox
         }
         return prev
       },

--- a/libs/util/shared/src/lib/utils/geojson.spec.ts
+++ b/libs/util/shared/src/lib/utils/geojson.spec.ts
@@ -1,5 +1,13 @@
-import { getGeometryFromGeoJSON } from './geojson'
-import { GeometryCollection } from 'geojson'
+import { getGeometryBoundingBox, getGeometryFromGeoJSON } from './geojson'
+import {
+  GeometryCollection,
+  LineString,
+  MultiLineString,
+  MultiPoint,
+  MultiPolygon,
+  Point,
+  Polygon,
+} from 'geojson'
 import { polygonFeatureCollectionFixture } from '@geonetwork-ui/common/fixtures'
 
 describe('geojson utils', () => {
@@ -48,6 +56,106 @@ describe('geojson utils', () => {
       it('returns null', () => {
         expect(getGeometryFromGeoJSON(input)).toBe(null)
       })
+    })
+  })
+
+  describe('getGeometryBoundingBox', () => {
+    const polygon: Polygon = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [1, 1],
+          [1, 4],
+          [4, 4],
+          [4, 1],
+          [1, 1],
+        ],
+        [
+          [2, 2],
+          [2, 3],
+          [130, 3],
+          [130, 2],
+          [2, 2],
+        ],
+      ],
+    }
+    const lineString: LineString = {
+      type: 'LineString',
+      coordinates: [
+        [10, 20],
+        [20, 20],
+        [50, 10],
+        [100, -5],
+        [-100, -100],
+      ],
+    }
+    const point: Point = {
+      type: 'Point',
+      coordinates: [50, -200],
+    }
+
+    it('computes the bounding box correctly for a Polygon', () => {
+      const bbox = getGeometryBoundingBox(polygon)
+      expect(bbox).toEqual([1, 1, 130, 4])
+    })
+    it('computes the bounding box correctly for a LineString', () => {
+      const bbox = getGeometryBoundingBox(lineString)
+      expect(bbox).toEqual([-100, -100, 100, 20])
+    })
+    it('computes the bounding box correctly for a Point', () => {
+      const bbox = getGeometryBoundingBox(point)
+      expect(bbox).toEqual([50, -200, 50, -200])
+    })
+    it('computes the bounding box correctly for a MultiPolygon', () => {
+      const multiPolygon: MultiPolygon = {
+        type: 'MultiPolygon',
+        coordinates: [
+          polygon.coordinates,
+          [
+            [
+              [-20, -20],
+              [-20, 30],
+              [20, 30],
+              [20, -20],
+              [-20, -20],
+            ],
+          ],
+        ],
+      }
+      const bbox = getGeometryBoundingBox(multiPolygon)
+      expect(bbox).toEqual([-20, -20, 130, 30])
+    })
+    it('computes the bounding box correctly for a MultiLineString', () => {
+      const multiLineString: MultiLineString = {
+        type: 'MultiLineString',
+        coordinates: [
+          lineString.coordinates,
+          [
+            [-2, -2],
+            [2, 3],
+            [150, 200],
+            [100, 10],
+          ],
+        ],
+      }
+      const bbox = getGeometryBoundingBox(multiLineString)
+      expect(bbox).toEqual([-100, -100, 150, 200])
+    })
+    it('computes the bounding box correctly for a MultiPoint', () => {
+      const multiPoint: MultiPoint = {
+        type: 'MultiPoint',
+        coordinates: [point.coordinates, [200, 300]],
+      }
+      const bbox = getGeometryBoundingBox(multiPoint)
+      expect(bbox).toEqual([50, -200, 200, 300])
+    })
+    it('computes the bounding box correctly for a GeometryCollection', () => {
+      const geom: GeometryCollection = {
+        type: 'GeometryCollection',
+        geometries: [lineString, polygon, point],
+      }
+      const bbox = getGeometryBoundingBox(geom)
+      expect(bbox).toEqual([-100, -200, 130, 20])
     })
   })
 })

--- a/libs/util/shared/src/lib/utils/geojson.ts
+++ b/libs/util/shared/src/lib/utils/geojson.ts
@@ -1,8 +1,11 @@
-import { Feature, FeatureCollection, Geometry } from 'geojson'
+import type { Feature, FeatureCollection, Geometry, Position } from 'geojson'
 
+/**
+ * @returns The geometry if available, otherwise null.
+ */
 export function getGeometryFromGeoJSON(
   data: FeatureCollection | Feature | Geometry
-): Geometry {
+): Geometry | null {
   if (data.type === 'FeatureCollection') {
     return data?.features?.[0]?.geometry || null
   }
@@ -23,4 +26,71 @@ export function getGeometryFromGeoJSON(
     return data || null
   }
   return null
+}
+
+// FIXME: this type should be more generic across the project
+export type BoundingBox = [number, number, number, number]
+
+export function getGeometryBoundingBox(geometry: Geometry): BoundingBox {
+  // use the bounding box if specified in the GeoJSON object
+  if (geometry.bbox) {
+    return geometry.bbox.length > 4
+      ? [geometry.bbox[0], geometry.bbox[1], geometry.bbox[3], geometry.bbox[4]]
+      : (geometry.bbox as BoundingBox)
+  }
+
+  const coordinatesReducer = (prev: BoundingBox, coords: Position) =>
+    [
+      Math.min(prev[0], coords[0]),
+      Math.min(prev[1], coords[1]),
+      Math.max(prev[2], coords[0]),
+      Math.max(prev[3], coords[1]),
+    ] as BoundingBox
+  const coordinatesArrayReducer = (
+    prev: BoundingBox,
+    coordsArray: Position[]
+  ) => {
+    const bbox = coordsArray.reduce(coordinatesReducer, emptyExtent)
+    return [
+      Math.min(prev[0], bbox[0]),
+      Math.min(prev[1], bbox[1]),
+      Math.max(prev[2], bbox[2]),
+      Math.max(prev[3], bbox[3]),
+    ] as BoundingBox
+  }
+  const emptyExtent = [Infinity, Infinity, -Infinity, -Infinity] as BoundingBox
+
+  switch (geometry.type) {
+    case 'MultiPolygon':
+      return geometry.coordinates.reduce((prev, polygonCoords) => {
+        const bbox = polygonCoords.reduce(coordinatesArrayReducer, emptyExtent)
+        return [
+          Math.min(prev[0], bbox[0]),
+          Math.min(prev[1], bbox[1]),
+          Math.max(prev[2], bbox[2]),
+          Math.max(prev[3], bbox[3]),
+        ] as BoundingBox
+      }, emptyExtent)
+    case 'GeometryCollection':
+      return geometry.geometries.reduce((prev, geom) => {
+        const bbox = getGeometryBoundingBox(geom)
+        return [
+          Math.min(prev[0], bbox[0]),
+          Math.min(prev[1], bbox[1]),
+          Math.max(prev[2], bbox[2]),
+          Math.max(prev[3], bbox[3]),
+        ] as BoundingBox
+      }, emptyExtent)
+    case 'Polygon':
+    case 'MultiLineString':
+      return geometry.coordinates.reduce(coordinatesArrayReducer, emptyExtent)
+    case 'LineString':
+    case 'MultiPoint':
+      return geometry.coordinates.reduce<BoundingBox>(
+        coordinatesReducer,
+        emptyExtent
+      )
+    case 'Point':
+      return coordinatesReducer(emptyExtent, geometry.coordinates)
+  }
 }


### PR DESCRIPTION
### Description

Implements https://github.com/geonetwork/geonetwork-ui/issues/1286

When a `filter_geometry` is specified in the configuration, the distance between records and this geometry is now also taken into account when boosting records accordingly. This should result in better results when doing spatial searches.

This changes also impact the Standalone Search when calling `GNUI.recordsRepository.search({..., geometry: ...})`

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

None

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [x] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Start the Datahub locally using `nx serve datahub`
1. Specify a geometry in the `default.toml` config file:
```toml
filter_geometry_data = '''
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "coordinates": [
          [
            [
              2.6445356971199487,
              51.46980190817237
            ],
            [
              2.6445356971199487,
              50.32165144785273
            ],
            [
              5.97151956114206,
              50.32165144785273
            ],
            [
              5.97151956114206,
              51.46980190817237
            ],
            [
              2.6445356971199487,
              51.46980190817237
            ]
          ]
        ],
        "type": "Polygon"
      }
    }
  ]
}
'''
```
<img width="813" height="487" alt="image" src="https://github.com/user-attachments/assets/4d8caf62-88bd-4b34-af55-a7dbbbe3bb60" />


3. Notice that records relevant to that extent are shown on top.

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

Sponsored by Swisstopo
