### PR TITLE
[Datahub] Disable aggregation field when no numeric columns and fix Y axis alignment

### DIFF
--- a/libs/feature/dataviz/src/lib/chart-view/chart-view.component.html
+++ b/libs/feature/dataviz/src/lib/chart-view/chart-view.component.html
@@ -20,7 +20,7 @@
     ></gn-ui-dropdown-selector>
     @if (yChoices$ | async; as yChoices) {
       <gn-ui-dropdown-selector
-        class="basis-1/4 select-y-prop"
+        class="basis-1/4 flex items-center select-y-prop"
         [choices]="yChoices"
         [disabled]="isCountAggregation"
         (selectValue)="yProperty$.next($event)"
@@ -29,9 +29,9 @@
       ></gn-ui-dropdown-selector>
     }
     <gn-ui-dropdown-selector
-      class="basis-1/4"
+      class="basis-1/4 aggregation-choices"
       [choices]="aggregationChoices"
-      class="aggregation-choices"
+      [disabled]="!yProperty$.value"
       (selectValue)="aggregation$.next($event)"
       [selected]="aggregation$.value"
       [title]="'chart.dropdown.aggregation' | translate"

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.ts
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.ts
@@ -102,7 +102,7 @@ export class DropdownSelectorComponent implements OnInit {
   }
 
   getChoiceLabel(): string {
-    return this.selectedChoice?.label
+    return this.selectedChoice?.label ?? '\u00A0'
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
### Description

Follow up on https://github.com/geonetwork/geonetwork-ui/pull/1514

This PR addresses two issues in the chart view:

1. The aggregation dropdown remained active even when no numeric columns were available, even though "count" was the only valid option.
2. The Y axis dropdown would shrink and misalign vertically when it was empty and disabled, causing a visual inconsistency.

**Changed**

- **Disable Aggregation Dropdown:** The aggregation dropdown is now disabled when no numeric columns are available (i.e., when `yProperty` is empty). This ensures that users cannot interact with the dropdown when "count" is the only valid option.
- **Fix Y Axis Alignment:** The Y axis dropdown now has `flex` and `items-center` applied to its host element, ensuring its content is vertically centered even when the dropdown is stretched by the parent flex container.
- **Prevent Shrinking of Disabled Dropdowns:** A non-breaking space (`\u00A0`) is returned as a fallback in the `getChoiceLabel()` method of the `DropdownSelectorComponent`. This ensures that dropdown buttons maintain their height and do not shrink when they are empty or disabled. This fix is applied at the component level, making it reusable for all dropdowns.


<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

None.

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

<img width="4032" height="3024" alt="BeforeAfterLandscape copy (1) (1)" src="https://github.com/user-attachments/assets/efa61bbf-9a5b-404f-8a54-546f43ded20d" />


<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

1. Update `proxy-config.js` to point to **geo2france** .
2. Navigate to http://localhost:4200/dataset/zones-de-stationnement-du-centre-ville-de-dunkerque
3. Click on the chart tab
4. Make sure the Y-Axis and the Agregation drop downs are disabled and are properly aligned.