### PR TITLE
[Datahub] Add ability to disable default search presets

### DIFF
--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -45,24 +45,26 @@
             (action)="listFavorites($event)"
           ></datahub-header-badge-button>
         }
-        <div>
-          <button
-            type="button"
-            class="badge-btn text-primary-white bg-primary-opacity-50 hover-bg-primary-opacity-100"
-            (click)="clearSearchAndSort(SORT_BY_PARAMS.RESOURCE_DATES)"
-          >
-            <span translate>datahub.header.lastRecords</span>
-          </button>
-        </div>
-        <div>
-          <button
-            type="button"
-            class="badge-btn text-primary-white bg-primary-opacity-50 hover-bg-primary-opacity-100"
-            (click)="clearSearchAndSort(SORT_BY_PARAMS.POPULARITY)"
-          >
-            <span translate>datahub.header.popularRecords</span>
-          </button>
-        </div>
+        @if (!searchConfig?.DO_NOT_USE_DEFAULT_SEARCH_PRESET) {
+          <div>
+            <button
+              type="button"
+              class="badge-btn text-primary-white bg-primary-opacity-50 hover-bg-primary-opacity-100"
+              (click)="clearSearchAndSort(SORT_BY_PARAMS.RESOURCE_DATES)"
+            >
+              <span translate>datahub.header.lastRecords</span>
+            </button>
+          </div>
+          <div>
+            <button
+              type="button"
+              class="badge-btn text-primary-white bg-primary-opacity-50 hover-bg-primary-opacity-100"
+              (click)="clearSearchAndSort(SORT_BY_PARAMS.POPULARITY)"
+            >
+              <span translate>datahub.header.popularRecords</span>
+            </button>
+          </div>
+        }
         @for (preset of searchConfig?.SEARCH_PRESET; track preset) {
           <div>
             <div>

--- a/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
@@ -26,6 +26,7 @@ jest.mock('@geonetwork-ui/util/app-config', () => {
       HEADER_BACKGROUND: 'red',
     }),
     getOptionalSearchConfig: () => ({
+      DO_NOT_USE_DEFAULT_SEARCH_PRESET: false,
       SEARCH_PRESET: [
         {
           sort: '-createDate',
@@ -260,6 +261,22 @@ describe('HomeHeaderComponent', () => {
               thisIs: 'a fake filter',
             })
           })
+        })
+      })
+
+      describe('given do_not_use_default_search_preset = true', () => {
+        beforeEach(() => {
+          const appConfig = jest.requireMock('@geonetwork-ui/util/app-config')
+          jest.spyOn(appConfig, 'getOptionalSearchConfig').mockReturnValue({
+            DO_NOT_USE_DEFAULT_SEARCH_PRESET: true,
+            SEARCH_PRESET: [],
+          })
+          fixture = TestBed.createComponent(HomeHeaderComponent)
+          fixture.detectChanges()
+        })
+        it('should not render default badges but only custom badges', () => {
+          const allBadges = fixture.debugElement.queryAll(By.css('.badge-btn'))
+          expect(allBadges.length).toBe(0)
         })
       })
 

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -97,6 +97,10 @@ background_color = "#fdfbff"
 # WARNING: 'resourceType' filter has been deprecated, please use 'recordKind' instead. Breaking change: 'resourceType' filter won't retrieve featureCatalog anymore.
 # advanced_filters = ['organization', 'format', 'publicationYear', 'topic', 'isSpatial', 'license']
 
