### PR TITLE
feat: adapt height of metadata-editor when an element is added on top of md-editor-root

### DIFF
--- a/apps/metadata-editor/src/app/app.component.html
+++ b/apps/metadata-editor/src/app/app.component.html
@@ -1,3 +1,3 @@
-<div gnUiSearchRouterContainer="editor" class="h-full">
+<div gnUiSearchRouterContainer="editor" class="h-full grow">
   <router-outlet></router-outlet>
 </div>

--- a/apps/metadata-editor/src/app/dashboard/dashboard-page.component.html
+++ b/apps/metadata-editor/src/app/dashboard/dashboard-page.component.html
@@ -1,5 +1,5 @@
-<div>
-  <div class="flex h-screen">
+<div class="h-full">
+  <div class="flex h-full">
     <aside class="w-[370px] shrink-0 border-r">
       <md-editor-sidebar></md-editor-sidebar>
     </aside>

--- a/apps/metadata-editor/src/app/records/all-records/all-records.component.css
+++ b/apps/metadata-editor/src/app/records/all-records/all-records.component.css
@@ -1,4 +1,0 @@
-/* set max-height for overflow-y-auto */
-main {
-  max-height: calc(100vh - 60px);
-}

--- a/apps/metadata-editor/src/app/records/my-draft/my-draft.component.css
+++ b/apps/metadata-editor/src/app/records/my-draft/my-draft.component.css
@@ -1,4 +1,0 @@
-/* set max-height for overflow-y-auto */
-main {
-  max-height: calc(100vh - 60px);
-}

--- a/apps/metadata-editor/src/app/records/my-records/my-records.component.css
+++ b/apps/metadata-editor/src/app/records/my-records/my-records.component.css
@@ -1,4 +1,0 @@
-/* set max-height for overflow-y-auto */
-main {
-  max-height: calc(100vh - 60px);
-}

--- a/apps/metadata-editor/src/index.html
+++ b/apps/metadata-editor/src/index.html
@@ -14,7 +14,7 @@
       crossorigin
     />
   </head>
-  <body>
-    <md-editor-root></md-editor-root>
+  <body class="flex flex-col">
+    <md-editor-root class="flex-1 flex min-h-0"></md-editor-root>
   </body>
 </html>

--- a/apps/metadata-editor/src/styles.css
+++ b/apps/metadata-editor/src/styles.css
@@ -1,6 +1,7 @@
 html,
 body {
   height: 100%;
+  margin: 0;
   color: var(--color-main);
 
   --gn-ui-button-rounded: 8px;
@@ -48,4 +49,11 @@ body {
 .mdc-menu-surface .mat-mdc-option {
   @apply !font-sans;
   min-height: 28px;
+}
+md-editor-all-records,
+md-editor-my-records-state-wrapper,
+md-editor-my-draft {
+  flex: 1 1 auto;
+  min-height: 0; /* needed for scroll inside flexbox */
+  overflow-y: auto;
 }


### PR DESCRIPTION
### Description

This PR introduces height adaptation if an element is added to the dom. 

By example in geORchestra we add the header after the body: 
```
  <script src="https://cdn.jsdelivr.net/gh/georchestra/header@dist/header.js"></script>
  <geor-header active-app="metadata-editor" height="80" logo-url="https://www.georchestra.org/public/georchestra-logo.svg" legacy-header="false" >
  </geor-header>
  ```

Which was resulting in multiple scrollbars. 

Now we only have one scrollable no matter there's something or not.

Closes #1265 
<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->


### Screenshots

With something
<img width="1360" height="996" alt="image" src="https://github.com/user-attachments/assets/89e8101a-7ea6-4c9c-ac4e-8f364cb74a46" />

Without
<img width="1360" height="996" alt="image" src="https://github.com/user-attachments/assets/51c1203f-62ba-497b-9e38-de082a74e206" />


<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Add something line 18 before md-editor-root in metadata-editor/index.html.

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
