### PR TITLE
[Datahub]: default dataviz if config error

### DIFF
--- a/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.spec.ts
+++ b/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.spec.ts
@@ -5,7 +5,7 @@ import {
   tick,
 } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
-import { BehaviorSubject, of } from 'rxjs'
+import { BehaviorSubject, of, throwError } from 'rxjs'
 import {
   MAX_FEATURE_COUNT,
   RecordDataPreviewComponent,
@@ -594,6 +594,52 @@ describe('RecordDataPreviewComponent', () => {
       expect(component.datavizConfig.chartConfig.chartType).toBe('line')
     }))
     it('should fallback to default behavior if no config file', fakeAsync(() => {
+      facade.mapApiLinks$.next(['link'])
+      facade.dataLinks$.next(['link'])
+
+      fixture = TestBed.createComponent(RecordDataPreviewComponent)
+      component = fixture.componentInstance
+      component.recordUuid = 'test-uuid-1234'
+
+      tick()
+      component.ngOnInit()
+      tick()
+      fixture.detectChanges()
+
+      expect(component.datavizConfig.view).toBe('map')
+    }))
+    it('should fallback to default behavior if an error occurs while reading the attachments', fakeAsync(() => {
+      platformServiceInterface.getRecordAttachments = jest
+        .fn()
+        .mockReturnValue(throwError(() => new Error('Attachment read error')))
+
+      facade.mapApiLinks$.next(['link'])
+      facade.dataLinks$.next(['link'])
+
+      fixture = TestBed.createComponent(RecordDataPreviewComponent)
+      component = fixture.componentInstance
+      component.recordUuid = 'test-uuid-1234'
+
+      tick()
+      component.ngOnInit()
+      tick()
+      fixture.detectChanges()
+
+      expect(component.datavizConfig.view).toBe('map')
+    }))
+    it('should fallback to default behavior if an error occurs while reading the config', fakeAsync(() => {
+      platformServiceInterface.getRecordAttachments = jest.fn().mockReturnValue(
+        of([
+          {
+            fileName: 'datavizConfig.json',
+            url: new URL('http://example.com/attachment/datavizConfig.json'),
+          },
+        ])
+      )
+      platformServiceInterface.getFileContent = jest
+        .fn()
+        .mockReturnValue(throwError(() => new Error('File read error')))
+
       facade.mapApiLinks$.next(['link'])
       facade.dataLinks$.next(['link'])
 

--- a/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.ts
+++ b/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.ts
@@ -27,6 +27,7 @@ import { TranslateDirective, TranslatePipe } from '@ngx-translate/core'
 import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import {
   BehaviorSubject,
+  catchError,
   combineLatest,
   map,
   of,
@@ -137,19 +138,18 @@ export class RecordDataPreviewComponent implements OnInit {
   config$ = this.recordUuid$.pipe(
     switchMap((uuid) => {
       if (!uuid) return of(null)
-
-      return this.platformServiceInterface.getRecordAttachments(uuid).pipe(
-        map((attachments) =>
-          attachments.find((att) => att.fileName === 'datavizConfig.json')
-        ),
-        switchMap((configAttachment) =>
-          (configAttachment
-            ? this.platformServiceInterface.getFileContent(configAttachment.url)
-            : of(null)
-          ).pipe(map((config: DatavizConfigModel) => config))
-        )
-      )
-    })
+      return this.platformServiceInterface.getRecordAttachments(uuid)
+    }),
+    map((attachments) => {
+      return attachments?.find((att) => att.fileName === 'datavizConfig.json')
+    }),
+    switchMap((configAttachment) => {
+      return configAttachment
+        ? this.platformServiceInterface.getFileContent(configAttachment.url)
+        : of(null)
+    }),
+    map((config: DatavizConfigModel) => config),
+    catchError(() => of(null))
   )
 
   displayViewShare$ = combineLatest([


### PR DESCRIPTION
### Description

This PR handles error in dataviz config loading. All the errors are ignored and the default behavior (same as if there was no configuration at all) is applied.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](docs) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Either find a platform where reading the config file returns an error (like https://dev.datagrandest.fr/datahub/dataset/FR-200052264-A0157-0000 at the time of writing) or use a browser extention to fake network errors on /geonetwork/srv/api/records/{uuid}/attachments or /geonetwork/srv/api/records/{uuid}/attachments/datavizConfig.json.

The dataviz should be displayed correctly, with no configuration applied.