### PR TITLE
[Datahub]: Make the header nav menu act the same for mobile as desktop

### DIFF
--- a/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.html
+++ b/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.html
@@ -1,4 +1,15 @@
 @if ((isMobile$ | async) === false) {
+  <ng-container *ngTemplateOutlet="tabLinksButtons"></ng-container>
+}
+@if ((isMobile$ | async) === true) {
+  <div
+    class="fixed bottom-0 text-white bg-secondary w-full flex justify-around"
+  >
+    <ng-container *ngTemplateOutlet="tabLinksButtons"></ng-container>
+  </div>
+}
+
+<ng-template #tabLinksButtons>
   @for (l of tabLinks; track l) {
     <button
       [routerLink]="l.link"
@@ -7,46 +18,11 @@
           ? 'decoration-primary'
           : 'decoration-transparent hover:decoration-primary transition-colors'
       "
-      class="sm:py-4 uppercase truncate underline decoration-4 underline-offset-[19px]"
+      class="py-4 uppercase truncate underline decoration-4 underline-offset-[19px]"
       [style.color]="foregroundColor"
       translate
     >
       {{ l.label }}
     </button>
   }
-}
-@if ((isMobile$ | async) === true) {
-  <button
-    (click)="toggleMobileMenu()"
-    class="uppercase truncate text-white bg-primary w-full flex justify-start cursor-pointer z-50"
-  >
-    <button
-      type="button"
-      class="h-12 inline-flex items-center justify-center align-middle pl-6 rounded-md shrink-0"
-    >
-      <ng-icon class="align-middle" name="matMenuOutline"></ng-icon>
-    </button>
-    @if (displayMobileMenu) {
-      <div class="shrink truncate">
-        @for (l of tabLinks; track l) {
-          <div>
-            <button
-              [routerLink]="l.link"
-              class="block pl-5 pr-3 py-3 rounded-md text-[18px] font-medium uppercase tracking-wider w-full text-left truncate"
-              translate
-            >
-              {{ l.label }}
-            </button>
-          </div>
-        }
-      </div>
-    }
-    @if (!displayMobileMenu) {
-      <button
-        class="block pl-5 pr-3 py-3 rounded-md text-[18px] font-medium uppercase tracking-wider shrink truncate"
-      >
-        {{ (activeLink$ | async).label | translate }}
-      </button>
-    }
-  </button>
-}
+</ng-template>

--- a/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.ts
+++ b/apps/datahub/src/app/home/navigation-menu/navigation-menu.component.ts
@@ -12,13 +12,7 @@ import {
 import { getThemeConfig } from '@geonetwork-ui/util/app-config'
 import { CommonModule } from '@angular/common'
 import { RouterLink } from '@angular/router'
-import {
-  NgIconComponent,
-  provideIcons,
-  provideNgIconsConfig,
-} from '@ng-icons/core'
-import { TranslateDirective, TranslatePipe } from '@ngx-translate/core'
-import { matMenuOutline } from '@ng-icons/material-icons/outline'
+import { TranslateDirective } from '@ngx-translate/core'
 import { getIsMobile } from '@geonetwork-ui/util/shared'
 
 marker('datahub.header.news')
@@ -30,21 +24,7 @@ marker('datahub.header.organizations')
   templateUrl: './navigation-menu.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [
-    CommonModule,
-    RouterLink,
-    NgIconComponent,
-    TranslatePipe,
-    TranslateDirective,
-  ],
-  providers: [
-    provideNgIconsConfig({
-      size: '1.5em',
-    }),
-    provideIcons({
-      matMenuOutline,
-    }),
-  ],
+  imports: [CommonModule, RouterLink, TranslateDirective],
 })
 export class NavigationMenuComponent {
   private routerFacade = inject(RouterFacade)


### PR DESCRIPTION
### Description

This PR removes the header navigation menu when mobile, as it may be conflicting with other headers when the DataHub in integrated (geOrchestra, portal...). Instead, the same behavior as not mobile is kept to navigate between news, search and organization.

### Screenshots

Mobile:
<img width="376" height="671" alt="Screenshot from 2026-01-07 17-14-18" src="https://github.com/user-attachments/assets/71ad13fc-4530-4e7c-93c7-2f7e36ed7491" />

Mobile scrolled
<img width="376" height="671" alt="Screenshot from 2026-01-07 17-14-38" src="https://github.com/user-attachments/assets/56a4267e-171f-4fc7-a44a-3f24473df5f1" />

Desktop:
<img width="775" height="825" alt="Screenshot from 2026-01-07 17-15-19" src="https://github.com/user-attachments/assets/51bc6a97-3f59-489f-ba17-7edc5c6bf8aa" />

Desktop scrolled:
<img width="775" height="825" alt="Screenshot from 2026-01-07 17-15-28" src="https://github.com/user-attachments/assets/06f8d5ce-b7de-4893-9c8b-d5a1faedb87c" />

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Navigate to the news, search and organization routes, and check the tabs and search bar behavior, for both mobile and desktop, initially and after some scroll.
