### PR TITLE
[Dataviz]: Never get null labels for chart

### DIFF
--- a/libs/ui/dataviz/src/lib/chart/chart.component.ts
+++ b/libs/ui/dataviz/src/lib/chart/chart.component.ts
@@ -200,11 +200,11 @@ export class ChartComponent implements OnChanges, AfterViewInit {
         ) {
           if (secondaryProperty) {
             return {
-              y: target[index][property],
-              x: target[index][secondaryProperty],
+              y: target[index][property] || '',
+              x: target[index][secondaryProperty] || '',
             }
           } else {
-            return target[index][property]
+            return target[index][property] || ''
           }
         }
         return target[index]


### PR DESCRIPTION
### Description

This PR fixes a wrong behavior that is sometimes happening when loading complex data into the chart dataviz, and then playing with options.

As the data is complex, it might be loaded after the new label property has been set. The issue is that the label property is used to extract label from the raw data to give it to the chart library. When trying to read the labels on the previous data, none are matching the property, and data with null labels is sent to the chat library. The library will then throw an error and not react to any new input.

The nice fix would be to properly synchronize the data and label events, but it's way more complex to implement.
The quick fix here is to give empty strings instead of null labels to the chart library. Thus, it doesn't throw an error and is reacting correctly to the next input with the correct data and labels.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

To just see the wrong behavior on label and data events not synchronized and firing twice, visit http://localhost:4200/dataset/ed34db28-5dd4-480f-bf29-dc08f0086131 and play with the chart options. You can see that setting the view to pie and the X property to "lot" will refresh the chart twice, the first with undefined labels (don't know why those are not throwing an error), the second with the correct data and labels.

The bug has first been reported on this record https://geoportal.georhena.eu/datahub/dataset/e3b6d1ff-53ad-43eb-88e9-194191d1594b, when changing the options to pie and then the X property to "energy_type".
