### PR TITLE
[Datahub] Avoid detecting DOI links as TIFF downloads

### DIFF
--- a/libs/util/shared/src/lib/links/link-utils.spec.ts
+++ b/libs/util/shared/src/lib/links/link-utils.spec.ts
@@ -218,6 +218,29 @@ describe('link utils', () => {
         expect(getFileFormat(aSetOfLinksFixture().dataZip())).toEqual('zip')
       })
     })
+    describe('for format names in link labels', () => {
+      const namesToTest = [
+        ['Digital Object Identifier (DOI)', null],
+        ['Certificat de conformité', null],
+        ['Télécharger au format GeoTIFF', 'tiff'],
+        ['ESRI Shapefile', 'shp'],
+      ]
+
+      describe.each(namesToTest)(
+        'link name=%s, recognized file format=%s',
+        (name, fileFormat) => {
+          it('returns the correct file format', () => {
+            expect(
+              getFileFormat({
+                name,
+                url: new URL('https://example.com/download'),
+                type: 'download',
+              })
+            ).toEqual(fileFormat)
+          })
+        }
+      )
+    })
 
     // format name, file extension, mime type
     const toTest = [

--- a/libs/util/shared/src/lib/links/link-utils.spec.ts
+++ b/libs/util/shared/src/lib/links/link-utils.spec.ts
@@ -222,8 +222,9 @@ describe('link utils', () => {
       const namesToTest = [
         ['Digital Object Identifier (DOI)', null],
         ['Certificat de conformité', null],
+        ['Tiffany Lane dataset', null],
         ['Télécharger au format GeoTIFF', 'tiff'],
-        ['ESRI Shapefile', 'shp'],
+        ['ESRI Shapefile (SHP)', 'shp'],
       ]
 
       describe.each(namesToTest)(

--- a/libs/util/shared/src/lib/links/link-utils.ts
+++ b/libs/util/shared/src/lib/links/link-utils.ts
@@ -266,7 +266,7 @@ export function checkFileFormat(
       new RegExp(`[./]${format}`, 'i').test(link.name.toLowerCase())) ||
     ('url' in link &&
       new RegExp(`[./]${format}`, 'i').test(link.url.toString())) ||
-    ('name' in link && new RegExp(`\\b${format}`, 'i').test(link.name))
+    ('name' in link && new RegExp(`\\b${format}\\b`, 'i').test(link.name))
   )
 }
 

--- a/libs/util/shared/src/lib/links/link-utils.ts
+++ b/libs/util/shared/src/lib/links/link-utils.ts
@@ -266,7 +266,7 @@ export function checkFileFormat(
       new RegExp(`[./]${format}`, 'i').test(link.name.toLowerCase())) ||
     ('url' in link &&
       new RegExp(`[./]${format}`, 'i').test(link.url.toString())) ||
-    ('name' in link && link.name.toLowerCase().includes(format))
+    ('name' in link && new RegExp(`\\b${format}`, 'i').test(link.name))
   )
 }
 


### PR DESCRIPTION
### Description

This PR fixes link format detection so links titled as `Digital Object Identifier (DOI)` are no longer incorrectly detected as TIFF downloads because they contain the letters `tif` inside `Identifier`.

The format detection now matches format aliases only when they form a full word, so valid labels like `GeoTIFF` and `ESRI Shapefile (SHP)` are still recognized.

### Architectural changes

None.

### Screenshots

<img width="4032" height="3024" alt="BeforeAfterLandscape copy (1)" src="https://github.com/user-attachments/assets/395ef532-af6d-4719-a0e1-bceb664e290e" />

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Import this dataset:
   https://geode.cirad.fr/geonetwork/srv/api/records/26c934db-0d13-43ad-849d-0f94d16d8ce9/formatters/xml
2. Open the record links section.
3. Before this change, the DOI link was shown as TIFF.
4. After this change, the DOI link should no longer show as TIFF.