### PR TITLE
[Datahub] Make dataset no-link banner less aggressive

### DIFF
--- a/libs/ui/elements/src/lib/error/error.component.html
+++ b/libs/ui/elements/src/lib/error/error.component.html
@@ -1,5 +1,9 @@
 <div
-  class="p-[1.7em] bg-red-50 text-red-800 text-[1.5em] text-center rounded-lg"
+  class="p-[1.7em] text-[1.5em] text-center rounded-lg"
+  [ngClass]="{
+    'bg-red-50 text-red-800': type !== types.DATASET_HAS_NO_LINK,
+    'bg-gray-100 text-black': type === types.DATASET_HAS_NO_LINK,
+  }"
 >
   <div
     *ngIf="type === types.COULD_NOT_REACH_API"

--- a/translations/en.json
+++ b/translations/en.json
@@ -552,7 +552,7 @@
   "search.error.organizationHasNoDataset": "This organization has no records yet.",
   "search.error.organizationNotFound": "This organization could not be found.",
   "search.error.receivedError": "An error was received",
-  "search.error.recordHasnolink": "This record currently has no link yet, please come back later.",
+  "search.error.recordHasnolink": "This record currently has no link.",
   "search.error.recordNotFound": "The record with identifier \"{ id }\" could not be found.",
   "search.field.any.placeholder": "Search in the catalog ...",
   "search.field.sortBy": "Sort by:",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -552,7 +552,7 @@
   "search.error.organizationHasNoDataset": "Cette organisation n'a pas encore de ressources.",
   "search.error.organizationNotFound": "L'organisation n'a pas pu être trouvée.",
   "search.error.receivedError": "Erreur retournée",
-  "search.error.recordHasnolink": "Cette ressource n'a pas encore de lien, réessayez plus tard s'il vous plaît.",
+  "search.error.recordHasnolink": "Cette ressource n'a actuellement aucun lien.",
   "search.error.recordNotFound": "La ressource dont l'identifiant est \"{ id }\" n'a pas pu être trouvée.",
   "search.field.any.placeholder": "Rechercher dans le catalogue...",
   "search.field.sortBy": "Trier par :",

--- a/translations/it.json
+++ b/translations/it.json
@@ -552,7 +552,7 @@
   "search.error.organizationHasNoDataset": "Questa organizzazione non ha ancora records.",
   "search.error.organizationNotFound": "Impossibile trovare l'organizzazione.",
   "search.error.receivedError": "Errore restituito",
-  "search.error.recordHasnolink": "Questo record non ha ancora alcun collegamento, riprova più tardi.",
+  "search.error.recordHasnolink": "Questo record non ha attualmente alcun collegamento.",
   "search.error.recordNotFound": "Impossibile trovare questi record.",
   "search.field.any.placeholder": "Cerca del catalogo...",
   "search.field.sortBy": "Ordina per:",


### PR DESCRIPTION
### Description
This PR makes the dataset no link banner less aggressive by changing its visual styling and messaging. Using the same background color as other blocks.

### Screenshots

<img width="4032" height="3024" alt="BeforeAfter2 (4)" src="https://github.com/user-attachments/assets/a97092f7-a76c-498e-954e-9e96284cacd3" />

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. You can go to the record titled 'Record with no link ' (a3774ef6-809d-4dd1-984f-9254f49cbd0a)
2. The red no links banner should be updated.
