### PR TITLE
Fix spatial extent display on load

### DIFF
--- a/libs/ui/map/src/lib/components/map-container/map-container.component.spec.ts
+++ b/libs/ui/map/src/lib/components/map-container/map-container.component.spec.ts
@@ -257,9 +257,10 @@ describe('MapContainerComponent', () => {
           view: mapCtxFixture().view,
         }
       )
-      expect(applyContextDiffToMap).toHaveBeenCalledWith(component.olMap, {
-        'this is': 'a diff',
-      })
+      expect(applyContextDiffToMap).toHaveBeenCalledWith(
+        await component.openlayersMap,
+        { 'this is': 'a diff' }
+      )
     })
     describe('resolvedExtentChange emission on view changes', () => {
       it('emits resolvedExtentChange when viewChanges is true and output is subscribed to', async () => {

--- a/libs/ui/map/src/lib/components/map-container/map-container.component.ts
+++ b/libs/ui/map/src/lib/components/map-container/map-container.component.ts
@@ -204,11 +204,12 @@ export class MapContainerComponent implements AfterViewInit, OnChanges {
 
   async ngOnChanges(changes: SimpleChanges) {
     if ('context' in changes && !changes['context'].isFirstChange()) {
+      const olMap = await this.openlayersMap
       const diff = computeMapContextDiff(
         this.processContext(changes['context'].currentValue),
         this.processContext(changes['context'].previousValue)
       )
-      await applyContextDiffToMap(this.olMap, diff)
+      await applyContextDiffToMap(olMap, diff)
 
       if (this._resolvedExtentChange && diff.viewChanges) {
         this._resolvedExtentChange.emit(this.calculateCurrentMapExtent())

--- a/libs/ui/map/src/lib/components/spatial-extent/spatial-extent.component.ts
+++ b/libs/ui/map/src/lib/components/spatial-extent/spatial-extent.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core'
+import { ChangeDetectorRef, Component, inject, Input } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { Geometry } from 'geojson'
 import { GeoJSONFeatureCollection } from 'ol/format/GeoJSON.js'
@@ -10,8 +10,8 @@ import {
   MapContextLayer,
 } from '@geospatial-sdk/core'
 import { MapContainerComponent } from '../map-container/map-container.component'
-import { BehaviorSubject, Observable } from 'rxjs'
-import { switchMap } from 'rxjs/operators'
+import { BehaviorSubject, from, Observable, of } from 'rxjs'
+import { map, switchMap, tap } from 'rxjs/operators'
 import { DatasetSpatialExtent } from '@geonetwork-ui/common/domain/model/record'
 
 @Component({
@@ -22,14 +22,16 @@ import { DatasetSpatialExtent } from '@geonetwork-ui/common/domain/model/record'
   styleUrl: './spatial-extent.component.css',
 })
 export class SpatialExtentComponent {
+  private _cdr = inject(ChangeDetectorRef)
+
   @Input() set spatialExtents(value: DatasetSpatialExtent[]) {
     this.spatialExtents$.next(value)
   }
   spatialExtents$ = new BehaviorSubject<DatasetSpatialExtent[]>([])
   mapContext$: Observable<MapContext> = this.spatialExtents$.pipe(
-    switchMap(async (extents) => {
+    switchMap((extents) => {
       if (extents.length === 0) {
-        return null // null extent means default view
+        return of(null)
       }
       const featureCollection: GeoJSONFeatureCollection = {
         type: 'FeatureCollection',
@@ -61,11 +63,10 @@ export class SpatialExtentComponent {
           'fill-color': 'rgba(153, 153, 153, 0.3)',
         },
       }
-      const view = await createViewFromLayer(layer)
-      return {
-        view,
-        layers: [layer],
-      }
+      return from(createViewFromLayer(layer)).pipe(
+        map((view) => ({ view, layers: [layer] }) as MapContext),
+        tap(() => this._cdr.markForCheck())
+      )
     })
   )
 


### PR DESCRIPTION
### Description

This PR fixes spatial extent display in zoneless app & error occuring with nullish map passed to `applyContextDiffToMap`.

With the help of @claude as zone's thing is not my favourite part of Angular 😁.


  ### Bug 1 — Spatial extent not displayed on load

  Root cause: The app uses provideZonelessChangeDetection(). In SpatialExtentComponent, mapContext$ used switchMap(async ...) which returns a Promise resolving outside Angular's change
  detection cycle. In zoneless + OnPush mode this means MapContainerComponent.ngOnChanges is never called with the real context → map stays at world view.

  ### Bug 2 — TypeError: Cannot read properties of undefined (reading 'getLayers')

  Root cause: ngAfterViewInit is async but Angular doesn't await it. ngOnChanges (non-first change) could fire before createMapFromContext resolved, leaving this.olMap undefined when
  passed to applyContextDiffToMap.




**Watchout**: as the key factor of the first bug was the use of components in zoneless app, I asked Claude if there was others places in the lib in the code where the same kind of bug could occur, looks like there are 3:

<img width="1850" height="289" alt="image" src="https://github.com/user-attachments/assets/392ed5fe-475c-46bb-8eda-db8959d74a5a" />

This PR is only related to spatial extent for now, should I take the opportunity to proactively fix those potential issues here?

