### PR TITLE
add sorting param to gn-results-list wc

### DIFF
--- a/apps/webcomponents/src/app/components/gn-results-list/gn-results-list-sort.sample.html
+++ b/apps/webcomponents/src/app/components/gn-results-list/gn-results-list-sort.sample.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Web Component Demo</title>
+    <base href="./" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&amp;family=Inter:wght@200;300;400;500;600;700&amp;display=swap"
+      rel="stylesheet"
+      type="text/css"
+    />
+    <style>
+      html,
+      body {
+        font-family: var(--font-family-main);
+      }
+      .container {
+        max-width: 1024px;
+        margin-left: auto;
+        margin-right: auto;
+        margin-top: 3rem;
+      }
+      code {
+        background-color: #f6f6f6;
+        padding: 8px 14px;
+        border-radius: 3px;
+      }
+    </style>
+  </head>
+  <body>
+    <script src="gn-wc.js"></script>
+    <main class="container">
+      <div style="margin: 60px 16px">
+        <p>
+          Use the <b><i>sort</i></b> attribute to control the sort order on a
+          <b><i>gn-results-list</i></b> web component.
+        </p>
+        <p>
+          Prefix the field name with <code>-</code> for descending order:
+          <code>sort="-revisionDateForResource"</code>
+        </p>
+      </div>
+
+      <h1>Sort by most recently updated (descending)</h1>
+      <gn-results-list
+        api-url="https://www.geocat.ch/geonetwork/srv/api"
+        size="5"
+        layout="TITLE"
+        primary-color="#0f4395"
+        main-font="'Inter', sans-serif"
+        sort="-revisionDateForResource"
+      ></gn-results-list>
+    </main>
+  </body>
+</html>

--- a/apps/webcomponents/src/app/components/gn-results-list/gn-results-list.component.ts
+++ b/apps/webcomponents/src/app/components/gn-results-list/gn-results-list.component.ts
@@ -31,6 +31,7 @@ export class GnResultsListComponent extends BaseComponent {
   @Input() size = '10' // will be converted to number later
   @Input() query: string
   @Input() filter: string
+  @Input() sort: string
   @Input() catalogUrl: string
   @Input() showMore: ResultsListShowMoreStrategy = 'none'
 
@@ -56,6 +57,12 @@ export class GnResultsListComponent extends BaseComponent {
     if (filter) {
       const configFilters: FieldFilters = JSON.parse(filter)
       this.facade.setConfigFilters(configFilters)
+    }
+    if (this.sort) {
+      const desc = this.sort.startsWith('-')
+      const field = desc ? this.sort.slice(1).trim() : this.sort.trim()
+      const sortPayload: SearchStateParams['sort'] = [desc ? 'desc' : 'asc', field]
+      searchActionPayload.sort = sortPayload
     }
     this.facade.setSearch(searchActionPayload)
   }

--- a/apps/webcomponents/src/index.html
+++ b/apps/webcomponents/src/index.html
@@ -63,6 +63,11 @@
             >Results List TITLE, filters</a
           >
         </li>
+        <li>
+          <a href="gn-results-list-sort.sample.html"
+            >Results List TITLE, sort ascending / descending</a
+          >
+        </li>
         <li class="mt-5">
           <a href="gn-search-input.sample.html">Search Input</a>
         </li>


### PR DESCRIPTION
### Description

This PR introduces a new sorting parameter `sort` to the `gn-results-list` web component.in relation with the feature request #1486.

### Screenshots

<img width="1865" height="922" alt="image" src="https://github.com/user-attachments/assets/bb759f2d-6877-4b30-984d-1bb60c0838ae" />

<img width="1863" height="641" alt="image" src="https://github.com/user-attachments/assets/ab02d3c6-2adf-4806-a747-c0b1fa5bbc01" />

<img width="1865" height="1193" alt="image" src="https://github.com/user-attachments/assets/5802ce84-40d5-4e0d-9730-93b6b5bf4bd0" />

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews

### How to test

Add the `sort` parameter with its associated values in one of the webcomponent examples for example gn-search-input-and-results-multilingual.sample.html

```
      <gn-results-list
        size="10"
        api-url="https://www.geocat.ch/geonetwork/srv/api"
        catalog-url="https://www.geocat.ch/datahub/dataset/{uuid}"
        metadata-language="current"
        sort="-revisionDateForResource"
        text-language="de"
        layout="ROW"
        primary-color="#251"
        secondary-color="#c40"
        main-color="#555"
        background-color="#fdfbff"
        main-font="'Inter', sans-serif"
        title-font="'DM Serif Display', serif"
        show-more="auto"
      ></gn-results-list>
```

The records displayed by default should correspond to the following results: on the related [GeoNetwork](https://www.geocat.ch/geonetwork/srv/fre/catalog.search#/search?sortBy=revisionDateForResource&sortOrder=desc&from=1&to=10) and [datahub](https://www.geocat.ch/datahub/search?_sort=-revisionDateForResource) instances.