### PR TITLE
[Metadata-Editor] Duplicate metadata records into the user's group

### DIFF
--- a/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
@@ -109,6 +109,26 @@ let _supportsAuthentication = true
 class PlatformServiceInterfaceMock {
   getApiVersion = jest.fn(() => of('4.2.5'))
   supportsAuthentication = jest.fn(() => _supportsAuthentication)
+  getUserPermissionsByGroup = jest.fn(() =>
+    of([
+      {
+        groupId: 105,
+        groupName: 'Groupe Reviewers',
+        isMember: true,
+        canEdit: true,
+        canApprove: true,
+        canAdministrate: false,
+      },
+      {
+        groupId: 103,
+        groupName: 'Groupe Editors',
+        isMember: true,
+        canEdit: true,
+        canApprove: false,
+        canAdministrate: false,
+      },
+    ])
+  )
 }
 
 let allowEditHarvested = false
@@ -743,6 +763,53 @@ describe('Gn4Repository', () => {
     })
     it('returns the record as serialized', () => {
       expect(recordSource).toMatch(/<mdb:MD_Metadata/)
+    })
+    it('uses the first reviewer group id when calling create', () => {
+      expect(gn4RecordsApi.create).toHaveBeenCalledWith(
+        '1234-5678',
+        '105',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      )
+    })
+    describe('when getUserPermissionsByGroup returns empty (anonymous or no groups)', () => {
+      beforeEach(async () => {
+        ;(
+          platformService.getUserPermissionsByGroup as jest.Mock
+        ).mockReturnValueOnce(of([]))
+        ;(gn4RecordsApi.getRecordAs as jest.Mock).mockReturnValueOnce(
+          of(duplicateDatasetRecordAsXmlFixture()).pipe(
+            map((xml) => ({ body: xml }))
+          )
+        )
+        ;[record, recordSource, savedOnce] = await lastValueFrom(
+          repository.openRecordForDuplication('1234-5678')
+        )
+      })
+      it('falls back to group 2', () => {
+        expect(gn4RecordsApi.create).toHaveBeenLastCalledWith(
+          '1234-5678',
+          '2',
+          expect.anything(),
+          expect.anything(),
+          expect.anything(),
+          undefined,
+          expect.anything(),
+          expect.anything(),
+          undefined,
+          expect.anything(),
+          expect.anything(),
+          expect.anything()
+        )
+      })
     })
   })
   // note: we're using a simple record here otherwise there might be loss of information when converting

