### PR TITLE
[Editor]: map first email address as email for users

### DIFF
--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.mapper.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.mapper.ts
@@ -43,18 +43,26 @@ export class Gn4PlatformMapper {
   userFromApi(apiUser: UserApiModel): UserModel {
     if (!apiUser) return null
     const {
-      enabled,
+      addresses,
       emailAddresses,
-      organization,
+      enabled,
+      id,
       kind,
       lastLoginDate,
+      security,
+      primaryAddress,
+      authorities,
       accountNonExpired,
       accountNonLocked,
-      id,
       credentialsNonExpired,
       ...user
     } = apiUser
-    return { ...apiUser, id: id.toString() } as UserModel
+
+    return {
+      ...user,
+      id: id.toString(),
+      email: emailAddresses ? emailAddresses[0] || '' : '',
+    } as UserModel
   }
 
   keywordsFromApi(

--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.spec.ts
@@ -65,12 +65,12 @@ class UsersApiServiceMock {
     return of([
       {
         username: 'ken',
-        email: 'ken@sf2.com',
+        emailAddresses: ['ken@sf2.com'],
         id: 1,
       },
       {
         username: 'ryu',
-        email: 'ryu@sf2.com',
+        emailAddresses: ['ryu@sf2.com'],
         id: 2,
       },
     ])

--- a/libs/data-access/gn4/src/openapi/model/user.api.model.ts
+++ b/libs/data-access/gn4/src/openapi/model/user.api.model.ts
@@ -21,7 +21,7 @@ export interface UserApiModel {
   emailAddresses?: Set<string>
   addresses?: Set<AddressApiModel>
   primaryAddress?: AddressApiModel
-  organization?: string
+  organisation?: string
   kind?: string
   lastLoginDate?: string
   authorities?: Array<GrantedAuthorityApiModel>


### PR DESCRIPTION
### Description

The same user model is used when reading from the "me" api and from the "users", but not the same fields are indexed. In the editor, for the first time, the email of other users than the one currently connected are neded.

This PR fixes the mapping to extract the first email address as the user email.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Open the metadata editor on a record and add a contact from a user correctly created with an email. Confirm that the user email is correctly extracted into the saved contact.

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [DataGrandEst](https://www.datagrandest.fr/portail/fr)**.
