### PR TITLE
[Datahub] open internal link cards in the same tab

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetDetailPage.cy.ts
@@ -584,11 +584,8 @@ describe('Sections', () => {
     cy.get('@proviLink')
       .invoke('attr', 'href')
       .then((link) => {
-        const targetLink = link
-        cy.get('@proviLink')
-          .invoke('removeAttr', 'target') // this prevents having a target="_blank" attribute
-          .click()
-        cy.url().should('include', targetLink)
+        cy.get('@proviLink').click()
+        cy.url().should('include', link)
       })
 
     // When there is no link

--- a/apps/datahub/src/app/record/record-internal-links/record-internal-links.component.html
+++ b/apps/datahub/src/app/record/record-internal-links/record-internal-links.component.html
@@ -41,7 +41,6 @@
     <gn-ui-internal-link-card
       #block
       [linkHref]="recordUrlGetter(record)"
-      [linkTarget]="'_blank'"
       [record]="record"
       [favoriteTemplate]="favoriteTemplate"
       [metadataQualityDisplay]="metadataQualityDisplay"

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.html
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.html
@@ -1,6 +1,6 @@
 <a
   [attr.href]="linkHref"
-  [target]="linkTarget"
+  target="_self"
   class="record-card"
   [ngClass]="cardClass"
 >

--- a/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
+++ b/libs/ui/elements/src/lib/internal-link-card/internal-link-card.component.ts
@@ -58,7 +58,6 @@ export class InternalLinkCardComponent implements OnInit {
   protected elementRef = inject(ElementRef)
 
   @Input() record: CatalogRecord
-  @Input() linkTarget = '_blank'
   @Input() linkHref: string = null
   @Input() metadataQualityDisplay: boolean
   @Input() favoriteTemplate: TemplateRef<{ $implicit: CatalogRecord }>

--- a/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.html
+++ b/libs/ui/search/src/lib/record-preview-row/record-preview-row.component.html
@@ -1,6 +1,5 @@
 <gn-ui-internal-link-card
   [linkHref]="linkHref"
-  [linkTarget]="linkTarget"
   [record]="record"
   [favoriteTemplate]="favoriteTemplate"
   [metadataQualityDisplay]="metadataQualityDisplay"


### PR DESCRIPTION
### Description

This PR introduces a fix for the internal link card behavior in the Datahub. Previously, internal links were opening in a new tab (_blank). With this change, internal links now open in the same tab (_self).


<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Navigate to a page with internal link card (e.g: http://localhost:4200/dataset/e27e7006-fdf9-4004-b6c5-af2a5a5c025c).
2. Click on an internal card and confirm that it opens in the same tab.
