### PR TITLE
[Datahub] Keep Y-axis dropdown visible but disabled when aggregation is "count"

### DIFF
--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.html
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.html
@@ -19,16 +19,14 @@
       [title]="'chart.dropdown.xProperty' | translate"
     ></gn-ui-dropdown-selector>
     @if (yChoices$ | async; as yChoices) {
-      @if (!isCountAggregation) {
-        <gn-ui-dropdown-selector
-          class="basis-1/4"
-          [choices]="yChoices"
-          (selectValue)="yProperty$.next($event)"
-          [selected]="yProperty$.value"
-          [title]="'chart.dropdown.yProperty' | translate"
-          class="select-y-prop"
-        ></gn-ui-dropdown-selector>
-      }
+      <gn-ui-dropdown-selector
+        class="basis-1/4 select-y-prop"
+        [choices]="yChoices"
+        [disabled]="isCountAggregation"
+        (selectValue)="yProperty$.next($event)"
+        [selected]="yProperty$.value"
+        [title]="'chart.dropdown.yProperty' | translate"
+      ></gn-ui-dropdown-selector>
     }
     <gn-ui-dropdown-selector
       class="basis-1/4"

--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.spec.ts
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.spec.ts
@@ -329,9 +329,9 @@ describe('ChartViewComponent', () => {
       ])
       expect(DatasetReaderMock.instance.read).toHaveBeenCalledTimes(1)
     })
-    it('hides the Y property field', () => {
+    it('disables the Y property field', () => {
       const select = fixture.debugElement.query(By.css('.select-y-prop'))
-      expect(select).toBeFalsy()
+      expect(select.componentInstance.disabled).toBe(true)
     })
   })
 


### PR DESCRIPTION
### Description

Previously, the Y-axis (Axe Y) dropdown in the chart preview was removed from the DOM when the user selected the count aggregation operator (or when the dataset had no numeric/date properties). This caused the layout to shift and gave no visual indication to the user that a Y-axis field even exists.

This change keeps the dropdown always rendered but sets it to a disabled (grayed out) state under those same conditions, providing a more consistent and informative UI.

### Screenshots

<img width="4032" height="3024" alt="BeforeAfterLandscape copy (1)" src="https://github.com/user-attachments/assets/bcfe6f99-c808-4ffb-ad53-cbe0110faef1" />

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Open any dataset record that has chart data, e.g.: http://localhost:4200/dataset/04bcec79-5b25-4b16-b635-73115f7456e4
3. Navigate to the Chart tab
4. Change the Aggregation dropdown to Count
5. Verify that the Y-axis dropdown is still visible in the row of dropdowns, it should appear grayed out / disabled, not vanish from the layout