### PR TITLE
Enhance nginx configuration for caching and gzip

### DIFF
--- a/tools/docker/nginx.apps.conf
+++ b/tools/docker/nginx.apps.conf
@@ -10,17 +10,16 @@ server {
 
         gzip on;
         gzip_types text/plain text/css application/javascript application/json image/svg+xml;
-        gzip_min_length 256;
 
 
         location ~ /index.html|.*\.toml|.*\.json$ {
           expires -1;
-          add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0' always;
+          add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
         }
 
         location ~ .*\.css$|.*\.js$ {
           # cached for 1 year because hash ensures cache invalidation when content changes
-          add_header Cache-Control "public, max-age=31536000, immutable" always;
+          add_header Cache-Control "max-age=31536000, immutable";
         }
 
         location ~ .*\.otf$|.*\.ttf$|.*\.woff2?$ {
@@ -29,7 +28,6 @@ server {
 
         location / {
           try_files $uri $uri/ /APP_NAME/index.html;
-          add_header Cache-Control "no-cache" always;
         }
 
         error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
Updated gzip settings and Cache-Control headers for better performance.

Index.html is not cached as it controls versioning

### Description

This PR introduces Gzip and cache control for docker images as default. 

Time has been incresed to 1 year for js resources as thez are invalidated if index.html change.

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

