### PR TITLE
[Datahub]: add proxy path to data view share

### DIFF
--- a/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.spec.ts
@@ -8,6 +8,7 @@ import { MdViewFacade } from '../state'
 import { provideRepositoryUrl } from '@geonetwork-ui/api/repository'
 import { MockBuilder } from 'ng-mocks'
 import { provideI18n } from '@geonetwork-ui/util/i18n'
+import { PROXY_PATH } from '@geonetwork-ui/util/shared'
 
 const chartConfig1 = {
   aggregation: 'sum',
@@ -46,38 +47,146 @@ describe('DataViewPermalinkComponent', () => {
   let component: DataViewPermalinkComponent
   let fixture: ComponentFixture<DataViewPermalinkComponent>
   let facade
+  describe('without proxy path', () => {
+    beforeEach(() => MockBuilder(DataViewPermalinkComponent))
 
-  beforeEach(() => MockBuilder(DataViewPermalinkComponent))
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        providers: [
+          provideI18n(),
+          provideRepositoryUrl('http://gn-api.url/'),
+          {
+            provide: MdViewFacade,
+            useClass: MdViewFacadeMock,
+          },
+          {
+            provide: WEB_COMPONENT_EMBEDDER_URL,
+            useValue: baseUrl,
+          },
+        ],
+      }).compileComponents()
+      facade = TestBed.inject(MdViewFacade)
+      fixture = TestBed.createComponent(DataViewPermalinkComponent)
+      component = fixture.componentInstance
+      component.viewType$.next('chart')
+      fixture.detectChanges()
+    })
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      providers: [
-        provideI18n(),
-        provideRepositoryUrl('http://gn-api.url/'),
-        {
-          provide: MdViewFacade,
-          useClass: MdViewFacadeMock,
-        },
-        {
-          provide: WEB_COMPONENT_EMBEDDER_URL,
-          useValue: baseUrl,
-        },
-      ],
-    }).compileComponents()
-    facade = TestBed.inject(MdViewFacade)
-    fixture = TestBed.createComponent(DataViewPermalinkComponent)
-    component = fixture.componentInstance
-    component.viewType$.next('chart')
-    fixture.detectChanges()
+    it('should create', () => {
+      expect(component).toBeTruthy()
+    })
+
+    describe('Chart view', () => {
+      describe('init permalinkUrl$', () => {
+        it('should generate URL based on configs', async () => {
+          const url = await firstValueFrom(component.permalinkUrl$)
+          expect(url).toBe(
+            `https://example.com/wc-embedder?v=v1.2.3&e=gn-dataset-view-chart&a=aggregation%3D${
+              chartConfig1.aggregation
+            }&a=x-property%3D${chartConfig1.xProperty}&a=y-property%3D${
+              chartConfig1.yProperty
+            }&a=chart-type%3D${
+              chartConfig1.chartType
+            }&a=api-url%3D${encodeURIComponent(
+              component.config.basePath
+            )}&a=dataset-id%3D${
+              metadata.uniqueIdentifier
+            }&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff`
+          )
+        })
+      })
+      describe('update permalinkUrl$', () => {
+        beforeEach(() => {
+          facade.chartConfig$.next(chartConfig2)
+        })
+        it('should update URL based on configs', async () => {
+          const url = await firstValueFrom(component.permalinkUrl$)
+          expect(url).toBe(
+            `https://example.com/wc-embedder?v=v1.2.3&e=gn-dataset-view-chart&a=aggregation%3D${
+              chartConfig2.aggregation
+            }&a=x-property%3D${chartConfig2.xProperty}&a=y-property%3D${
+              chartConfig2.yProperty
+            }&a=chart-type%3D${
+              chartConfig2.chartType
+            }&a=api-url%3D${encodeURIComponent(
+              component.config.basePath
+            )}&a=dataset-id%3D${
+              metadata.uniqueIdentifier
+            }&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff`
+          )
+        })
+      })
+    })
+    describe('Map view', () => {
+      beforeEach(() => {
+        component.viewType$.next('map')
+      })
+      describe('init permalinkUrl$', () => {
+        it('should generate URL based on configs', async () => {
+          const url = await firstValueFrom(component.permalinkUrl$)
+          expect(url).toBe(
+            `https://example.com/wc-embedder?v=v1.2.3&e=gn-dataset-view-map&a=api-url%3D${encodeURIComponent(
+              component.config.basePath
+            )}&a=dataset-id%3D${
+              metadata.uniqueIdentifier
+            }&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff`
+          )
+        })
+      })
+    })
+    describe('Table view', () => {
+      beforeEach(() => {
+        component.viewType$.next('table')
+      })
+      describe('init permalinkUrl$', () => {
+        it('should generate URL based on configs', async () => {
+          const url = await firstValueFrom(component.permalinkUrl$)
+          expect(url).toBe(
+            `https://example.com/wc-embedder?v=v1.2.3&e=gn-dataset-view-table&a=api-url%3D${encodeURIComponent(
+              component.config.basePath
+            )}&a=dataset-id%3D${
+              metadata.uniqueIdentifier
+            }&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff`
+          )
+        })
+      })
+    })
   })
