### PR TITLE
Update GML32 import path to include .js extension

### DIFF
--- a/libs/api/metadata-converter/src/lib/iso19139/utils/geometry.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/utils/geometry.ts
@@ -1,6 +1,6 @@
 import { XmlElement } from '@rgrove/parse-xml'
 import { Geometry } from 'geojson'
-import GML32 from 'ol/format/GML32'
+import GML32 from 'ol/format/GML32.js'
 import GeoJSON from 'ol/format/GeoJSON'
 import { parse } from 'ol/xml'
 import {


### PR DESCRIPTION
Explicitly import GML32 from `.js` file to allow importing the geonetwork-ui package into a vite/vitest project.