### PR TITLE
Filter results in search and results wc

### DIFF
--- a/apps/webcomponents/cypress/e2e/search-input-and-results.cy.ts
+++ b/apps/webcomponents/cypress/e2e/search-input-and-results.cy.ts
@@ -25,8 +25,7 @@ describe('gn-search-input-and-results', () => {
       cy.get('mat-option').should('have.text', ' Accroches vélos MEL ').click()
       cy.url().should('include', '/dataset/')
     })
-    // FIXME
-    it.skip('should display the search results on click on icon and close suggestions', () => {
+    it('should display the search results on click on icon and close suggestions', () => {
       cy.get('gn-ui-fuzzy-search').type('velo')
       cy.get('mat-option').should('have.length.above', 0)
       cy.get('ng-icon')
@@ -41,8 +40,7 @@ describe('gn-search-input-and-results', () => {
         .should('contain', 'Accroches vélos MEL')
       cy.screenshot({ capture: 'viewport' })
     })
-    // FIXME
-    it.skip('should display the search results on enter touch and close suggestions', () => {
+    it('should display the search results on enter touch and close suggestions', () => {
       cy.get('gn-ui-fuzzy-search').type('velo{enter}')
       cy.get('gn-ui-record-preview-row').should('have.length', 1)
       cy.get('mat-option').should('have.length', 0)

--- a/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.component.ts
+++ b/apps/webcomponents/src/app/components/gn-search-input/gn-search-input.component.ts
@@ -30,6 +30,8 @@ export class GnSearchInputComponent extends BaseComponent {
     if (this.openOnSearch) {
       const landingPage = this.openOnSearch.replace(/\$\{search}/, any)
       window.open(landingPage, '_self').focus()
+    } else {
+      this.facade.setFilters({ any })
     }
   }
 


### PR DESCRIPTION
### Description

This PR is a minimal fix extract of https://github.com/geonetwork/geonetwork-ui/pull/1458.

It sets the search filter when the user validates the search input and no `openOnSearch` has been configured.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [X] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

Note: the CI can't compute the GN version matrix, because neither the Dathub app nor the Metadata-Editor app are affected. This is not a real issue.

### How to test

- checkout the branch
- start the docker composition
  - `cd support-services/`
  - `docker compose up init`
- start the WC demo
  - `nvm use`
  - `npm run demo`
- navigate to the search and results sample pages
  - http://localhost:8001/webcomponents/gn-search-input-and-results.sample.html
  - http://localhost:8001/webcomponents/gn-search-input-and-results-multilingual.sample.html
- type a search and validate
- check the proper refresh of the results list

You can also play with the filter argument on the results webcomponent, and chech that both filters (user input and argument) are correctly combined.

For example, an argument of `filter='{"OrgForResourceObject.default": { "Odema": true } }'` and an input of `collecte` should show results, but none for Géo2France.