+  describe('without proxy path', () => {
+    beforeEach(() => MockBuilder(DataViewPermalinkComponent))
 
-  it('should create', () => {
-    expect(component).toBeTruthy()
-  })
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        providers: [
+          provideI18n(),
+          provideRepositoryUrl('http://gn-api.url/'),
+          {
+            provide: MdViewFacade,
+            useClass: MdViewFacadeMock,
+          },
+          {
+            provide: PROXY_PATH,
+            useValue: '/mapstore/proxy/?url=',
+          },
+          {
+            provide: WEB_COMPONENT_EMBEDDER_URL,
+            useValue: baseUrl,
+          },
+        ],
+      }).compileComponents()
+      facade = TestBed.inject(MdViewFacade)
+      fixture = TestBed.createComponent(DataViewPermalinkComponent)
+      component = fixture.componentInstance
+      component.viewType$.next('chart')
+      fixture.detectChanges()
+    })
 
-  describe('Chart view', () => {
-    describe('init permalinkUrl$', () => {
-      it('should generate URL based on configs', async () => {
+    it('should create', () => {
+      expect(component).toBeTruthy()
+    })
+
+    describe('Chart view', () => {
+      it('should generate URL with the proxy path', async () => {
         const url = await firstValueFrom(component.permalinkUrl$)
         expect(url).toBe(
           `https://example.com/wc-embedder?v=v1.2.3&e=gn-dataset-view-chart&a=aggregation%3D${
@@ -88,61 +197,44 @@ describe('DataViewPermalinkComponent', () => {
             chartConfig1.chartType
           }&a=api-url%3D${encodeURIComponent(
             component.config.basePath
+          )}&a=proxy-path%3D${encodeURIComponent(
+            '/mapstore/proxy/?url='
           )}&a=dataset-id%3D${
             metadata.uniqueIdentifier
           }&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff`
         )
       })
     })
-    describe('update permalinkUrl$', () => {
+
+    describe('Map view', () => {
       beforeEach(() => {
-        facade.chartConfig$.next(chartConfig2)
+        component.viewType$.next('map')
       })
-      it('should update URL based on configs', async () => {
-        const url = await firstValueFrom(component.permalinkUrl$)
-        expect(url).toBe(
-          `https://example.com/wc-embedder?v=v1.2.3&e=gn-dataset-view-chart&a=aggregation%3D${
-            chartConfig2.aggregation
-          }&a=x-property%3D${chartConfig2.xProperty}&a=y-property%3D${
-            chartConfig2.yProperty
-          }&a=chart-type%3D${
-            chartConfig2.chartType
-          }&a=api-url%3D${encodeURIComponent(
-            component.config.basePath
-          )}&a=dataset-id%3D${
-            metadata.uniqueIdentifier
-          }&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff`
-        )
-      })
-    })
-  })
-  describe('Map view', () => {
-    beforeEach(() => {
-      component.viewType$.next('map')
-    })
-    describe('init permalinkUrl$', () => {
-      it('should generate URL based on configs', async () => {
+      it('should generate URL with the proxy path', async () => {
         const url = await firstValueFrom(component.permalinkUrl$)
         expect(url).toBe(
           `https://example.com/wc-embedder?v=v1.2.3&e=gn-dataset-view-map&a=api-url%3D${encodeURIComponent(
             component.config.basePath
+          )}&a=proxy-path%3D${encodeURIComponent(
+            '/mapstore/proxy/?url='
           )}&a=dataset-id%3D${
             metadata.uniqueIdentifier
           }&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff`
         )
       })
     })
-  })
-  describe('Table view', () => {
-    beforeEach(() => {
-      component.viewType$.next('table')
-    })
-    describe('init permalinkUrl$', () => {
-      it('should generate URL based on configs', async () => {
+
+    describe('Table view', () => {
+      beforeEach(() => {
+        component.viewType$.next('table')
+      })
+      it('should generate URL with the proxy path', async () => {
         const url = await firstValueFrom(component.permalinkUrl$)
         expect(url).toBe(
           `https://example.com/wc-embedder?v=v1.2.3&e=gn-dataset-view-table&a=api-url%3D${encodeURIComponent(
             component.config.basePath
+          )}&a=proxy-path%3D${encodeURIComponent(
+            '/mapstore/proxy/?url='
           )}&a=dataset-id%3D${
             metadata.uniqueIdentifier
           }&a=primary-color%3D%230f4395&a=secondary-color%3D%238bc832&a=main-color%3D%23555&a=background-color%3D%23fdfbff`

--- a/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.ts
+++ b/libs/feature/record/src/lib/data-view-permalink/data-view-permalink.component.ts
@@ -12,7 +12,7 @@ import { MdViewFacade } from '../state'
 import { CopyTextButtonComponent } from '@geonetwork-ui/ui/inputs'
 import { CommonModule } from '@angular/common'
 import { TranslatePipe } from '@ngx-translate/core'
-import { GEONETWORK_UI_TAG_NAME } from '@geonetwork-ui/util/shared'
+import { GEONETWORK_UI_TAG_NAME, PROXY_PATH } from '@geonetwork-ui/util/shared'
 
 export const WEB_COMPONENT_EMBEDDER_URL = new InjectionToken<string>(
   'webComponentEmbedderUrl'
@@ -60,6 +60,9 @@ export class DataViewPermalinkComponent {
         url.searchParams.append('e', `gn-dataset-view-map`)
       }
       url.searchParams.append('a', `api-url=${this.config.basePath}`)
+      if (this.proxyPath) {
+        url.searchParams.append('a', `proxy-path=${this.proxyPath}`)
+      }
       url.searchParams.append('a', `dataset-id=${metadata.uniqueIdentifier}`)
       url.searchParams.append('a', `primary-color=#0f4395`)
       url.searchParams.append('a', `secondary-color=#8bc832`)
@@ -71,6 +74,9 @@ export class DataViewPermalinkComponent {
 
   constructor(
     @Inject(Configuration) private config: Configuration,
+    @Optional()
+    @Inject(PROXY_PATH)
+    private proxyPath: string,
     @Optional()
     @Inject(WEB_COMPONENT_EMBEDDER_URL)
     protected wcEmbedderBaseUrl: string,

--- a/libs/feature/record/src/lib/data-view-web-component/data-view-web-component.component.spec.ts
+++ b/libs/feature/record/src/lib/data-view-web-component/data-view-web-component.component.spec.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject, firstValueFrom } from 'rxjs'
 import { MdViewFacade } from '../state'
 import { provideRepositoryUrl } from '@geonetwork-ui/api/repository'
 import { MockBuilder } from 'ng-mocks'
+import { PROXY_PATH } from '@geonetwork-ui/util/shared'
 
 const chartConfig1 = {
   aggregation: 'sum',
@@ -40,36 +41,36 @@ describe('DataViewWebComponentComponent', () => {
   let component: DataViewWebComponentComponent
   let fixture: ComponentFixture<DataViewWebComponentComponent>
   let facade
+  describe('without proxy path', () => {
+    beforeEach(() => MockBuilder(DataViewWebComponentComponent))
 
-  beforeEach(() => MockBuilder(DataViewWebComponentComponent))
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        providers: [
+          provideRepositoryUrl('http://gn-api.url/'),
+          {
+            provide: MdViewFacade,
+            useClass: MdViewFacadeMock,
+          },
+        ],
+      }).compileComponents()
+      facade = TestBed.inject(MdViewFacade)
+      fixture = TestBed.createComponent(DataViewWebComponentComponent)
+      component = fixture.componentInstance
+      component.viewType$.next('chart')
+      fixture.detectChanges()
+    })
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      providers: [
-        provideRepositoryUrl('http://gn-api.url/'),
-        {
-          provide: MdViewFacade,
-          useClass: MdViewFacadeMock,
-        },
-      ],
-    }).compileComponents()
-    facade = TestBed.inject(MdViewFacade)
-    fixture = TestBed.createComponent(DataViewWebComponentComponent)
-    component = fixture.componentInstance
-    component.viewType$.next('chart')
-    fixture.detectChanges()
-  })
+    it('should create', () => {
+      expect(component).toBeTruthy()
+    })
 
-  it('should create', () => {
-    expect(component).toBeTruthy()
-  })
-
-  describe('Chart view', () => {
-    describe('init webComponentHtml$', () => {
-      it('should generate HTML based on configs', async () => {
-        const html = await firstValueFrom(component.webComponentHtml$)
-        expect(html).toBe(
-          `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
+    describe('Chart view', () => {
+      describe('init webComponentHtml$', () => {
+        it('should generate HTML based on configs', async () => {
+          const html = await firstValueFrom(component.webComponentHtml$)
+          expect(html).toBe(
+            `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
   <gn-dataset-view-chart
           api-url="http://gn-api.url/"
           dataset-id="${metadata.uniqueIdentifier}"
@@ -84,17 +85,17 @@ describe('DataViewWebComponentComponent', () => {
           main-font="'Inter', sans-serif"
           title-font="'DM Serif Display', serif"
   ></gn-dataset-view-chart>`
-        )
+          )
+        })
       })
-    })
-    describe('update webComponentHtml$', () => {
-      beforeEach(() => {
-        facade.chartConfig$.next(chartConfig2)
-      })
-      it('should update HTML based on configs', async () => {
-        const html = await firstValueFrom(component.webComponentHtml$)
-        expect(html).toBe(
-          `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
+      describe('update webComponentHtml$', () => {
+        beforeEach(() => {
+          facade.chartConfig$.next(chartConfig2)
+        })
+        it('should update HTML based on configs', async () => {
+          const html = await firstValueFrom(component.webComponentHtml$)
+          expect(html).toBe(
+            `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
   <gn-dataset-view-chart
           api-url="http://gn-api.url/"
           dataset-id="${metadata.uniqueIdentifier}"
@@ -109,19 +110,19 @@ describe('DataViewWebComponentComponent', () => {
           main-font="'Inter', sans-serif"
           title-font="'DM Serif Display', serif"
   ></gn-dataset-view-chart>`
-        )
+          )
+        })
       })
     })
-  })
-  describe('Map view', () => {
-    beforeEach(() => {
-      component.viewType$.next('map')
-    })
-    describe('init webComponentHtml$', () => {
-      it('should generate HTML based on configs', async () => {
-        const html = await firstValueFrom(component.webComponentHtml$)
-        expect(html).toBe(
-          `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
+    describe('Map view', () => {
+      beforeEach(() => {
+        component.viewType$.next('map')
+      })
+      describe('init webComponentHtml$', () => {
+        it('should generate HTML based on configs', async () => {
+          const html = await firstValueFrom(component.webComponentHtml$)
+          expect(html).toBe(
+            `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
 <gn-dataset-view-map
         api-url="http://gn-api.url/"
         dataset-id="${metadata.uniqueIdentifier}"
@@ -132,19 +133,19 @@ describe('DataViewWebComponentComponent', () => {
         main-font="'Inter', sans-serif"
         title-font="'DM Serif Display', serif"
 ></gn-dataset-view-map>`
-        )
+          )
+        })
       })
     })
-  })
-  describe('Table view', () => {
-    beforeEach(() => {
-      component.viewType$.next('table')
-    })
-    describe('init webComponentHtml$', () => {
-      it('should generate HTML based on configs', async () => {
-        const html = await firstValueFrom(component.webComponentHtml$)
-        expect(html).toBe(
-          `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
+    describe('Table view', () => {
+      beforeEach(() => {
+        component.viewType$.next('table')
+      })
+      describe('init webComponentHtml$', () => {
+        it('should generate HTML based on configs', async () => {
+          const html = await firstValueFrom(component.webComponentHtml$)
+          expect(html).toBe(
+            `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
   <gn-dataset-view-table
           api-url="http://gn-api.url/"
           dataset-id="${metadata.uniqueIdentifier}"
@@ -155,7 +156,104 @@ describe('DataViewWebComponentComponent', () => {
           main-font="'Inter', sans-serif"
           title-font="'DM Serif Display', serif"
   ></gn-dataset-view-table>`
-        )
+          )
+        })
+      })
+    })
+    describe('with proxy path', () => {
+      beforeEach(() => MockBuilder(DataViewWebComponentComponent))
+
+      beforeEach(async () => {
+        await TestBed.configureTestingModule({
+          providers: [
+            provideRepositoryUrl('http://gn-api.url/'),
+            {
+              provide: MdViewFacade,
+              useClass: MdViewFacadeMock,
+            },
+            {
+              provide: PROXY_PATH,
+              useValue: '/mapstore/proxy/?url=',
+            },
+          ],
+        }).compileComponents()
+        facade = TestBed.inject(MdViewFacade)
+        fixture = TestBed.createComponent(DataViewWebComponentComponent)
+        component = fixture.componentInstance
+        component.viewType$.next('chart')
+        fixture.detectChanges()
+      })
+
+      it('should create', () => {
+        expect(component).toBeTruthy()
+      })
+
+      describe('Chart view', () => {
+        it('should generate HTML with the proxy path', async () => {
+          const html = await firstValueFrom(component.webComponentHtml$)
+          expect(html).toBe(
+            `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
+  <gn-dataset-view-chart
+          api-url="http://gn-api.url/"
+          proxy-path="/mapstore/proxy/?url="
+          dataset-id="${metadata.uniqueIdentifier}"
+          aggregation="${chartConfig1.aggregation}"
+          x-property="${chartConfig1.xProperty}"
+          y-property="${chartConfig1.yProperty}"
+          chart-type="${chartConfig1.chartType}"
+          primary-color="#0f4395"
+          secondary-color="#8bc832"
+          main-color="#555"
+          background-color="#fdfbff"
+          main-font="'Inter', sans-serif"
+          title-font="'DM Serif Display', serif"
+  ></gn-dataset-view-chart>`
+          )
+        })
+      })
+      describe('Map view', () => {
+        beforeEach(() => {
+          component.viewType$.next('map')
+        })
+        it('should generate HTML with the proxy path', async () => {
+          const html = await firstValueFrom(component.webComponentHtml$)
+          expect(html).toBe(
+            `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
+<gn-dataset-view-map
+        api-url="http://gn-api.url/"
+        proxy-path="/mapstore/proxy/?url="
+        dataset-id="${metadata.uniqueIdentifier}"
+        primary-color="#0f4395"
+        secondary-color="#8bc832"
+        main-color="#555"
+        background-color="#fdfbff"
+        main-font="'Inter', sans-serif"
+        title-font="'DM Serif Display', serif"
+></gn-dataset-view-map>`
+          )
+        })
+      })
+      describe('Table view', () => {
+        beforeEach(() => {
+          component.viewType$.next('table')
+        })
+        it('should generate HTML with the proxy path', async () => {
+          const html = await firstValueFrom(component.webComponentHtml$)
+          expect(html).toBe(
+            `<script src="https://cdn.jsdelivr.net/gh/geonetwork/geonetwork-ui@wc-dist-v1.2.3/gn-wc.js"></script>
+  <gn-dataset-view-table
+          api-url="http://gn-api.url/"
+          proxy-path="/mapstore/proxy/?url="
+          dataset-id="${metadata.uniqueIdentifier}"
+          primary-color="#0f4395"
+          secondary-color="#8bc832"
+          main-color="#555"
+          background-color="#fdfbff"
+          main-font="'Inter', sans-serif"
+          title-font="'DM Serif Display', serif"
+  ></gn-dataset-view-table>`
+          )
+        })
       })
     })
   })

--- a/libs/feature/record/src/lib/data-view-web-component/data-view-web-component.component.ts
+++ b/libs/feature/record/src/lib/data-view-web-component/data-view-web-component.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   Inject,
   Input,
+  Optional,
 } from '@angular/core'
 import { Configuration } from '@geonetwork-ui/data-access/gn4'
 import { MdViewFacade } from '../state'
@@ -10,7 +11,7 @@ import { BehaviorSubject, combineLatest, map } from 'rxjs'
 import { CopyTextButtonComponent } from '@geonetwork-ui/ui/inputs'
 import { CommonModule } from '@angular/common'
 import { TranslatePipe } from '@ngx-translate/core'
-import { GEONETWORK_UI_TAG_NAME } from '@geonetwork-ui/util/shared'
+import { GEONETWORK_UI_TAG_NAME, PROXY_PATH } from '@geonetwork-ui/util/shared'
 
 @Component({
   selector: 'gn-ui-data-view-web-component',
@@ -42,7 +43,12 @@ export class DataViewWebComponentComponent {
           api-url="${new URL(
             this.config.basePath,
             window.location.origin
-          ).toString()}"
+          ).toString()}"${
+            this.proxyPath
+              ? `
+          proxy-path="${this.proxyPath}"`
+              : ''
+          }
           dataset-id="${metadata.uniqueIdentifier}"
           aggregation="${aggregation}"
           x-property="${xProperty}"
@@ -65,7 +71,12 @@ export class DataViewWebComponentComponent {
           api-url="${new URL(
             this.config.basePath,
             window.location.origin
-          ).toString()}"
+          ).toString()}"${
+            this.proxyPath
+              ? `
+          proxy-path="${this.proxyPath}"`
+              : ''
+          }
           dataset-id="${metadata.uniqueIdentifier}"
           primary-color="#0f4395"
           secondary-color="#8bc832"
@@ -82,7 +93,12 @@ export class DataViewWebComponentComponent {
         api-url="${new URL(
           this.config.basePath,
           window.location.origin
-        ).toString()}"
+        ).toString()}"${
+          this.proxyPath
+            ? `
+        proxy-path="${this.proxyPath}"`
+            : ''
+        }
         dataset-id="${metadata.uniqueIdentifier}"
         primary-color="#0f4395"
         secondary-color="#8bc832"
@@ -97,6 +113,9 @@ export class DataViewWebComponentComponent {
 
   constructor(
     @Inject(Configuration) private config: Configuration,
+    @Optional()
+    @Inject(PROXY_PATH)
+    private proxyPath: string,
     private facade: MdViewFacade
   ) {}
 }


### PR DESCRIPTION
### Description

This PR is a follow up on https://github.com/geonetwork/geonetwork-ui/pull/1379.
It adds the proxy path attribute to the generated embedder link and webcomponent script.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

### How to test

Configure the proxy path with the dev proxy in the `default.toml`: `proxy_path = "/dev-proxy?"`
Configure the `web_component_embedder_url` (any mock value will do)
Run the Datahub locally and visit a record, for example http://localhost:4200/dataset/ed34db28-5dd4-480f-bf29-dc08f0086131
Check that the proxy path is correctly set in the share section:

<img width="1016" height="122" alt="image" src="https://github.com/user-attachments/assets/c3512f56-6054-4cbf-8d40-7ea15154847b" />

<img width="1016" height="197" alt="image" src="https://github.com/user-attachments/assets/83f856d9-b8cd-49b7-bd15-1d358ee6c30f" />
