### PR TITLE
[Webcomponent]: correctly build link from npm dev version

### DIFF
--- a/libs/util/shared/src/lib/gn-ui-version.spec.ts
+++ b/libs/util/shared/src/lib/gn-ui-version.spec.ts
@@ -20,6 +20,12 @@ describe('GN UI version exports', () => {
       const module = await import('@geonetwork-ui/util/shared')
       expect(module.GEONETWORK_UI_VERSION).toBe('4.5.6-dev')
     })
+    it('returns the full version (dev npm version)', async () => {
+      currentVersion = '4.5.6-dev.c7f35f0e1'
+      // eslint-disable-next-line @nx/enforce-module-boundaries
+      const module = await import('@geonetwork-ui/util/shared')
+      expect(module.GEONETWORK_UI_VERSION).toBe('4.5.6-dev.c7f35f0e1')
+    })
     it('returns the full version (stable version)', async () => {
       currentVersion = '4.5.6'
       // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -30,6 +36,12 @@ describe('GN UI version exports', () => {
   describe('GEONETWORK_UI_TAG_NAME', () => {
     it('returns the tag name (dev version)', async () => {
       currentVersion = '4.5.6-dev'
+      // eslint-disable-next-line @nx/enforce-module-boundaries
+      const module = await import('@geonetwork-ui/util/shared')
+      expect(module.GEONETWORK_UI_TAG_NAME).toBe('main')
+    })
+    it('returns the tag name (dev npm version)', async () => {
+      currentVersion = '4.5.6-dev.c7f35f0e1'
       // eslint-disable-next-line @nx/enforce-module-boundaries
       const module = await import('@geonetwork-ui/util/shared')
       expect(module.GEONETWORK_UI_TAG_NAME).toBe('main')

--- a/libs/util/shared/src/lib/gn-ui-version.ts
+++ b/libs/util/shared/src/lib/gn-ui-version.ts
@@ -2,7 +2,8 @@ import packageJson from '../../../../../package.json'
 
 export const GEONETWORK_UI_VERSION = packageJson.version
 
-export const GEONETWORK_UI_TAG_NAME =
-  GEONETWORK_UI_VERSION.split('-')[1] === 'dev'
-    ? 'main'
-    : `v${packageJson.version}`
+export const GEONETWORK_UI_TAG_NAME = GEONETWORK_UI_VERSION.split(
+  '-'
+)[1]?.startsWith('dev')
+  ? 'main'
+  : `v${packageJson.version}`


### PR DESCRIPTION
### Description

This PR fixes the extraction of webcomponent version when importing a dev version from NPM.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves