### PR TITLE
update setup instruction to apps/webcomponents/README.md

### DIFF
--- a/apps/webcomponents/README.md
+++ b/apps/webcomponents/README.md
@@ -28,6 +28,14 @@ npm run build:demo
 
 You'll find the built files in `webcomponents/dist/demo/webcomponents` folder
 
+## Setup
+
+Before running the web components, make sure to install the project dependencies from the root directory:
+
+```shell script
+npm install
+```
+
 ## Run
 
 ### Storybook


### PR DESCRIPTION
This PR adds package installation instructions (`npm install`) to the webcomponents documentation to prevent dependency errors.