### PR TITLE
translations - CORS error message made clearer

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -662,7 +662,7 @@
   "wfs.feature.limit": "Zu viele Features, um den WFS-Layer anzuzeigen!",
   "wfs.featuretype.notfound": "Kein passender Feature-Typ wurde im Dienst gefunden",
   "wfs.geojsongml.notsupported": "Dieser Dienst unterstützt das GeoJSON- oder GML-Format nicht",
-  "wfs.unreachable.cors": "Der Dienst konnte aufgrund von CORS-Beschränkungen nicht erreicht werden",
+  "wfs.unreachable.cors": "Der Remote-Dienst ist nicht für den Datenempfang (CORS) konfiguriert",
   "wfs.unreachable.http": "Der Dienst hat einen HTTP-Fehler zurückgegeben",
   "wfs.unreachable.unknown": "Der Dienst konnte nicht erreicht werden"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -662,7 +662,7 @@
   "wfs.feature.limit": "Too many features to display the WFS layer!",
   "wfs.featuretype.notfound": "No matching feature type was found in the service",
   "wfs.geojsongml.notsupported": "This service does not support the GeoJSON or GML format",
-  "wfs.unreachable.cors": "The service could not be reached due to CORS limitations",
+  "wfs.unreachable.cors": "The remote service is not configured to allow data retrieval (CORS)",
   "wfs.unreachable.http": "The service returned an HTTP error",
   "wfs.unreachable.unknown": "The service could not be reached"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -662,7 +662,7 @@
   "wfs.feature.limit": "Trop d'objets pour afficher la couche WFS !",
   "wfs.featuretype.notfound": "La classe d'objets n'a pas été trouvée dans le service",
   "wfs.geojsongml.notsupported": "Le service ne supporte pas le format GeoJSON ou GML",
-  "wfs.unreachable.cors": "Le service n'est pas accessible en raison de limitations CORS",
+  "wfs.unreachable.cors": "Le service distant n'est pas configuré pour autoriser la consommation des données (CORS)",
   "wfs.unreachable.http": "Le service a retourné une erreur HTTP",
   "wfs.unreachable.unknown": "Le service n'est pas accessible"
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -662,7 +662,7 @@
   "wfs.feature.limit": "Troppi oggetti per visualizzare il WFS layer!",
   "wfs.featuretype.notfound": "La classe di oggetto non è stata trovata nel servizio",
   "wfs.geojsongml.notsupported": "Il servizio non supporta il formato GeoJSON o GML",
-  "wfs.unreachable.cors": "Il servizio non è accessibile a causa di limitazioni CORS",
+  "wfs.unreachable.cors": "Il servizio remoto non è configurato per consentire il consumo di dati (CORS)",
   "wfs.unreachable.http": "Il servizio ha restituito un errore HTTP",
   "wfs.unreachable.unknown": "Il servizio non è accessibile"
 }

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -662,7 +662,7 @@
   "wfs.feature.limit": "",
   "wfs.featuretype.notfound": "V službe nebol nájdený žiadny zodpovedajúci typ funkcie",
   "wfs.geojsongml.notsupported": "Táto služba nepodporuje formát GeoJSON alebo GML",
-  "wfs.unreachable.cors": "Službu nemožno dosiahnuť z dôvodu obmedzení CORS",
+  "wfs.unreachable.cors": "Vzdialená služba nie je nakonfigurovaná tak, aby povoľovala spotrebu dát (CORS)",
   "wfs.unreachable.http": "Služba vrátila chybu HTTP",
   "wfs.unreachable.unknown": "So službou sa nedalo spojiť"
 }


### PR DESCRIPTION
This PR is an attempt to make it clearer to data reusers that the remote service is responsible for the broken data preview, due to misconfiguration.