### PR TITLE
[Datahub]: Show STAC tab only if items link

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset/datasetPreview.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetPreview.cy.ts
@@ -153,17 +153,12 @@ describe('Preview section', () => {
       .children('div')
       .eq(3)
       .as('chartTab')
-    cy.get('@previewSection')
-      .find('.mat-mdc-tab-labels')
-      .children('div')
-      .eq(4)
-      .as('stacTab')
 
     // it should display the tabs
     cy.get('@previewSection')
       .find('.mat-mdc-tab-labels')
       .children('div')
-      .should('have.length', 5)
+      .should('have.length', 4)
 
     // it should display the dataset dropdown with at least 1 option
     cy.get('@previewSection')
@@ -522,11 +517,6 @@ describe('Preview section', () => {
         .children('div')
         .eq(3)
         .as('chartTab')
-      cy.get('@previewSection')
-        .find('.mat-mdc-tab-labels')
-        .children('div')
-        .eq(4)
-        .as('stacTab')
     })
     it('should NOT show the config saving btn when logged out', () => {
       cy.get('@configTab').find('gn-ui-button').should('not.exist')

--- a/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.html
+++ b/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.html
@@ -93,14 +93,18 @@
                 </div>
               }
             </mat-tab>
-            <mat-tab [disabled]="(displayStac$ | async) === false">
-              <ng-template mat-tab-label>
-                <span class="tab-header-label" translate>record.tab.stac</span>
-              </ng-template>
-              <ng-template matTabContent>
-                <gn-ui-stac-view></gn-ui-stac-view>
-              </ng-template>
-            </mat-tab>
+            @if ((displayStac$ | async) === true) {
+              <mat-tab>
+                <ng-template mat-tab-label>
+                  <span class="tab-header-label" translate
+                    >record.tab.stac</span
+                  >
+                </ng-template>
+                <ng-template matTabContent>
+                  <gn-ui-stac-view></gn-ui-stac-view>
+                </ng-template>
+              </mat-tab>
+            }
           </mat-tab-group>
         </div>
       </div>

--- a/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.spec.ts
+++ b/apps/datahub/src/app/record/record-data-preview/record-data-preview.component.spec.ts
@@ -288,9 +288,8 @@ describe('RecordDataPreviewComponent', () => {
 
         stacTab = fixture.debugElement.queryAll(By.directive(MatTab))[4]
       }))
-      it('renders STAC tab and is disabled', () => {
-        expect(stacTab).toBeDefined()
-        expect(stacTab.componentInstance.disabled).toBe(true)
+      it('does not render STAC tab', () => {
+        expect(stacTab).toBeUndefined()
       })
     })
     describe('when only a STAC link present', () => {
@@ -304,9 +303,8 @@ describe('RecordDataPreviewComponent', () => {
         stacTab = fixture.debugElement.queryAll(By.directive(MatTab))[4]
         tabGroup = fixture.debugElement.queryAll(By.directive(MatTabGroup))[0]
       }))
-      it('renders STAC tab and is enabled', () => {
+      it('renders STAC tab', () => {
         expect(stacTab).toBeDefined()
-        expect(stacTab.componentInstance.disabled).toBe(false)
       })
       it('stac tab is selected', () => {
         expect(tabGroup.componentInstance.selectedIndex).toBe(4)


### PR DESCRIPTION
### Description

The STAC tab for the dataviz preview was introduced in 2.8.0 for datasets with a STAC Items link.

This new tab is rarely used, and should not add complexity to the datasets not concerned with STAC.

In this case, it's better not to show the tab at all, and keep it only for datasets with a STAC Items link.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [X] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Open a record without a STAC Items link.
Make sure the dataviz preview tabs are correctly displayed for map, table and chart, desktop and mobile.
Make sure the dataviz saving button is till correctly displayed when admin/owner, mobile and desktop.

Open a record with a STAC Items link.
Make sure the dataviz preview tabs are correctly displayed for map, table, chart and STAC, desktop and mobile.
Make sure the dataviz saving button is till correctly displayed when admin/owner, mobile and desktop.