### PR TITLE
Fix search and results wc records catalog redirection

### DIFF
--- a/apps/webcomponents/cypress/e2e/search-input-and-results.cy.ts
+++ b/apps/webcomponents/cypress/e2e/search-input-and-results.cy.ts
@@ -19,8 +19,7 @@ describe('gn-search-input-and-results', () => {
       cy.get('gn-ui-fuzzy-search').type('velo')
       cy.get('mat-option').should('have.text', ' Accroches vélos MEL ')
     })
-    // FIXME
-    it.skip('should go to the dataset page when clicking on the autocomplete result', () => {
+    it('should go to the dataset page when clicking on the autocomplete result', () => {
       cy.get('gn-ui-fuzzy-search').type('velo')
       cy.get('mat-option').should('have.text', ' Accroches vélos MEL ').click()
       cy.url().should('include', '/dataset/')

--- a/apps/webcomponents/src/app/components/gn-search-input/gn-search-input-and-results-multilingual.sample.html
+++ b/apps/webcomponents/src/app/components/gn-search-input/gn-search-input-and-results-multilingual.sample.html
@@ -37,6 +37,7 @@
         <script src="gn-wc.js"></script>
         <gn-search-input
           api-url="https://www.geocat.ch/geonetwork/srv/api"
+          open-on-select="https://www.geocat.ch/datahub/dataset/${uuid}"
           metadata-language="current"
           text-language="de"
         ></gn-search-input>

--- a/apps/webcomponents/src/app/components/gn-search-input/gn-search-input-and-results.sample.html
+++ b/apps/webcomponents/src/app/components/gn-search-input/gn-search-input-and-results.sample.html
@@ -37,6 +37,7 @@
         <script src="gn-wc.js"></script>
         <gn-search-input
           api-url="https://www.geo2france.fr/geonetwork/srv/api"
+          open-on-select="https://www.geo2france.fr/datahub/dataset/${uuid}"
         ></gn-search-input>
       </div>
     </header>


### PR DESCRIPTION
### Description

This PR is a minimal fix extract of https://github.com/geonetwork/geonetwork-ui/pull/1433.

It simply adds missing open-on-select argument on search and results samples.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

Note: the CI can't compute the GN version matrix, because neither the Dathub app nor the Metadata-Editor app are affected. This is not a real issue.

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

- checkout the branch
- start the docker composition
  - `cd support-services/`
  - `docker compose up init`
- start the WC demo
  - `nvm use`
  - `npm run demo`
- navigate to the search and results sample pages
  - http://localhost:8001/webcomponents/gn-search-input-and-results.sample.html
  - http://localhost:8001/webcomponents/gn-search-input-and-results-multilingual.sample.html
- type a search and click on a suggestion
- check the proper redirect to the catalog's record