### PR TITLE
Add groupId to gn4 insert record

### DIFF
--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -425,7 +425,7 @@ export class Gn4Repository implements RecordsRepositoryInterface {
           publishToAll,
           undefined,
           'OVERWRITE',
-          undefined,
+          '2',
           undefined,
           undefined,
           '_none_',


### PR DESCRIPTION

### Description

Because it's mandatory in 4.4.10 and may not harm lower versions.

As 2 is already used in this file (sample group), I reused it here.



### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Use GN 4.4.10 and try to execute:

Won't work:
```shell
curl --request PUT \
  --url 'https://mel.integration.apps.gs-fr-prod.camptocamp.com/geonetwork/srv/api/records?metadataType=METADATA&publishToAll=false&uuidProcessing=OVERWRITE&transformWith=_none_' \
  --header 'Cookie: XSRF-TOKEN=<token>' \
  --header 'accept: application/json' \
  --header 'content-type: application/xml' \
  --header 'x-xsrf-token: <token>' \
  --data '<?xml version="1.0" encoding="UTF-8"?>
<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink">
</gmd:MD_Metadata>'
```

Works:
```shell
curl --request PUT \
  --url 'https://mel.integration.apps.gs-fr-prod.camptocamp.com/geonetwork/srv/api/records?metadataType=METADATA&publishToAll=false&uuidProcessing=OVERWRITE&transformWith=_none_&group=2' \
  --header 'Cookie: XSRF-TOKEN=<token>' \
  --header 'accept: application/json' \
  --header 'content-type: application/xml' \
  --header 'x-xsrf-token: <token>' \
  --data '<?xml version="1.0" encoding="UTF-8"?>
<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink">
</gmd:MD_Metadata>'
```
