### PR TITLE
[Datahub]: use contactsForResource on reuse too

### DIFF
--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.html
@@ -85,7 +85,7 @@
               class="!w-5 !h-5 !text-[20px] opacity-75 shrink-0"
               name="matPersonOutline"
             ></ng-icon>
-            <div class="flex flex-col ml-2">
+            <div class="flex flex-col ml-2" data-cy="contact-full-name">
               <p class="text-sm">
                 {{ contacts[0]?.firstName || '' }}
                 {{ contacts[0]?.lastName || '' }}

--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.spec.ts
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.spec.ts
@@ -18,67 +18,99 @@ describe('MetadataContactComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(MetadataContactComponent)
     component = fixture.componentInstance
-    component.metadata = {
-      kind: 'dataset',
-      ownerOrganization: {
-        name: 'Worldcorp',
-        website: new URL('https://john.world.co'),
-      },
-      contactsForResource: [
-        {
-          name: 'john',
-          organization: 'Worldcorp',
-          email: 'john@world.co',
-          website: 'https://john.world.co',
-        },
-        {
-          name: 'billy',
-          organization: 'small corp',
-          email: 'billy@small.co',
-          website: 'https://billy.small.co',
-        },
-      ],
-    } as any
-    fixture.detectChanges()
   })
 
   it('should create', () => {
     expect(component).toBeTruthy()
   })
-  describe('on contact click', () => {
+  describe('kind dataset', () => {
     beforeEach(() => {
-      jest.resetAllMocks()
-      jest.spyOn(component.organizationClick, 'emit')
+      component.metadata = {
+        kind: 'dataset',
+        ownerOrganization: {
+          name: 'Worldcorp',
+          website: new URL('https://john.world.co'),
+        },
+        contactsForResource: [
+          {
+            firstName: 'john',
+            lastName: 'doe',
+            organization: 'Worldcorp',
+            email: 'john@world.co',
+            website: 'https://john.world.co',
+          },
+          {
+            firstName: 'billy',
+            lastName: 'smith',
+            organization: 'small corp',
+            email: 'billy@small.co',
+            website: 'https://billy.small.co',
+          },
+        ],
+      } as any
+      fixture.detectChanges()
     })
-    it('emit contact click with contact name', () => {
-      const el = fixture.debugElement.query(
-        By.css('[data-cy="organization-name-link"]')
-      ).nativeElement
-      el.click()
-      expect(component.organizationClick.emit).toHaveBeenCalledWith({
-        name: 'Worldcorp',
-        website: new URL('https://john.world.co'),
+    describe('on organization click', () => {
+      beforeEach(() => {
+        jest.resetAllMocks()
+        jest.spyOn(component.organizationClick, 'emit')
+      })
+      it('emit organization click with organization name', () => {
+        const el = fixture.debugElement.query(
+          By.css('[data-cy="organization-name-link"]')
+        ).nativeElement
+        el.click()
+        expect(component.organizationClick.emit).toHaveBeenCalledWith({
+          name: 'Worldcorp',
+          website: new URL('https://john.world.co'),
+        })
+      })
+    })
+    describe('content', () => {
+      let email
+      beforeEach(() => {
+        email = fixture.debugElement.queryAll(By.css('a'))[1]
+      })
+      it('displays the organization name', () => {
+        const el = fixture.debugElement.query(
+          By.css('[data-cy="organization-name-link"]')
+        ).nativeElement
+        expect(el.innerHTML).toBe(' Worldcorp ')
+      })
+      it('displays the contact email', () => {
+        expect(email.attributes.href).toBe('mailto:john@world.co')
+      })
+      it('displays a link to the contact website', () => {
+        const a = fixture.debugElement.query(By.css('.contact-website'))
+        expect(a.attributes.href).toBe('https://john.world.co/')
+        expect(a.attributes.target).toBe('_blank')
       })
     })
   })
-  describe('content', () => {
-    let email
+
+  describe('kind service', () => {
     beforeEach(() => {
-      email = fixture.debugElement.queryAll(By.css('a'))[1]
+      component.metadata = {
+        kind: 'service',
+        ownerOrganization: {
+          name: 'Service Corp',
+        },
+        contacts: [
+          {
+            firstName: 'samantha',
+            lastName: 'smith',
+          },
+        ],
+      } as any
+      fixture.detectChanges()
     })
-    it('displays the contact name', () => {
-      const el = fixture.debugElement.query(
-        By.css('[data-cy="organization-name-link"]')
-      ).nativeElement
-      expect(el.innerHTML).toBe(' Worldcorp ')
-    })
-    it('displays the contact email', () => {
-      expect(email.attributes.href).toBe('mailto:john@world.co')
-    })
-    it('displays a link to the contact website', () => {
-      const a = fixture.debugElement.query(By.css('.contact-website'))
-      expect(a.attributes.href).toBe('https://john.world.co/')
-      expect(a.attributes.target).toBe('_blank')
+    describe('content', () => {
+      it('displays the contact name', () => {
+        const el = fixture.debugElement.query(
+          By.css('[data-cy="contact-full-name"] > p')
+        ).nativeElement
+        expect(el.innerHTML).toBe(' samantha smith ')
+      })
     })
   })
 })

--- a/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.ts
+++ b/libs/ui/elements/src/lib/metadata-contact/metadata-contact.component.ts
@@ -52,9 +52,9 @@ export class MetadataContactComponent {
 
   get contacts() {
     return (
-      (this.metadata.kind === 'dataset'
-        ? this.metadata.contactsForResource
-        : this.metadata.contacts) || []
+      (this.metadata.kind === 'service'
+        ? this.metadata.contacts
+        : this.metadata.contactsForResource) || []
     )
   }
 


### PR DESCRIPTION
### Description

This PR fixes the contact displayed for reuse records. It's now showing the first contact for resource, same as dataset records. Only service records will display the first contact (their shouldn't be any contact for resource on a service).

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Load a service record with both contacts and contacts for resource. Make sure the first contact (not for resource) is displayed.
Load a reuse record with both contacts and contacts for resource. Make sure the first contact for resource is displayed.