### PR TITLE
[Datahub]: download links fixes on errors

### DIFF
--- a/apps/datahub/src/app/record/record-downloads/record-downloads.component.spec.ts
+++ b/apps/datahub/src/app/record/record-downloads/record-downloads.component.spec.ts
@@ -125,6 +125,15 @@ describe('RecordDownloadsComponent', () => {
             type: 'service',
             accessServiceProtocol: 'wfs',
           },
+          {
+            name: 'Surveillance littorale OGC',
+            description: 'OGC API service',
+            url: newUrl(
+              'https://demo.ldproxy.net/zoomstack/collections/airports/items'
+            ),
+            type: 'service',
+            accessServiceProtocol: 'ogcFeatures',
+          },
         ])
         fixture.detectChanges()
       })
@@ -140,6 +149,93 @@ describe('RecordDownloadsComponent', () => {
             name: 'surval_parametre_point.csv',
             url: newUrl('https://www.ifremer.fr/surval_parametre_point.csv'),
             type: 'download',
+          },
+          {
+            description: 'OGC API service',
+            mimeType: 'application/geo+json',
+            name: 'Surveillance littorale OGC',
+            title: 'collection1',
+            url: newUrl(
+              'https://demo.ldproxy.net/zoomstack/collections/airports/items'
+            ),
+            type: 'service',
+            accessServiceProtocol: 'ogcFeatures',
+          },
+          {
+            description: 'OGC API service',
+            mimeType: 'application/json',
+            name: 'Surveillance littorale OGC',
+            title: 'collection2',
+            url: newUrl(
+              'https://demo.ldproxy.net/zoomstack/collections/airports/items'
+            ),
+            type: 'service',
+            accessServiceProtocol: 'ogcFeatures',
+          },
+        ])
+      }))
+    })
+
+    describe('when the OGC API service fails', () => {
+      beforeEach(() => {
+        facade.downloadLinks$.next([
+          {
+            description: 'Lieu de surveillance (point)',
+            name: 'surval_parametre_point.csv',
+            url: newUrl('https://www.ifremer.fr/surval_parametre_point.csv'),
+            type: 'download',
+          },
+          {
+            description: 'Lieu de surveillance (ligne)',
+            name: 'surval_parametre_ligne',
+            url: newUrl(
+              'https://www.ifremer.fr/services/wfs/surveillance_littorale'
+            ),
+            type: 'service',
+            accessServiceProtocol: 'wfs',
+          },
+          {
+            name: 'Some erroneous OGC API service',
+            description: 'OGC API service',
+            url: newUrl('https://error.org/collections/airports/items'),
+            type: 'service',
+            accessServiceProtocol: 'ogcFeatures',
+          },
+        ])
+        fixture.detectChanges()
+      })
+      it('emits the other links', fakeAsync(() => {
+        let downloadLinks = []
+        component.links$.subscribe((links: DatasetOnlineResource[]) => {
+          downloadLinks = links
+        })
+        tick(200)
+        expect(downloadLinks).toEqual([
+          {
+            description: 'Lieu de surveillance (point)',
+            name: 'surval_parametre_point.csv',
+            url: newUrl('https://www.ifremer.fr/surval_parametre_point.csv'),
+            type: 'download',
+          },
+          {
+            description: 'Lieu de surveillance (ligne)',
+            mimeType: 'text/csv',
+            name: 'surval_parametre_ligne',
+            url: newUrl(
+              'https://www.ifremer.fr/services/wfs/surveillance_littorale'
+            ),
+            type: 'service',
+            accessServiceProtocol: 'wfs',
+          },
+          {
+            description: 'Lieu de surveillance (ligne)',
+            name: 'surval_parametre_ligne',
+            mimeType: 'application/geo+json',
+            url: newUrl(
+              'https://www.ifremer.fr/services/wfs/surveillance_littorale'
+            ),
+            type: 'service',
+            accessServiceProtocol: 'wfs',
           },
         ])
       }))

--- a/apps/datahub/src/app/record/record-downloads/record-downloads.component.spec.ts
+++ b/apps/datahub/src/app/record/record-downloads/record-downloads.component.spec.ts
@@ -143,13 +143,6 @@ describe('RecordDownloadsComponent', () => {
           },
         ])
       }))
-      // disable error handling in UI
-      it.skip('shows an error', () => {
-        const popup = fixture.debugElement.query(
-          By.directive(PopupAlertComponent)
-        )
-        expect(popup).toBeTruthy()
-      })
     })
 
     describe('with no link compatible with DOWNLOAD usage', () => {

--- a/apps/datahub/src/app/record/record-downloads/record-downloads.component.ts
+++ b/apps/datahub/src/app/record/record-downloads/record-downloads.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { DataService } from '@geonetwork-ui/feature/dataviz'
 import { getFileFormat, getLinkPriority } from '@geonetwork-ui/util/shared'
-import { combineLatest, of } from 'rxjs'
+import { forkJoin, of } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
 import {
   DatasetOnlineResource,
@@ -60,7 +60,7 @@ export class RecordDownloadsComponent {
 
       this.error = null
 
-      return combineLatest([
+      return forkJoin([
         ...(wfsLinks.length > 0
           ? wfsLinks.map((link) =>
               this.dataService
@@ -68,7 +68,7 @@ export class RecordDownloadsComponent {
                 .pipe(
                   catchError((e) => {
                     this.error = e.message
-                    return [of([] as DatasetOnlineResource[])]
+                    return of([] as DatasetOnlineResource[])
                   })
                 )
             )

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -625,7 +625,7 @@
   "share.tab.permalink": "Partager",
   "share.tab.webComponent": "Intégrer",
   "table.loading.data": "Chargement des données...",
-  "table.object.count": "enregistrements dans ces données",
+  "table.object.count": "enregistrements dans ce jeu de données",
   "table.paginator.firstPage": "Première page",
   "table.paginator.itemsPerPage": "Éléments par page",
   "table.paginator.lastPage": "Dernière page",


### PR DESCRIPTION
### Description

This PR is a follow up on https://github.com/geonetwork/geonetwork-ui/pull/872 and fixes the return type on error (observable of array, instead of array of observable).

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

On a record with both WFS and OGC API links, when the WFS is not working, test that the download links from the OGC API are still displayed in the Download section of the Datahub.
