### PR TITLE
Standalone Search / Support changing metadata language after initialization

### DIFF
--- a/apps/webcomponents/src/app/configuration.ts
+++ b/apps/webcomponents/src/app/configuration.ts
@@ -13,4 +13,5 @@ export const standaloneConfigurationObject = {
   apiConfiguration: new Configuration(),
   textLanguage: 'browser',
   metadataLanguage: null,
+  metadataLanguageFactory: () => standaloneConfigurationObject.metadataLanguage,
 }

--- a/apps/webcomponents/src/app/standalone-search.module.ts
+++ b/apps/webcomponents/src/app/standalone-search.module.ts
@@ -31,7 +31,7 @@ import {
   providers: [
     {
       provide: METADATA_LANGUAGE,
-      useFactory: () => standaloneConfigurationObject.metadataLanguage,
+      useFactory: () => standaloneConfigurationObject.metadataLanguageFactory,
     },
     provideHttpClient(),
     {

--- a/apps/webcomponents/src/app/standalone-search.module.ts
+++ b/apps/webcomponents/src/app/standalone-search.module.ts
@@ -31,7 +31,7 @@ import {
   providers: [
     {
       provide: METADATA_LANGUAGE,
-      useFactory: () => standaloneConfigurationObject.metadataLanguageFactory,
+      useValue: standaloneConfigurationObject.metadataLanguageFactory,
     },
     provideHttpClient(),
     {

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -13,7 +13,7 @@ datahub_url = "/datahub"
 # This is an optional parameter: leave empty to disable proxy usage
 proxy_path = ""
 # This optional parameter defines, in which language metadata should be queried in elasticsearch.
-# Use ISO 639-2/B (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format to indicate the language of the metadata.
+# Use ISO 639-1 (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format in 2 characters to indicate the language of the metadata.
 # Setting to "current" will use the current language of the User Interface.
 # If not indicated, a wildcard is used and no language preference is applied for the search.
 # metadata_language = "current"

--- a/docs/developers/i18n.md
+++ b/docs/developers/i18n.md
@@ -61,7 +61,7 @@ The `TranslateService` service can be injected anywhere and offers several funct
 - reading the current language using `currentLang` (this gives the value at a certain time and is not an observable)
 - changing the current language using the `use()` method
 
-Languages in GeoNetwork-UI should always be identified by their [two-character codes following the ISO-639-1 list](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+Languages in GeoNetwork-UI should always be identified by their [two-character codes following the ISO 639-1 list](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
 
 ## Supported languages
 

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -37,7 +37,7 @@ Some additional notes:
 
   This optional parameter defines the languages that will be provided in the UI language switcher. Available languages are listed [in this file](https://github.com/geonetwork/geonetwork-ui/blob/1533e02e24258814ef19f21e991a45e01fd06f36/libs/util/i18n/src/lib/i18n.constants.ts#L25).
 
-  Languages should be provided as an array, for instance:
+  Languages should be provided as ISO 639 codes in an array, for instance:
 
   ```toml
   languages = ['en', 'fr', 'de']
@@ -49,7 +49,7 @@ Some additional notes:
 
   This optional parameter lets you specify which language to use when searching in the catalog connected to GeoNetwork-UI. This might improve the search experience by showing results relevant to your users' language.
 
-  Use [ISO three-letter codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) to indicate the language used in the search (e.g. "fre" or "ger"). Alternatively, setting to "current" will use the current language of the User Interface.
+  Use [ISO 639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) to indicate the language used in the search (e.g. `fr` or `de`). Alternatively, a value of `current` will use the current language of the User Interface.
 
   If not indicated, the search will be done across all localized values for each record, potentially showing more results that expected or unrelated results.
 
@@ -65,9 +65,9 @@ Some additional notes:
 
   The following three placeholders can be part of this URL:
 
-  - `${current_url}`: indicates where the current location should be injected in the constructed login URL
+  - `${current_url}`: replaced by the current browser URL
 
-  - `${lang2}`, `${lang3}`: indicates if and where the current language should be part of the login URL in 2- or 3-letters ISO format
+  - `${lang2}`, `${lang3}`: replaced by the SIO-639 code of the current language, respectively in in 2- or 3-characters format
 
   Example for a platform relying on CAS:
 

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -16,7 +16,7 @@ This file uses the [TOML format](https://toml.io/en/), which is an easy-to-read 
 
 Some additional notes:
 
-- Languages in the configuration are specified using [two-letters ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) unless noted otherwise
+- Languages in the configuration should be specified using [two-letters ISO 639-1 codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes); 3-character codes might work but using them is not recommended
 - Tokens in URL templates are specified using the `${token_name}` syntax
 
 ### Sections

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -67,7 +67,7 @@ Some additional notes:
 
   - `${current_url}`: replaced by the current browser URL
 
-  - `${lang2}`, `${lang3}`: replaced by the SIO-639 code of the current language, respectively in in 2- or 3-characters format
+  - `${lang2}`, `${lang3}`: replaced by the ISO-639 code of the current language, respectively in 2- or 3-characters format
 
   Example for a platform relying on CAS:
 

--- a/docs/guide/standalone-search.md
+++ b/docs/guide/standalone-search.md
@@ -15,7 +15,7 @@ To use the Standalone Search, you have to:
 - import the Standalone Search script exported by Angular (available via jsdelivr)
 - call `GNUI.init(options)` with the following options:
   - `apiUrl`: the URL of the GeoNetwork API to use
-  - `textLanguage`: the language to use for labels; can be either `localStorage` (will read the language from local storage as described in [this section](../developers/i18n.md#how-the-user-interface-language-is-detected)), `browser` (will use the browser language) or a 2-char code (e.g. `en`)
+  - `textLanguage`: the language to use for labels; can be either `localStorage` (will read the language from local storage as described in [this section](../developers/i18n.md#how-the-user-interface-language-is-detected)), `browser` (will use the browser language) or an ISO 639 language code (e.g. `en`)
   - `metadataLanguage`: identical to the [`metadata_language` configuration option](./configure.md#global)
 
 ```html

--- a/libs/api/metadata-converter/src/lib/dcat-ap/read-parts.ts
+++ b/libs/api/metadata-converter/src/lib/dcat-ap/read-parts.ts
@@ -18,7 +18,7 @@ import { getAsValidUrl } from '../common/url'
 import { fullNameToParts } from '../iso19139/utils/individual-name'
 import { readLicenseFromString } from '../common/license'
 import { matchProtocol } from '../common/distribution.mapper'
-import { getLang2FromLang3 } from '@geonetwork-ui/util/i18n/language-codes'
+import { toLang2 } from '@geonetwork-ui/util/i18n/language-codes'
 
 function getDatasetNode(dataStore: Store, recordNode: NamedNode): NamedNode {
   return (dataStore.the(recordNode, FOAF('primaryTopic'), null) ||
@@ -455,9 +455,6 @@ export function readDefaultLanguage(dataStore: Store, recordNode: NamedNode) {
   }
   if (!statements.length) return null
   const languageNode = statements[0].object as NamedNode
-  let language = languageNode.value.split('/').pop().toLowerCase()
-  if (language.length === 3) {
-    language = getLang2FromLang3(language) ?? language
-  }
-  return language.substring(0, 2)
+  const language = languageNode.value.split('/').pop().toLowerCase()
+  return toLang2(language) ?? language
 }

--- a/libs/api/metadata-converter/src/lib/gn4/metadata-url.service.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/metadata-url.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from '@angular/core'
 import { Configuration } from '@geonetwork-ui/data-access/gn4'
 import { TranslateService } from '@ngx-translate/core'
-import { getLang3FromLang2 } from '@geonetwork-ui/util/i18n'
+import { toLang3 } from '@geonetwork-ui/util/i18n'
 
 @Injectable({
   providedIn: 'root',
@@ -14,7 +14,7 @@ export class MetadataUrlService {
 
   getUrl(uuid: string, apiPath: string = this.apiConfiguration.basePath) {
     const prefix = `${apiPath}/../`
-    return `${prefix}${getLang3FromLang2(
+    return `${prefix}${toLang3(
       this.translate.currentLang
     )}/catalog.search#/metadata/${uuid}`
   }

--- a/libs/api/metadata-converter/src/lib/iso19115-3/read-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19115-3/read-parts.ts
@@ -41,7 +41,7 @@ import {
 } from '@geonetwork-ui/common/domain/model/record'
 import { matchMimeType } from '../common/distribution.mapper'
 import { fullNameToParts } from '../iso19139/utils/individual-name'
-import { getLang2FromLang3 } from '@geonetwork-ui/util/i18n/language-codes'
+import { toLang2 } from '@geonetwork-ui/util/i18n/language-codes'
 import { getResourceType, getReuseType } from '../common/resource-types'
 
 export function readKind(rootEl: XmlElement): RecordKind {
@@ -370,7 +370,7 @@ export function readLocaleElement(): ChainableFunction<
   return pipe(
     findChildElement('lan:LanguageCode'),
     readAttribute('codeListValue'),
-    map((lang) => getLang2FromLang3(lang?.toLowerCase()) ?? lang)
+    map((lang) => toLang2(lang?.toLowerCase()) ?? lang)
   )
 }
 

--- a/libs/api/metadata-converter/src/lib/iso19115-3/write-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19115-3/write-parts.ts
@@ -49,7 +49,7 @@ import {
 } from '../iso19139/write-parts'
 import { findIdentification } from '../iso19139/read-parts'
 import { namePartsToFull } from '../iso19139/utils/individual-name'
-import { getLang3FromLang2 } from '@geonetwork-ui/util/i18n/language-codes'
+import { toLang3 } from '@geonetwork-ui/util/i18n/language-codes'
 import { kindToCodeListValue } from '../common/resource-types'
 
 export function writeUniqueIdentifier(
@@ -529,7 +529,7 @@ export function writeOnlineResources(
 }
 
 function writeLocaleElement(language: LanguageCode) {
-  const lang3 = getLang3FromLang2(language.toLowerCase()) ?? language
+  const lang3 = toLang3(language.toLowerCase()) ?? language
   return pipe(
     findChildOrCreate('lan:PT_Locale'),
     writeAttribute('id', language.toUpperCase()),

--- a/libs/api/metadata-converter/src/lib/iso19139/read-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/read-parts.ts
@@ -55,7 +55,7 @@ import { getKeywordTypeFromKeywordTypeCode } from './utils/keyword.mapper'
 import { getRoleFromRoleCode } from './utils/role.mapper'
 import { getStatusFromStatusCode } from './utils/status.mapper'
 import { getUpdateFrequencyFromFrequencyCode } from './utils/update-frequency.mapper'
-import { getLang2FromLang3 } from '@geonetwork-ui/util/i18n/language-codes'
+import { toLang2 } from '@geonetwork-ui/util/i18n/language-codes'
 import { getResourceType, getReuseType } from '../common/resource-types'
 
 export function extractCharacterString(): ChainableFunction<
@@ -1164,7 +1164,7 @@ export function readOtherLanguages(rootEl: XmlElement): LanguageCode[] {
       pipe(
         findChildElement('lan:LanguageCode'),
         readAttribute('codeListValue'),
-        map((lang) => getLang2FromLang3(lang?.toLowerCase()) ?? lang)
+        map((lang) => toLang2(lang?.toLowerCase()) ?? lang)
       )
     ),
     map((languages) =>
@@ -1179,7 +1179,7 @@ export function readDefaultLanguage(rootEl: XmlElement): LanguageCode {
     findChildElement('gmd:language', false),
     findChildElement('lan:LanguageCode'),
     readAttribute('codeListValue'),
-    map((lang) => (lang ? getLang2FromLang3(lang.toLowerCase()) : null))
+    map((lang) => (lang ? toLang2(lang.toLowerCase()) : null))
   )(rootEl)
 }
 

--- a/libs/api/metadata-converter/src/lib/iso19139/write-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/write-parts.ts
@@ -53,7 +53,7 @@ import {
 import { readKind } from './read-parts'
 import { writeGeometry } from './utils/geometry'
 import { namePartsToFull } from './utils/individual-name'
-import { getLang3FromLang2 } from '@geonetwork-ui/util/i18n/language-codes'
+import { toLang3 } from '@geonetwork-ui/util/i18n/language-codes'
 import { kindToCodeListValue } from '../common/resource-types'
 
 function writeLocalizedElement(
@@ -1476,7 +1476,7 @@ export function writeLanguages(record: DatasetRecord, rootEl: XmlElement) {
       writeAttribute('id', lang.toUpperCase()),
       createNestedChild('gmd:languageCode', 'gmd:LanguageCode'),
       writeAttribute('codeList', 'http://www.loc.gov/standards/iso639-2/'),
-      writeAttribute('codeListValue', getLang3FromLang2(lang) ?? lang)
+      writeAttribute('codeListValue', toLang3(lang) ?? lang)
     )
 
   // add new languages (only if other than default one)
@@ -1490,7 +1490,7 @@ export function writeDefaultLanguage(
   record: DatasetRecord,
   rootEl: XmlElement
 ) {
-  const lang3 = getLang3FromLang2(record.defaultLanguage.toLowerCase())
+  const lang3 = toLang3(record.defaultLanguage.toLowerCase())
   return pipe(
     findNestedChildOrCreate('gmd:language', 'gmd:LanguageCode'),
     writeAttribute('codeList', 'http://www.loc.gov/standards/iso639-2/'),

--- a/libs/api/repository/src/index.ts
+++ b/libs/api/repository/src/index.ts
@@ -1,3 +1,3 @@
-export * from './lib/metadata-language'
+export * from './lib/metadata-language.token'
 export * from './lib/repository-url'
 export * from './lib/gn4'

--- a/libs/api/repository/src/lib/gn4/auth/auth.service.ts
+++ b/libs/api/repository/src/lib/gn4/auth/auth.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, InjectionToken, Optional } from '@angular/core'
-import { getLang3FromLang2 } from '@geonetwork-ui/util/i18n'
+import { toLang2, toLang3 } from '@geonetwork-ui/util/i18n'
 import { TranslateService } from '@ngx-translate/core'
 import { Location } from '@angular/common'
 
@@ -35,8 +35,8 @@ export class AuthService {
         '${current_url}',
         new URL(this.location.path(), window.location.href).toString()
       )
-      .replace('${lang2}', this.translateService.currentLang)
-      .replace('${lang3}', getLang3FromLang2(this.translateService.currentLang))
+      .replace('${lang2}', toLang2(this.translateService.currentLang))
+      .replace('${lang3}', toLang3(this.translateService.currentLang))
   }
 
   get logoutUrl() {
@@ -46,7 +46,7 @@ export class AuthService {
   get settingsUrl() {
     return this.baseSettingsUrl.replace(
       '${lang3}',
-      getLang3FromLang2(this.translateService.currentLang)
+      toLang3(this.translateService.currentLang)
     )
   }
 

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -5,14 +5,14 @@ import {
 } from '@geonetwork-ui/common/fixtures'
 import { EsSearchParams } from '@geonetwork-ui/api/metadata-converter'
 import { TestBed } from '@angular/core/testing'
-import { METADATA_LANGUAGE } from '../../metadata-language'
+import { METADATA_LANGUAGE } from '../../metadata-language.token'
 import { TranslateService } from '@ngx-translate/core'
 
 class TranslateServiceMock {
   currentLang = 'en'
 }
 
-let currentMetadataLang: string
+let currentMetadataLang: string | (() => string)
 
 describe('ElasticsearchService', () => {
   let service: ElasticsearchService
@@ -1183,6 +1183,166 @@ Cette section contient des *caractères internationaux* (ainsi que des "caractè
             { type: 'histogram' } as any
           )
         ).toStrictEqual(expectedHistogram)
+      })
+    })
+  })
+
+  describe('with METADATA_LANGUAGE not set', () => {
+    beforeEach(() => {
+      TestBed.resetTestingModule()
+      TestBed.configureTestingModule({
+        providers: [
+          {
+            provide: TranslateService,
+            useClass: TranslateServiceMock,
+          },
+        ],
+      })
+      service = TestBed.inject(ElasticsearchService)
+    })
+    it('uses a catch-all behavior', () => {
+      const query = service['buildPayloadQuery'](
+        {
+          any: 'hello',
+        },
+        {}
+      )
+
+      expect(query).toEqual({
+        bool: {
+          filter: [
+            {
+              terms: {
+                isTemplate: ['n'],
+              },
+            },
+          ],
+          should: [],
+          must: [
+            {
+              query_string: {
+                default_operator: 'AND',
+                fields: [
+                  'resourceTitleObject.*^5',
+                  'tag.*^4',
+                  'resourceAbstractObject.*^3',
+                  'lineageObject.*^2',
+                  'any.*',
+                  'uuid',
+                ],
+                query: 'hello',
+              },
+            },
+          ],
+          must_not: [
+            {
+              query_string: {
+                query:
+                  'resourceType:featureCatalog AND !resourceType:dataset AND !cl_level.key:dataset',
+              },
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe('with METADATA_LANGUAGE set to a language factory instead of literal value', () => {
+    let langFactoryResult
+    beforeEach(() => {
+      langFactoryResult = 'ger'
+      currentMetadataLang = () => langFactoryResult // use a language factory
+      service = TestBed.inject(ElasticsearchService)
+    })
+    it('properly handles a language factory', () => {
+      const query = service['buildPayloadQuery'](
+        {
+          any: 'hello',
+        },
+        {}
+      )
+
+      expect(query).toEqual({
+        bool: {
+          filter: [
+            {
+              terms: {
+                isTemplate: ['n'],
+              },
+            },
+          ],
+          should: [],
+          must: [
+            {
+              query_string: {
+                default_operator: 'AND',
+                fields: [
+                  'resourceTitleObject.langger^5',
+                  'tag.langger^4',
+                  'resourceAbstractObject.langger^3',
+                  'lineageObject.langger^2',
+                  'any.langger',
+                  'uuid',
+                ],
+                query: 'hello',
+              },
+            },
+          ],
+          must_not: [
+            {
+              query_string: {
+                query:
+                  'resourceType:featureCatalog AND !resourceType:dataset AND !cl_level.key:dataset',
+              },
+            },
+          ],
+        },
+      })
+    })
+    it('properly handles a language value change', () => {
+      langFactoryResult = 'eng'
+      const query = service['buildPayloadQuery'](
+        {
+          any: 'hello',
+        },
+        {}
+      )
+
+      expect(query).toEqual({
+        bool: {
+          filter: [
+            {
+              terms: {
+                isTemplate: ['n'],
+              },
+            },
+          ],
+          should: [],
+          must: [
+            {
+              query_string: {
+                default_operator: 'AND',
+                fields: [
+                  'resourceTitleObject.langeng^5',
+                  'tag.langeng^4',
+                  'resourceAbstractObject.langeng^3',
+                  'lineageObject.langeng^2',
+                  'any.langeng',
+                  'uuid',
+                ],
+                query: 'hello',
+              },
+            },
+          ],
+          must_not: [
+            {
+              query_string: {
+                query:
+                  'resourceType:featureCatalog AND !resourceType:dataset AND !cl_level.key:dataset',
+              },
+            },
+          ],
+        },
       })
     })
   })

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -15,7 +15,7 @@ import {
   FiltersAggregationParams,
   SortByField,
 } from '@geonetwork-ui/common/domain/model/search'
-import { METADATA_LANGUAGE } from '../../metadata-language'
+import { METADATA_LANGUAGE } from '../../metadata-language.token'
 import {
   AggregationResult,
   EsSearchParams,
@@ -28,7 +28,10 @@ import {
 } from '@geonetwork-ui/api/metadata-converter'
 import { getLang3FromLang2 } from '@geonetwork-ui/util/i18n'
 import { formatDate, isDateRange } from './date-range.utils'
-import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
+import {
+  CatalogRecord,
+  LanguageCode,
+} from '@geonetwork-ui/common/domain/model/record'
 import { TranslateService } from '@ngx-translate/core'
 import { getGeometryBoundingBox } from '@geonetwork-ui/util/shared'
 import { getLength as getGeodesicLength } from 'ol/sphere'
@@ -48,8 +51,9 @@ export class ElasticsearchService {
   private get lang3() {
     return getLang3FromLang2(this.translateService.currentLang)
   }
-  private get metadataLang() {
-    return this.injector.get(METADATA_LANGUAGE, null)
+  private get metadataLang(): LanguageCode {
+    const mdLangValue = this.injector.get(METADATA_LANGUAGE, null)
+    return typeof mdLangValue === 'function' ? mdLangValue() : mdLangValue
   }
 
   constructor(

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -26,7 +26,7 @@ import {
   SortParams,
   TermsAggregationResult,
 } from '@geonetwork-ui/api/metadata-converter'
-import { getLang3FromLang2 } from '@geonetwork-ui/util/i18n'
+import { toLang3 } from '@geonetwork-ui/util/i18n'
 import { formatDate, isDateRange } from './date-range.utils'
 import {
   CatalogRecord,
@@ -48,9 +48,6 @@ export class ElasticsearchService {
   private runtimeFields: Record<string, string> = {}
 
   // we're using getters in case the defined languages change over time
-  private get lang3() {
-    return getLang3FromLang2(this.translateService.currentLang)
-  }
   private get metadataLang(): LanguageCode {
     const mdLangValue = this.injector.get(METADATA_LANGUAGE, null)
     return typeof mdLangValue === 'function' ? mdLangValue() : mdLangValue
@@ -237,9 +234,12 @@ export class ElasticsearchService {
 
   private getQueryLang(): string {
     if (this.metadataLang) {
-      return this.isCurrentSearchLang()
-        ? `lang${this.lang3}`
-        : `lang${this.metadataLang}`
+      const lang3 = toLang3(
+        this.isCurrentSearchLang()
+          ? this.translateService.currentLang
+          : this.metadataLang
+      )
+      return `lang${lang3}`
     } else return '*'
   }
   private isCurrentSearchLang() {

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -48,7 +48,7 @@ import {
 import { catchError, map, tap } from 'rxjs/operators'
 import { lt } from 'semver'
 import { ElasticsearchService } from './elasticsearch'
-import { getLang2FromLang3 } from '@geonetwork-ui/util/i18n'
+import { toLang2 } from '@geonetwork-ui/util/i18n'
 import { Gn4SettingsService } from './settings/gn4-settings.service'
 
 const minPublicationApiVersion = '4.2.5'
@@ -562,7 +562,7 @@ export class Gn4Repository implements RecordsRepositoryInterface {
       .pipe(
         map((languages) =>
           languages
-            .map((lang) => getLang2FromLang3(lang.id))
+            .map((lang) => toLang2(lang.id))
             .filter((code): code is string => !!code)
         )
       )

--- a/libs/api/repository/src/lib/gn4/organizations/organizations-from-groups.service.ts
+++ b/libs/api/repository/src/lib/gn4/organizations/organizations-from-groups.service.ts
@@ -7,7 +7,7 @@ import {
 import { forkJoin, Observable, of } from 'rxjs'
 import { map, shareReplay } from 'rxjs/operators'
 import { TranslateService } from '@ngx-translate/core'
-import { getLang3FromLang2 } from '@geonetwork-ui/util/i18n'
+import { toLang3 } from '@geonetwork-ui/util/i18n'
 import { FieldFilters } from '@geonetwork-ui/common/domain/model/search'
 import {
   CatalogRecord,
@@ -52,7 +52,7 @@ export class OrganizationsFromGroupsService
   organisationsCount$ = this.organisations$.pipe(map((orgs) => orgs.length))
 
   private get lang3() {
-    return getLang3FromLang2(this.translateService.currentLang)
+    return toLang3(this.translateService.currentLang)
   }
 
   constructor(

--- a/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.ts
+++ b/libs/api/repository/src/lib/gn4/organizations/organizations-from-metadata.service.ts
@@ -33,7 +33,7 @@ import {
   tap,
   withLatestFrom,
 } from 'rxjs/operators'
-import { getLocalizedIndexKey } from '@geonetwork-ui/util/i18n'
+import { toLang3 } from '@geonetwork-ui/util/i18n'
 import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.service.interface'
 import { coerce, satisfies, valid } from 'semver'
 import { TranslateService } from '@ngx-translate/core'
@@ -126,7 +126,7 @@ export class OrganizationsFromMetadataService
   ) {}
 
   private get langIndex() {
-    return getLocalizedIndexKey(this.translateService.currentLang)
+    return `lang${toLang3(this.translateService.currentLang)}`
   }
 
   equalsNormalizedStrings(

--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.ts
@@ -45,7 +45,7 @@ import {
   throwError,
 } from 'rxjs'
 import { TranslateService } from '@ngx-translate/core'
-import { getLang3FromLang2 } from '@geonetwork-ui/util/i18n'
+import { toLang3 } from '@geonetwork-ui/util/i18n'
 
 const minApiVersion = '4.2.2'
 
@@ -98,7 +98,7 @@ export class Gn4PlatformService implements PlatformServiceInterface {
   private keywordsByThesauri: Record<string, Observable<Keyword[]>> = {}
 
   private get lang3() {
-    return getLang3FromLang2(this.translateService.currentLang)
+    return toLang3(this.translateService.currentLang)
   }
 
   constructor(

--- a/libs/api/repository/src/lib/metadata-language.token.ts
+++ b/libs/api/repository/src/lib/metadata-language.token.ts
@@ -1,0 +1,8 @@
+import { InjectionToken } from '@angular/core'
+import { LanguageCode } from '@geonetwork-ui/common/domain/model/record'
+
+export type LanguageCodeFactory = () => LanguageCode
+
+export const METADATA_LANGUAGE = new InjectionToken<
+  LanguageCode | LanguageCodeFactory
+>('metadata-language')

--- a/libs/api/repository/src/lib/metadata-language.ts
+++ b/libs/api/repository/src/lib/metadata-language.ts
@@ -1,3 +1,0 @@
-import { InjectionToken } from '@angular/core'
-
-export const METADATA_LANGUAGE = new InjectionToken<string>('metadata-language')

--- a/libs/feature/catalog/src/lib/sources/sources.service.ts
+++ b/libs/feature/catalog/src/lib/sources/sources.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs'
 import { filter, map, shareReplay } from 'rxjs/operators'
 import { CatalogSource } from './sources.model'
 import { TranslateService } from '@ngx-translate/core'
-import { getLang3FromLang2 } from '@geonetwork-ui/util/i18n'
+import { toLang3 } from '@geonetwork-ui/util/i18n'
 
 @Injectable({
   providedIn: 'root',
@@ -23,10 +23,7 @@ export class SourcesService {
     return this.sources$.pipe(
       map((sources) => sources.filter((source) => source.uuid === uuid)[0]),
       filter((source) => !!source),
-      map(
-        (source) =>
-          source.label[getLang3FromLang2(this.translateService.currentLang)]
-      )
+      map((source) => source.label[toLang3(this.translateService.currentLang)])
     )
   }
 }

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -85,7 +85,7 @@ describe('app config utils', () => {
     describe('loadAppConfig', () => {
       it('logs a warning', () => {
         expect(console.warn).toHaveBeenCalledWith(
-          expect.stringMatching(/(?=.*metadata_language = "fra")/)
+          expect.stringMatching(/(?=.*metadata_language = "abc")/)
         )
       })
     })
@@ -94,7 +94,7 @@ describe('app config utils', () => {
         expect(getGlobalConfig()).toEqual({
           GN4_API_URL: '/geonetwork/srv/api',
           PROXY_PATH: '/proxy/?url=',
-          METADATA_LANGUAGE: 'fra',
+          METADATA_LANGUAGE: 'abc',
         })
       })
     })

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -124,7 +124,7 @@ export const wrongLanguageCodeConfigFixture = () => `
 [global]
 geonetwork4_api_url = "/geonetwork/srv/api"
 proxy_path = "/proxy/?url="
-metadata_language = "fra"
+metadata_language = "abc"
 
 [map]
 

--- a/libs/util/app-config/src/lib/parse-utils.ts
+++ b/libs/util/app-config/src/lib/parse-utils.ts
@@ -1,4 +1,4 @@
-import { LANGUAGE_CODES_ISO_3 } from './constants'
+import { toLang2 } from '@geonetwork-ui/util/i18n'
 
 const flatten = (
   base: string,
@@ -129,13 +129,10 @@ export function checkMetadataLanguage(
   parsedConfigSection: any,
   outWarnings: string[]
 ) {
-  if (
-    LANGUAGE_CODES_ISO_3.indexOf(
-      parsedConfigSection.metadata_language.toLowerCase()
-    ) === -1
-  ) {
+  const lang2 = toLang2(parsedConfigSection.metadata_language.toLowerCase())
+  if (lang2?.length !== 2) {
     outWarnings.push(
-      `In the [global] section: metadata_language = "${parsedConfigSection.metadata_language}" is not in ISO 639-2/B format`
+      `In the [global] section: metadata_language = "${parsedConfigSection.metadata_language}" is not a recognized ISO 639 language code`
     )
   }
   return parsedConfigSection

--- a/libs/util/i18n/src/lib/language-codes.spec.ts
+++ b/libs/util/i18n/src/lib/language-codes.spec.ts
@@ -1,23 +1,38 @@
-import {
-  getLang2FromLang3,
-  getLang3FromLang2,
-  getLocalizedIndexKey,
-} from './language-codes'
+import { toLang2, toLang3 } from './language-codes'
 
 describe('Language codes utils', () => {
-  describe('getLang3FromLang2', () => {
+  describe('toLang3', () => {
     it('return lang in iso3', () => {
-      expect(getLang3FromLang2('fr')).toBe('fre')
+      expect(toLang3('fr')).toBe('fre')
+      expect(toLang3('fr_FR')).toBe('fre')
+      expect(toLang3('ab_CD')).toBe('ab_CD')
+      expect(toLang3('fre')).toBe('fre')
+      expect(toLang3('de')).toBe('ger')
+      expect(toLang3('DE')).toBe('ger')
+      expect(toLang3('deu')).toBe('ger')
+      expect(toLang3('en')).toBe('eng')
+      expect(toLang3('ENG')).toBe('eng')
+      expect(toLang3('unknown')).toBe('unknown')
+      expect(toLang3('unk')).toBe('unk')
+      expect(toLang3('un')).toBe('un')
+      expect(toLang3(null)).toBe(null)
     })
   })
-  describe('getLang2FromLang3', () => {
+  describe('toLang2', () => {
     it('return lang in iso2', () => {
-      expect(getLang2FromLang3('fre')).toBe('fr')
-    })
-  })
-  describe('getLang2FromLang3', () => {
-    it('return index property selector for lang2', () => {
-      expect(getLocalizedIndexKey('fr')).toBe('langfre')
+      expect(toLang2('fr')).toBe('fr')
+      expect(toLang2('EN')).toBe('en')
+      expect(toLang2('fr_FR')).toBe('fr')
+      expect(toLang2('ab_CD')).toBe('ab')
+      expect(toLang2('fre')).toBe('fr')
+      expect(toLang2('ger')).toBe('de')
+      expect(toLang2('GER')).toBe('de')
+      expect(toLang2('deu')).toBe('de')
+      expect(toLang2('eng')).toBe('en')
+      expect(toLang2('unknown')).toBe('unknown')
+      expect(toLang2('unk')).toBe('unk')
+      expect(toLang2('unk')).toBe('unk')
+      expect(toLang2(null)).toBe(null)
     })
   })
 })

--- a/libs/util/i18n/src/lib/language-codes.spec.ts
+++ b/libs/util/i18n/src/lib/language-codes.spec.ts
@@ -31,7 +31,7 @@ describe('Language codes utils', () => {
       expect(toLang2('eng')).toBe('en')
       expect(toLang2('unknown')).toBe('unknown')
       expect(toLang2('unk')).toBe('unk')
-      expect(toLang2('unk')).toBe('unk')
+      expect(toLang2('un')).toBe('un')
       expect(toLang2(null)).toBe(null)
     })
   })

--- a/libs/util/i18n/src/lib/language-codes.ts
+++ b/libs/util/i18n/src/lib/language-codes.ts
@@ -1,21 +1,32 @@
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 
+/**
+ * Taken from https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
+ * Note: some languages have multiple 3-char codes, like 'fre' and 'fra'; in that case, the one to be used
+ * in priority is the one defined last
+ */
 const LANG_3_TO_2_MAPPER = {
   eng: 'en',
+  nld: 'nl', // duplicate for "dut"
   dut: 'nl',
+  fra: 'fr', // "duplicate for "fre"
   fre: 'fr',
-  deu: 'de',
+  deu: 'de', // duplicate for "ger"
   ger: 'de',
   kor: 'ko',
   spa: 'es',
+  ces: 'cs', // duplicate for "cze"
   cze: 'cs',
   cat: 'ca',
   fin: 'fi',
+  isl: 'is', // duplicate for "ice"
   ice: 'is',
   ita: 'it',
   por: 'pt',
   rus: 'ru',
+  zho: 'zh', // duplicate for "chi"
   chi: 'zh',
+  slk: 'sk', // duplicate for "slo"
   slo: 'sk',
   roh: 'rm',
   ara: 'ar',
@@ -26,8 +37,10 @@ const LANG_3_TO_2_MAPPER = {
   tur: 'tr',
   arm: 'hy',
   aze: 'az',
+  kat: 'ka', // duplicate for "geo"
   geo: 'ka',
   ukr: 'uk',
+  cym: 'cy', // duplicate for "wel"
   wel: 'cy',
 } as const
 

--- a/libs/util/i18n/src/lib/language-codes.ts
+++ b/libs/util/i18n/src/lib/language-codes.ts
@@ -9,7 +9,7 @@ const LANG_3_TO_2_MAPPER = {
   eng: 'en',
   nld: 'nl', // duplicate for "dut"
   dut: 'nl',
-  fra: 'fr', // "duplicate for "fre"
+  fra: 'fr', // duplicate for "fre"
   fre: 'fr',
   deu: 'de', // duplicate for "ger"
   ger: 'de',
@@ -74,8 +74,8 @@ export const LANGUAGE_NAMES = {
   wel: 'Cymraeg',
 } as const
 
-export type LanguageCode2 = keyof typeof LANG_3_TO_2_MAPPER
-export type LanguageCode3 = (typeof LANG_3_TO_2_MAPPER)[LanguageCode2]
+export type LanguageCode3 = keyof typeof LANG_3_TO_2_MAPPER
+export type LanguageCode2 = (typeof LANG_3_TO_2_MAPPER)[LanguageCode3]
 
 export const LANG_2_TO_3_MAPPER = Object.entries(LANG_3_TO_2_MAPPER).reduce(
   (mapperObject, langEntry) => {


### PR DESCRIPTION
### Description

This PR changes the way the `metadataLanguage` of the Standalone Search works by allowing it to change after it has been initialized. This is because the `METADATA_LANGUAGE` injection token can now also take a factory function as value; a static language code can still be provided to not break custom apps.

This PR also makes the handling of language codes more streamlined and flexible. Before that, the `metadata_language` and `languages` configuration keys were both using different formats (3-char codes and 2-char codes). This PR allows using 2-char or 3-char codes indifferently; the `toLang3` and `toLang2` utility functions will now always make sure to transform the code into whatever format is expected; this is retro-compatible but also makes configuration easier. 

### Architectural changes

none

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [x] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Follow these instructions to confirm

* run `npm run demo`
* open the standalone search example: http://127.0.0.1:8001/webcomponents/gn-standalone-search.sample.html
* write down something in search field and look at the network requests: the `_search` request should have a payload that contains these:
  ```
  fields: [
    "resourceTitleObject.langger^5",
    "tag.langger^4",
    "resourceAbstractObject.langger^3",
    "lineageObject.langger^2",
    "any.langger",
    "uuid"
  ]
  ```
* run the following command in the console to switch the language
  ```
  GNUI.init({
    apiUrl: 'https://www.geocat.ch/geonetwork/srv/api',
    metadataLanguage: 'en', // this is what changes the language used in the search body
    textLanguage: 'de',
  })
  ```
* write down something else in the search field and look at the network requests: the latest `_search` request should now have this in the payload:
  ```
  fields: [
    "resourceTitleObject.langeng^5",
    "tag.langeng^4",
    "resourceAbstractObject.langeng^3",
    "lineageObject.langeng^2",
    "any.langeng",
    "uuid"
  ]
  ```
  This is because the language used for metadata search has been properly changed.
* Try doing the same with other language codes in various formats (`nl`, `fr_CA`, `deu` etc.) and see how it behaves
---

<!--
Please give credit to the sponsor of this work if possible.
-->

This work is sponsored by Swisstopo
