### PR TITLE
Better limits on OGC API Features URLs - download links

### DIFF
--- a/libs/feature/dataviz/src/lib/service/data.service.spec.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.spec.ts
@@ -132,16 +132,22 @@ jest.mock('@camptocamp/ogc-client', () => ({
         return Promise.resolve({
           name: collectionName,
           id: collectionName === 'collection1' ? 'collection1' : 'collection2',
-          bulkDownloadLinks: { json: 'http://json', csv: 'http://csv' },
+          bulkDownloadLinks: {
+            json: 'http://json?limit=10000',
+            csv: 'http://csv?limit=10000',
+          },
         })
       }
       if (this.url.indexOf('nojson') > -1) {
         return Promise.resolve({
-          bulkDownloadLinks: { csv: 'http://csv' },
+          bulkDownloadLinks: { csv: 'http://csv?limit=10000' },
         })
       }
       return Promise.resolve({
-        bulkDownloadLinks: { json: 'http://json', csv: 'http://csv' },
+        bulkDownloadLinks: {
+          json: 'http://json?limit=10000',
+          csv: 'http://csv?limit=10000',
+        },
       })
     }
     featureCollections =
@@ -678,22 +684,26 @@ describe('DataService', () => {
             type: 'service',
             accessServiceProtocol: 'ogcFeatures',
           })
-          expect(links).toEqual([
-            {
-              name: 'collection1',
-              mimeType: 'application/json',
-              url: new URL('http://json'),
-              type: 'download',
-              accessServiceProtocol: 'ogcFeatures',
-            },
-            {
-              name: 'collection1',
-              mimeType: 'text/csv',
-              url: new URL('http://csv'),
-              type: 'download',
-              accessServiceProtocol: 'ogcFeatures',
-            },
-          ])
+          expect(JSON.parse(JSON.stringify(links))).toEqual(
+            JSON.parse(
+              JSON.stringify([
+                {
+                  name: 'collection1',
+                  mimeType: 'application/json',
+                  url: new URL('http://json'),
+                  type: 'download',
+                  accessServiceProtocol: 'ogcFeatures',
+                },
+                {
+                  name: 'collection1',
+                  mimeType: 'text/csv',
+                  url: new URL('http://csv'),
+                  type: 'download',
+                  accessServiceProtocol: 'ogcFeatures',
+                },
+              ])
+            )
+          )
         })
 
         it('should OGC override the collection title when it is wrong', async () => {

--- a/libs/feature/dataviz/src/lib/service/data.service.ts
+++ b/libs/feature/dataviz/src/lib/service/data.service.ts
@@ -211,14 +211,19 @@ export class DataService {
     const collectionInfo = await this.getDownloadUrlsFromOgcApi(
       ogcApiLink.url.href
     )
-    return Object.keys(collectionInfo.bulkDownloadLinks).map((downloadLink) => {
+
+    return Object.keys(collectionInfo.bulkDownloadLinks).map((mimeType) => {
+      const urlWithoutLimit = new URL(
+        collectionInfo.bulkDownloadLinks[mimeType]
+      )
+      urlWithoutLimit.searchParams.delete('limit')
       return {
         ...ogcApiLink,
         name: collectionInfo.id,
         type: 'download',
-        url: new URL(collectionInfo.bulkDownloadLinks[downloadLink]),
+        url: urlWithoutLimit,
         mimeType: getMimeTypeForFormat(
-          getFileFormatFromServiceOutput(downloadLink)
+          getFileFormatFromServiceOutput(mimeType)
         ),
       }
     })


### PR DESCRIPTION
### Description

Follow up on https://github.com/geonetwork/geonetwork-ui/pull/1510

This PR also removes the limit on download links for OGC API Features services.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

On a record containing an online resource pointing to a huge collection of more than 10.000 items
https://mel.integration.apps.gs-fr-prod.camptocamp.com/geoserver/ogc/features/v1/collections/mel_administration_et_action_publique:deliberation/items
Check that the download links don't have any limit

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [Métropole Européenne de Lille](https://data.lillemetropole.fr/)**.
