### PR TITLE
[Webcomponents]: fix settings and user api services

### DIFF
--- a/libs/api/repository/src/lib/gn4/settings/gn4-settings.service.ts
+++ b/libs/api/repository/src/lib/gn4/settings/gn4-settings.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core'
 import { SiteApiService } from '@geonetwork-ui/data-access/gn4'
+import { Observable, of, switchMap } from 'rxjs'
 import { map, shareReplay } from 'rxjs/operators'
-import { Observable } from 'rxjs'
 
 @Injectable({
   providedIn: 'root',
@@ -25,7 +25,8 @@ export class Gn4SettingsService {
   constructor(private siteApiService: SiteApiService) {}
 
   private getSettingsSetValueByKey(key: string) {
-    return this.siteApiService.getSettingsSet(null, [key]).pipe(
+    return of(true).pipe(
+      switchMap(() => this.siteApiService.getSettingsSet(null, [key])),
       map((v) => v[key]),
       shareReplay({ bufferSize: 1, refCount: true })
     )


### PR DESCRIPTION
### Description

This PR fixes a bug introduced in https://github.com/geonetwork/geonetwork-ui/pull/1340/commits/f19f272dc0ff37dda1ff163cc05e372feb08d420, as the `SiteApiService` was instantiated before the configuration was ready for webcomponents. It was always sending requests to "demo.georchestra.org". Same for the `MeApiService`.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Run the webcomponents demo with the devTools open on the network tab.
Visit http://localhost:8001/webcomponents/gn-search-input-and-results-multilingual.sample.html

Before the fix:

<img width="664" height="257" alt="image" src="https://github.com/user-attachments/assets/7ed2ca99-9ced-449b-9f2a-b7af9ee72d21" />

After the fix:

<img width="626" height="259" alt="image" src="https://github.com/user-attachments/assets/e5d1849d-25fb-4a7c-ada4-515e4430d1f1" />
