### PR TITLE
[Datahub]: Search only once in fuzzy autocomplete

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/dashboard/dashboard.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/dashboard/dashboard.cy.ts
@@ -308,7 +308,7 @@ describe('dashboard (landing page)', () => {
     cy.url().should('not.include', 'owner')
 
     // it should not show the feature catalog
-    cy.get('gn-ui-autocomplete').type('catalog')
+    cy.get('gn-ui-autocomplete').type('{selectall}{del}catalog')
     cy.get('mat-option').should('not.have.text', 'Feature Catalog')
   })
 

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.spec.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.spec.ts
@@ -243,14 +243,19 @@ describe('AutocompleteComponent', () => {
           },
         }
         component.displayWithFn = (item) => item.title
+        fixture.detectChanges()
         component.ngOnChanges(simpleChanges)
       })
       it('set control value', () => {
         expect(component.control.value).toEqual({ title: 'hello' })
       })
+      it('set input value', () => {
+        expect(component.inputRef.nativeElement.value).toEqual('hello')
+      })
     })
     describe('when changed', () => {
       beforeEach(() => {
+        component.control.setValue('hello')
         const simpleChanges: any = {
           value: {
             previousValue: { title: 'hello' },
@@ -258,15 +263,20 @@ describe('AutocompleteComponent', () => {
           },
         }
         component.displayWithFn = (item) => item.title
+        fixture.detectChanges()
         component.ngOnChanges(simpleChanges)
       })
       it('set control value', () => {
         expect(component.control.value).toEqual({ title: 'good bye' })
       })
+      it('set input value', () => {
+        expect(component.inputRef.nativeElement.value).toEqual('good bye')
+      })
     })
-    describe('when ref changed but same text', () => {
-      let anyEmitted
+    describe('when changed but same text', () => {
       beforeEach(() => {
+        jest.spyOn(component, 'updateInputValue')
+        component.control.setValue('good bye')
         const simpleChanges: any = {
           value: {
             previousValue: { title: 'good bye' },
@@ -274,14 +284,11 @@ describe('AutocompleteComponent', () => {
           },
         }
         component.displayWithFn = (item) => item.title
-        component.inputSubmitted.subscribe((event) => (anyEmitted = event))
+        fixture.detectChanges()
         component.ngOnChanges(simpleChanges)
       })
-      it('does not set control value', () => {
-        expect(component.control.value).toBeNull()
-      })
-      it('does not emit any value', () => {
-        expect(anyEmitted).toBeUndefined()
+      it('does not update input value', () => {
+        expect(component.updateInputValue).not.toHaveBeenCalled()
       })
     })
     describe('when not set on init (firstChange == true)', () => {

--- a/tools/e2e/commands.ts
+++ b/tools/e2e/commands.ts
@@ -253,7 +253,10 @@ Cypress.Commands.add('editor_createRecordCopy', (uuidToCopy, titleToCopy) => {
 
   // Clear any existing copy of the test record
   cy.visit('/catalog/search')
-  cy.get('gn-ui-fuzzy-search input').type(`${recordTitle}{enter}`)
+  cy.wait(400) // wait for the autocomplete debounce ?
+  cy.get('gn-ui-fuzzy-search input').type(
+    `{selectall}{del}${recordTitle}{enter}`
+  )
   cy.get('[data-cy="table-row"]')
     .should('have.length.lt', 10) // making sure the records were updated
     .then((rows$) => {


### PR DESCRIPTION
### Description

This PR fixes two wrong behaviors in the DataHub home fuzzy search:
- the search was sent twice on each new input for the autocomplete
- the search was run again twice when validating the search (instead of clicking on one of the suggestions)

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Datahub:
- open the Datahub on the catalog page
- open the network tab in the devTools
- start typing in the fuzzy search input
- check that only one search request is sent per change (debounce when typing is 400ms)
- validate the search input
- check that only one more search request is sent

<img width="972" height="436" alt="image" src="https://github.com/user-attachments/assets/b2fe884b-211c-4dcc-9b73-a3a29e173709" />

Metadata Editor:
The same component is used for keywords, layer in OGC services, and contacts, but not sending a search request.
Make sure you can find and validate autocomplete results (no network check needed).

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
