### PR TITLE
Update Thumbnail Sizes and Positions

### DIFF
--- a/apps/datahub/src/app/record/header-record/header-record.component.html
+++ b/apps/datahub/src/app/record/header-record/header-record.component.html
@@ -124,12 +124,14 @@
               </div>
             </div>
             @if ((thumbnailUrl$ | async) && showOverlay) {
-              <gn-ui-image-overlay-preview
-                class="block h-[228px] w-full self-center"
-                [imageUrl]="thumbnailUrl$ | async"
-                (isPlaceholderShown)="showOverlay = !$event"
-              >
-              </gn-ui-image-overlay-preview>
+              <div class="h-[228px] overflow-visible">
+                <gn-ui-image-overlay-preview
+                  class="block h-auto aspect-square w-full"
+                  [imageUrl]="thumbnailUrl$ | async"
+                  (isPlaceholderShown)="showOverlay = !$event"
+                >
+                </gn-ui-image-overlay-preview>
+              </div>
             }
           </div>
         </div>

--- a/apps/datahub/src/app/record/header-record/header-record.component.html
+++ b/apps/datahub/src/app/record/header-record/header-record.component.html
@@ -5,7 +5,7 @@
   <ng-template let-expandRatio>
     <header
       class="w-full sm:h-[344px] grid"
-      [ngClass]="(thumbnailUrl$ | async) ? 'h-[554px]' : 'h-[344px]'"
+      [ngClass]="(thumbnailUrl$ | async) ? 'h-[640px]' : 'h-[344px]'"
     >
       <div
         [style.background]="backgroundCss"
