### PR TITLE
chore(i18n): clean data services error translation keys

### DIFF
--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -33,18 +33,16 @@ import {
 } from '@geonetwork-ui/common/domain/model/record'
 import { DatavizConfigModel } from '@geonetwork-ui/common/domain/model/dataviz/dataviz-configuration.model'
 
+marker('wfs.unreachable.unknown')
 marker('wfs.unreachable.cors')
 marker('wfs.unreachable.http')
-marker('dataset.error.forbidden')
-marker('wfs.unreachable.unknown')
+marker('wfs.unreachable.parse')
+marker('wfs.unreachable.unsupportedType')
 marker('wfs.featuretype.notfound')
 marker('wfs.geojsongml.notsupported')
 marker('ogc.unreachable.unknown')
-marker('dataset.error.network')
-marker('dataset.error.http')
-marker('dataset.error.parse')
-marker('dataset.error.unsupportedType')
-marker('dataset.error.unknown')
+marker('tms.unreachable.unknown')
+marker('stac.unreachable.unknown')
 
 interface WfsDownloadUrls {
   all: { [format: string]: string }
@@ -64,21 +62,21 @@ export class DataService {
     ).pipe(
       catchError((error: FetchError | Error) => {
         if (error instanceof Error) {
-          throw new Error(`wfs.unreachable.unknown`)
+          throw new Error('wfs.unreachable.unknown')
         } else {
           if (error.type === 'network') {
-            throw new Error(`wfs.unreachable.cors`)
+            throw new Error('wfs.unreachable.cors')
           }
           if (error.type === 'http') {
-            throw new Error(`wfs.unreachable.http`)
+            throw new Error('wfs.unreachable.http')
           }
           if (error.type === 'parse') {
-            throw new Error(`wfs.unreachable.parse`)
+            throw new Error('wfs.unreachable.parse')
           }
           if (error.type === 'unsupportedType') {
-            throw new Error(`wfs.unreachable.unsupportedType`)
+            throw new Error('wfs.unreachable.unsupportedType')
           } else {
-            throw new Error(`wfs.unreachable.unknown`)
+            throw new Error('wfs.unreachable.unknown')
           }
         }
       })
@@ -254,7 +252,7 @@ export class DataService {
     return await StacEndpoint.getItemsFromUrl(url, options)
       .then((response) => response)
       .catch(() => {
-        throw new Error(`ogc.unreachable.unknown`)
+        throw new Error(`stac.unreachable.unknown`)
       })
   }
 
@@ -266,7 +264,7 @@ export class DataService {
       tmsLink.url.toString().replace(/\/?$/, `/${tmsLink.name}`)
     )
     const tileMaps = await endpoint.allTileMaps.catch(() => {
-      throw new Error(`ogc.unreachable.unknown`)
+      throw new Error(`tms.unreachable.unknown`)
     })
     if (!tileMaps?.length) return null
 

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -74,9 +74,13 @@ import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import { FetchError } from '@geonetwork-ui/data-fetcher'
 
 marker('map.dropdown.placeholder')
-marker('wfs.feature.limit')
-marker('dataset.error.restrictedAccess')
 marker('map.select.style')
+marker('wfs.feature.limit')
+marker('dataset.error.http')
+marker('dataset.error.forbidden')
+marker('dataset.error.restrictedAccess')
+marker('dataset.error.network')
+marker('dataset.error.unknown')
 
 @Component({
   selector: 'gn-ui-map-view',

--- a/translations/de.json
+++ b/translations/de.json
@@ -58,10 +58,8 @@
   "dataset.error.forbidden": "Der Zugriff auf diese Ressource ist eingeschränkt",
   "dataset.error.http": "Die Daten konnten aufgrund eines HTTP-Fehlers nicht geladen werden: \"{ info }\"",
   "dataset.error.network": "Die Daten konnten aufgrund eines Netzwerkfehlers oder CORS-Beschränkungen nicht geladen werden: \"{ info }\"",
-  "dataset.error.parse": "Die Daten wurden geladen, konnten aber nicht gelesen werden: \"{ info }\"",
   "dataset.error.restrictedAccess": "",
   "dataset.error.unknown": "Die Daten können nicht angezeigt werden: \"{ info }\"",
-  "dataset.error.unsupportedType": "Der folgende Inhaltstyp wird nicht unterstützt: \"{ info }\"",
   "daterange.filter.from": "",
   "daterange.filter.period": "",
   "daterange.filter.to": "",
@@ -641,6 +639,7 @@
   "share.tab.webComponent": "Integrieren",
   "stac.filter.reset": "",
   "stac.results.noResults": "Ihre Suchfilter lieferten keine Ergebnisse",
+  "stac.unreachable.unknown": "Der Dienst konnte nicht erreicht werden",
   "table.loading.data": "Daten werden geladen...",
   "table.object.count": "Objekte in diesem Datensatz",
   "table.paginator.firstPage": "Erste Seite",
@@ -650,6 +649,7 @@
   "table.paginator.previousPage": "Vorherige Seite",
   "table.paginator.rangeLabel": "{startIndex} - {endIndex} von {length}",
   "table.select.data": "Datenquelle",
+  "tms.unreachable.unknown": "Der Dienst konnte nicht erreicht werden",
   "tooltip.html.copy": "HTML kopieren",
   "tooltip.id.copy": "Eindeutige Kennung kopieren",
   "tooltip.url.copy": "URL kopieren",
@@ -660,5 +660,7 @@
   "wfs.geojsongml.notsupported": "Dieser Dienst unterstützt das GeoJSON- oder GML-Format nicht",
   "wfs.unreachable.cors": "Der Dienst konnte aufgrund von CORS-Beschränkungen nicht erreicht werden",
   "wfs.unreachable.http": "Der Dienst hat einen HTTP-Fehler zurückgegeben",
-  "wfs.unreachable.unknown": "Der Dienst konnte nicht erreicht werden"
+  "wfs.unreachable.parse": "Die Daten wurden geladen, konnten aber nicht gelesen werden: \"{ info }\"",
+  "wfs.unreachable.unknown": "Der Dienst konnte nicht erreicht werden",
+  "wfs.unreachable.unsupportedType": "Der folgende Inhaltstyp wird nicht unterstützt: \"{ info }\""
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -58,10 +58,8 @@
   "dataset.error.forbidden": "Access to this resource is restricted",
   "dataset.error.http": "The data could not be loaded because of an HTTP error: \"{ info }\"",
   "dataset.error.network": "The data could not be loaded because of a network error or CORS limitations: \"{ info }\"",
-  "dataset.error.parse": "The data was loaded but could not be parsed: \"{ info }\"",
   "dataset.error.restrictedAccess": "Access to this resource is restricted",
   "dataset.error.unknown": "The data cannot be displayed: \"{ info }\"",
-  "dataset.error.unsupportedType": "The following content type is unsupported: \"{ info }\"",
   "daterange.filter.from": "From",
   "daterange.filter.period": "Period",
   "daterange.filter.to": "To",
@@ -641,6 +639,7 @@
   "share.tab.webComponent": "Integrate",
   "stac.filter.reset": "Reset filters",
   "stac.results.noResults": "Your search filters did not match any items",
+  "stac.unreachable.unknown": "The service could not be reached",
   "table.loading.data": "Loading data...",
   "table.object.count": "Objects in this dataset",
   "table.paginator.firstPage": "First page",
@@ -650,6 +649,7 @@
   "table.paginator.previousPage": "Previous page",
   "table.paginator.rangeLabel": "{startIndex} - {endIndex} of {length}",
   "table.select.data": "Data source",
+  "tms.unreachable.unknown": "The service could not be reached",
   "tooltip.html.copy": "Copy HTML",
   "tooltip.id.copy": "Copy unique identifier",
   "tooltip.url.copy": "Copy URL",
@@ -660,5 +660,7 @@
   "wfs.geojsongml.notsupported": "This service does not support the GeoJSON or GML format",
   "wfs.unreachable.cors": "The service could not be reached due to CORS limitations",
   "wfs.unreachable.http": "The service returned an HTTP error",
-  "wfs.unreachable.unknown": "The service could not be reached"
+  "wfs.unreachable.parse": "The data was loaded but could not be parsed: \"{ info }\"",
+  "wfs.unreachable.unknown": "The service could not be reached",
+  "wfs.unreachable.unsupportedType": "The following content type is unsupported: \"{ info }\""
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -58,10 +58,8 @@
   "dataset.error.forbidden": "El acceso a este recurso está restringido",
   "dataset.error.http": "",
   "dataset.error.network": "",
-  "dataset.error.parse": "",
   "dataset.error.restrictedAccess": "",
   "dataset.error.unknown": "",
-  "dataset.error.unsupportedType": "",
   "daterange.filter.from": "",
   "daterange.filter.period": "",
   "daterange.filter.to": "",
@@ -641,6 +639,7 @@
   "share.tab.webComponent": "",
   "stac.filter.reset": "",
   "stac.results.noResults": "",
+  "stac.unreachable.unknown": "",
   "table.loading.data": "",
   "table.object.count": "",
   "table.paginator.firstPage": "Primera página",
@@ -650,6 +649,7 @@
   "table.paginator.previousPage": "Página anterior",
   "table.paginator.rangeLabel": "{startIndex} - {endIndex} de {length}",
   "table.select.data": "",
+  "tms.unreachable.unknown": "",
   "tooltip.html.copy": "",
   "tooltip.id.copy": "",
   "tooltip.url.copy": "",
@@ -660,5 +660,7 @@
   "wfs.geojsongml.notsupported": "",
   "wfs.unreachable.cors": "",
   "wfs.unreachable.http": "",
-  "wfs.unreachable.unknown": ""
+  "wfs.unreachable.parse": "",
+  "wfs.unreachable.unknown": "",
+  "wfs.unreachable.unsupportedType": ""
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -58,10 +58,8 @@
   "dataset.error.forbidden": "L’accès à cette ressource est restreint",
   "dataset.error.http": "Le chargement des données a échoué en raison d'une erreur HTTP: \"{ info }\"",
   "dataset.error.network": "Le chargement des données a échoué en raison d'une erreur réseau ou de limitations CORS: \"{ info }\"",
-  "dataset.error.parse": "Les données ont été chargées mais leur décodage a échoué: \"{ info }\"",
   "dataset.error.restrictedAccess": "L’accès à cette ressource est restreint",
   "dataset.error.unknown": "Les données ne peuvent être affichées: \"{ info }\"",
-  "dataset.error.unsupportedType": "Le type de contenu suivant n'est pas pris en charge: \"{ info }\"",
   "daterange.filter.from": "Du",
   "daterange.filter.period": "Choix de la période",
   "daterange.filter.to": "Au",
@@ -641,6 +639,7 @@
   "share.tab.webComponent": "Intégrer",
   "stac.filter.reset": "Réinitialiser les filtres",
   "stac.results.noResults": "Vos filtres ne permettent pas d’afficher de résultats",
+  "stac.unreachable.unknown": "Le service n'est pas accessible",
   "table.loading.data": "Chargement des données...",
   "table.object.count": "enregistrements dans ce jeu de données",
   "table.paginator.firstPage": "Première page",
@@ -650,6 +649,7 @@
   "table.paginator.previousPage": "Page précédente",
   "table.paginator.rangeLabel": "{startIndex} - {endIndex} sur {length}",
   "table.select.data": "Source de données",
+  "tms.unreachable.unknown": "Le service n'est pas accessible",
   "tooltip.html.copy": "Copier le HTML",
   "tooltip.id.copy": "Copier l'identifiant unique",
   "tooltip.url.copy": "Copier l'URL",
@@ -660,5 +660,7 @@
   "wfs.geojsongml.notsupported": "Le service ne supporte pas le format GeoJSON ou GML",
   "wfs.unreachable.cors": "Le service n'est pas accessible en raison de limitations CORS",
   "wfs.unreachable.http": "Le service a retourné une erreur HTTP",
-  "wfs.unreachable.unknown": "Le service n'est pas accessible"
+  "wfs.unreachable.parse": "Les données ont été chargées mais leur décodage a échoué: \"{ info }\"",
+  "wfs.unreachable.unknown": "Le service n'est pas accessible",
+  "wfs.unreachable.unsupportedType": "Le type de contenu suivant n'est pas pris en charge: \"{ info }\""
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -58,10 +58,8 @@
   "dataset.error.forbidden": "L'accesso a questa risorsa è limitato",
   "dataset.error.http": "Il caricamento dei dati non è riuscito a causa di un errore HTTP: \"{info}\"",
   "dataset.error.network": "Il caricamento dei dati non è riuscito a causa di un errore di rete o di limitazioni CORS: \"{info}\"",
-  "dataset.error.parse": "I dati sono stati caricati ma la decodifica non è riuscita: \"{info}\"",
   "dataset.error.restrictedAccess": "L'accesso a questa risorsa è limitato",
   "dataset.error.unknown": "Impossibile visualizzare i dati: \"{info}\"",
-  "dataset.error.unsupportedType": "Il seguente tipo di contenuto non è supportato: \"{info}\"",
   "daterange.filter.from": "",
   "daterange.filter.period": "",
   "daterange.filter.to": "",
@@ -641,6 +639,7 @@
   "share.tab.webComponent": "Incorporare",
   "stac.filter.reset": "",
   "stac.results.noResults": "",
+  "stac.unreachable.unknown": "Il servizio non è accessibile",
   "table.loading.data": "Caricamento dei dati...",
   "table.object.count": "record in questi dati",
   "table.paginator.firstPage": "Prima pagina",
@@ -650,6 +649,7 @@
   "table.paginator.previousPage": "Pagina precedente",
   "table.paginator.rangeLabel": "{startIndex} - {endIndex} di {total}",
   "table.select.data": "Sorgente dati",
+  "tms.unreachable.unknown": "Il servizio non è accessibile",
   "tooltip.html.copy": "Copiare il HTML",
   "tooltip.id.copy": "Copiare l'identificatore unico",
   "tooltip.url.copy": "Copiare l'URL",
@@ -660,5 +660,7 @@
   "wfs.geojsongml.notsupported": "Il servizio non supporta il formato GeoJSON o GML",
   "wfs.unreachable.cors": "Il servizio non è accessibile a causa di limitazioni CORS",
   "wfs.unreachable.http": "Il servizio ha restituito un errore HTTP",
-  "wfs.unreachable.unknown": "Il servizio non è accessibile"
+  "wfs.unreachable.parse": "I dati sono stati caricati ma la decodifica non è riuscita: \"{info}\"",
+  "wfs.unreachable.unknown": "Il servizio non è accessibile",
+  "wfs.unreachable.unsupportedType": "Il seguente tipo di contenuto non è supportato: \"{info}\""
 }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -58,10 +58,8 @@
   "dataset.error.forbidden": "",
   "dataset.error.http": "",
   "dataset.error.network": "",
-  "dataset.error.parse": "",
   "dataset.error.restrictedAccess": "",
   "dataset.error.unknown": "",
-  "dataset.error.unsupportedType": "",
   "daterange.filter.from": "",
   "daterange.filter.period": "",
   "daterange.filter.to": "",
@@ -641,6 +639,7 @@
   "share.tab.webComponent": "",
   "stac.filter.reset": "",
   "stac.results.noResults": "",
+  "stac.unreachable.unknown": "",
   "table.loading.data": "",
   "table.object.count": "",
   "table.paginator.firstPage": "",
@@ -650,6 +649,7 @@
   "table.paginator.previousPage": "",
   "table.paginator.rangeLabel": "",
   "table.select.data": "",
+  "tms.unreachable.unknown": "",
   "tooltip.html.copy": "",
   "tooltip.id.copy": "",
   "tooltip.url.copy": "",
@@ -660,5 +660,7 @@
   "wfs.geojsongml.notsupported": "",
   "wfs.unreachable.cors": "",
   "wfs.unreachable.http": "",
-  "wfs.unreachable.unknown": ""
+  "wfs.unreachable.parse": "",
+  "wfs.unreachable.unknown": "",
+  "wfs.unreachable.unsupportedType": ""
 }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -58,10 +58,8 @@
   "dataset.error.forbidden": "",
   "dataset.error.http": "",
   "dataset.error.network": "",
-  "dataset.error.parse": "",
   "dataset.error.restrictedAccess": "",
   "dataset.error.unknown": "",
-  "dataset.error.unsupportedType": "",
   "daterange.filter.from": "",
   "daterange.filter.period": "",
   "daterange.filter.to": "",
@@ -641,6 +639,7 @@
   "share.tab.webComponent": "",
   "stac.filter.reset": "",
   "stac.results.noResults": "",
+  "stac.unreachable.unknown": "",
   "table.loading.data": "",
   "table.object.count": "",
   "table.paginator.firstPage": "",
@@ -650,6 +649,7 @@
   "table.paginator.previousPage": "",
   "table.paginator.rangeLabel": "",
   "table.select.data": "",
+  "tms.unreachable.unknown": "",
   "tooltip.html.copy": "",
   "tooltip.id.copy": "",
   "tooltip.url.copy": "",
@@ -660,5 +660,7 @@
   "wfs.geojsongml.notsupported": "",
   "wfs.unreachable.cors": "",
   "wfs.unreachable.http": "",
-  "wfs.unreachable.unknown": ""
+  "wfs.unreachable.parse": "",
+  "wfs.unreachable.unknown": "",
+  "wfs.unreachable.unsupportedType": ""
 }

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -58,10 +58,8 @@
   "dataset.error.forbidden": "",
   "dataset.error.http": "Dáta sa nedajú načítať kvôli chybe HTTP: \"{ info }\"",
   "dataset.error.network": "Dáta sa nedajú načítať kvôli chybe v sieti alebo obmedzeniam CORS: \"{ info }\"",
-  "dataset.error.parse": "Dáta boli načítané, ale nedajú sa analyzovať: \"{ info }\"",
   "dataset.error.restrictedAccess": "",
   "dataset.error.unknown": "Dáta nie je možné zobraziť: \"{ info }\"",
-  "dataset.error.unsupportedType": "Nepodporovaný typ obsahu: \"{ info }\"",
   "daterange.filter.from": "",
   "daterange.filter.period": "",
   "daterange.filter.to": "",
@@ -641,6 +639,7 @@
   "share.tab.webComponent": "Integrovať",
   "stac.filter.reset": "",
   "stac.results.noResults": "",
+  "stac.unreachable.unknown": "So službou sa nedalo spojiť",
   "table.loading.data": "Načítanie údajov...",
   "table.object.count": "objekty v tomto súbore údajov",
   "table.paginator.firstPage": "",
@@ -650,6 +649,7 @@
   "table.paginator.previousPage": "",
   "table.paginator.rangeLabel": "",
   "table.select.data": "Zdroj údajov",
+  "tms.unreachable.unknown": "So službou sa nedalo spojiť",
   "tooltip.html.copy": "Kopírovať HTML",
   "tooltip.id.copy": "Kopírovať jedinečný identifikátor",
   "tooltip.url.copy": "Kopírovať URL",
@@ -660,5 +660,7 @@
   "wfs.geojsongml.notsupported": "Táto služba nepodporuje formát GeoJSON alebo GML",
   "wfs.unreachable.cors": "Službu nemožno dosiahnuť z dôvodu obmedzení CORS",
   "wfs.unreachable.http": "Služba vrátila chybu HTTP",
-  "wfs.unreachable.unknown": "So službou sa nedalo spojiť"
+  "wfs.unreachable.parse": "Dáta boli načítané, ale nedajú sa analyzovať: \"{ info }\"",
+  "wfs.unreachable.unknown": "So službou sa nedalo spojiť",
+  "wfs.unreachable.unsupportedType": "Nepodporovaný typ obsahu: \"{ info }\""
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -55,11 +55,11 @@
       "@geonetwork-ui/ui/widgets": ["libs/ui/widgets/src/index.ts"],
       "@geonetwork-ui/util/app-config": ["libs/util/app-config/src/index.ts"],
       "@geonetwork-ui/util/i18n": ["libs/util/i18n/src/index.ts"],
-      "@geonetwork-ui/util/i18n/language-codes": [
-        "libs/util/i18n/src/lib/language-codes.ts"
-      ],
       "@geonetwork-ui/util/i18n/date-locales": [
         "libs/util/i18n/src/lib/date-locales.ts"
+      ],
+      "@geonetwork-ui/util/i18n/language-codes": [
+        "libs/util/i18n/src/lib/language-codes.ts"
       ],
       "@geonetwork-ui/util/shared": ["libs/util/shared/src/index.ts"]
     },


### PR DESCRIPTION
This PR introduces specific translation keys for tms and stac endpoints errors.

It also renames dataset error translation keys that were at some point converted to wfs errors.