### PR TITLE
Fix: Stop event propagation in url-input component

### DIFF
--- a/libs/ui/inputs/src/lib/url-input/url-input.component.html
+++ b/libs/ui/inputs/src/lib/url-input/url-input.component.html
@@ -6,7 +6,7 @@
     type="url"
     [value]="inputValue"
     (input)="handleInput($event)"
-    (keydown.enter)="handleUpload(input)"
+    (keydown.enter)="handleUpload(input, $event)"
     [placeholder]="placeholder"
     [attr.aria-label]="placeholder"
     [disabled]="disabled"
@@ -25,7 +25,7 @@
       extraClass="absolute inset-y-[var(--side-padding)] right-[var(--side-padding)]"
       type="primary"
       [disabled]="disabled || input.value === '' || !isValidUrl(input.value)"
-      (buttonClick)="handleUpload(input)"
+      (buttonClick)="handleUpload(input, $event)"
     >
       <ng-content>
         <ng-icon name="iconoirArrowUp"></ng-icon>

--- a/libs/ui/inputs/src/lib/url-input/url-input.component.spec.ts
+++ b/libs/ui/inputs/src/lib/url-input/url-input.component.spec.ts
@@ -47,7 +47,7 @@ describe('UrlInputComponent', () => {
         let emitted
         component.uploadClick.subscribe((v) => (emitted = v))
         inputEl.value = 'http://aaa.com/bcd'
-        button.triggerEventHandler('buttonClick', null)
+        button.triggerEventHandler('buttonClick', new MouseEvent('click'))
         expect(emitted).toBe('http://aaa.com/bcd')
       })
       it('does not emit the value on an input event', () => {
@@ -85,13 +85,20 @@ describe('UrlInputComponent', () => {
         inputEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'enter' }))
         expect(emitted).toBe('http://bla')
       })
+      it('stops event propagation so parent components are not triggered', () => {
+        const event = new KeyboardEvent('keydown', { key: 'enter' })
+        const stopPropagation = jest.spyOn(event, 'stopPropagation')
+        inputEl.value = 'http://aaa.com/bcd'
+        inputEl.dispatchEvent(event)
+        expect(stopPropagation).toHaveBeenCalled()
+      })
     })
     describe('valueChange', () => {
       it('does not the value on a button click event', () => {
         let emitted = null
         component.valueChange.subscribe((v) => (emitted = v))
         inputEl.value = 'http://aaa.com/bcd'
-        button.triggerEventHandler('buttonClick', null)
+        button.triggerEventHandler('buttonClick', new MouseEvent('click'))
         expect(emitted).toBe(null)
       })
       it('emits the value on an input event', () => {

--- a/libs/ui/inputs/src/lib/url-input/url-input.component.ts
+++ b/libs/ui/inputs/src/lib/url-input/url-input.component.ts
@@ -81,7 +81,8 @@ export class UrlInputComponent implements OnChanges {
     this.valueChange.next(value)
   }
 
-  handleUpload(element: HTMLInputElement) {
+  handleUpload(element: HTMLInputElement, event: Event) {
+    event.stopPropagation()
     const value = element.value
     if (!value || !this.isValidUrl(value)) return
     this.uploadClick.next(value)


### PR DESCRIPTION
### Description

This PR fixes unwanted enter key triggering in `url-input.component` parent components such as `file-input.component`.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Access http://localhost:4400/?path=/story/inputs-fileinputcomponent--primary on storybook and make sure the file explorer does not open when submitting a URL with the enter key.

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
