### PR TITLE
Remove unused elastic search field

### DIFF
--- a/libs/api/repository/src/lib/gn4/elasticsearch/constant.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/constant.ts
@@ -7,7 +7,6 @@ export const ES_SOURCE_SUMMARY = [
   'resourceAbstractObject',
   'overview',
   'logo',
-  'codelist_status_text',
   'link',
   'linkProtocol',
   'contactForResource*.organisation*',

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -789,7 +789,6 @@ describe('ElasticsearchService', () => {
           'resourceAbstractObject',
           'overview',
           'logo',
-          'codelist_status_text',
           'link',
           'linkProtocol',
           'contactForResource*.organisation*',

--- a/libs/feature/search/src/lib/constants.ts
+++ b/libs/feature/search/src/lib/constants.ts
@@ -11,7 +11,6 @@ export const FIELDS_SUMMARY: FieldName[] = [
   'resourceAbstractObject',
   'overview',
   'logo',
-  'codelist_status_text',
   'link',
   'linkProtocol',
   'contactForResource*.organisation*',


### PR DESCRIPTION
### Description

This PR removes an unused field from the elastic search payload.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves
