### PR TITLE
[Datahub]: Hide keywords when there are too many of them.

### DIFF
--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -24,7 +24,7 @@
     ghostClass="h-[31px] w-3/4"
     [showContent]="fieldReady('keywords')"
   >
-    <div *ngIf="metadata.keywords?.length">
+    <gn-ui-max-lines [maxLines]="7" *ngIf="metadata.keywords?.length">
       <div class="metadata-info-keywords sm:pb-4 flex flex-wrap gap-2">
         <gn-ui-badge
           class="inline-block lowercase"
@@ -34,7 +34,7 @@
           >{{ keyword.label }}</gn-ui-badge
         >
       </div>
-    </div>
+    </gn-ui-max-lines>
   </gn-ui-content-ghost>
 </div>
 


### PR DESCRIPTION
### Description

This PR hides the keywords when they are taking up too much space. This answers to the feature request on https://github.com/geonetwork/geonetwork-ui/issues/1307
I have chosen the threshold to be of 4 lines of badges (which translates to 7 lines of text for the component doing the hiding job), but this is of course debatable.

### Architectural changes

No changes

### Screenshots

<img width="1243" height="925" alt="image" src="https://github.com/user-attachments/assets/1cf4b01e-18ea-4c87-b57d-77bf57640999" />

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Import a record with many keywords, such as the BD TOPO. Check that over record with less keywords don't have the section hidden.
