### PR TITLE
Upgrade ogc-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "20.3.19",
         "@angular/router": "20.3.19",
         "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-        "@camptocamp/ogc-client": "1.3.1-dev.12086e8",
+        "@camptocamp/ogc-client": "1.3.1-dev.afd9c26",
         "@geospatial-sdk/core": "0.0.5-dev.61",
         "@geospatial-sdk/geocoding": "0.0.5-dev.61",
         "@geospatial-sdk/legend": "0.0.5-dev.61",
@@ -4274,9 +4274,9 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.3.1-dev.12086e8",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.1-dev.12086e8.tgz",
-      "integrity": "sha512-VBgxdMexS/8DH6CM3JcToCwRYEsbf6yIV/z/h9yuC7gfV8OGQjVeZSRJSDPRhUQJF7CZ4UM6pVGL8bDJpzoyoA==",
+      "version": "1.3.1-dev.afd9c26",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.1-dev.afd9c26.tgz",
+      "integrity": "sha512-G2YKPSIZIlO5tN+n5e/3h9OOUL3TgueTux9DlL6YFxR2FeA/qult7y7I+BS1ycUbO03HmYwf6ke7PWocy45ogQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@angular/platform-server": "20.3.19",
     "@angular/router": "20.3.19",
     "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-    "@camptocamp/ogc-client": "1.3.1-dev.12086e8",
+    "@camptocamp/ogc-client": "1.3.1-dev.afd9c26",
     "@geospatial-sdk/core": "0.0.5-dev.61",
     "@geospatial-sdk/geocoding": "0.0.5-dev.61",
     "@geospatial-sdk/legend": "0.0.5-dev.61",

--- a/package/package.json
+++ b/package/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-    "@camptocamp/ogc-client": "1.3.1-dev.12086e8",
+    "@camptocamp/ogc-client": "1.3.1-dev.afd9c26",
     "@geospatial-sdk/core": "0.0.5-dev.61",
     "@geospatial-sdk/geocoding": "0.0.5-dev.61",
     "@geospatial-sdk/legend": "0.0.5-dev.61",


### PR DESCRIPTION
### Description

This PR upgrades ogc-client to make the `setCacheExpiryDuration` and `getCacheExpiryDuration` functions available.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### How to test

Check if the functions can now be imported properly.
