### PR TITLE
[Datahub] Expand sort dropdown to full width on mobile

### DIFF
--- a/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
+++ b/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
@@ -1,20 +1,16 @@
 <div
   class="bg-primary text-white p-5 shadow-xl rounded-lg grid grid-cols-6 gap-4 transition-[height] duration-100"
-  [ngClass]="{ 'sm:bg-white sm:text-main': !isOpen }"
+  [ngClass]="{ 'md:bg-white md:text-main': !isOpen }"
 >
   <div
-    class="sm:col-span-4 grid grid-cols-1 sm:grid-cols-2 gap-7 sm:gap-4 sm:grid-rows-auto"
-    [ngClass]="
-      isOpen
-        ? 'col-span-6 mb-7 sm:mb-0'
-        : 'col-span-4 sm:col-span-3 lg:col-span-4'
-    "
+    class="md:col-span-4 grid grid-cols-1 md:grid-cols-2 gap-7 md:gap-4 md:grid-rows-auto"
+    [ngClass]="isOpen ? 'col-span-6 mb-7 md:mb-0' : 'col-span-4 lg:col-span-4'"
   >
     @if ((isMobile$ | async) === true || isOpen) {
-      <div class="sm:col-span-2" [ngClass]="{ flex: isOpen }">
+      <div class="md:col-span-2" [ngClass]="{ flex: isOpen }">
         <div class="w-full flex flex-row justify-between">
           <div
-            class="flex flex-col sm:flex-row items-baseline justify-start gap-2"
+            class="flex flex-col md:flex-row items-baseline justify-start gap-2"
           >
             <h2 class="text-xl mr-4 font-title" translate>
               search.filters.title
@@ -62,7 +58,7 @@
       }
     }
     @if (isOpen && (searchFacade.hasSpatialFilter$ | async)) {
-      <div class="spatial-filter-toggle sm:col-span-2">
+      <div class="spatial-filter-toggle md:col-span-2">
         <gn-ui-check-toggle
           [title]="'search.filters.useSpatialFilterHelp' | translate"
           [label]="'search.filters.useSpatialFilter' | translate"
@@ -73,7 +69,7 @@
       </div>
     }
     @if (shouldShowMyRecordsToggle) {
-      <div class="sm:col-span-2">
+      <div class="md:col-span-2">
         <gn-ui-check-toggle
           [title]="'search.filters.myRecordsHelp' | translate"
           [label]="'search.filters.myRecords' | translate"
@@ -84,7 +80,7 @@
       </div>
     }
     @if (shouldShowOtherRecordsButton | async) {
-      <div class="sm:col-span-2">
+      <div class="md:col-span-2">
         <gn-ui-button
           type="light"
           extraClass="text-sm align-middle"
@@ -99,16 +95,16 @@
   <div
     class="flex flex-col justify-between"
     [ngClass]="{
-      'col-span-2 sm:col-span-3 lg:col-span-2': !isOpen,
-      'col-span-6 sm:col-span-2': isOpen,
+      'col-span-2 md:col-span-2 lg:col-span-2': !isOpen,
+      'col-span-6 md:col-span-2': isOpen,
     }"
   >
     <div
-      class="flex flex-row gap-7 sm:gap-4"
+      class="flex flex-row gap-7 md:gap-4"
       [ngClass]="
         isOpen
-          ? 'justify-start sm:justify-end'
-          : 'justify-end sm:justify-between'
+          ? 'justify-start md:justify-end'
+          : 'justify-end md:justify-between'
       "
     >
       @if ((isMobile$ | async) === false && !isOpen) {
@@ -138,7 +134,7 @@
       @if ((isMobile$ | async) === false || isOpen) {
         <gn-ui-sort-by
           class="overflow-hidden"
-          [ngClass]="{ 'block text-white mb-1 sm:w-auto w-full': isOpen }"
+          [ngClass]="{ 'block text-white mb-1 md:w-auto w-full': isOpen }"
           [isQualitySortable]="isQualitySortable"
         ></gn-ui-sort-by>
       }

--- a/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
+++ b/apps/datahub/src/app/home/search/search-filters/search-filters.component.html
@@ -97,8 +97,11 @@
     }
   </div>
   <div
-    class="col-span-2 flex flex-col justify-between"
-    [ngClass]="{ 'sm:col-span-3 lg:col-span-2': !isOpen }"
+    class="flex flex-col justify-between"
+    [ngClass]="{
+      'col-span-2 sm:col-span-3 lg:col-span-2': !isOpen,
+      'col-span-6 sm:col-span-2': isOpen,
+    }"
   >
     <div
       class="flex flex-row gap-7 sm:gap-4"
@@ -135,7 +138,7 @@
       @if ((isMobile$ | async) === false || isOpen) {
         <gn-ui-sort-by
           class="overflow-hidden"
-          [ngClass]="{ 'block text-white mb-1': isOpen }"
+          [ngClass]="{ 'block text-white mb-1 sm:w-auto w-full': isOpen }"
           [isQualitySortable]="isQualitySortable"
         ></gn-ui-sort-by>
       }


### PR DESCRIPTION
### Description

This PR fixes the sort dropdown width on mobile.  When the filter panel is expanded on mobile, the "Sort by" dropdown was constrained to 2 grid columns while all other filter dropdowns (Organization, Formats, Topics, Is spatial data) spanned the full width. The sort dropdown now matches the width of the other filter dropdowns on mobile screens.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->


### Screenshots

<img width="4032" height="3024" alt="BeforeAfter2" src="https://github.com/user-attachments/assets/99a93ded-c965-457b-b7e3-cd19e540ba8a" />

<!--


If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Open DataHub in a mobile viewport.
2. Verify the "Sort by" dropdown now spans the full width, matching the filter dropdowns above it.
3. Switch to a desktop viewport and open the filter panel.
4. Verify the "Sort by" dropdown remains right aligned at its normal compact size.