### PR TITLE
Don't reject on first error when getting feature types

### DIFF
--- a/libs/util/shared/src/lib/links/link-utils.spec.ts
+++ b/libs/util/shared/src/lib/links/link-utils.spec.ts
@@ -46,6 +46,10 @@ const mockWfsFeatureType = [
     name: 'ft3',
     title: 'Feature Type 3',
   },
+  {
+    name: 'fte',
+    title: 'Feature Type Error',
+  },
 ]
 
 jest.mock('@camptocamp/ogc-client', () => ({
@@ -58,12 +62,16 @@ jest.mock('@camptocamp/ogc-client', () => ({
       return mockWfsFeatureType
     }
     getFeatureTypeFull(name: string) {
-      return Promise.resolve({
-        name,
-        title: mockWfsFeatureType.find((layer) => layer.name === name)?.title,
-        abstract: mockWfsFeatureType.find((layer) => layer.name === name)
-          ?.title,
-      })
+      if (name === 'fte') {
+        return Promise.reject('Something went wrong')
+      } else {
+        return Promise.resolve({
+          name,
+          title: mockWfsFeatureType.find((layer) => layer.name === name)?.title,
+          abstract: mockWfsFeatureType.find((layer) => layer.name === name)
+            ?.title,
+        })
+      }
     }
   },
   OgcApiEndpoint: class {
@@ -533,7 +541,7 @@ describe('link utils', () => {
       ])
     })
 
-    it('should return WFS feature types', async () => {
+    it('should return fulfilled WFS feature types', async () => {
       const layers = await getLayers('https://example.com', 'wfs')
       expect(layers).toEqual([
         {

--- a/libs/util/shared/src/lib/links/link-utils.ts
+++ b/libs/util/shared/src/lib/links/link-utils.ts
@@ -331,11 +331,15 @@ export async function getLayers(url: string, serviceProtocol: ServiceProtocol) {
     case 'wfs': {
       const endpointWfs = await new WfsEndpoint(url).isReady()
       const featureTypes = await endpointWfs.getFeatureTypes()
-      const layers = await Promise.all(
-        featureTypes.map(async (collection) => {
-          return await endpointWfs.getFeatureTypeFull(collection.name)
-        })
+      const layers = (
+        await Promise.allSettled(
+          featureTypes.map((collection) => {
+            return endpointWfs.getFeatureTypeFull(collection.name)
+          })
+        )
       )
+        .filter((settled) => settled.status === 'fulfilled')
+        .map((fulfilled) => fulfilled.value)
       return layers
     }
     case 'wms': {


### PR DESCRIPTION
### Description

This PR fixes a wrong behavior when getting WFS layers:
- for display in the service capabilities section of a record (DH)
- for the dropdown in the online resource record form (ME)

If only one WFS layer was failing, none were shown. Now, all WFS layers correctly described are shown. 

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

Find a server with WFS capabilities listing a WFS layer which will fail on DescribeFeatureType request.
Or trust the completed unit test.