### PR TITLE
Remove static favicon to let config default.toml set it

### DIFF
--- a/apps/metadata-editor/src/app/app.component.ts
+++ b/apps/metadata-editor/src/app/app.component.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core'
+import { Component, OnInit } from '@angular/core'
+import { ThemeService } from '@geonetwork-ui/util/shared'
+import { getThemeConfig } from '@geonetwork-ui/util/app-config'
 
 @Component({
   selector: 'md-editor-root',
@@ -6,8 +8,11 @@ import { Component } from '@angular/core'
   styleUrls: ['./app.component.css'],
   standalone: false,
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'metadata-editor'
-  const favicon = getThemeConfig().FAVICON
-  if (favicon) ThemeService.setFavicon(favicon)
+
+  ngOnInit(): void {
+    const favicon = getThemeConfig().FAVICON
+    if (favicon) ThemeService.setFavicon(favicon)
+  }
 }

--- a/apps/metadata-editor/src/app/app.component.ts
+++ b/apps/metadata-editor/src/app/app.component.ts
@@ -8,4 +8,6 @@ import { Component } from '@angular/core'
 })
 export class AppComponent {
   title = 'metadata-editor'
+  const favicon = getThemeConfig().FAVICON
+  if (favicon) ThemeService.setFavicon(favicon)
 }

--- a/apps/metadata-editor/src/index.html
+++ b/apps/metadata-editor/src/index.html
@@ -5,7 +5,6 @@
     <title>MetadataEditor</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
     <link rel="stylesheet" href="assets/css/materials-symbols-outline.css" />
     <link
       rel="preload"


### PR DESCRIPTION
### Description

This PR is fixing the issue found in https://github.com/geonetwork/geonetwork-ui/issues/1512

connected with https://github.com/geonetwork/geonetwork-ui/pull/713

### Architectural changes

None


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [x] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [x] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [x] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [x] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves


### How to test

- Configure this line in default.toml

[geonetwork-ui/conf/default.toml](https://github.com/geonetwork/geonetwork-ui/blob/5eea424cab5511653ca9ec647473f7e135e35e0c/conf/default.toml#L73)

- The favicon should change.

Tested on online platform

