### PR TITLE
Export common domain model - GPF API DL BREAKING CHANGE

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset/datasetPreview.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetPreview.cy.ts
@@ -103,7 +103,7 @@ beforeEach(() => {
   )
   cy.intercept(
     'GET',
-    'https://stacapi-cdos.apps.okd.crocc.meso.umontpellier.fr/collections/sentinel2-l2a-sen2cor/items?limit=12&datetime=2016-01-02T10%3A54%3A42.030Z%2F2019-12-31T23%3A00%3A00.000Z',
+    'https://stacapi-cdos.apps.okd.crocc.meso.umontpellier.fr/collections/sentinel2-l2a-sen2cor/items?limit=12&datetime=2016-01-02T10%3A54%3A42.030Z%2F2020-01-01T00%3A00%3A00.000Z',
     {
       fixture: 'stac-items-date-modified.json',
     }

--- a/libs/common/domain/src/index.ts
+++ b/libs/common/domain/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/model/index'
 export * from './lib/organizations.service.interface'
 export * from './lib/platform.service.interface'
 export * from './lib/repository/records-repository.interface'

--- a/libs/common/domain/src/lib/model/index.ts
+++ b/libs/common/domain/src/lib/model/index.ts
@@ -1,0 +1,3 @@
+export * from './dataviz/dataviz-configuration.model'
+export * from './record'
+export * from './search'

--- a/libs/common/domain/src/lib/model/record/index.ts
+++ b/libs/common/domain/src/lib/model/record/index.ts
@@ -1,5 +1,5 @@
 export * from './contact.model'
-export * from './organization.model'
 export * from './metadata.model'
-export * from './user-feedbacks.model'
+export * from './organization.model'
 export * from './translation.model'
+export * from './user-feedbacks.model'

--- a/libs/common/domain/src/lib/model/search/index.ts
+++ b/libs/common/domain/src/lib/model/search/index.ts
@@ -1,5 +1,5 @@
 export * from './aggregation.model'
+export * from './field.model'
 export * from './filter.model'
 export * from './search.model'
 export * from './sort-by.model'
-export * from './field.model'

--- a/libs/feature/record/src/lib/gpf-api-dl/gpf-api-dl.component.ts
+++ b/libs/feature/record/src/lib/gpf-api-dl/gpf-api-dl.component.ts
@@ -20,8 +20,8 @@ export interface Label {
 export interface FormatProduit {
   title: string
   update: string
-  format: Array<TermBucket>
-  zone: Array<TermBucket>
+  format: Array<GpfApiDlTermBucket>
+  zone: Array<GpfApiDlTermBucket>
 }
 
 export interface FormatSortieProduit {
@@ -39,7 +39,7 @@ export interface ListChoice {
   crs: Choice[]
 }
 
-export interface TermBucket {
+export interface GpfApiDlTermBucket {
   term: string
   label: string | number
 }
@@ -77,7 +77,11 @@ export class GpfApiDlComponent implements OnInit {
   page$ = new BehaviorSubject(1)
   url =
     'https://data.geopf.fr/telechargement/capabilities?outputFormat=application/json'
-  choices: { zone: TermBucket[]; format: TermBucket[]; category: TermBucket[] }
+  choices: {
+    zone: GpfApiDlTermBucket[]
+    format: GpfApiDlTermBucket[]
+    category: GpfApiDlTermBucket[]
+  }
   bucketPromisesZone: Choice[]
   bucketPromisesFormat: Choice[]
   bucketPromisesCrs: Choice[]


### PR DESCRIPTION
### Description

This PR exports dataviz, record and search models, to be used by custom apps.

BREAKING CHANGE: the `TermBucket` exported by the feature-record lib (gpf-api-dl) had to be renamed to be more specific and not overlap common domain model.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

This change is necessary for the https://github.com/camptocamp/mel-dataplatform/ migration to GN-UI 2.8+.
It can be tested by pulling https://github.com/camptocamp/mel-dataplatform/pull/149 and linking to the locally build package. 

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [Métropole Européenne de Lille](https://data.lillemetropole.fr/)**.