--- a/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
@@ -781,33 +781,16 @@ describe('Gn4Repository', () => {
       )
     })
     describe('when getUserPermissionsByGroup returns empty (anonymous or no groups)', () => {
-      beforeEach(async () => {
+      it('throws an error', async () => {
         ;(
           platformService.getUserPermissionsByGroup as jest.Mock
         ).mockReturnValueOnce(of([]))
-        ;(gn4RecordsApi.getRecordAs as jest.Mock).mockReturnValueOnce(
-          of(duplicateDatasetRecordAsXmlFixture()).pipe(
-            map((xml) => ({ body: xml }))
-          )
-        )
-        ;[record, recordSource, savedOnce] = await lastValueFrom(
+        let error: Error
+        await lastValueFrom(
           repository.openRecordForDuplication('1234-5678')
-        )
-      })
-      it('falls back to group 2', () => {
-        expect(gn4RecordsApi.create).toHaveBeenLastCalledWith(
-          '1234-5678',
-          '2',
-          expect.anything(),
-          expect.anything(),
-          expect.anything(),
-          undefined,
-          expect.anything(),
-          expect.anything(),
-          undefined,
-          expect.anything(),
-          expect.anything(),
-          expect.anything()
+        ).catch((e) => (error = e))
+        expect(error).toEqual(
+          new Error('Current user has no writable group to duplicate into')
         )
       })
     })

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -386,12 +386,16 @@ export class Gn4Repository implements RecordsRepositoryInterface {
     uniqueIdentifier: string
   ): Observable<[CatalogRecord, string, true] | null> {
     return this.platformService.getUserPermissionsByGroup().pipe(
-      map(
-        (permissions) =>
+      map((permissions) => {
+        const groupId =
           permissions.find((p) => p.canApprove)?.groupId?.toString() ??
-          permissions.find((p) => p.canEdit)?.groupId?.toString() ??
-          '2'
-      ),
+          permissions.find((p) => p.canEdit)?.groupId?.toString()
+        if (!groupId)
+          throw new Error(
+            'Current user has no writable group to duplicate into'
+          )
+        return groupId
+      }),
       switchMap((groupId) =>
         this.gn4RecordsApi
           .create(

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -385,38 +385,48 @@ export class Gn4Repository implements RecordsRepositoryInterface {
   openRecordForDuplication(
     uniqueIdentifier: string
   ): Observable<[CatalogRecord, string, true] | null> {
-    return this.gn4RecordsApi
-      .create(
-        uniqueIdentifier,
-        '2',
-        'METADATA',
-        '',
-        false,
-        undefined,
-        true,
-        false,
-        undefined,
-        'body',
-        false,
-        {
-          httpHeaderAccept: 'application/json',
-          httpContentTypeSelected: 'application/json;charset=UTF-8',
-        }
-      )
-      .pipe(
-        switchMap((uniqueIdentifier) => {
-          return this.getRecordAsXml(uniqueIdentifier)
-        }),
-        switchMap((xml) => {
-          return from(
-            findConverterForDocument(xml)
-              .readRecord(xml)
-              .then((record) => {
-                return [record, xml, true] as [CatalogRecord, string, true]
-              })
+    return this.platformService.getUserPermissionsByGroup().pipe(
+      map(
+        (permissions) =>
+          permissions.find((p) => p.canApprove)?.groupId?.toString() ??
+          permissions.find((p) => p.canEdit)?.groupId?.toString() ??
+          '2'
+      ),
+      switchMap((groupId) =>
+        this.gn4RecordsApi
+          .create(
+            uniqueIdentifier,
+            groupId,
+            'METADATA',
+            '',
+            false,
+            undefined,
+            true,
+            false,
+            undefined,
+            'body',
+            false,
+            {
+              httpHeaderAccept: 'application/json',
+              httpContentTypeSelected: 'application/json;charset=UTF-8',
+            }
           )
-        })
+          .pipe(
+            switchMap((uniqueIdentifier) => {
+              return this.getRecordAsXml(uniqueIdentifier)
+            }),
+            switchMap((xml) => {
+              return from(
+                findConverterForDocument(xml)
+                  .readRecord(xml)
+                  .then((record) => {
+                    return [record, xml, true] as [CatalogRecord, string, true]
+                  })
+              )
+            })
+          )
       )
+    )
   }
 
   saveRecord(

--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.spec.ts
@@ -1,4 +1,5 @@
 import {
+  GroupsApiService,
   MeApiService,
   RecordsApiService,
   RegistriesApiService,
@@ -203,6 +204,17 @@ class UserfeedbackApiServiceMock {
   newUserFeedback = jest.fn(() => of(undefined))
 }
 
+class GroupsApiServiceMock {
+  // intentionally different order than me response arrays to validate ordering logic
+  getGroups = jest.fn(() =>
+    of([
+      { id: 22, name: 'Autre groupe' },
+      { id: 103, name: 'Groupe Editors' },
+      { id: 105, name: 'Groupe Reviewers' },
+    ])
+  )
+}
+
 describe('Gn4PlatformService', () => {
   let service: Gn4PlatformService
   let meApiService: MeApiService
@@ -256,6 +268,10 @@ describe('Gn4PlatformService', () => {
         {
           provide: RecordsApiService,
           useClass: RecordsApiServiceMock,
+        },
+        {
+          provide: GroupsApiService,
+          useClass: GroupsApiServiceMock,
         },
       ],
       imports: [HttpClientTestingModule],
@@ -374,6 +390,96 @@ describe('Gn4PlatformService', () => {
           const isAnonymous = await firstValueFrom(service.isAnonymous())
           expect(isAnonymous).toBe(true)
         })
+      })
+    })
+    describe('getUserPermissionsByGroup', () => {
+      it('maps canApprove from groupsWithReviewer and canEdit from groupsWithEditor for non-admin user', async () => {
+        const permissionsPromise = firstValueFrom(
+          service.getUserPermissionsByGroup()
+        )
+        ;(meApiService as any)._me$.next({
+          admin: false,
+          groupsWithRegisteredUser: [],
+          groupsWithEditor: [103],
+          groupsWithReviewer: [105],
+          groupsWithUserAdmin: [],
+        })
+        const permissions = await permissionsPromise
+        expect(permissions).toEqual([
+          {
+            groupId: 105,
+            groupName: 'Groupe Reviewers',
+            isMember: false,
+            canEdit: false,
+            canApprove: true,
+            canAdministrate: false,
+          },
+          {
+            groupId: 103,
+            groupName: 'Groupe Editors',
+            isMember: false,
+            canEdit: true,
+            canApprove: false,
+            canAdministrate: false,
+          },
+          {
+            groupId: 22,
+            groupName: 'Autre groupe',
+            isMember: false,
+            canEdit: false,
+            canApprove: false,
+            canAdministrate: false,
+          },
+        ])
+      })
+
+      it('returns all groups with all flags set to true for admin user', async () => {
+        const permissionsPromise = firstValueFrom(
+          service.getUserPermissionsByGroup()
+        )
+        ;(meApiService as any)._me$.next({
+          admin: true,
+          groupsWithRegisteredUser: [],
+          groupsWithEditor: [],
+          groupsWithReviewer: [],
+          groupsWithUserAdmin: [],
+        })
+        const permissions = await permissionsPromise
+        expect(permissions).toEqual([
+          {
+            groupId: 22,
+            groupName: 'Autre groupe',
+            isMember: true,
+            canEdit: true,
+            canApprove: true,
+            canAdministrate: true,
+          },
+          {
+            groupId: 103,
+            groupName: 'Groupe Editors',
+            isMember: true,
+            canEdit: true,
+            canApprove: true,
+            canAdministrate: true,
+          },
+          {
+            groupId: 105,
+            groupName: 'Groupe Reviewers',
+            isMember: true,
+            canEdit: true,
+            canApprove: true,
+            canAdministrate: true,
+          },
+        ])
+      })
+
+      it('returns empty array when user is anonymous', async () => {
+        const permissionsPromise = firstValueFrom(
+          service.getUserPermissionsByGroup()
+        )
+        ;(meApiService as any)._me$.next(null)
+        const permissions = await permissionsPromise
+        expect(permissions).toEqual([])
       })
     })
     describe('#translateKey', () => {

--- a/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.ts
+++ b/libs/api/repository/src/lib/gn4/platform/gn4-platform.service.ts
@@ -12,11 +12,13 @@ import {
 } from '@geonetwork-ui/common/domain/model/record'
 import { KeywordType } from '@geonetwork-ui/common/domain/model/thesaurus'
 import { UserModel } from '@geonetwork-ui/common/domain/model/user/user.model'
+import { GroupModel } from '@geonetwork-ui/common/domain/model/user/group.model'
 import {
   PlatformServiceInterface,
   UploadEvent,
 } from '@geonetwork-ui/common/domain/platform.service.interface'
 import {
+  GroupsApiService,
   MeApiService,
   RecordsApiService,
   RegistriesApiService,
@@ -57,6 +59,7 @@ export const DISABLE_AUTH = new InjectionToken<boolean>('gnDisableAuth', {
 export class Gn4PlatformService implements PlatformServiceInterface {
   private meApi = inject(MeApiService)
   private usersApi = inject(UsersApiService)
+  private groupsApi = inject(GroupsApiService)
   private mapper = inject(Gn4PlatformMapper)
   private toolsApiService = inject(ToolsApiService)
   private registriesApiService = inject(RegistriesApiService)
@@ -153,6 +156,49 @@ export class Gn4PlatformService implements PlatformServiceInterface {
 
   getUsers(): Observable<UserModel[]> {
     return this.users$
+  }
+
+  getUserPermissionsByGroup(): Observable<GroupModel[]> {
+    if (this.disableAuth) return of([])
+    return combineLatest([this.meApi.getMe(), this.groupsApi.getGroups()]).pipe(
+      map(([meResponse, groups]) => {
+        if (!meResponse) return []
+        if (meResponse.admin) {
+          return groups.map((group) => ({
+            groupId: group.id,
+            groupName: group.name,
+            isMember: true,
+            canEdit: true,
+            canApprove: true,
+            canAdministrate: true,
+          }))
+        }
+        const reviewerIds = meResponse.groupsWithReviewer ?? []
+        const editorIds = meResponse.groupsWithEditor ?? []
+        const memberIds = meResponse.groupsWithRegisteredUser ?? []
+        const adminIds = meResponse.groupsWithUserAdmin ?? []
+        const groupsById = new Map(groups.map((g) => [g.id, g]))
+        return [
+          ...new Set([
+            ...reviewerIds,
+            ...editorIds,
+            ...groups.map((g) => g.id),
+          ]),
+        ]
+          .filter((id) => groupsById.has(id))
+          .map((id) => {
+            const group = groupsById.get(id)
+            return {
+              groupId: group.id,
+              groupName: group.name,
+              isMember: memberIds.includes(id),
+              canEdit: editorIds.includes(id),
+              canApprove: reviewerIds.includes(id),
+              canAdministrate: adminIds.includes(id),
+            }
+          })
+      })
+    )
   }
 
   translateKey(key: string): Observable<string> {

--- a/libs/common/domain/src/lib/model/user/group.model.ts
+++ b/libs/common/domain/src/lib/model/user/group.model.ts
@@ -1,0 +1,8 @@
+export interface GroupModel {
+  groupId: number
+  groupName: string
+  isMember: boolean
+  canEdit: boolean
+  canApprove: boolean
+  canAdministrate: boolean
+}

--- a/libs/common/domain/src/lib/model/user/index.ts
+++ b/libs/common/domain/src/lib/model/user/index.ts
@@ -1,1 +1,2 @@
 export * from './user.model'
+export * from './group.model'

--- a/libs/common/domain/src/lib/platform.service.interface.ts
+++ b/libs/common/domain/src/lib/platform.service.interface.ts
@@ -1,5 +1,6 @@
 import type { Observable } from 'rxjs'
 import type { UserModel } from './model/user/user.model'
+import type { GroupModel } from './model/user/group.model'
 import type { Organization } from './model/record/organization.model'
 import { CatalogRecord, Keyword, UserFeedback } from './model/record'
 import { KeywordType } from './model/thesaurus'
@@ -28,6 +29,7 @@ export abstract class PlatformServiceInterface {
   abstract getMe(): Observable<UserModel>
   abstract isAnonymous(): Observable<boolean>
   abstract getUsers(): Observable<UserModel[]>
+  abstract getUserPermissionsByGroup(): Observable<GroupModel[]>
   abstract getUsersByOrganization(
     organisation: Organization
   ): Observable<UserModel[]>


### PR DESCRIPTION
### Description

This PR updates metadata duplication so duplicated records are created in the current user’s group instead of always using group `2`.

The selected group follows the expected priority:
- first group where the user has reviewer permissions
- otherwise first group where the user has editor permissions
- throw error when no writable group found for duplication

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

Adds `GroupModel` in the common domain user models.

Adds `getUserPermissionsByGroup()` to the platform service interface and implements it for GN4.

`Gn4Repository.openRecordForDuplication()` now asks the platform service for group permissions before calling the GeoNetwork duplicate endpoint.

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Log in as `barbie`
2. Confirm `/geonetwork/srv/api/me` returns editor permissions for group `102`:

```
{
  "id": "101",
  "username": "barbie",
  "name": "Barbara",
  "surname": "Roberts",
  "organisation": "Barbie Inc.",
  "admin": false,
  "groupsWithRegisteredUser": [],
  "groupsWithEditor": [102],
  "groupsWithReviewer": [],
  "groupsWithUserAdmin": [103]
}
```
3. Duplicate a metadata record from the metadata editor.
4. In the browser Network tab, check the request to `/geonetwork/srv/api/records/duplicate` it should include: `group=102`
5. Copy the new UUID returned by the duplicate request.
6. Confirm the stored owner group: `http://localhost:8080/geonetwork/srv/api/records/<new-uuid>/sharing`
7. Expected response contains:
```
{
  "groupOwner": "102"
}
```
8. To test other conditions, log in as `admin`, open the GeoNetwork admin console, update users’ group, then repeat the duplication flow. For example, give a user a Reviewer group and an Editor group to confirm the Reviewer group is selected first.