### PR TITLE
[Datahub] Remove unused FeatureEditorModule references from Datahub

### DIFF
--- a/apps/datahub/src/app/app.component.spec.ts
+++ b/apps/datahub/src/app/app.component.spec.ts
@@ -5,7 +5,6 @@ import { StoreModule } from '@ngrx/store'
 import { provideGn4, provideRepositoryUrl } from '@geonetwork-ui/api/repository'
 import { FeatureSearchModule } from '@geonetwork-ui/feature/search'
 import { FeatureRecordModule } from '@geonetwork-ui/feature/record'
-import { FeatureEditorModule } from '@geonetwork-ui/feature/editor'
 import { EffectsModule } from '@ngrx/effects'
 import { provideI18n } from '@geonetwork-ui/util/i18n'
 
@@ -17,7 +16,6 @@ describe('AppComponent', () => {
           StoreModule.forRoot({}),
           FeatureSearchModule,
           FeatureRecordModule,
-          FeatureEditorModule,
           EffectsModule.forRoot(),
         ]),
         provideGn4(),

--- a/apps/datahub/src/main.ts
+++ b/apps/datahub/src/main.ts
@@ -25,7 +25,6 @@ import {
 } from './app/app.providers'
 import { FeatureSearchModule } from '@geonetwork-ui/feature/search'
 import { FeatureRecordModule } from '@geonetwork-ui/feature/record'
-import { FeatureEditorModule } from '@geonetwork-ui/feature/editor'
 import { provideI18n } from '@geonetwork-ui/util/i18n'
 import { EffectsModule } from '@ngrx/effects'
 import { StoreDevtoolsModule } from '@ngrx/store-devtools'
@@ -59,7 +58,6 @@ loadAppConfig().then(() => {
           : [],
         FeatureSearchModule,
         FeatureRecordModule,
-        FeatureEditorModule,
         EffectsModule.forRoot(),
       ]),
       provideRouter(


### PR DESCRIPTION
### Description

This PR cleans up unused references to `FeatureEditorModule` (from `@geonetwork-ui/feature/editor`) within the Datahub application (`apps/datahub`). 

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

