### PR TITLE
[Datahub] New component to edit a single online resource

### DIFF
--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-single-link-resource/form-field-online-single-link-resource.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-single-link-resource/form-field-online-single-link-resource.component.html
@@ -1,0 +1,5 @@
+<gn-ui-url-input
+  [value]="displayUrl"
+  [showValidateButton]="false"
+  (valueChange)="handleUrlChange($event)"
+></gn-ui-url-input>

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-single-link-resource/form-field-online-single-link-resource.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-single-link-resource/form-field-online-single-link-resource.component.spec.ts
@@ -1,0 +1,93 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { FormFieldOnlineSingleLinkResourceComponent } from './form-field-online-single-link-resource.component'
+import { MockBuilder } from 'ng-mocks'
+import { aSetOfLinksFixture } from '@geonetwork-ui/common/fixtures'
+import { provideI18n } from '@geonetwork-ui/util/i18n'
+import { OnlineLinkResource } from '@geonetwork-ui/common/domain/model/record'
+
+describe('FormFieldOnlineSingleLinkResourceComponent', () => {
+  let component: FormFieldOnlineSingleLinkResourceComponent
+  let fixture: ComponentFixture<FormFieldOnlineSingleLinkResourceComponent>
+
+  beforeEach(() => {
+    return MockBuilder(FormFieldOnlineSingleLinkResourceComponent)
+  })
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [provideI18n()],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(
+      FormFieldOnlineSingleLinkResourceComponent
+    )
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  describe('read mode', () => {
+    it('displays the URL of the first resource', () => {
+      component.value = [
+        aSetOfLinksFixture().readmeLink(),
+        aSetOfLinksFixture().doiLink(),
+      ]
+      expect(component.displayUrl).toBe(
+        aSetOfLinksFixture().readmeLink().url.toString()
+      )
+    })
+
+    it('displays an empty string when the array is empty', () => {
+      component.value = []
+      expect(component.displayUrl).toBe('')
+    })
+  })
+
+  describe('write mode', () => {
+    describe('when the array is empty and user enters a URL', () => {
+      let valueChange: any
+      beforeEach(() => {
+        valueChange = null
+        component.valueChange.subscribe((v) => (valueChange = v))
+        component.value = []
+      })
+
+      it('emits a new array with a single link resource with a default name', () => {
+        component.handleUrlChange('https://example.com/my-resource')
+        expect(valueChange).toEqual([
+          {
+            type: 'link',
+            url: new URL('https://example.com/my-resource'),
+            name: 'editor.record.form.field.onlineLinkageResource.defaultName',
+          },
+        ])
+      })
+    })
+
+    describe('when the array is non-empty and user modifies the URL', () => {
+      let valueChange: any
+      beforeEach(() => {
+        valueChange = null
+        component.valueChange.subscribe((v) => (valueChange = v))
+        component.value = [
+          aSetOfLinksFixture().readmeLink(),
+          aSetOfLinksFixture().doiLink(),
+        ]
+      })
+
+      it('emits updated resources with modified first resource URL, keeping others unchanged', () => {
+        component.handleUrlChange('https://new-url.example.com/page')
+        expect(valueChange).toEqual([
+          {
+            ...aSetOfLinksFixture().readmeLink(),
+            url: new URL('https://new-url.example.com/page'),
+          },
+          aSetOfLinksFixture().doiLink(),
+        ])
+      })
+    })
+  })
+})

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-single-link-resource/form-field-online-single-link-resource.component.stories.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-single-link-resource/form-field-online-single-link-resource.component.stories.ts
@@ -1,0 +1,41 @@
+import { applicationConfig, Meta, StoryObj } from '@storybook/angular'
+import { FormFieldOnlineSingleLinkResourceComponent } from './form-field-online-single-link-resource.component'
+import { aSetOfLinksFixture } from '@geonetwork-ui/common/fixtures'
+import { provideI18n } from '@geonetwork-ui/util/i18n'
+
+export default {
+  title: 'Editor/FormFieldOnlineSingleLinkResourceComponent',
+  component: FormFieldOnlineSingleLinkResourceComponent,
+  decorators: [
+    applicationConfig({
+      providers: [provideI18n()],
+    }),
+  ],
+  argTypes: {
+    valueChange: { action: 'valueChange' },
+  },
+} as Meta<FormFieldOnlineSingleLinkResourceComponent>
+
+export const Empty: StoryObj<FormFieldOnlineSingleLinkResourceComponent> = {
+  args: {
+    value: [],
+  },
+}
+
+export const WithExistingLink: StoryObj<FormFieldOnlineSingleLinkResourceComponent> =
+  {
+    args: {
+      value: [aSetOfLinksFixture().readmeLink()],
+    },
+  }
+
+export const WithMultipleResources: StoryObj<FormFieldOnlineSingleLinkResourceComponent> =
+  {
+    args: {
+      value: [
+        aSetOfLinksFixture().readmeLink(),
+        aSetOfLinksFixture().doiLink(),
+        aSetOfLinksFixture().dataCsv(),
+      ],
+    },
+  }

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-single-link-resource/form-field-online-single-link-resource.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-online-single-link-resource/form-field-online-single-link-resource.component.ts
@@ -1,0 +1,89 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  inject,
+} from '@angular/core'
+import { marker } from '@biesbjerg/ngx-translate-extract-marker'
+import {
+  OnlineLinkResource,
+  OnlineResource,
+} from '@geonetwork-ui/common/domain/model/record'
+import { NotificationsService } from '@geonetwork-ui/feature/notifications'
+import { UrlInputComponent } from '@geonetwork-ui/ui/inputs'
+import { TranslateService } from '@ngx-translate/core'
+
+marker('editor.record.form.field.onlineLinkageResource.defaultName')
+
+@Component({
+  selector: 'gn-ui-form-field-online-single-link-resource',
+  templateUrl: './form-field-online-single-link-resource.component.html',
+  styleUrls: ['./form-field-online-single-link-resource.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [UrlInputComponent],
+})
+export class FormFieldOnlineSingleLinkResourceComponent {
+  private notificationsService = inject(NotificationsService)
+  private translateService = inject(TranslateService)
+
+  @Input() set value(onlineResources: Array<OnlineResource>) {
+    this.allResources = onlineResources ?? []
+    const firstResource = this.allResources[0]
+    this.displayUrl = firstResource?.url?.toString() ?? ''
+  }
+  @Output() valueChange: EventEmitter<Array<OnlineResource>> =
+    new EventEmitter()
+
+  private allResources: OnlineResource[] = []
+  displayUrl = ''
+
+  handleUrlChange(url: string | null) {
+    if (!url) return
+
+    try {
+      const parsedUrl = new URL(url)
+
+      if (this.allResources.length === 0) {
+        const defaultName = this.translateService.instant(
+          'editor.record.form.field.onlineLinkageResource.defaultName'
+        )
+        const newResource: OnlineLinkResource = {
+          type: 'link',
+          url: parsedUrl,
+          name: defaultName,
+        }
+        this.valueChange.emit([newResource])
+      } else {
+        const updatedFirst: OnlineResource = {
+          ...this.allResources[0],
+          url: parsedUrl,
+        }
+        this.valueChange.emit([updatedFirst, ...this.allResources.slice(1)])
+      }
+    } catch (error) {
+      this.handleError(error as Error)
+    }
+  }
+
+  private handleError(error: Error) {
+    this.notificationsService.showNotification(
+      {
+        type: 'error',
+        title: this.translateService.instant(
+          'editor.record.onlineResourceError.title'
+        ),
+        text: `${this.translateService.instant(
+          'editor.record.onlineResourceError.body'
+        )} ${error.message}`,
+        closeMessage: this.translateService.instant(
+          'editor.record.onlineResourceError.closeMessage'
+        ),
+      },
+      undefined,
+      error
+    )
+  }
+}

--- a/translations/de.json
+++ b/translations/de.json
@@ -159,6 +159,7 @@
   "editor.record.form.field.legalConstraints": "Rechtliche Einschränkung",
   "editor.record.form.field.license": "Lizenz",
   "editor.record.form.field.onlineLinkResources": "Beigefügte Ressourcen",
+  "editor.record.form.field.onlineLinkageResource.defaultName": "Link",
   "editor.record.form.field.onlineResource.cancel": "Abbrechen",
   "editor.record.form.field.onlineResource.confirm": "Bestätigen",
   "editor.record.form.field.onlineResource.dialogTitle": "Vorschau des Datensatzes bearbeiten",

--- a/translations/en.json
+++ b/translations/en.json
@@ -159,6 +159,7 @@
   "editor.record.form.field.legalConstraints": "Legal constraint",
   "editor.record.form.field.license": "License",
   "editor.record.form.field.onlineLinkResources": "Attached resources",
+  "editor.record.form.field.onlineLinkageResource.defaultName": "Link",
   "editor.record.form.field.onlineResource.cancel": "Cancel",
   "editor.record.form.field.onlineResource.confirm": "Confirm",
   "editor.record.form.field.onlineResource.dialogTitle": "Modify the dataset preview",

--- a/translations/es.json
+++ b/translations/es.json
@@ -159,6 +159,7 @@
   "editor.record.form.field.legalConstraints": "",
   "editor.record.form.field.license": "",
   "editor.record.form.field.onlineLinkResources": "",
+  "editor.record.form.field.onlineLinkageResource.defaultName": "",
   "editor.record.form.field.onlineResource.cancel": "",
   "editor.record.form.field.onlineResource.confirm": "",
   "editor.record.form.field.onlineResource.dialogTitle": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -159,6 +159,7 @@
   "editor.record.form.field.legalConstraints": "Contrainte légale",
   "editor.record.form.field.license": "Licence",
   "editor.record.form.field.onlineLinkResources": "Ressources attachées",
+  "editor.record.form.field.onlineLinkageResource.defaultName": "Lien",
   "editor.record.form.field.onlineResource.cancel": "Annuler",
   "editor.record.form.field.onlineResource.confirm": "Valider",
   "editor.record.form.field.onlineResource.dialogTitle": "Modifier l'aperçu du jeu de données",

--- a/translations/it.json
+++ b/translations/it.json
@@ -159,6 +159,7 @@
   "editor.record.form.field.legalConstraints": "Vincolo legale",
   "editor.record.form.field.license": "Licenza",
   "editor.record.form.field.onlineLinkResources": "Risorse allegate",
+  "editor.record.form.field.onlineLinkageResource.defaultName": "Link",
   "editor.record.form.field.onlineResource.cancel": "Annulla",
   "editor.record.form.field.onlineResource.confirm": "Convalida",
   "editor.record.form.field.onlineResource.dialogTitle": "Modifica anteprima dataset",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -159,6 +159,7 @@
   "editor.record.form.field.legalConstraints": "",
   "editor.record.form.field.license": "",
   "editor.record.form.field.onlineLinkResources": "",
+  "editor.record.form.field.onlineLinkageResource.defaultName": "",
   "editor.record.form.field.onlineResource.cancel": "",
   "editor.record.form.field.onlineResource.confirm": "",
   "editor.record.form.field.onlineResource.dialogTitle": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -159,6 +159,7 @@
   "editor.record.form.field.legalConstraints": "",
   "editor.record.form.field.license": "",
   "editor.record.form.field.onlineLinkResources": "",
+  "editor.record.form.field.onlineLinkageResource.defaultName": "",
   "editor.record.form.field.onlineResource.cancel": "",
   "editor.record.form.field.onlineResource.confirm": "",
   "editor.record.form.field.onlineResource.dialogTitle": "",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -159,6 +159,7 @@
   "editor.record.form.field.legalConstraints": "",
   "editor.record.form.field.license": "Licencia",
   "editor.record.form.field.onlineLinkResources": "",
+  "editor.record.form.field.onlineLinkageResource.defaultName": "",
   "editor.record.form.field.onlineResource.cancel": "",
   "editor.record.form.field.onlineResource.confirm": "",
   "editor.record.form.field.onlineResource.dialogTitle": "",


### PR DESCRIPTION
### Description

This PR introduces a new form field component to edit a single online resource of type `link` using only its linkage URL.
It accepts and emits an `Array<OnlineResource>`, displays the linkage of the first online resource, and preserves any remaining online resources unchanged.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots

<img width="871" height="74" alt="image" src="https://github.com/user-attachments/assets/f9c70fc6-e2fa-4752-b4b6-2512bbef90d0" />

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test
1. Run Storybook.
2. Open the `FormFieldOnlineSingleLinkResourceComponent` story.
3. Add a new URL or update the existing URL in the input.
4. Open the Storybook **Actions** tab.
5. Verify the emitted value for each use case:
   - **Empty value:** when a URL is added, the emitted array contains a new `OnlineResource` object with the entered URL as its linkage.
   - **Existing value:** when the URL is updated, the emitted array contains the updated first `OnlineResource` object.
   - **Multiple values:** when the first URL is updated, only the first `OnlineResource` object is changed and the remaining objects are preserved unchanged.
