### PR TITLE
[Datahub]: Preview section - build components only when triggered

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset/datasetPreview.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetPreview.cy.ts
@@ -325,7 +325,7 @@ describe('Preview section', () => {
       it('should show the config saving btn', () => {
         cy.get('@configTab')
           .find('gn-ui-button')
-          .should('have.text', ' Set as default preview ')
+          .should('have.text', 'Set as default preview')
       })
       it('should save and use a map config with TMS styles', () => {
         cy.visit('/dataset/zzz_nl_test_wfs_syth_la_ciotat')

--- a/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.html
+++ b/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.html
@@ -50,7 +50,7 @@
             <div
               class="block"
               style="height: 639px"
-              *ngIf="displayMap$ | async"
+              *ngIf="(displayMap$ | async) && (selectedView$ | async) === 'map'"
             >
               <gn-ui-map-view
                 [exceedsLimit]="exceedsMaxFeatureCount$ | async"
@@ -65,7 +65,12 @@
             <ng-template mat-tab-label>
               <span class="tab-header-label" translate>record.tab.data</span>
             </ng-template>
-            <div class="block" *ngIf="displayData$ | async">
+            <div
+              class="block"
+              *ngIf="
+                (displayData$ | async) && (selectedView$ | async) === 'table'
+              "
+            >
               <gn-ui-data-view
                 [exceedsLimit]="exceedsMaxFeatureCount$ | async"
                 (linkSelected)="onSelectedLinkChange($event)"
@@ -82,7 +87,12 @@
             <ng-template mat-tab-label>
               <span class="tab-header-label" translate>record.tab.chart</span>
             </ng-template>
-            <div class="block" *ngIf="displayData$ | async">
+            <div
+              class="block"
+              *ngIf="
+                (displayData$ | async) && (selectedView$ | async) === 'chart'
+              "
+            >
               <gn-ui-data-view
                 [exceedsLimit]="exceedsMaxFeatureCount$ | async"
                 (linkSelected)="onSelectedLinkChange($event)"

--- a/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.html
+++ b/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.html
@@ -26,20 +26,9 @@
                 (buttonClick)="saveDatavizConfig()"
                 [disabled]="savingStatus === 'saving'"
               >
-                <ng-container [ngSwitch]="savingStatus">
-                  <span *ngSwitchCase="'idle'" translate>
-                    record.metadata.preview.config.idle
-                  </span>
-                  <span *ngSwitchCase="'saving'" translate>
-                    record.metadata.preview.config.saving
-                  </span>
-                  <span *ngSwitchCase="'saved'" translate>
-                    record.metadata.preview.config.saved
-                  </span>
-                  <span *ngSwitchCase="'error'" translate>
-                    record.metadata.preview.config.error
-                  </span>
-                </ng-container>
+                <span
+                  [translate]="'record.metadata.preview.config.' + savingStatus"
+                ></span>
               </gn-ui-button>
             </ng-template>
           </mat-tab>

--- a/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.spec.ts
+++ b/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.spec.ts
@@ -207,10 +207,10 @@ describe('RecordDataPreviewComponent', () => {
       it('renders preview, chart tab is enabled', () => {
         expect(chartTab.componentInstance.disabled).toBe(false)
       })
-      it('renders two data view components (for table and chart tabs)', () => {
+      it('renders the table component only (the first tab)', () => {
         expect(
           fixture.debugElement.queryAll(By.directive(DataViewComponent)).length
-        ).toEqual(2)
+        ).toEqual(1)
       })
       it('does render the permalink component', () => {
         expect(
@@ -242,10 +242,10 @@ describe('RecordDataPreviewComponent', () => {
       it('renders preview, chart tab is enabled', () => {
         expect(chartTab.componentInstance.disabled).toBe(false)
       })
-      it('renders two data view components (for table and chart tabs)', () => {
+      it('renders the table component only (the first tab)', () => {
         expect(
           fixture.debugElement.queryAll(By.directive(DataViewComponent)).length
-        ).toEqual(2)
+        ).toEqual(1)
       })
     })
   })


### PR DESCRIPTION
### Description

This PR makes sure the record page only builds the preview tabs content when triggered, as a way to make the page less heavy. 

### Architectural changes

None

### Screenshots

No UI change.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

The weight reduction/complexity reduction of the page is not testable per se, but you can check that the "non triggered" components, like the table and chart components are not build by logging something in their `constructor`.
You may also check that everything still loads correctly, and that the `max_features_count` and preview config features still work fine.