### PR TITLE
[Package]: export records repository interface

### DIFF
--- a/libs/common/domain/src/index.ts
+++ b/libs/common/domain/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/organizations.service.interface'
 export * from './lib/platform.service.interface'
+export * from './lib/repository/records-repository.interface'


### PR DESCRIPTION
This PR adds `RecordsRepositoryInterface` to the exports included in the geonetwork-ui package.

This is needed for any custom app that will use the editor, and in particular `openRecordForEdition` to load the record into the editor store.