### PR TITLE
[Datahub]: use allCollections from ogc api for items and download links

### DIFF
--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -139,11 +139,11 @@ jest.mock('@camptocamp/ogc-client', () => ({
         bulkDownloadLinks: { json: 'http://json', csv: 'http://csv' },
       })
     }
-    featureCollections =
+    allCollections =
       this.url.indexOf('error.http') > -1
         ? Promise.reject(new Error())
-        : Promise.resolve(['collection1', 'collection2'])
-    getCollectionItems(_collection: string) {
+        : Promise.resolve([{ name: 'collection1' }, { name: 'collection2' }])
+    getCollectionItems() {
       return Promise.resolve(['item1'])
     }
   },

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -1,16 +1,21 @@
 import { Injectable } from '@angular/core'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import {
+  GetCollectionItemsOptions,
   OgcApiCollectionInfo,
+  OgcApiCollectionItem,
   OgcApiEndpoint,
-  OgcApiRecord,
+  StacEndpoint,
+  StacItemsDocument,
+  TmsEndpoint,
   WfsEndpoint,
   WfsVersion,
-  TmsEndpoint,
-  StacEndpoint,
-  GetCollectionItemsOptions,
-  StacItemsDocument,
 } from '@camptocamp/ogc-client'
+import { DatavizConfigModel } from '@geonetwork-ui/common/domain/model/dataviz/dataviz-configuration.model'
+import {
+  DatasetOnlineResource,
+  DatasetServiceDistribution,
+} from '@geonetwork-ui/common/domain/model/record'
 import {
   BaseReader,
   FetchError,
@@ -27,11 +32,6 @@ import {
 import type { FeatureCollection } from 'geojson'
 import { from, Observable, throwError } from 'rxjs'
 import { catchError, map, switchMap, tap } from 'rxjs/operators'
-import {
-  DatasetOnlineResource,
-  DatasetServiceDistribution,
-} from '@geonetwork-ui/common/domain/model/record'
-import { DatavizConfigModel } from '@geonetwork-ui/common/domain/model/dataviz/dataviz-configuration.model'
 
 marker('wfs.unreachable.cors')
 marker('wfs.unreachable.http')
@@ -225,21 +225,24 @@ export class DataService {
 
   async getDownloadUrlsFromOgcApi(url: string): Promise<OgcApiCollectionInfo> {
     const endpoint = new OgcApiEndpoint(url)
-    return await endpoint.featureCollections
+    return await endpoint.allCollections
       .then((collections) => {
-        return endpoint.getCollectionInfo(collections[0])
+        return endpoint.getCollectionInfo(collections[0].name)
       })
       .catch((error) => {
         throw new Error(`ogc.unreachable.unknown`)
       })
   }
 
-  async getItemsFromOgcApi(url: string): Promise<OgcApiRecord[]> {
+  async getItemsFromOgcApi(
+    url: string,
+    limit?: number
+  ): Promise<OgcApiCollectionItem[]> {
     const endpoint = new OgcApiEndpoint(url)
-    return await endpoint.featureCollections
+    return await endpoint.allCollections
       .then((collections) => {
         return collections.length
-          ? endpoint.getCollectionItems(collections[0])
+          ? endpoint.getCollectionItems(collections[0].name, limit)
           : null
       })
       .catch(() => {

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -19,7 +19,6 @@ import {
   UserFeedback,
 } from '@geonetwork-ui/common/domain/model/record'
 import { AvatarServiceInterface } from '@geonetwork-ui/api/repository'
-import { OgcApiRecord } from '@camptocamp/ogc-client'
 import { from, of } from 'rxjs'
 import { DataService } from '@geonetwork-ui/feature/dataviz'
 
@@ -166,9 +165,9 @@ export class MdViewFacade {
               link.accessServiceProtocol === 'ogcFeatures'
             ) {
               return from(
-                this.dataService.getItemsFromOgcApi(link.url.href)
+                this.dataService.getItemsFromOgcApi(link.url.href, 1)
               ).pipe(
-                map((collectionRecords: OgcApiRecord[]) => {
+                map((collectionRecords) => {
                   return collectionRecords &&
                     collectionRecords[0] &&
                     collectionRecords[0].geometry


### PR DESCRIPTION
### Description

This PR partially reverts 542b486d1127182b7c418011a124f2d875b8ff7e in https://github.com/geonetwork/geonetwork-ui/pull/1354.

The call to `allCollections` is better than the one to `featureCollections`, as features are limited to geographical data only. For the Datahub, we want to get both geographical (map) and non geographical data (table, chart) for the dataviz and the download links.

Note: feature collections should be available for map display, but when json links are used to check for geometry, the data is non-geographic (expected). The logic should not stop at the json link, and check the geojson link too if it exists (not part of the regression fix here).

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Import locally or configure the Datahub to point to a catalog containing a record with only an OGC API Features service, containing only a record collection, for example https://mel.integration.apps.gs-fr-prod.camptocamp.com/catalogue/dataset/fac8f894-78e5-4a7d-84a8-2de3cfe1dbdf.

The data should be available as table and graph.
