### PR TITLE
[Datahub]: get first json format for ogc features download

### DIFF
--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -135,6 +135,11 @@ jest.mock('@camptocamp/ogc-client', () => ({
           bulkDownloadLinks: { json: 'http://json', csv: 'http://csv' },
         })
       }
+      if (this.url.indexOf('nojson') > -1) {
+        return Promise.resolve({
+          bulkDownloadLinks: { csv: 'http://csv' },
+        })
+      }
       return Promise.resolve({
         bulkDownloadLinks: { json: 'http://json', csv: 'http://csv' },
       })
@@ -835,6 +840,24 @@ describe('DataService', () => {
             )
           )
           await expect(result.read()).resolves.toEqual(SAMPLE_GEOJSON.features)
+        })
+      })
+      describe('GeoJSON not supported by OGC API Features', () => {
+        it('returns an observable that errors with a relevant error', async () => {
+          try {
+            await lastValueFrom(
+              service.getDataset(
+                {
+                  type: 'service',
+                  accessServiceProtocol: 'ogcFeatures',
+                  url: new URL('https://my.ogc.api/features_nojson'),
+                },
+                cacheActive
+              )
+            )
+          } catch (e) {
+            expect(e).toEqual('ogc.geojson.notsupported')
+          }
         })
       })
     })

--- a/translations/de.json
+++ b/translations/de.json
@@ -387,6 +387,7 @@
   "multiselect.filter.placeholder": "Suche",
   "nav.back": "Zurück",
   "navbar.mobile.menuTitle": "Schnellzugriff",
+  "ogc.geojson.notsupported": "Dieser OGC API-Dienst unterstützt das GeoJSON-Format nicht.",
   "ogc.unreachable.unknown": "Der Dienst konnte nicht erreicht werden",
   "organisation.filter.placeholder": "Ergebnisse filtern",
   "organisation.sort.sortBy": "Sortieren nach:",

--- a/translations/en.json
+++ b/translations/en.json
@@ -387,6 +387,7 @@
   "multiselect.filter.placeholder": "Search",
   "nav.back": "Back",
   "navbar.mobile.menuTitle": "Quick access",
+  "ogc.geojson.notsupported": "This OGC API does not support the GeoJSON format",
   "ogc.unreachable.unknown": "The service could not be reached",
   "organisation.filter.placeholder": "Filter results",
   "organisation.sort.sortBy": "Sort by:",

--- a/translations/es.json
+++ b/translations/es.json
@@ -387,6 +387,7 @@
   "multiselect.filter.placeholder": "",
   "nav.back": "",
   "navbar.mobile.menuTitle": "Acceso rápido",
+  "ogc.geojson.notsupported": "",
   "ogc.unreachable.unknown": "",
   "organisation.filter.placeholder": "",
   "organisation.sort.sortBy": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -387,6 +387,7 @@
   "multiselect.filter.placeholder": "Rechercher",
   "nav.back": "Retour",
   "navbar.mobile.menuTitle": "Navigation rapide",
+  "ogc.geojson.notsupported": "Le service OGC API ne supporte pas le format GeoJSON",
   "ogc.unreachable.unknown": "Le service n'est pas accessible",
   "organisation.filter.placeholder": "Filtrer les résultats",
   "organisation.sort.sortBy": "Trier par :",

--- a/translations/it.json
+++ b/translations/it.json
@@ -387,6 +387,7 @@
   "multiselect.filter.placeholder": "Cerca",
   "nav.back": "Indietro",
   "navbar.mobile.menuTitle": "Accesso rapido",
+  "ogc.geojson.notsupported": "Il servizio OGC API non supporta il formato GeoJSON.",
   "ogc.unreachable.unknown": "Il servizio non è accessibile",
   "organisation.filter.placeholder": "Filtra i risultati",
   "organisation.sort.sortBy": "Ordina per:",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -387,6 +387,7 @@
   "multiselect.filter.placeholder": "",
   "nav.back": "",
   "navbar.mobile.menuTitle": "",
+  "ogc.geojson.notsupported": "",
   "ogc.unreachable.unknown": "",
   "organisation.filter.placeholder": "",
   "organisation.sort.sortBy": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -387,6 +387,7 @@
   "multiselect.filter.placeholder": "",
   "nav.back": "",
   "navbar.mobile.menuTitle": "",
+  "ogc.geojson.notsupported": "",
   "ogc.unreachable.unknown": "",
   "organisation.filter.placeholder": "",
   "organisation.sort.sortBy": "",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -387,6 +387,7 @@
   "multiselect.filter.placeholder": "Hľadať",
   "nav.back": "Späť",
   "navbar.mobile.menuTitle": "",
+  "ogc.geojson.notsupported": "",
   "ogc.unreachable.unknown": "So službou sa nedalo spojiť",
   "organisation.filter.placeholder": "Filtrovať výsledky",
   "organisation.sort.sortBy": "Zoradiť podľa:",


### PR DESCRIPTION
### Description

This PR changes the order in which the formats are prioritized when downloading from an OGC API Features service.
Previously, the download link was computed by `ogc-client`, cascading from JSON FG to GeoJSON to JSON.
This is problematic for the sources without a geometry, as the JSON FG served by GeoServer will then crash with an NPE.

As a quickfix, it's been decided to have the same format logic between WFS and OGC API Features, meaning the first JSON format found will be used. If no JSON format is found, an error is shown.

Note: it's still possible to have an error, for both WFS and OGC API Features, if the JSON FG format is the first JSON format published by the server on a non-geographic layer. This is rarely the case, and would be better fixed on the server side.

### Screenshots

When no JSON format is found:

<img width="1032" height="243" alt="image" src="https://github.com/user-attachments/assets/f65f8438-c5af-4280-9335-a8f8b058bc35" />

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Plug your local Datahub to `geonetwork4_api_url = "https://mel.integration.apps.gs-fr-prod.camptocamp.com/geonetwork/srv/api"` or import the following record:
https://mel.integration.apps.gs-fr-prod.camptocamp.com/catalogue/dataset/2fbebea9-1038-46d7-9733-c47845ae3519

See that the dataviz error

<img width="1051" height="368" alt="image" src="https://github.com/user-attachments/assets/5e17c37c-c173-458a-946e-fa7edd0c092d" />

is now fixed

<img width="1051" height="368" alt="image" src="https://github.com/user-attachments/assets/729d1c7b-238f-40b6-b22e-08bd6ae22aec" />


---

**This work is sponsored by [Métropole Européenne de Lille](https://data.lillemetropole.fr/)**.
