### PR TITLE
[Datahub]: Reformat html to keep only one space in header date

### DIFF
--- a/apps/datahub/src/app/record/header-record/header-record.component.html
+++ b/apps/datahub/src/app/record/header-record/header-record.component.html
@@ -104,8 +104,9 @@
                     <div>
                       <p class="text-sm">
                         <span translate>{{ resourceDate.label }}</span
-                        >&nbsp;
-                        <span [gnUiHumanizeDate]="resourceDate.date"></span>
+                        >&nbsp;<span
+                          [gnUiHumanizeDate]="resourceDate.date"
+                        ></span>
                       </p>
                     </div>
                   }


### PR DESCRIPTION
### Description

This PR keeps only one space in the date display of the header.

### Screenshots

Before:
<img width="223" height="104" alt="image" src="https://github.com/user-attachments/assets/0967ebf2-83f3-450a-94c5-55cff4059984" />

After:
<img width="189" height="62" alt="image" src="https://github.com/user-attachments/assets/7802301a-7c20-4742-a458-44143cba9592" />