### PR TITLE
[Datahub]: do not deselect a layer in service capabilities

### DIFF
--- a/libs/ui/elements/src/lib/service-capabilities/service-capabilities.component.spec.ts
+++ b/libs/ui/elements/src/lib/service-capabilities/service-capabilities.component.spec.ts
@@ -90,7 +90,7 @@ describe('ServiceCapabilitiesComponent', () => {
       expect(component.selectedLayer).toBe(layer)
     })
 
-    it('should deselect a layer if the same layer is selected again', () => {
+    it('should not deselect a layer if the same layer is selected again', () => {
       const layer = {
         title: 'Sample Layer',
         abstract: 'This is a sample layer.',
@@ -101,8 +101,8 @@ describe('ServiceCapabilitiesComponent', () => {
       expect(component.layerInformation.length).toBeGreaterThan(0)
 
       component.selectLayer(layer)
-      expect(component.selectedLayer).toBeNull()
-      expect(component.layerInformation.length).toBe(0)
+      expect(component.selectedLayer).toBe(layer)
+      expect(component.layerInformation.length).toBeGreaterThan(0)
     })
   })
 })

--- a/libs/ui/elements/src/lib/service-capabilities/service-capabilities.component.ts
+++ b/libs/ui/elements/src/lib/service-capabilities/service-capabilities.component.ts
@@ -136,12 +136,6 @@ export class ServiceCapabilitiesComponent implements OnInit {
   }
 
   selectLayer(layer: WfsFeatureTypeFull | WmsLayerFull | WmtsLayer) {
-    if (layer === this.selectedLayer) {
-      this.selectedLayer = null
-      this.layerInformation = []
-      return
-    }
-
     this.selectedLayer = layer
     const filteredInfo = []
     Object.keys(layer).map((key) => {


### PR DESCRIPTION
This PR changes the behavior of the service capabilities component, so that clicking again on the same layer will keep the layer selected and the information displayed.