### PR TITLE
[Metadata-Editor] Make default language for new records configurable

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/record-actions/record-actions.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/record-actions/record-actions.cy.ts
@@ -383,4 +383,34 @@ describe('record-actions', () => {
     cy.get('md-editor-publish-button').click()
     cy.get('[data-test="publish-warning"]').should('not.exist')
   })
+
+  it('new record default language should follow configuration', () => {
+    // with no editor config (default to English)
+    cy.get('[data-cy="create-record"]').click()
+    cy.editor_readFormUniqueIdentifier().as('defaultLangRecordUuid')
+    cy.intercept({ method: 'PUT', pathname: '**/records' }).as('publishDefault')
+    cy.get('md-editor-publish-button').click()
+    cy.wait('@publishDefault')
+      .its('request.body')
+      .should('include', 'codeListValue="eng"')
+    cy.get<string>('@defaultLangRecordUuid').then((uuid) =>
+      cy.deleteRecord(uuid)
+    )
+
+    // with new_record_default_language = "fr"
+    cy.intercept('GET', '/assets/configuration/default.toml', {
+      fixture: 'config-with-french-default-language.toml',
+    })
+    cy.visit('/catalog/search')
+    cy.get('[data-cy="create-record"]').click()
+    cy.editor_readFormUniqueIdentifier().as('frenchLangRecordUuid')
+    cy.intercept({ method: 'PUT', pathname: '**/records' }).as('publishFrench')
+    cy.get('md-editor-publish-button').click()
+    cy.wait('@publishFrench')
+      .its('request.body')
+      .should('include', 'codeListValue="fre"')
+    cy.get<string>('@frenchLangRecordUuid').then((uuid) =>
+      cy.deleteRecord(uuid)
+    )
+  })
 })

--- a/apps/metadata-editor-e2e/src/fixtures/config-with-french-default-language.toml
+++ b/apps/metadata-editor-e2e/src/fixtures/config-with-french-default-language.toml
@@ -1,0 +1,12 @@
+[global]
+geonetwork4_api_url = "/geonetwork/srv/api"
+proxy_path = ""
+
+[theme]
+primary_color = "#c82850"
+secondary_color = "#001638"
+main_color = "#212029"
+background_color = "#fdfbff"
+
+[editor]
+new_record_default_language = "fr"

--- a/apps/metadata-editor-e2e/src/fixtures/config-with-french-default-language.toml
+++ b/apps/metadata-editor-e2e/src/fixtures/config-with-french-default-language.toml
@@ -8,5 +8,5 @@ secondary_color = "#001638"
 main_color = "#212029"
 background_color = "#fdfbff"
 
-[editor]
+[editing]
 new_record_default_language = "fr"

--- a/apps/metadata-editor/src/app/new-record.resolver.spec.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.spec.ts
@@ -27,6 +27,7 @@ jest.mock('@geonetwork-ui/util/app-config', () => ({
 }))
 
 class TranslateServiceMock {
+  currentLang = 'de'
   instant = jest.fn((key: string) => key)
 }
 
@@ -110,8 +111,8 @@ describe('NewRecordResolver', () => {
       ])
     })
 
-    it('defaults to English when no language is configured', () => {
-      expect(resolvedData[0].defaultLanguage).toBe('en')
+    it('defaults to the current UI language when no language is configured', () => {
+      expect(resolvedData[0].defaultLanguage).toBe('de')
     })
   })
 

--- a/apps/metadata-editor/src/app/new-record.resolver.spec.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.spec.ts
@@ -17,6 +17,14 @@ import {
 } from '@geonetwork-ui/common/fixtures'
 import { TranslateService } from '@ngx-translate/core'
 import { NOT_KNOWN_CONSTRAINT } from '@geonetwork-ui/feature/editor'
