### PR TITLE
[2.8.x] Merge pull request #1494 from geonetwork/custom-app-npm-dev-tag-wc-link

### DIFF
--- a/libs/util/shared/src/lib/gn-ui-version.spec.ts
+++ b/libs/util/shared/src/lib/gn-ui-version.spec.ts
@@ -20,6 +20,12 @@ describe('GN UI version exports', () => {
       const module = await import('@geonetwork-ui/util/shared')
       expect(module.GEONETWORK_UI_VERSION).toBe('4.5.6-dev')
     })
+    it('returns the full version (dev npm version)', async () => {
+      currentVersion = '4.5.6-dev.c7f35f0e1'
+      // eslint-disable-next-line @nx/enforce-module-boundaries
+      const module = await import('@geonetwork-ui/util/shared')
+      expect(module.GEONETWORK_UI_VERSION).toBe('4.5.6-dev.c7f35f0e1')
+    })
     it('returns the full version (stable version)', async () => {
       currentVersion = '4.5.6'
       // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -30,6 +36,12 @@ describe('GN UI version exports', () => {
   describe('GEONETWORK_UI_TAG_NAME', () => {
     it('returns the tag name (dev version)', async () => {
       currentVersion = '4.5.6-dev'
+      // eslint-disable-next-line @nx/enforce-module-boundaries
+      const module = await import('@geonetwork-ui/util/shared')
+      expect(module.GEONETWORK_UI_TAG_NAME).toBe('2.8.x')
+    })
+    it('returns the tag name (dev npm version)', async () => {
+      currentVersion = '4.5.6-dev.c7f35f0e1'
       // eslint-disable-next-line @nx/enforce-module-boundaries
       const module = await import('@geonetwork-ui/util/shared')
       expect(module.GEONETWORK_UI_TAG_NAME).toBe('2.8.x')

--- a/libs/util/shared/src/lib/gn-ui-version.ts
+++ b/libs/util/shared/src/lib/gn-ui-version.ts
@@ -2,7 +2,8 @@ import packageJson from '../../../../../package.json'
 
 export const GEONETWORK_UI_VERSION = packageJson.version
 
-export const GEONETWORK_UI_TAG_NAME =
-  GEONETWORK_UI_VERSION.split('-')[1] === 'dev'
-    ? '2.8.x'
-    : `v${packageJson.version}`
+export const GEONETWORK_UI_TAG_NAME = GEONETWORK_UI_VERSION.split(
+  '-'
+)[1]?.startsWith('dev')
+  ? '2.8.x'
+  : `v${packageJson.version}`


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `2.8.x`:
 - [Merge pull request #1494 from geonetwork/custom-app-npm-dev-tag-wc-link](https://github.com/geonetwork/geonetwork-ui/pull/1494)