### PR TITLE
Datahub Web Component / generate correct links to internal records

### DIFF
--- a/apps/webcomponents/cypress/e2e/gn-datahub.cy.ts
+++ b/apps/webcomponents/cypress/e2e/gn-datahub.cy.ts
@@ -12,7 +12,8 @@ it('gn-datahub', () => {
   cy.title().as('initialPageTitle')
 
   // should display the search bar and header buttons
-  cy.get('gn-ui-fuzzy-search', { timeout: 10000 }).should('be.visible')
+  cy.get('gn-ui-fuzzy-search', { timeout: 6000 }) // we use a higher timeout because the web component takes a while to boot in dev mode
+    .should('be.visible')
   cy.get('datahub-navigation-menu').find('button').should('have.length', 3)
 
   // should display news page

--- a/apps/webcomponents/cypress/e2e/gn-datahub.cy.ts
+++ b/apps/webcomponents/cypress/e2e/gn-datahub.cy.ts
@@ -12,7 +12,7 @@ it('gn-datahub', () => {
   cy.title().as('initialPageTitle')
 
   // should display the search bar and header buttons
-  cy.get('gn-ui-fuzzy-search').should('be.visible')
+  cy.get('gn-ui-fuzzy-search', { timeout: 10000 }).should('be.visible')
   cy.get('datahub-navigation-menu').find('button').should('have.length', 3)
 
   // should display news page
@@ -41,6 +41,11 @@ it('gn-datahub', () => {
     'have.length.above',
     0
   )
+  cy.get('gn-ui-results-list gn-ui-results-list-item')
+    .first()
+    .find('a[href]')
+    .invoke('attr', 'href')
+    .should('contain', '#/dataset/')
   cy.get('gn-ui-filter-dropdown').should('be.visible')
   cy.title().then(function (pageTitle) {
     expect(pageTitle).to.equal(this.initialPageTitle)
@@ -48,7 +53,7 @@ it('gn-datahub', () => {
   cy.url().should('contain', '#/search')
 
   // navigate to a record
-  cy.get('gn-ui-results-list gn-ui-results-list-item').eq(0).click()
+  cy.get('gn-ui-results-list gn-ui-results-list-item').eq(7).click()
   cy.get('datahub-record-page').should('be.visible')
   cy.get('datahub-record-header').should('be.visible')
   cy.get('datahub-record-header header .font-title')
@@ -66,7 +71,14 @@ it('gn-datahub', () => {
   cy.title().then(function (pageTitle) {
     expect(pageTitle).to.equal(this.initialPageTitle)
   })
-  cy.url().should('contain', '#/dataset/')
+  cy.url().should('match', /#\/(dataset|service|reuse)\//)
+
+  // check internal record links
+  cy.get('datahub-record-internal-links gn-ui-internal-link-card')
+    .first()
+    .find('a[href]')
+    .invoke('attr', 'href')
+    .should('match', /#\/(dataset|service|reuse)\//)
 
   // reload & stay on same page
   // cy.reload()

--- a/apps/webcomponents/src/app/components/gn-datahub/gn-datahub.component.ts
+++ b/apps/webcomponents/src/app/components/gn-datahub/gn-datahub.component.ts
@@ -23,6 +23,23 @@ import { TranslateService } from '@ngx-translate/core'
 import { DATAHUB_CONFIG_PROVIDERS } from '@geonetwork-ui/apps/datahub/app.providers.ts'
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { AppComponent } from '@geonetwork-ui/apps/datahub/app.component.ts'
+import {
+  RECORD_DATASET_URL_TOKEN,
+  RECORD_REUSE_URL_TOKEN,
+  RECORD_SERVICE_URL_TOKEN,
+} from '@geonetwork-ui/feature/search'
+import {
+  ROUTE_PARAMS,
+  ROUTER_ROUTE_DATASET,
+  ROUTER_ROUTE_ORGANIZATION,
+  ROUTER_ROUTE_REUSE,
+  ROUTER_ROUTE_SEARCH,
+  ROUTER_ROUTE_SERVICE,
+} from '@geonetwork-ui/feature/router'
+import {
+  ORGANIZATION_PAGE_URL_TOKEN,
+  ORGANIZATION_URL_TOKEN,
+} from '@geonetwork-ui/feature/catalog'
 
 @Component({
   selector: 'wc-gn-datahub',
@@ -37,6 +54,28 @@ import { AppComponent } from '@geonetwork-ui/apps/datahub/app.component.ts'
     },
     provideGn4({ disableAuth: true }),
     DATAHUB_CONFIG_PROVIDERS,
+    // we're overriding the URL providers so that they work with our hash-based navigation
+    // TODO: rely on the router for generating these links!
+    {
+      provide: RECORD_DATASET_URL_TOKEN,
+      useValue: `#/${ROUTER_ROUTE_DATASET}/\${uuid}`,
+    },
+    {
+      provide: RECORD_SERVICE_URL_TOKEN,
+      useValue: `#/${ROUTER_ROUTE_SERVICE}/\${uuid}`,
+    },
+    {
+      provide: RECORD_REUSE_URL_TOKEN,
+      useValue: `#/${ROUTER_ROUTE_REUSE}/\${uuid}`,
+    },
+    {
+      provide: ORGANIZATION_PAGE_URL_TOKEN,
+      useValue: `#/${ROUTER_ROUTE_ORGANIZATION}/\${name}`,
+    },
+    {
+      provide: ORGANIZATION_URL_TOKEN,
+      useValue: `#/${ROUTER_ROUTE_SEARCH}?${ROUTE_PARAMS.PUBLISHER}=\${name}`,
+    },
   ],
   standalone: true,
   imports: [AppComponent, AsyncPipe],


### PR DESCRIPTION
### Description

This PR fixes an issue where internal record links (e.g. in search results or related records) in the Datahub Web Component were given an invalid `href` attribute. The Web Component relies on hash-based navigation but these links were generated with the assumption that the navigation was url-based.

### Architectural changes

none

### Screenshots

<img width="1265" height="304" alt="image" src="https://github.com/user-attachments/assets/86baa01d-0293-4561-83a6-c296dc3f6a8d" />


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. start support services
2. run `npm run docs:dev`
3. run `npm run dev:webcomponents`
4. Go to http://localhost:5173/webcomponents/gn-datahub.html
5. Try right clicking a record and clicking on "open in new tab"
6. The new tab should correctly open on the selected record inside the web component

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by DataGrandEst**