### PR TITLE
[Datahub]: Fix organizations with slash

### DIFF
--- a/apps/datahub/src/app/organization/organization-page/organization-page.component.spec.ts
+++ b/apps/datahub/src/app/organization/organization-page/organization-page.component.spec.ts
@@ -64,5 +64,23 @@ describe('OrganizationPageComponent', () => {
         expect(org).toBe(expectedOrganization)
       })
     })
+    it('should match orgs with a slash', () => {
+      const orgWithSlash = {
+        ...expectedOrganization,
+        name: 'org/withslash',
+      }
+
+      const orgService = TestBed.inject(OrganizationsServiceInterface) as any
+      orgService.organisations$ = of([orgWithSlash])
+
+      const router = TestBed.inject(RouterFacade) as any
+      router.pathParams$ = of({ name: 'orgwithslash' })
+
+      component.ngOnInit()
+
+      component.organization$.subscribe((org) => {
+        expect(org).toEqual(orgWithSlash)
+      })
+    })
   })
 })

--- a/apps/datahub/src/app/organization/organization-page/organization-page.component.ts
+++ b/apps/datahub/src/app/organization/organization-page/organization-page.component.ts
@@ -40,7 +40,8 @@ export class OrganizationPageComponent implements OnInit {
       filter(([pathParams, _]) => Object.keys(pathParams).length > 0),
       switchMap(([pathParams, organizations]) => {
         const organization = organizations.find(
-          (organization) => organization.name === pathParams['name']
+          (organization) =>
+            organization.name.replace('/', '') === pathParams['name']
         )
         return of(organization)
       })

--- a/libs/feature/router/src/lib/default/state/router.facade.ts
+++ b/libs/feature/router/src/lib/default/state/router.facade.ts
@@ -63,7 +63,8 @@ export class RouterFacade {
   }
 
   goToOrganization(organizationName: string) {
-    const path = `${this.routerService.getOrganizationPageRoute()}/${organizationName}`
+    const safeOrgName = organizationName.replace('/', '')
+    const path = `${this.routerService.getOrganizationPageRoute()}/${safeOrgName}`
     this.go({
       path,
       queryParamsHandling: '',


### PR DESCRIPTION
### Description

This PR fixes the behavior where an Organization with a name such as "Abc / def", with a slash is not recognized when opening the organization page. The user was re-routed to the /news page.

To fix it, the slash is removed from the path and from the matching upon initialization of the organization page.

### Architectural changes

None

### Screenshots

No UI change

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Import a record with an orgName that contains a slash, such as https://dev.geo2france.fr/geonetwork/srv/fre/catalog.search#/metadata/f63f945a-8295-40b0-90e3-83c1cff208d4
Go to `http://localhost:4200/organisations` and look for the org "MEEM / DGALN". Click on it, and verify that the dedicated org page opens.