+import {
+  EditorConfig,
+  getOptionalEditorConfig,
+} from '@geonetwork-ui/util/app-config'
+
+jest.mock('@geonetwork-ui/util/app-config', () => ({
+  getOptionalEditorConfig: jest.fn(),
+}))
 
 class TranslateServiceMock {
   instant = jest.fn((key: string) => key)
@@ -37,6 +45,7 @@ describe('NewRecordResolver', () => {
   let resolvedData: [CatalogRecord, string, boolean]
 
   beforeEach(() => {
+    ;(getOptionalEditorConfig as jest.Mock).mockReturnValue(null)
     TestBed.configureTestingModule({
       schemas: [NO_ERRORS_SCHEMA],
       providers: [
@@ -99,6 +108,23 @@ describe('NewRecordResolver', () => {
         null,
         false,
       ])
+    })
+
+    it('defaults to English when no language is configured', () => {
+      expect(resolvedData[0].defaultLanguage).toBe('en')
+    })
+  })
+
+  describe('defaultLanguage from config', () => {
+    beforeEach(() => {
+      ;(getOptionalEditorConfig as jest.Mock).mockReturnValue({
+        NEW_RECORD_DEFAULT_LANGUAGE: 'fr',
+      } as EditorConfig)
+      resolver.resolve().subscribe((r) => (resolvedData = r))
+    })
+
+    it('uses the configured language', () => {
+      expect(resolvedData[0].defaultLanguage).toBe('fr')
     })
   })
 })

--- a/apps/metadata-editor/src/app/new-record.resolver.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.ts
@@ -21,8 +21,12 @@ export class NewRecordResolver {
   private translateService = inject(TranslateService)
 
   resolve(): Observable<[CatalogRecord, string, boolean]> {
+    const configuredLang =
+      getOptionalEditorConfig()?.NEW_RECORD_DEFAULT_LANGUAGE
     const defaultLang =
-      getOptionalEditorConfig()?.NEW_RECORD_DEFAULT_LANGUAGE ?? 'en'
+      !configuredLang || configuredLang === 'current'
+        ? this.translateService.currentLang
+        : configuredLang
     return this.getCurrentUserAsPointOfContact().pipe(
       map((userContact) => {
         const catalogRecord: CatalogRecord = {

--- a/apps/metadata-editor/src/app/new-record.resolver.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.ts
@@ -21,12 +21,9 @@ export class NewRecordResolver {
   private translateService = inject(TranslateService)
 
   resolve(): Observable<[CatalogRecord, string, boolean]> {
-    const configuredLang =
-      getOptionalEditorConfig()?.NEW_RECORD_DEFAULT_LANGUAGE
     const defaultLang =
-      !configuredLang || configuredLang === 'current'
-        ? this.translateService.currentLang
-        : configuredLang
+      getOptionalEditorConfig()?.NEW_RECORD_DEFAULT_LANGUAGE ??
+      this.translateService.currentLang
     return this.getCurrentUserAsPointOfContact().pipe(
       map((userContact) => {
         const catalogRecord: CatalogRecord = {

--- a/apps/metadata-editor/src/app/new-record.resolver.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.ts
@@ -10,6 +10,7 @@ import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.
 import { OrganizationsServiceInterface } from '@geonetwork-ui/common/domain/organizations.service.interface'
 import { TranslateService } from '@ngx-translate/core'
 import { NOT_KNOWN_CONSTRAINT } from '@geonetwork-ui/feature/editor'
+import { getOptionalEditorConfig } from '@geonetwork-ui/util/app-config'
 
 @Injectable({
   providedIn: 'root',
@@ -20,6 +21,8 @@ export class NewRecordResolver {
   private translateService = inject(TranslateService)
 
   resolve(): Observable<[CatalogRecord, string, boolean]> {
+    const defaultLang =
+      getOptionalEditorConfig()?.NEW_RECORD_DEFAULT_LANGUAGE ?? 'en'
     return this.getCurrentUserAsPointOfContact().pipe(
       map((userContact) => {
         const catalogRecord: CatalogRecord = {
@@ -33,7 +36,7 @@ export class NewRecordResolver {
           recordUpdated: new Date(),
           updateFrequency: 'unknown',
           otherLanguages: [],
-          defaultLanguage: 'en',
+          defaultLanguage: defaultLang,
           topics: [],
           keywords: [],
           licenses: [],

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -151,6 +151,14 @@ background_color = "#fdfbff"
 # enabled = true
 # If u want to use metadata quality widget this configuration is required
 
+### EDITOR SETTINGS
+
+# This section contains settings specific to the Metadata Editor application.
+[editor]
+# Optional; defines the default language assigned to newly created records (e.g. 'en', 'fr', 'de').
+# If not set, defaults to 'en'.
+# new_record_default_language = "fr"
+
 ### MAP SETTINGS
 
 # The map section allows to customize how maps are configured.

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -156,7 +156,8 @@ background_color = "#fdfbff"
 # This section contains settings specific to the Metadata Editor application.
 [editor]
 # Optional; defines the default language assigned to newly created records (e.g. 'en', 'fr', 'de').
-# If not set, defaults to 'en'.
+# Use "current" to assign the current UI language at the time of record creation.
+# If not set, defaults to the current UI language.
 # new_record_default_language = "fr"
 
 ### MAP SETTINGS

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -151,12 +151,11 @@ background_color = "#fdfbff"
 # enabled = true
 # If u want to use metadata quality widget this configuration is required
 
-### EDITOR SETTINGS
+### EDITING SETTINGS
 
-# This section contains settings specific to the Metadata Editor application.
-[editor]
+# This section contains settings for metadata editing behavior in the Metadata Editor application.
+[editing]
 # Optional; defines the default language assigned to newly created records (e.g. 'en', 'fr', 'de').
-# Use "current" to assign the current UI language at the time of record creation.
 # If not set, defaults to the current UI language.
 # new_record_default_language = "fr"
 

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -266,19 +266,18 @@ To show Metadata Quality scores on records and allow sorting, enabling the setti
 
   By default, the widget is not activated; to enable it, just set this parameter to "true".
 
-#### `[editor]`
+#### `[editing]`
 
-This section contains settings specific to the Metadata Editor application.
+This section contains settings for metadata editing behavior in the Metadata Editor application.
 
 - `new_record_default_language` (optional)
 
   Defines the default language assigned to newly created metadata records (e.g. `en`, `fr`, `de`).
-  Use `"current"` to assign the current UI language at the time of record creation.
 
   If not set, defaults to the current UI language.
 
   ```toml
-  [editor]
+  [editing]
   new_record_default_language = "fr"
   ```
 

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -273,8 +273,9 @@ This section contains settings specific to the Metadata Editor application.
 - `new_record_default_language` (optional)
 
   Defines the default language assigned to newly created metadata records (e.g. `en`, `fr`, `de`).
+  Use `"current"` to assign the current UI language at the time of record creation.
 
-  If not set, defaults to `en`.
+  If not set, defaults to the current UI language.
 
   ```toml
   [editor]

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -266,6 +266,21 @@ To show Metadata Quality scores on records and allow sorting, enabling the setti
 
   By default, the widget is not activated; to enable it, just set this parameter to "true".
 
+#### `[editor]`
+
+This section contains settings specific to the Metadata Editor application.
+
+- `new_record_default_language` (optional)
+
+  Defines the default language assigned to newly created metadata records (e.g. `en`, `fr`, `de`).
+
+  If not set, defaults to `en`.
+
+  ```toml
+  [editor]
+  new_record_default_language = "fr"
+  ```
+
 #### `[map]`
 
 The map section lets you customize how maps appear and behave across GeoNetwork-UI applications.

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -257,7 +257,7 @@ describe('app config utils', () => {
           () =>
             minimalAppConfigFixture() +
             `
-[editor]
+[editing]
 new_record_default_language = "fr"
 `
         )
@@ -276,7 +276,7 @@ new_record_default_language = "fr"
           () =>
             minimalAppConfigFixture() +
             `
-[editor]
+[editing]
 new_record_default_language = "fre"
 `
         )
@@ -295,7 +295,7 @@ new_record_default_language = "fre"
           () =>
             minimalAppConfigFixture() +
             `
-[editor]
+[editing]
 new_record_default_language = "xyz"
 `
         )

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -3,6 +3,7 @@ import {
   _reset,
   getCustomTranslations,
   getGlobalConfig,
+  getOptionalEditorConfig,
   getOptionalMapConfig,
   getOptionalSearchConfig,
   getThemeConfig,
@@ -244,6 +245,73 @@ describe('app config utils', () => {
     describe('getOptionalSearchConfig', () => {
       it('returns null', () => {
         expect(getOptionalSearchConfig()).toEqual(null)
+      })
+    })
+  })
+
+  describe('when the configuration file contains new_record_default_language', () => {
+    describe('when set to a valid 2-letter code', () => {
+      beforeEach(async () => {
+        fetchMock.get(
+          'end:default.toml',
+          () =>
+            minimalAppConfigFixture() +
+            `
+[editor]
+new_record_default_language = "fr"
+`
+        )
+        await loadAppConfig()
+      })
+
+      it('stores the language code in editorConfig', () => {
+        expect(getOptionalEditorConfig().NEW_RECORD_DEFAULT_LANGUAGE).toBe('fr')
+      })
+    })
+
+    describe('when set to a 3-letter code', () => {
+      beforeEach(async () => {
+        fetchMock.get(
+          'end:default.toml',
+          () =>
+            minimalAppConfigFixture() +
+            `
+[editor]
+new_record_default_language = "fre"
+`
+        )
+        await loadAppConfig()
+      })
+
+      it('normalizes to the 2-letter equivalent', () => {
+        expect(getOptionalEditorConfig().NEW_RECORD_DEFAULT_LANGUAGE).toBe('fr')
+      })
+    })
+
+    describe('when set to an unrecognized code', () => {
+      beforeEach(async () => {
+        fetchMock.get(
+          'end:default.toml',
+          () =>
+            minimalAppConfigFixture() +
+            `
+[editor]
+new_record_default_language = "xyz"
+`
+        )
+        await loadAppConfig()
+      })
+
+      it('logs a warning', () => {
+        expect(console.warn).toHaveBeenCalledWith(
+          expect.stringMatching(/new_record_default_language.*xyz/)
+        )
+      })
+
+      it('stores undefined in editorConfig', () => {
+        expect(
+          getOptionalEditorConfig().NEW_RECORD_DEFAULT_LANGUAGE
+        ).toBeUndefined()
       })
     })
   })

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -1,6 +1,7 @@
 import * as TOML from '@ltd/j-toml'
 import {
   checkMetadataLanguage,
+  checkNewRecordDefaultLanguage,
   parseConfigSection,
   parseMultiConfigSection,
   parseTranslationsConfigSection,
@@ -8,6 +9,7 @@ import {
 import {
   CustomTranslations,
   CustomTranslationsAllLanguages,
+  EditorConfig,
   GlobalConfig,
   LayerConfig,
   MapConfig,
@@ -49,6 +51,12 @@ let searchConfig: SearchConfig = null
 
 export function getOptionalSearchConfig(): SearchConfig | null {
   return searchConfig
+}
+
+let editorConfig: EditorConfig = null
+
+export function getOptionalEditorConfig(): EditorConfig | null {
+  return editorConfig
 }
 
 let metadataQualityConfig: MetadataQualityConfig = null
@@ -285,6 +293,33 @@ export function loadAppConfig(configUrl = 'assets/configuration/default.toml') {
               SORTABLE: parsedMetadataQualitySection.sortable,
             } as MetadataQualityConfig)
 
+      let parsedEditorSection = parseConfigSection(
+        parsed,
+        'editor',
+        [],
+        ['new_record_default_language'],
+        warnings,
+        errors
+      )
+      if (
+        parsedEditorSection !== null &&
+        parsedEditorSection.new_record_default_language !== undefined
+      ) {
+        parsedEditorSection = checkNewRecordDefaultLanguage(
+          parsedEditorSection,
+          warnings
+        )
+      }
+      editorConfig =
+        parsedEditorSection === null
+          ? null
+          : ({
+              NEW_RECORD_DEFAULT_LANGUAGE:
+                parsedEditorSection.new_record_default_language as
+                  | string
+                  | undefined,
+            } as EditorConfig)
+
       customTranslations = parseTranslationsConfigSection(
         parsed,
         'translations'
@@ -309,6 +344,7 @@ export function isConfigLoaded() {
 export function _reset() {
   globalConfig = null
   themeConfig = null
+  editorConfig = null
   customTranslations = null
 }
 

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -293,29 +293,29 @@ export function loadAppConfig(configUrl = 'assets/configuration/default.toml') {
               SORTABLE: parsedMetadataQualitySection.sortable,
             } as MetadataQualityConfig)
 
-      let parsedEditorSection = parseConfigSection(
+      let parsedEditingSection = parseConfigSection(
         parsed,
-        'editor',
+        'editing',
         [],
         ['new_record_default_language'],
         warnings,
         errors
       )
       if (
-        parsedEditorSection !== null &&
-        parsedEditorSection.new_record_default_language !== undefined
+        parsedEditingSection !== null &&
+        parsedEditingSection.new_record_default_language !== undefined
       ) {
-        parsedEditorSection = checkNewRecordDefaultLanguage(
-          parsedEditorSection,
+        parsedEditingSection = checkNewRecordDefaultLanguage(
+          parsedEditingSection,
           warnings
         )
       }
       editorConfig =
-        parsedEditorSection === null
+        parsedEditingSection === null
           ? null
           : ({
               NEW_RECORD_DEFAULT_LANGUAGE:
-                parsedEditorSection.new_record_default_language as
+                parsedEditingSection.new_record_default_language as
                   | string
                   | undefined,
             } as EditorConfig)

--- a/libs/util/app-config/src/lib/model.ts
+++ b/libs/util/app-config/src/lib/model.ts
@@ -69,6 +69,10 @@ export interface MetadataQualityConfig {
   ENABLED: boolean
 }
 
+export interface EditorConfig {
+  NEW_RECORD_DEFAULT_LANGUAGE?: string
+}
+
 export type CustomTranslations = { [translationKey: string]: string }
 export type CustomTranslationsAllLanguages = {
   [lang: string]: CustomTranslations

--- a/libs/util/app-config/src/lib/parse-utils.ts
+++ b/libs/util/app-config/src/lib/parse-utils.ts
@@ -142,19 +142,20 @@ export function checkNewRecordDefaultLanguage(
   parsedConfigSection: any,
   outWarnings: string[]
 ) {
-  if (parsedConfigSection.new_record_default_language === 'current') {
-    return parsedConfigSection
-  }
   const lang2 = toLang2(
     parsedConfigSection.new_record_default_language.toLowerCase()
   )
   if (!(lang2 in LANG_2_TO_3_MAPPER)) {
     outWarnings.push(
-      `In the [editor] section: new_record_default_language = "${parsedConfigSection.new_record_default_language}" is not a recognized ISO 639 language code`
+      `In the [editing] section: new_record_default_language = "${parsedConfigSection.new_record_default_language}" is not a recognized ISO 639 language code`
     )
-    parsedConfigSection.new_record_default_language = undefined
-  } else {
-    parsedConfigSection.new_record_default_language = lang2
+    return {
+      ...parsedConfigSection,
+      new_record_default_language: undefined,
+    }
   }
-  return parsedConfigSection
+  return {
+    ...parsedConfigSection,
+    new_record_default_language: lang2,
+  }
 }

--- a/libs/util/app-config/src/lib/parse-utils.ts
+++ b/libs/util/app-config/src/lib/parse-utils.ts
@@ -142,6 +142,9 @@ export function checkNewRecordDefaultLanguage(
   parsedConfigSection: any,
   outWarnings: string[]
 ) {
+  if (parsedConfigSection.new_record_default_language === 'current') {
+    return parsedConfigSection
+  }
   const lang2 = toLang2(
     parsedConfigSection.new_record_default_language.toLowerCase()
   )

--- a/libs/util/app-config/src/lib/parse-utils.ts
+++ b/libs/util/app-config/src/lib/parse-utils.ts
@@ -1,4 +1,4 @@
-import { toLang2 } from '@geonetwork-ui/util/i18n'
+import { LANG_2_TO_3_MAPPER, toLang2 } from '@geonetwork-ui/util/i18n'
 
 const flatten = (
   base: string,
@@ -134,6 +134,24 @@ export function checkMetadataLanguage(
     outWarnings.push(
       `In the [global] section: metadata_language = "${parsedConfigSection.metadata_language}" is not a recognized ISO 639 language code`
     )
+  }
+  return parsedConfigSection
+}
+
+export function checkNewRecordDefaultLanguage(
+  parsedConfigSection: any,
+  outWarnings: string[]
+) {
+  const lang2 = toLang2(
+    parsedConfigSection.new_record_default_language.toLowerCase()
+  )
+  if (!(lang2 in LANG_2_TO_3_MAPPER)) {
+    outWarnings.push(
+      `In the [editor] section: new_record_default_language = "${parsedConfigSection.new_record_default_language}" is not a recognized ISO 639 language code`
+    )
+    parsedConfigSection.new_record_default_language = undefined
+  } else {
+    parsedConfigSection.new_record_default_language = lang2
   }
   return parsedConfigSection
 }


### PR DESCRIPTION
### Description

This PR introduces a configurable default language for newly created metadata records in the metadata-editor app.
Previously, the default language was hardcoded to `'en'` in `new-record.resolver.ts`. Now the default is `current`.

#### Changes

- `default.toml` : added a new `[editor]` section with the `new_record_default_language` key
- `configure.md` : document the new `[editor]` section
- `app-config` : added `EditorConfig` model, `[editor]` section parser, `checkNewRecordDefaultLanguage()` and `getOptionalEditorConfig()` getter
- `metadata-editor` : resolver reads from config, falls back to `'current'`
- `e2e-test` : Added e2e test and a fixture to change the language in config

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. In `default.toml`, set `new_record_default_language = "fr"` under the `[editor]` section.
2. Start the metadata-editor app.
3. Create a new record, its default language should be French, not English.
4. Open the newly created record's XML view and confirm the language element shows `codeListValue="fre"`. If the config is absent or invalid, it should fall back to `codeListValue="eng"`.
5. Remove or comment out the key, confirm the default falls back to English.