### PR TITLE
[Datahub]: display dataviz save button only if multiple displays available

### DIFF
--- a/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.spec.ts
+++ b/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.spec.ts
@@ -496,6 +496,23 @@ describe('RecordDataPreviewComponent', () => {
         done()
       })
     })
+    it('should emit false if display is map only', (done) => {
+      ;(platformServiceInterface.getMe as jest.Mock).mockReturnValue(
+        of({ profile: 'Administrator', username: 'admin' })
+      )
+      fixture = TestBed.createComponent(RecordDataPreviewComponent)
+      component = fixture.componentInstance
+      facade.metadata$.next({
+        ...SAMPLE_RECORD,
+        extras: { ownerInfo: 'someone|other', isPublishedToAll: true },
+      })
+      facade.mapApiLinks$.next(['link'])
+      fixture.detectChanges()
+      component.displayDatavizConfig$.subscribe((result) => {
+        expect(result).toBe(false)
+        done()
+      })
+    })
   })
   describe('Config saving', () => {
     const chartConf = {

--- a/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.ts
+++ b/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.ts
@@ -189,14 +189,16 @@ export class RecordDataPreviewComponent implements OnInit, OnDestroy {
   displayDatavizConfig$ = combineLatest([
     this.platformServiceInterface.getMe(),
     this.metadataViewFacade.metadata$,
+    this.displayMap$,
+    this.displayData$,
   ]).pipe(
-    map(([userInfo, metadata]) => {
+    map(([userInfo, metadata, displayMap, displayData]) => {
       const isAdmin =
         userInfo?.profile === 'Administrator' ||
         userInfo?.username ===
           (metadata?.extras?.ownerInfo as string).split('|')[0]
       const isPublished = metadata?.extras?.isPublishedToAll
-      return isAdmin && isPublished
+      return isAdmin && isPublished && !(displayMap && !displayData)
     })
   )
 


### PR DESCRIPTION
### Description

This PR removes the dataviz saving button when only the map preview is available, as then the only config that can be saved is the default one.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Import or create a record with only a map preview, usually with only a WMS online resource, such as https://www.geo2france.fr/datahub/dataset/056d8c48-5ef0-4a1d-8bd4-3e084c311f84.
Make sure the dataviz saving button isn't displayed for this record (but still displayed for other records you own, or logged in as an admin).

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [Géo2France](https://www.geo2france.fr/)**.
