### PR TITLE
[Datahub]: bump ogc-client to 1.3.0

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetDetailPage.cy.ts
@@ -97,7 +97,7 @@ beforeEach(() => {
   cy.intercept('GET', '/data/ogcapi/conformance?f=json', {
     fixture: 'ogcapi_conformance.json',
   })
-  cy.intercept('GET', '/data/ogcapi/?f=json', {
+  cy.intercept('GET', '/data/ogcapi?f=json', {
     fixture: 'ogcapi.json',
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@angular/router": "18.2.13",
         "@bartholomej/ngx-translate-extract": "~8.0.2",
         "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-        "@camptocamp/ogc-client": "1.2.1-dev.b1a75df",
+        "@camptocamp/ogc-client": "^1.3.0",
         "@geospatial-sdk/core": "0.0.5-dev.37",
         "@geospatial-sdk/geocoding": "0.0.5-dev.37",
         "@geospatial-sdk/legend": "0.0.5-dev.37",
@@ -3419,9 +3419,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.2.1-dev.b1a75df",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.2.1-dev.b1a75df.tgz",
-      "integrity": "sha512-1B9kt7LaaLUz9BCVxu0BdrfTWVkt9w4GxOj8nPgELzXTCTVG/c7DCn88Ax3MPNGY/Sh3biy00uLqqj0lc28r3A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.0.tgz",
+      "integrity": "sha512-E1g11pBbVyWRudlWMVJrHtSfwK6nvCP0bLy8+RyCWLjlEEg92BICKep1Eg/daS/0d2Gjxlpnr1/aXowvvnosMA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/router": "18.2.13",
     "@bartholomej/ngx-translate-extract": "~8.0.2",
     "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-    "@camptocamp/ogc-client": "1.2.1-dev.b1a75df",
+    "@camptocamp/ogc-client": "^1.3.0",
     "@geospatial-sdk/core": "0.0.5-dev.37",
     "@geospatial-sdk/geocoding": "0.0.5-dev.37",
     "@geospatial-sdk/legend": "0.0.5-dev.37",

--- a/package/package.json
+++ b/package/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-    "@camptocamp/ogc-client": "1.2.1-dev.b1a75df",
+    "@camptocamp/ogc-client": "^1.3.0",
     "@geospatial-sdk/core": "0.0.5-dev.37",
     "@geospatial-sdk/geocoding": "0.0.5-dev.37",
     "@geospatial-sdk/legend": "0.0.5-dev.37",


### PR DESCRIPTION
This PR upgrades the ogc-client version to 1.3.0.