@@ -124,9 +124,11 @@
               </div>
             </div>
             @if ((thumbnailUrl$ | async) && showOverlay) {
-              <div class="h-[228px] overflow-visible">
+              <div
+                class="h-[228px] overflow-visible flex justify-center sm:justify-end"
+              >
                 <gn-ui-image-overlay-preview
-                  class="block h-auto aspect-square w-full"
+                  class="block w-[314px] h-[314px]"
                   [imageUrl]="thumbnailUrl$ | async"
                   (isPlaceholderShown)="showOverlay = !$event"
                 >

--- a/apps/datahub/src/app/record/header-record/header-record.component.ts
+++ b/apps/datahub/src/app/record/header-record/header-record.component.ts
@@ -38,7 +38,7 @@ import { marker } from '@biesbjerg/ngx-translate-extract-marker'
 import { GnUiHumanizeDateDirective } from '@geonetwork-ui/util/shared'
 
 export const HEADER_HEIGHT_DEFAULT = 344
-export const HEADER_HEIGHT_MOBILE_THUMBNAIL = 554
+export const HEADER_HEIGHT_MOBILE_THUMBNAIL = 640
 
 marker('record.metadata.resourceUpdated')
 marker('record.metadata.resourcePublished')

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
@@ -12,8 +12,13 @@
         }
         @if ((metadataViewFacade.isPresent$ | async) === true) {
           <div class="grid gap-8 grid-cols-1 sm:gap-6 sm:grid-cols-3">
-            <div class="sm:col-span-2"
-              [ngClass]="(hasThumbnail$ | async) ? 'pt-[max(0px,_calc(100vw_-_341px))] sm:pt-0' : ''"
+            <div
+              class="sm:col-span-2"
+              [ngClass]="
+                (hasThumbnail$ | async)
+                  ? 'pt-[max(0px,_calc(100vw_-_341px))] sm:pt-0'
+                  : ''
+              "
             >
               <gn-ui-metadata-info
                 class="sm:block"
@@ -23,7 +28,8 @@
               >
               </gn-ui-metadata-info>
             </div>
-            <div class="flex flex-col gap-5"
+            <div
+              class="flex flex-col gap-5"
               [ngClass]="(hasThumbnail$ | async) ? 'sm:pt-10' : ''"
             >
               @if (metadataViewFacade.resourceDoi$ | async; as resourceDoi) {

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
@@ -12,7 +12,9 @@
         }
         @if ((metadataViewFacade.isPresent$ | async) === true) {
           <div class="grid gap-8 grid-cols-1 sm:gap-6 sm:grid-cols-3">
-            <div class="sm:col-span-2">
+            <div class="sm:col-span-2"
+              [ngClass]="(hasThumbnail$ | async) ? 'pt-[max(0px,_calc(100vw_-_341px))] sm:pt-0' : ''"
+            >
               <gn-ui-metadata-info
                 class="sm:block"
                 [metadata]="metadataViewFacade.metadata$ | async"
@@ -21,7 +23,9 @@
               >
               </gn-ui-metadata-info>
             </div>
-            <div class="flex flex-col gap-5">
+            <div class="flex flex-col gap-5"
+              [ngClass]="(hasThumbnail$ | async) ? 'sm:pt-10' : ''"
+            >
               @if (metadataViewFacade.resourceDoi$ | async; as resourceDoi) {
                 <gn-ui-metadata-doi
                   [code]="resourceDoi.code"

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.html
@@ -12,14 +12,7 @@
         }
         @if ((metadataViewFacade.isPresent$ | async) === true) {
           <div class="grid gap-8 grid-cols-1 sm:gap-6 sm:grid-cols-3">
-            <div
-              class="sm:col-span-2"
-              [ngClass]="
-                (hasThumbnail$ | async)
-                  ? 'pt-[max(0px,_calc(100vw_-_341px))] sm:pt-0'
-                  : ''
-              "
-            >
+            <div class="sm:col-span-2">
               <gn-ui-metadata-info
                 class="sm:block"
                 [metadata]="metadataViewFacade.metadata$ | async"

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -94,6 +94,10 @@ export class RecordMetadataComponent {
   @Input() metadataQualityDisplay: boolean
   @ViewChild('userFeedbacks') userFeedbacks: ElementRef<HTMLElement>
 
+  hasThumbnail$ = this.metadataViewFacade.metadata$.pipe(
+    map((metadata) => !!metadata?.overviews?.[0]?.url)
+  )
+
   private readonly displayConditions = {
     dataset: {
       download: (links) => links?.length > 0,

--- a/libs/ui/elements/src/lib/image-input/image-input.component.html
+++ b/libs/ui/elements/src/lib/image-input/image-input.component.html
@@ -1,6 +1,9 @@
 @if (previewUrl) {
   <div class="w-[314px] h-full flex flex-col gap-2">
-    <gn-ui-image-overlay-preview class="aspect-square" [imageUrl]="previewUrl">
+    <gn-ui-image-overlay-preview
+      class="w-[314px] h-[314px]"
+      [imageUrl]="previewUrl"
+    >
     </gn-ui-image-overlay-preview>
     @if (showAltTextInput) {
       <gn-ui-text-input

--- a/libs/ui/elements/src/lib/image-input/image-input.component.html
+++ b/libs/ui/elements/src/lib/image-input/image-input.component.html
@@ -1,6 +1,6 @@
 @if (previewUrl) {
-  <div class="w-80 h-full flex flex-col gap-2">
-    <gn-ui-image-overlay-preview class="h-48" [imageUrl]="previewUrl">
+  <div class="w-[314px] h-full flex flex-col gap-2">
+    <gn-ui-image-overlay-preview class="aspect-square" [imageUrl]="previewUrl">
     </gn-ui-image-overlay-preview>
     @if (showAltTextInput) {
       <gn-ui-text-input

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.html
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.html
@@ -14,7 +14,7 @@
     </div>
   }
   <div class="grow pt-1" [ngClass]="shouldShowThumbnail ? 'sm:w-0' : ''">
-    <div class="flex flex-col gap-2 h-full">
+    <div class="flex flex-col gap-2" [class.h-full]="size !== 'M'">
       <h4
         class="record-card__title"
         data-cy="recordTitle"
@@ -32,63 +32,70 @@
           [title]="abstract"
         ></gn-ui-markdown-parser>
       </div>
-      <div class="record-card__footer">
-        @if (record.ownerOrganization?.name) {
-          <div
-            data-cy="recordOrg"
-            class="grow flex flex-row gap-1 items-center text-primary-lighter"
-            [ngClass]="displayContactIconOnly ? 'justify-center' : ''"
+      @if (size !== 'M') {
+        <ng-container [ngTemplateOutlet]="footerTpl"></ng-container>
+      }
+    </div>
+  </div>
+  @if (size === 'M') {
+    <ng-container [ngTemplateOutlet]="footerTpl"></ng-container>
+  }
+</a>
+
+<ng-template #footerTpl>
+  <div class="record-card__footer">
+    @if (record.ownerOrganization?.name) {
+      <div
+        data-cy="recordOrg"
+        class="grow flex flex-row gap-1 items-center text-primary-lighter"
+        [ngClass]="displayContactIconOnly ? 'justify-center' : ''"
+      >
+        <ng-icon
+          name="iconoirBank"
+          class="text-primary -translate-y-[0.5px] shrink-0"
+          [title]="record.ownerOrganization.name"
+        ></ng-icon>
+        @if (!displayContactIconOnly) {
+          <span
+            data-cy="recordOrgName"
+            class="line-clamp-1"
+            [title]="record.ownerOrganization.name"
+            >{{ record.ownerOrganization.name }}</span
           >
-            <ng-icon
-              name="iconoirBank"
-              class="text-primary -translate-y-[0.5px] shrink-0"
-              [title]="record.ownerOrganization.name"
-            ></ng-icon>
-            @if (!displayContactIconOnly) {
-              <span
-                data-cy="recordOrgName"
-                class="line-clamp-1"
-                [title]="record.ownerOrganization.name"
-                >{{ record.ownerOrganization.name }}</span
-              >
-            }
-          </div>
         }
-        <div class="record-card__footer__other">
-          <div
-            class="xs:border-r last:border-r-0 flex grow gap-4 px-4 last:pr-0"
-          >
-            <gn-ui-kind-badge
-              [extraClass]="'text-[1.2em]'"
-              [styling]="'gray'"
-              [kind]="record?.kind"
-              [contentTemplate]="customTemplate"
-              class="pt-1"
-            >
-              <ng-template #customTemplate></ng-template
-            ></gn-ui-kind-badge>
-            @if (metadataQualityDisplay) {
-              <gn-ui-metadata-quality
-                class="flex items-center min-w-[113px]"
-                [smaller]="true"
-                [metadata]="record"
-                [metadataQualityDisplay]="metadataQualityDisplay"
-                [popoverDisplay]="true"
-              ></gn-ui-metadata-quality>
-            }
-          </div>
-          <div
-            class="flex justify-center"
-            data-cy="recordFav"
-            [ngClass]="displayContactIconOnly ? 'px-1' : 'px-4'"
-          >
-            <ng-container
-              [ngTemplateOutlet]="favoriteTemplate"
-              [ngTemplateOutletContext]="{ $implicit: record }"
-            ></ng-container>
-          </div>
-        </div>
+      </div>
+    }
+    <div class="record-card__footer__other">
+      <div class="xs:border-r last:border-r-0 flex grow gap-4 px-4 last:pr-0">
+        <gn-ui-kind-badge
+          [extraClass]="'text-[1.2em]'"
+          [styling]="'gray'"
+          [kind]="record?.kind"
+          [contentTemplate]="customTemplate"
+          class="pt-1"
+        >
+          <ng-template #customTemplate></ng-template
+        ></gn-ui-kind-badge>
+        @if (metadataQualityDisplay) {
+          <gn-ui-metadata-quality
+            class="flex items-center min-w-[113px]"
+            [smaller]="true"
+            [metadata]="record"
+            [metadataQualityDisplay]="metadataQualityDisplay"
+            [popoverDisplay]="true"
+          ></gn-ui-metadata-quality>
+        }
+      </div>
+      <div
+        class="flex justify-center"
+        data-cy="recordFav"
+        [ngClass]="displayContactIconOnly ? 'px-1' : 'px-4'"
+      >
+        <ng-container
+          [ngTemplateOutlet]="favoriteTemplate"
+          [ngTemplateOutletContext]="{ $implicit: record }"
+        ></ng-container>
       </div>
     </div>
   </div>
-</a>
+</ng-template>

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.scss
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.scss
@@ -6,7 +6,7 @@
   }
 
   &.size-M {
-    @apply max-w-[940px] md:h-[231px] gap-4;
+    @apply max-w-[940px] gap-4;
   }
 
   &.size-S {
@@ -28,11 +28,11 @@
   @apply border rounded-lg overflow-hidden shrink-0;
 
   .size-L & {
-    @apply w-full w-[190px] h-[184px];
+    @apply w-[190px] h-[190px];
   }
 
   .size-M & {
-    @apply w-full w-[138px] h-[207px];
+    @apply w-[138px] h-[138px];
   }
 }
 
@@ -78,6 +78,11 @@
 
 .record-card__footer {
   @apply flex sm:flex-row flex-col flex-nowrap gap-3 justify-end items-center w-full border-t pt-1 overflow-hidden;
+
+  .size-M & {
+    margin-left: calc(-138px - 1rem);
+    width: calc(100% + 138px + 1rem);
+  }
 
   .size-S & {
     @media (max-width: 450px) {

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.scss
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.scss
@@ -6,7 +6,7 @@
   }
 
   &.size-M {
-    @apply max-w-[940px] gap-4;
+    @apply max-w-[940px] gap-4 flex-wrap;
   }
 
   &.size-S {
@@ -28,7 +28,7 @@
   @apply border rounded-lg overflow-hidden shrink-0;
 
   .size-L & {
-    @apply w-[190px] h-[190px];
+    @apply w-[184px] h-[184px];
   }
 
   .size-M & {
@@ -44,7 +44,7 @@
   }
 
   .size-M & {
-    @apply line-clamp-2 ml-2;
+    @apply line-clamp-2;
   }
 
   .size-S & {
@@ -64,7 +64,7 @@
   }
 
   .size-M & {
-    @apply line-clamp-3 ml-2;
+    @apply line-clamp-3;
   }
 
   .size-S & {
@@ -78,11 +78,6 @@
 
 .record-card__footer {
   @apply flex sm:flex-row flex-col flex-nowrap gap-3 justify-end items-center w-full border-t pt-1 overflow-hidden;
-
-  .size-M & {
-    margin-left: calc(-138px - 1rem);
-    width: calc(100% + 138px + 1rem);
-  }
 
   .size-S & {
     @media (max-width: 450px) {

--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
@@ -30,7 +30,7 @@
           ></gn-ui-thumbnail>
         }
       </div>
-      <div class="flex flex-col overflow-hidden items-start">
+      <div class="flex flex-col overflow-hidden items-start grow">
         @if (hasOrganization) {
           <span
             class="font-bold transition duration-200 text-primary truncate max-w-full"
@@ -51,32 +51,35 @@
           >
         </p>
       </div>
-    </div>
-    <div class="pt-5 pb-5 px-10 relative">
-      <div class="absolute top-[0.85em] right-[0.85em]">
+      <div class="ml-3 shrink-0">
         <ng-container
           [ngTemplateOutlet]="favoriteTemplate"
           [ngTemplateOutletContext]="{ $implicit: record }"
         ></ng-container>
       </div>
-      <h1
-        class="font-title text-black text-[21px] font-medium mb-3 pr-8"
-        data-cy="recordTitle"
-      >
-        {{ record.title }}
-      </h1>
+    </div>
+    <div class="pt-5 pb-5 px-10 relative">
+      <div class="flex flex-row gap-4 mb-3">
+        @if (record.overviews?.[0]) {
+          <gn-ui-thumbnail
+            class="block shrink-0 w-[120px] h-[120px] border border-gray-100 rounded-lg overflow-hidden"
+            [thumbnailUrl]="record.overviews?.[0]?.url.toString()"
+            [fit]="'cover'"
+          ></gn-ui-thumbnail>
+        }
+        <h1
+          class="font-title text-black text-[21px] font-medium"
+          data-cy="recordTitle"
+        >
+          {{ record.title }}
+        </h1>
+      </div>
       <p class="line-clamp-3">
         <gn-ui-markdown-parser
           [textContent]="abstract"
           [whitoutStyles]="true"
         />
       </p>
-      @if (record.overviews?.[0]) {
-        <gn-ui-thumbnail
-          class="block mt-3 w-full h-[136px] border border-gray-100 rounded-lg overflow-hidden"
-          [thumbnailUrl]="record.overviews?.[0]?.url.toString()"
-        ></gn-ui-thumbnail>
-      }
       @if (isDownloadable || isViewable) {
         <div class="flex flex-row mt-3">
           @if (isDownloadable) {

--- a/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
+++ b/libs/ui/search/src/lib/record-preview-feed/record-preview-feed.component.html
@@ -59,7 +59,7 @@
       </div>
     </div>
     <div class="pt-5 pb-5 px-10 relative">
-      <div class="flex flex-row gap-4 mb-3">
+      <div class="flex flex-col sm:flex-row gap-4 mb-3">
         @if (record.overviews?.[0]) {
           <gn-ui-thumbnail
             class="block shrink-0 w-[120px] h-[120px] border border-gray-100 rounded-lg overflow-hidden"


### PR DESCRIPTION
### Description

This PR introduces a consistent 1:1 square aspect ratio with object-fit: cover cropping for all record thumbnails across DataHub and the Metadata Editor.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

No architectural changes. All changes are limited to existing component templates and styles.

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

<img width="4032" height="3024" alt="3" src="https://github.com/user-attachments/assets/391708da-c971-41dc-b612-bdf2c1c08ba6" />

---

<img width="4032" height="3024" alt="2" src="https://github.com/user-attachments/assets/2294fbf8-cad9-480a-837e-5823f01404d0" />

---

<img width="4032" height="3024" alt="1" src="https://github.com/user-attachments/assets/fe84d95f-56e6-464f-9efc-a72284a4f5d0" />


<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Open a record page with a thumbnail: The thumbnail in the header should appear as a square, overflowing slightly below the header background. The DOI/Contact sidebar below should not be overlapped.
2. Open a record page with no thumbnail: The header and content below should appear exactly as before.
3. Start the storybook and check :internal link card (size M) and (size L)
4. Open the Metadata Editor and edit a record with a thumbnail: The preview image should appear as a square.

<!--
Describe here the steps to confirm that the changes work as they should.
-->


<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
