### PR TITLE
chore: remove axios dependency

### DIFF
--- a/libs/feature/record/src/lib/gpf-api-dl/gpf-api-dl.component.spec.ts
+++ b/libs/feature/record/src/lib/gpf-api-dl/gpf-api-dl.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
-
 import { DatasetServiceDistribution } from '@geonetwork-ui/common/domain/model/record'
 import { firstValueFrom } from 'rxjs'
 import { Choice } from '@geonetwork-ui/ui/inputs'

--- a/libs/feature/record/src/lib/gpf-api-dl/gpf-api-dl.component.ts
+++ b/libs/feature/record/src/lib/gpf-api-dl/gpf-api-dl.component.ts
@@ -1,15 +1,14 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  inject,
   Input,
   OnInit,
-  inject,
 } from '@angular/core'
 import { DatasetServiceDistribution } from '@geonetwork-ui/common/domain/model/record'
 import { BehaviorSubject, combineLatest, map, mergeMap, Observable } from 'rxjs'
 import { HttpClient } from '@angular/common/http'
 import { Choice, DropdownSelectorComponent } from '@geonetwork-ui/ui/inputs'
-import axios from 'axios'
 import { CommonModule } from '@angular/common'
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core'
 import { GpfApiDlListItemComponent } from '../gpf-api-dl-list-item/gpf-api-dl-list-item.component'
@@ -209,9 +208,9 @@ export class GpfApiDlComponent implements OnInit {
     let pageCount = 1
 
     while (choicesTest === undefined && pageCount > page) {
-      const response = await axios.get(
+      const response = await fetch(
         this.url.concat(`&limit=200&page=${page}`)
-      )
+      ).then((resp) => resp.json())
 
       choicesTest = response.data.entry.filter(
         (element) => element['id'] == this.apiBaseUrl

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "@rgrove/parse-xml": "4.2.0",
         "@vendure/ngx-translate-extract": "~10.1.1",
         "alasql": "4.6.0",
-        "axios": "1.12.0",
         "basiclightbox": "^5.0.4",
         "chart.js": "4.4.7",
         "chroma-js": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@rgrove/parse-xml": "4.2.0",
     "@vendure/ngx-translate-extract": "~10.1.1",
     "alasql": "4.6.0",
-    "axios": "1.12.0",
     "basiclightbox": "^5.0.4",
     "chart.js": "4.4.7",
     "chroma-js": "3.1.2",

--- a/package/ng-package.json
+++ b/package/ng-package.json
@@ -21,7 +21,6 @@
     "@nx/angular",
     "@rgrove/parse-xml",
     "alasql",
-    "axios",
     "basiclightbox",
     "chart.js",
     "chroma-js",

--- a/package/package.json
+++ b/package/package.json
@@ -54,7 +54,6 @@
     "@nx/angular": "22.0.4",
     "@rgrove/parse-xml": "4.2.0",
     "alasql": "4.6.0",
-    "axios": "1.12.0",
     "basiclightbox": "^5.0.4",
     "chart.js": "4.4.7",
     "chroma-js": "3.1.2",


### PR DESCRIPTION
Following supply chain attack

(note that this does not remove axios from the transitive dependencies, only from the first level)