### PR TITLE
add current_path parameter

### DIFF
--- a/conf/default.toml
+++ b/conf/default.toml
@@ -31,7 +31,7 @@ proxy_path = ""
 # If not indicated, the default geonetwork login page is used.
 # The following three placeholders can be part of this URL:
 #  - ${current_url}: indicates where the current location should be injected in the constructed login URL (eg. start, end)
-#  - ${current_path}: indicates where the current path should be injected in the constructed login URL (eg. start, end)
+#  - ${current_path}: indicates where the path component of the current URL (i.e. the part after the host name, starting with "/") should be injected in the constructed login URL
 #  - ${lang2}, ${lang3}: indicates if and where the current language should be part of the login URL in language 2 or 3 letter code
 # Example to use the georchestra login page:
 # login_url = "/cas/login?service=${current_url}"

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -31,6 +31,7 @@ proxy_path = ""
 # If not indicated, the default geonetwork login page is used.
 # The following three placeholders can be part of this URL:
 #  - ${current_url}: indicates where the current location should be injected in the constructed login URL (eg. start, end)
+#  - ${current_path}: indicates where the current path should be injected in the constructed login URL (eg. start, end)
 #  - ${lang2}, ${lang3}: indicates if and where the current language should be part of the login URL in language 2 or 3 letter code
 # Example to use the georchestra login page:
 # login_url = "/cas/login?service=${current_url}"

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -67,6 +67,8 @@ Some additional notes:
 
   - `${current_url}`: replaced by the current browser URL
 
+  - `${current_path}`: replaced by the current browser URL path
+
   - `${lang2}`, `${lang3}`: replaced by the ISO-639 code of the current language, respectively in 2- or 3-characters format
 
   Example for a platform relying on CAS:

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -67,7 +67,7 @@ Some additional notes:
 
   - `${current_url}`: replaced by the current browser URL
 
-  - `${current_path}`: replaced by the *path component* of the current browser URL; in a URL like https://my.host.org/hello/world?param=value, the *path component* is `/hello/world?param=value` (it includes anything after the first `/`, including query params and hash fragments)
+  - `${current_path}`: replaced by the _path component_ of the current browser URL; in a URL like https://my.host.org/hello/world?param=value, the _path component_ is `/hello/world?param=value` (it includes anything after the first `/`, including query params and hash fragments)
 
   - `${lang2}`, `${lang3}`: replaced by the ISO-639 code of the current language, respectively in 2- or 3-characters format
 

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -67,7 +67,7 @@ Some additional notes:
 
   - `${current_url}`: replaced by the current browser URL
 
-  - `${current_path}`: replaced by the current browser URL path
+  - `${current_path}`: replaced by the *path component* of the current browser URL; in a URL like https://my.host.org/hello/world?param=value, the *path component* is `/hello/world?param=value` (it includes anything after the first `/`, including query params and hash fragments)
 
   - `${lang2}`, `${lang3}`: replaced by the ISO-639 code of the current language, respectively in 2- or 3-characters format
 

--- a/libs/api/repository/src/lib/gn4/auth/auth.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/auth/auth.service.spec.ts
@@ -80,7 +80,7 @@ describe('AuthService', () => {
     })
     it('should construct a login URL based on the injected value', () => {
       expect(service.loginUrl).toEqual(
-        '/geonetwork/srv/fre/catalog.signin?redirect=/localhost'
+        '/geonetwork/srv/fre/catalog.signin?redirect=/'
       )
     })
   })

--- a/libs/api/repository/src/lib/gn4/auth/auth.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/auth/auth.service.spec.ts
@@ -72,6 +72,18 @@ describe('AuthService', () => {
       expect(service.loginUrl).toEqual('http://localhost/?login')
     })
   })
+  describe('login URL from config (with current_path)', () => {
+    beforeEach(() => {
+      loginUrlTokenMock =
+        '/geonetwork/srv/fre/catalog.signin?redirect=${current_path}'
+      service = TestBed.inject(AuthService)
+    })
+    it('should construct a login URL based on the injected value', () => {
+      expect(service.loginUrl).toEqual(
+        '/geonetwork/srv/fre/catalog.signin?redirect=/localhost'
+      )
+    })
+  })
   describe('login URL from config (special georchestra case, appending a query param with existing query params)', () => {
     beforeEach(() => {
       mockAppBaseHref = '/datahub'

--- a/libs/api/repository/src/lib/gn4/auth/auth.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/auth/auth.service.spec.ts
@@ -74,13 +74,15 @@ describe('AuthService', () => {
   })
   describe('login URL from config (with current_path)', () => {
     beforeEach(() => {
+      mockAppBaseHref = '/datahub'
+      mockLocationPath = '/?org=Abcd&keywords=bla;bla&location'
       loginUrlTokenMock =
         '/geonetwork/srv/fre/catalog.signin?redirect=${current_path}'
       service = TestBed.inject(AuthService)
     })
     it('should construct a login URL based on the injected value', () => {
       expect(service.loginUrl).toEqual(
-        '/geonetwork/srv/fre/catalog.signin?redirect=/'
+        '/geonetwork/srv/fre/catalog.signin?redirect=/datahub/?org=Abcd&keywords=bla;bla&location'
       )
     })
   })

--- a/libs/api/repository/src/lib/gn4/auth/auth.service.ts
+++ b/libs/api/repository/src/lib/gn4/auth/auth.service.ts
@@ -44,6 +44,10 @@ export class AuthService {
           window.location.href
         ).toString()
       )
+      .replace(
+        '${current_path}',
+        this.location.prepareExternalUrl(this.location.path())
+      )
       .replace('${lang2}', toLang2(this.translateService.currentLang))
       .replace('${lang3}', toLang3(this.translateService.currentLang))
   }


### PR DESCRIPTION
### Description

This PR introduces a current_path parameter for the login redirect

related to #1592 

### Architectural changes

No change


### Screenshots

No visual changes

### Quality Assurance Checklist

- [x ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ x] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

Try the variable ${current_path} in the login_url variable configuration


Hello @jahow, you specified unit test in the issues, Run them but are they impacted by such a small modification ? IF so which one should I modify ? 

Do not hesitate to point anything wrong. 

Regards, Clément.
