### PR TITLE
[Webcomponents]: add support for proxy path

### DIFF
--- a/apps/webcomponents/src/app/components/base.component.ts
+++ b/apps/webcomponents/src/app/components/base.component.ts
@@ -31,6 +31,7 @@ import {
 })
 export class BaseComponent implements OnChanges, OnInit {
   @Input() apiUrl = null
+  @Input() proxyPath = null
   @Input() searchId: string
   @Input() primaryColor = '#9a9a9a'
   @Input() secondaryColor = '#767676'
@@ -78,6 +79,7 @@ export class BaseComponent implements OnChanges, OnInit {
 
   init() {
     standaloneConfigurationObject.apiConfiguration.basePath = this.apiUrl
+    standaloneConfigurationObject.proxyPath ??= this.proxyPath
     standaloneConfigurationObject.metadataLanguage ??= this.metadataLanguage
     standaloneConfigurationObject.textLanguage ??= this.textLanguage
 

--- a/apps/webcomponents/src/app/components/gn-dataset-view-chart/gn-dataset-view-chart.sample.html
+++ b/apps/webcomponents/src/app/components/gn-dataset-view-chart/gn-dataset-view-chart.sample.html
@@ -40,6 +40,7 @@
       <script src="gn-wc.js"></script>
       <gn-dataset-view-chart
         api-url="https://www.geo2france.fr/geonetwork/srv/api"
+        proxy-path="https://www.geo2france.fr/mapstore/proxy/?url="
         dataset-id="9da51f58-15c6-4325-82b1-2cf6c8e75d0f"
         aggregation="average"
         x-property="adresse"

--- a/apps/webcomponents/src/app/configuration.ts
+++ b/apps/webcomponents/src/app/configuration.ts
@@ -5,12 +5,15 @@ export type MetadataLanguage = 'current' | null | string // can be a hardcoded l
 
 export interface StandaloneConfiguration {
   apiUrl?: string
+  proxyPath?: string
   textLanguage?: TextLanguage
   metadataLanguage?: MetadataLanguage
 }
 
 export const standaloneConfigurationObject = {
   apiConfiguration: new Configuration(),
+  proxyPath: null,
+  proxyPathFactory: () => standaloneConfigurationObject.proxyPath,
   textLanguage: 'browser',
   metadataLanguage: null,
   metadataLanguageFactory: () => standaloneConfigurationObject.metadataLanguage,

--- a/apps/webcomponents/src/app/webcomponents.module.ts
+++ b/apps/webcomponents/src/app/webcomponents.module.ts
@@ -30,7 +30,7 @@ import {
 } from '@geonetwork-ui/feature/search'
 import { FigureComponent } from '@geonetwork-ui/ui/dataviz'
 import { ButtonComponent } from '@geonetwork-ui/ui/inputs'
-import { GEONETWORK_UI_VERSION } from '@geonetwork-ui/util/shared'
+import { GEONETWORK_UI_VERSION, PROXY_PATH } from '@geonetwork-ui/util/shared'
 import { EffectsModule } from '@ngrx/effects'
 import { StoreModule } from '@ngrx/store'
 import { StoreDevtoolsModule } from '@ngrx/store-devtools'
@@ -45,6 +45,7 @@ import { GnFigureDatasetsComponent } from './components/gn-figure-datasets/gn-fi
 import { GnMapViewerComponent } from './components/gn-map-viewer/gn-map-viewer.component'
 import { GnResultsListComponent } from './components/gn-results-list/gn-results-list.component'
 import { GnSearchInputComponent } from './components/gn-search-input/gn-search-input.component'
+import { standaloneConfigurationObject } from './configuration'
 import { StandaloneSearchModule } from './standalone-search.module'
 import { WebcomponentOverlayContainer } from './webcomponent-overlay-container'
 
@@ -103,6 +104,10 @@ const CUSTOM_ELEMENTS: [new (...args) => BaseComponent, string][] = [
     {
       provide: OverlayContainer,
       useClass: WebcomponentOverlayContainer,
+    },
+    {
+      provide: PROXY_PATH,
+      useFactory: standaloneConfigurationObject.proxyPathFactory,
     },
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/docs/guide/webcomponents.md
+++ b/docs/guide/webcomponents.md
@@ -29,6 +29,12 @@ Web Components are made to be easily included in any context. To do so, you have
 The Web Components script also includes the [Standalone Search](./standalone-search.md).
 :::
 
+## Proxy
+
+Web Components support the following attribute for handling proxification of URLs:
+
+- `proxy-path`: identical to the [`proxy_path` configuration option](./configure.md#global)
+
 ## Internationalization
 
 Web Components support the following attributes for handling internationalization:

--- a/libs/util/shared/src/lib/services/proxy.service.ts
+++ b/libs/util/shared/src/lib/services/proxy.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, InjectionToken, Optional } from '@angular/core'
+import { Injectable, InjectionToken, Injector } from '@angular/core'
 import { Location } from '@angular/common'
 
 export const PROXY_PATH = new InjectionToken<string>('proxyPath')
@@ -7,8 +7,12 @@ export const PROXY_PATH = new InjectionToken<string>('proxyPath')
   providedIn: 'root',
 })
 export class ProxyService {
+  private get proxyPath(): string | null {
+    return this.injector.get(PROXY_PATH, null)
+  }
+
   constructor(
-    @Optional() @Inject(PROXY_PATH) private proxyPath: string,
+    private injector: Injector,
     private location: Location
   ) {}
 


### PR DESCRIPTION
### Description

This PR introduces support for the proxy path parameter for the webcomponents. It will be used in exactly the same way as with a full GN-UI application.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Run the webcomponents demo locally. Open the sample page for the chart view, with the devTools open on the network tab (make sure the ogc-client cache has been deleted). See that the data is fetch on a proxified URL.

<img width="766" height="113" alt="image" src="https://github.com/user-attachments/assets/56792349-5c6e-42ef-873c-82679fc23ee2" />