+# Optional; if true, the default pre-configured searches ("The latest" and "The most popular")
+# will not be shown under the main search bar. Defaults to false.
+# do_not_use_default_search_preset = false
+
 # One or several search presets visible in form of badges can be defined here; every search preset is composed of:
 # - a name (which can be a translation key)
 # - a sort criteria (prepend the field name with - to do a descending sort):

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -193,6 +193,10 @@ For a detailed explanation on the classification system, see [this documentation
 
 ⚠️ **Breaking change**: Record of type featureCatalog are not retrieved anymore.
 
+- `do_not_use_default_search_preset` (optional)
+
+  If set to `true`, the two default pre-configured search badges ("The latest" and "The most popular") will not be shown under the main search bar. Defaults to `false`. Note that the "My favorites" badge cannot be disabled by configuration.
+
 - `[[search_preset]]` (multiple, optional)
 
   Search presets are shown in a prominent way in badges to the user and can be used to showcase certain records in the catalog or offer shortcuts to frequent search criteria.

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -161,6 +161,7 @@ describe('app config utils', () => {
         expect(getOptionalSearchConfig()).toEqual({
           RECORD_KIND_QUICK_FILTER: false,
           FILTER_GEOMETRY_URL: 'https://my.domain.org/geom.json',
+          DO_NOT_USE_DEFAULT_SEARCH_PRESET: false,
           SEARCH_PRESET: [
             {
               name: 'filterByOrgs',

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -229,6 +229,7 @@ export function loadAppConfig() {
           'record_kind_quick_filter',
           'filter_geometry_data',
           'filter_geometry_url',
+          'do_not_use_default_search_preset',
           'search_preset',
           'advanced_filters',
           'limit',
@@ -252,6 +253,8 @@ export function loadAppConfig() {
                 parsedSearchSection.record_kind_quick_filter,
               FILTER_GEOMETRY_DATA: parsedSearchSection.filter_geometry_data,
               FILTER_GEOMETRY_URL: parsedSearchSection.filter_geometry_url,
+              DO_NOT_USE_DEFAULT_SEARCH_PRESET:
+                !!parsedSearchSection.do_not_use_default_search_preset,
               SEARCH_PRESET: parsedSearchParams.map((param) => ({
                 sort: param.sort,
                 name: param.name,

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -40,6 +40,7 @@ fonts_stylesheet_url = "https://fonts.googleapis.com/css2?family=Open+Sans"
 [search]
 record_kind_quick_filter = false
 filter_geometry_url = 'https://my.domain.org/geom.json'
+do_not_use_default_search_preset = false
 advanced_filters = ['publicationYear', 'documentStandard', 'inspireKeyword', 'topic', 'license']
 
 [[search_preset]]

--- a/libs/util/app-config/src/lib/model.ts
+++ b/libs/util/app-config/src/lib/model.ts
@@ -58,6 +58,7 @@ export interface SearchConfig {
   RECORD_KIND_QUICK_FILTER?: boolean
   FILTER_GEOMETRY_URL?: string
   FILTER_GEOMETRY_DATA?: string
+  DO_NOT_USE_DEFAULT_SEARCH_PRESET?: boolean
   SEARCH_PRESET?: SearchPreset[]
   ADVANCED_FILTERS?: []
   LIMIT?: number


### PR DESCRIPTION
### Description

This PR introduces the ability to disable the default pre-configured search badges ("Most liked" and "Most recent") that appear under the main search bar in the DataHub. 

This is controlled via a new boolean configuration key: `do_not_use_default_search_preset` in the `[search]` section. Note that the "My favorites" badge is intentionally excluded from this configuration and will always be visible to authenticated users.

### Screenshots


<img width="1448" height="553" alt="image" src="https://github.com/user-attachments/assets/fd3dfd3b-ce90-459b-8ac2-9d05ac43715b" />

---

<img width="1448" height="553" alt="image" src="https://github.com/user-attachments/assets/61314bc9-4ee9-4f78-9c05-e576960093aa" />

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Open `default.toml`
2. In the `[search]` section (around line 102), uncomment `do_not_use_default_search_preset` and set it to `true`
3. Restart the server or let it reload.
4. Verify that the "The latest" and "The most popular" badges are no longer visible.

<!--
Describe here the steps to confirm that the changes work as they should.
-->

