### PR TITLE
Use `prepareExternalUrl` in `AuthService` to handle application base href

### DIFF
--- a/libs/api/repository/src/lib/gn4/auth/auth.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/auth/auth.service.spec.ts
@@ -10,12 +10,14 @@ const translateServiceMock = {
   currentLang: 'fr',
 }
 
-let windowLocation
+let mockAppBaseHref
+let mockLocationPath
 
 describe('AuthService', () => {
   let service: AuthService
   beforeEach(() => {
-    windowLocation = 'http://localhost'
+    mockAppBaseHref = ''
+    mockLocationPath = '/'
 
     TestBed.configureTestingModule({
       providers: [
@@ -28,7 +30,8 @@ describe('AuthService', () => {
           useValue: translateServiceMock,
         },
         MockProvider(Location, {
-          path: () => windowLocation,
+          prepareExternalUrl: (url: string) => `${mockAppBaseHref}${url}`,
+          path: () => mockLocationPath,
         }),
       ],
       imports: [HttpClientTestingModule],
@@ -71,7 +74,8 @@ describe('AuthService', () => {
   })
   describe('login URL from config (special georchestra case, appending a query param with existing query params)', () => {
     beforeEach(() => {
-      windowLocation = '/datahub/?org=Abcd&keywords=bla;bla&location'
+      mockAppBaseHref = '/datahub'
+      mockLocationPath = '/?org=Abcd&keywords=bla;bla&location'
       loginUrlTokenMock = '${current_url}?login&something=else'
       service = TestBed.inject(AuthService)
     })

--- a/libs/api/repository/src/lib/gn4/auth/auth.service.ts
+++ b/libs/api/repository/src/lib/gn4/auth/auth.service.ts
@@ -33,7 +33,10 @@ export class AuthService {
     return baseUrl
       .replace(
         '${current_url}',
-        new URL(this.location.path(), window.location.href).toString()
+        new URL(
+          this.location.prepareExternalUrl(this.location.path()),
+          window.location.href
+        ).toString()
       )
       .replace('${lang2}', toLang2(this.translateService.currentLang))
       .replace('${lang3}', toLang3(this.translateService.currentLang))


### PR DESCRIPTION
### Description

This PR fixes a change introduced while upgrading Angular version:
https://github.com/geonetwork/geonetwork-ui/commit/9b561bdd865c00e5e4884a529861bf917737971d#diff-a8cc3af3857477c6843f5f9a8853413d96800709fe5418693a2097bbcd8bef12R36

The URL constructed from the Angular location path is not working when the application is deployed with a base href.

Angular provides the `prepareExternalUrl` function for such cases.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Tests should be run locally both without a base href (http://localhost:4200) and with a base href (http://localhost:8080/application).

On the Datahub, check:
- login from favorite (search result or record page)
- login from Q/A section on a record page
- use of the proxy for the calls to outside services in the dataviz

On the Metadata Editor, check:
- logout
- login from a deep route

For example directly accessing http://localhost:8080/metadata-editor/edit/uuid when not already logged in should redirect to http://localhost:8080/metadata-editor/edit/uuid after login.

Follow the instructions in "docs/guide/run.md#with-docker" to check with an application deployed on "http://localhost:8080/application/".

To simulate the deployment of the Datahub on a path such as http://localhost/datahub you can try injecting the APP_BASE_HREF token, see: https://angular.dev/api/common/APP_BASE_HREF

(this token is set automatically when the app is built with --base=/datahub/)