### PR TITLE
[Datahub]: GeoServer OGC API support

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetDetailPage.cy.ts
@@ -97,7 +97,7 @@ beforeEach(() => {
   cy.intercept('GET', '/data/ogcapi/conformance?f=json', {
     fixture: 'ogcapi_conformance.json',
   })
-  cy.intercept('GET', '/data/ogcapi/?f=json', {
+  cy.intercept('GET', '/data/ogcapi?f=json', {
     fixture: 'ogcapi.json',
   })
 })

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -132,10 +132,6 @@ jest.mock('@camptocamp/ogc-client', () => ({
         bulkDownloadLinks: { json: 'http://json', csv: 'http://csv' },
       })
     }
-    allCollections = Promise.resolve([
-      { name: 'collection1' },
-      { name: 'collection2' },
-    ])
     featureCollections =
       this.url.indexOf('error.http') > -1
         ? Promise.reject(new Error())

--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -140,8 +140,8 @@ jest.mock('@camptocamp/ogc-client', () => ({
       this.url.indexOf('error.http') > -1
         ? Promise.reject(new Error())
         : Promise.resolve(['collection1', 'collection2'])
-    getCollectionItem(_collection: string, _id: string) {
-      return Promise.resolve('item1')
+    getCollectionItems(_collection: string) {
+      return Promise.resolve(['item1'])
     }
   },
 }))
@@ -990,11 +990,11 @@ describe('DataService', () => {
     })
     describe('#getItemsFromOgcApi', () => {
       describe('calling getItemsFromOgcApi() with a valid URL', () => {
-        it('returns the first collection item when collections array is not empty', async () => {
+        it('returns the first collection items when collections array is not empty', async () => {
           const item = await service.getItemsFromOgcApi(
             'https://my.ogc.api/features'
           )
-          expect(item).toBe('item1')
+          expect(item).toEqual(['item1'])
         })
       })
 

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -220,12 +220,12 @@ export class DataService {
       })
   }
 
-  async getItemsFromOgcApi(url: string): Promise<OgcApiRecord> {
+  async getItemsFromOgcApi(url: string): Promise<OgcApiRecord[]> {
     const endpoint = new OgcApiEndpoint(url)
-    return await endpoint.featureCollections
+    return await endpoint.allCollections
       .then((collections) => {
         return collections.length
-          ? endpoint.getCollectionItem(collections[0], '1')
+          ? endpoint.getCollectionItems(collections[0].name)
           : null
       })
       .catch(() => {

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -211,9 +211,9 @@ export class DataService {
 
   async getDownloadUrlsFromOgcApi(url: string): Promise<OgcApiCollectionInfo> {
     const endpoint = new OgcApiEndpoint(url)
-    return await endpoint.allCollections
+    return await endpoint.featureCollections
       .then((collections) => {
-        return endpoint.getCollectionInfo(collections[0].name)
+        return endpoint.getCollectionInfo(collections[0])
       })
       .catch((error) => {
         throw new Error(`ogc.unreachable.unknown`)
@@ -222,10 +222,10 @@ export class DataService {
 
   async getItemsFromOgcApi(url: string): Promise<OgcApiRecord[]> {
     const endpoint = new OgcApiEndpoint(url)
-    return await endpoint.allCollections
+    return await endpoint.featureCollections
       .then((collections) => {
         return collections.length
-          ? endpoint.getCollectionItems(collections[0].name)
+          ? endpoint.getCollectionItems(collections[0])
           : null
       })
       .catch(() => {

--- a/libs/feature/record/src/lib/state/mdview.facade.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.spec.ts
@@ -379,17 +379,19 @@ describe('MdViewFacade', () => {
       })
     })
     it('should return OGC links that have geometry', fakeAsync(() => {
-      jest.spyOn(facade.dataService, 'getItemsFromOgcApi').mockResolvedValue({
-        id: '123',
-        type: 'Feature',
-        time: null,
-        properties: {
-          type: '',
-          title: '',
+      jest.spyOn(facade.dataService, 'getItemsFromOgcApi').mockResolvedValue([
+        {
+          id: '123',
+          type: 'Feature',
+          time: null,
+          properties: {
+            type: '',
+            title: '',
+          },
+          links: [],
+          geometry: { type: 'MultiPolygon', coordinates: [] },
         },
-        links: [],
-        geometry: { type: 'MultiPolygon', coordinates: [] },
-      })
+      ])
       let result
       facade.geoDataLinksWithGeometry$.subscribe((v) => (result = v))
       tick()
@@ -424,17 +426,19 @@ describe('MdViewFacade', () => {
           },
         ],
       }
-      jest.spyOn(facade.dataService, 'getItemsFromOgcApi').mockResolvedValue({
-        id: '123',
-        type: 'Feature',
-        time: null,
-        properties: {
-          type: '',
-          title: '',
+      jest.spyOn(facade.dataService, 'getItemsFromOgcApi').mockResolvedValue([
+        {
+          id: '123',
+          type: 'Feature',
+          time: null,
+          properties: {
+            type: '',
+            title: '',
+          },
+          links: [],
+          geometry: null,
         },
-        links: [],
-        geometry: null,
-      })
+      ])
       let result
       facade.geoDataLinksWithGeometry$.subscribe((v) => (result = v))
       tick()
@@ -463,17 +467,19 @@ describe('MdViewFacade', () => {
             },
           ],
         }
-        jest.spyOn(facade.dataService, 'getItemsFromOgcApi').mockResolvedValue({
-          id: '123',
-          type: 'Feature',
-          time: null,
-          properties: {
-            type: '',
-            title: '',
+        jest.spyOn(facade.dataService, 'getItemsFromOgcApi').mockResolvedValue([
+          {
+            id: '123',
+            type: 'Feature',
+            time: null,
+            properties: {
+              type: '',
+              title: '',
+            },
+            links: [],
+            geometry: { type: 'MultiPolygon', coordinates: [] },
           },
-          links: [],
-          geometry: { type: 'MultiPolygon', coordinates: [] },
-        })
+        ])
         let result
         facade.geoDataLinksWithGeometry$.subscribe((v) => (result = v))
         tick()

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -139,8 +139,10 @@ export class MdViewFacade {
               return from(
                 this.dataService.getItemsFromOgcApi(link.url.href)
               ).pipe(
-                map((collectionRecords: OgcApiRecord) => {
-                  return collectionRecords && collectionRecords.geometry
+                map((collectionRecords: OgcApiRecord[]) => {
+                  return collectionRecords &&
+                    collectionRecords[0] &&
+                    collectionRecords[0].geometry
                     ? link
                     : null
                 }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@angular/router": "18.2.13",
         "@bartholomej/ngx-translate-extract": "~8.0.2",
         "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-        "@camptocamp/ogc-client": "1.2.1-dev.b1a75df",
+        "@camptocamp/ogc-client": "^1.3.0",
         "@geospatial-sdk/core": "0.0.5-dev.37",
         "@geospatial-sdk/geocoding": "0.0.5-dev.37",
         "@geospatial-sdk/legend": "0.0.5-dev.37",
@@ -3419,9 +3419,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.2.1-dev.b1a75df",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.2.1-dev.b1a75df.tgz",
-      "integrity": "sha512-1B9kt7LaaLUz9BCVxu0BdrfTWVkt9w4GxOj8nPgELzXTCTVG/c7DCn88Ax3MPNGY/Sh3biy00uLqqj0lc28r3A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.0.tgz",
+      "integrity": "sha512-E1g11pBbVyWRudlWMVJrHtSfwK6nvCP0bLy8+RyCWLjlEEg92BICKep1Eg/daS/0d2Gjxlpnr1/aXowvvnosMA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@angular/router": "18.2.13",
         "@bartholomej/ngx-translate-extract": "~8.0.2",
         "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-        "@camptocamp/ogc-client": "^1.3.0",
+        "@camptocamp/ogc-client": "^1.3.1-dev.b827e6d",
         "@geospatial-sdk/core": "0.0.5-dev.37",
         "@geospatial-sdk/geocoding": "0.0.5-dev.37",
         "@geospatial-sdk/legend": "0.0.5-dev.37",
@@ -3419,9 +3419,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.0.tgz",
-      "integrity": "sha512-E1g11pBbVyWRudlWMVJrHtSfwK6nvCP0bLy8+RyCWLjlEEg92BICKep1Eg/daS/0d2Gjxlpnr1/aXowvvnosMA==",
+      "version": "1.3.1-dev.b827e6d",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.1-dev.b827e6d.tgz",
+      "integrity": "sha512-LOmKKyiqWPASlSxgULr4v32WLchy+IYqmUSdNtPM5gwgbb3l0oAZs1HSEHExarDB7+sEGGNv/vexvaGZENEJxg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/router": "18.2.13",
     "@bartholomej/ngx-translate-extract": "~8.0.2",
     "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-    "@camptocamp/ogc-client": "^1.3.0",
+    "@camptocamp/ogc-client": "^1.3.1-dev.b827e6d",
     "@geospatial-sdk/core": "0.0.5-dev.37",
     "@geospatial-sdk/geocoding": "0.0.5-dev.37",
     "@geospatial-sdk/legend": "0.0.5-dev.37",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@angular/router": "18.2.13",
     "@bartholomej/ngx-translate-extract": "~8.0.2",
     "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-    "@camptocamp/ogc-client": "1.2.1-dev.b1a75df",
+    "@camptocamp/ogc-client": "^1.3.0",
     "@geospatial-sdk/core": "0.0.5-dev.37",
     "@geospatial-sdk/geocoding": "0.0.5-dev.37",
     "@geospatial-sdk/legend": "0.0.5-dev.37",

--- a/package/package.json
+++ b/package/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-    "@camptocamp/ogc-client": "1.2.1-dev.b1a75df",
+    "@camptocamp/ogc-client": "^1.3.0",
     "@geospatial-sdk/core": "0.0.5-dev.37",
     "@geospatial-sdk/geocoding": "0.0.5-dev.37",
     "@geospatial-sdk/legend": "0.0.5-dev.37",


### PR DESCRIPTION
### Description

This PR introduces all the necessary changes to support GeoServer OGC API services, as dataviz (map, table chart), download and API links in the Datahub.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

Will need the ogc-client bumped to a version that includes https://github.com/camptocamp/ogc-client/pull/120:

All formats of both enclosure and items links will be made available, without format duplicates, and giving the priority to bulk download over items.

### Breaking changes

Any OGC API that was previously supported by the ogc-client prior to 1.3.0 and no longer supported by the ogc-client 1.3.0+ will not be supported by the Datahub either.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [x] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->
---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [DataGrandEst](https://www.datagrandest.fr/portail/fr)**.
