### PR TITLE
feat(record): display metadata spatial extent on the data preview map

### DIFF
--- a/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.spec.ts
@@ -48,4 +48,49 @@ describe('MapUtilsService', () => {
       expect(service.getRecordExtent(record)).toEqual([1, 3, 8, 8])
     })
   })
+
+  describe('#getRecordExtentLayer', () => {
+    it('should return null when there is no spatial extent', () => {
+      expect(service.getRecordExtentLayer({})).toBeNull()
+      expect(service.getRecordExtentLayer({ spatialExtents: [] })).toBeNull()
+    })
+
+    it('should build a non-clickable overlay layer from the record extents', () => {
+      const record: Partial<CatalogRecord> = {
+        spatialExtents: [{ bbox: [0, 0, 1, 1] }],
+      }
+      expect(service.getRecordExtentLayer(record)).toEqual({
+        type: 'geojson',
+        clickable: false,
+        label: 'Spatial extent',
+        style: {
+          'stroke-color': 'rgba(0, 0, 0, 0.6)',
+          'stroke-width': 2,
+          'stroke-line-dash': [8, 6],
+          'fill-color': 'rgba(0, 0, 0, 0.03)',
+        },
+        data: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              properties: {},
+              geometry: {
+                type: 'Polygon',
+                coordinates: [
+                  [
+                    [0, 0],
+                    [0, 1],
+                    [1, 1],
+                    [1, 0],
+                    [0, 0],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+      })
+    })
+  })
 })

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -1,12 +1,24 @@
 import { Injectable } from '@angular/core'
 import { extend } from 'ol/extent.js'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
-import {
-  BoundingBox,
-  getGeometryBoundingBox,
-  spatialExtentsToFeatureCollection,
-} from '@geonetwork-ui/util/shared'
+import { BoundingBox, getGeometryBoundingBox } from '@geonetwork-ui/util/shared'
 import { MapContextLayer } from '@geospatial-sdk/core'
+import {
+  createSpatialExtentLayer,
+  SpatialExtentLayerStyle,
+} from '@geonetwork-ui/ui/map'
+
+/**
+ * Style of the extent overlay drawn on top of the previewed data: a dashed
+ * black outline over a very light fill, so the extent stays readable without
+ * hiding the data underneath.
+ */
+const RECORD_EXTENT_OVERLAY_STYLE: SpatialExtentLayerStyle = {
+  'stroke-color': 'rgba(0, 0, 0, 0.6)',
+  'stroke-width': 2,
+  'stroke-line-dash': [8, 6],
+  'fill-color': 'rgba(0, 0, 0, 0.03)',
+}
 
 @Injectable({
   providedIn: 'root',
@@ -35,26 +47,16 @@ export class MapUtilsService {
   /**
    * Builds a non-interactive overlay layer drawing the spatial extent(s)
    * declared in the record's metadata (bounding boxes and/or geometries).
-   * Returns null when the record has no spatial extent.
+   * Returns null when the record has no usable spatial extent.
    *
    * This is purely for display and is independent from the map's initial view,
    * which is derived separately (see {@link getRecordExtent}).
    */
   getRecordExtentLayer(record: Partial<CatalogRecord>): MapContextLayer | null {
-    if (!record.spatialExtents?.length) {
-      return null
-    }
-    return {
-      type: 'geojson',
-      data: spatialExtentsToFeatureCollection(record.spatialExtents),
+    return createSpatialExtentLayer(record.spatialExtents ?? [], {
       label: 'Spatial extent',
       clickable: false,
-      style: {
-        'stroke-color': 'rgba(0, 0, 0, 0.6)',
-        'stroke-width': 2,
-        'stroke-line-dash': [8, 6],
-        'fill-color': 'rgba(0, 0, 0, 0.03)',
-      },
-    }
+      style: RECORD_EXTENT_OVERLAY_STYLE,
+    })
   }
 }

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -1,7 +1,12 @@
 import { Injectable } from '@angular/core'
 import { extend } from 'ol/extent.js'
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
-import { BoundingBox, getGeometryBoundingBox } from '@geonetwork-ui/util/shared'
+import {
+  BoundingBox,
+  getGeometryBoundingBox,
+  spatialExtentsToFeatureCollection,
+} from '@geonetwork-ui/util/shared'
+import { MapContextLayer } from '@geospatial-sdk/core'
 
 @Injectable({
   providedIn: 'root',
@@ -25,5 +30,31 @@ export class MapUtilsService {
       },
       [Infinity, Infinity, -Infinity, -Infinity]
     )
+  }
+
+  /**
+   * Builds a non-interactive overlay layer drawing the spatial extent(s)
+   * declared in the record's metadata (bounding boxes and/or geometries).
+   * Returns null when the record has no spatial extent.
+   *
+   * This is purely for display and is independent from the map's initial view,
+   * which is derived separately (see {@link getRecordExtent}).
+   */
+  getRecordExtentLayer(record: Partial<CatalogRecord>): MapContextLayer | null {
+    if (!('spatialExtents' in record) || record.spatialExtents.length === 0) {
+      return null
+    }
+    return {
+      type: 'geojson',
+      data: spatialExtentsToFeatureCollection(record.spatialExtents),
+      label: 'Spatial extent',
+      clickable: false,
+      style: {
+        'stroke-color': 'rgba(0, 0, 0, 0.6)',
+        'stroke-width': 2,
+        'stroke-line-dash': [8, 6],
+        'fill-color': 'rgba(0, 0, 0, 0.03)',
+      },
+    }
   }
 }

--- a/libs/feature/map/src/lib/utils/map-utils.service.ts
+++ b/libs/feature/map/src/lib/utils/map-utils.service.ts
@@ -41,7 +41,7 @@ export class MapUtilsService {
    * which is derived separately (see {@link getRecordExtent}).
    */
   getRecordExtentLayer(record: Partial<CatalogRecord>): MapContextLayer | null {
-    if (!('spatialExtents' in record) || record.spatialExtents.length === 0) {
+    if (!record.spatialExtents?.length) {
       return null
     }
     return {

--- a/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
@@ -106,6 +106,7 @@ class MdViewFacadeMock {
 
 class MapUtilsServiceMock {
   getRecordExtent = jest.fn(() => recordMapExtent)
+  getRecordExtentLayer = jest.fn(() => null)
 }
 
 const SAMPLE_GEOJSON = {

--- a/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.spec.ts
@@ -23,7 +23,7 @@ import { Collection } from 'ol'
 import { Interaction } from 'ol/interaction.js'
 import { DataService } from '@geonetwork-ui/feature/dataviz'
 import * as geoSdkCore from '@geospatial-sdk/core'
-import { MapContext } from '@geospatial-sdk/core'
+import { MapContext, MapContextLayer } from '@geospatial-sdk/core'
 import {
   MapContainerComponent,
   MapLegendComponent,
@@ -226,6 +226,52 @@ describe('MapViewComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  describe('record spatial extent overlay', () => {
+    const extentLayer = {
+      type: 'geojson',
+      label: 'Spatial extent',
+      clickable: false,
+      data: { type: 'FeatureCollection', features: [] },
+    } as unknown as MapContextLayer
+    let mapUtils: {
+      getRecordExtent: jest.Mock
+      getRecordExtentLayer: jest.Mock
+    }
+
+    beforeEach(fakeAsync(() => {
+      mapUtils = TestBed.inject(MapUtilsService) as unknown as typeof mapUtils
+      mapUtils.getRecordExtentLayer.mockReturnValue(extentLayer)
+      mdViewFacade.mapApiLinks$.next([
+        {
+          url: new URL('http://abcd.com/'),
+          name: 'layer1',
+          type: 'service',
+          accessServiceProtocol: 'wms',
+        },
+      ])
+      mdViewFacade.geoDataLinksWithGeometry$.next([])
+      tick()
+      fixture.detectChanges()
+    }))
+
+    it('overlays the record extent layer on top of the data layers', () => {
+      expect(mapComponent.context.layers).toEqual([
+        {
+          url: 'http://abcd.com/',
+          name: 'layer1',
+          type: 'wms',
+          format: 'image/png',
+        },
+        extentLayer,
+      ])
+    })
+
+    it('keeps the initial view independent from the overlay', () => {
+      expect(mapUtils.getRecordExtentLayer).toHaveBeenCalled()
+      expect(mapComponent.context.view).toEqual({ extent: recordMapExtent })
+    })
   })
 
   describe('map layers', () => {

--- a/libs/feature/record/src/lib/map-view/map-view.component.ts
+++ b/libs/feature/record/src/lib/map-view/map-view.component.ts
@@ -431,11 +431,19 @@ export class MapViewComponent implements AfterViewInit {
     }),
     withLatestFrom(this.mdViewFacade.metadata$),
     map(([context, metadata]) => {
-      if (context.view) return context
+      // overlay the record's declared spatial extent on top of the data layers
+      const extentLayer = this.mapUtils.getRecordExtentLayer(metadata)
+      const layers = extentLayer
+        ? [...context.layers, extentLayer]
+        : context.layers
+      // the view (initial zoom) is derived from the data layer or, as a
+      // fallback, from the record extent — independently from the overlay above
+      if (context.view) return { ...context, layers }
       const extent = this.mapUtils.getRecordExtent(metadata)
       const view = extent ? { extent } : null
       return {
         ...context,
+        layers,
         view,
       }
     }),

--- a/libs/ui/map/src/lib/components/spatial-extent/spatial-extent.component.spec.ts
+++ b/libs/ui/map/src/lib/components/spatial-extent/spatial-extent.component.spec.ts
@@ -148,23 +148,4 @@ describe('FormFieldMapContainerComponent', () => {
     })
     expect(createViewFromLayer).toHaveBeenCalledWith(context.layers[0])
   })
-
-  it('should transform bbox to geometry', () => {
-    const bbox = [0, 0, 1, 1] as [number, number, number, number]
-    const geometry = component.bboxCoordsToGeometry(bbox)
-
-    expect(geometry.type).toEqual('Polygon')
-    expect(geometry).toEqual({
-      coordinates: [
-        [
-          [0, 0],
-          [0, 1],
-          [1, 1],
-          [1, 0],
-          [0, 0],
-        ],
-      ],
-      type: 'Polygon',
-    })
-  })
 })

--- a/libs/ui/map/src/lib/components/spatial-extent/spatial-extent.component.ts
+++ b/libs/ui/map/src/lib/components/spatial-extent/spatial-extent.component.ts
@@ -1,9 +1,5 @@
 import { ChangeDetectorRef, Component, inject, Input } from '@angular/core'
 import { CommonModule } from '@angular/common'
-import { Geometry } from 'geojson'
-import { GeoJSONFeatureCollection } from 'ol/format/GeoJSON.js'
-import GeoJSON from 'ol/format/GeoJSON.js'
-import { Polygon } from 'ol/geom.js'
 import {
   createViewFromLayer,
   MapContext,
@@ -13,6 +9,7 @@ import { MapContainerComponent } from '../map-container/map-container.component'
 import { BehaviorSubject, from, Observable, of } from 'rxjs'
 import { map, switchMap, tap } from 'rxjs/operators'
 import { DatasetSpatialExtent } from '@geonetwork-ui/common/domain/model/record'
+import { spatialExtentsToFeatureCollection } from '@geonetwork-ui/util/shared'
 
 @Component({
   selector: 'gn-ui-spatial-extent',
@@ -33,29 +30,9 @@ export class SpatialExtentComponent {
       if (extents.length === 0) {
         return of(null)
       }
-      const featureCollection: GeoJSONFeatureCollection = {
-        type: 'FeatureCollection',
-        features: [],
-      }
-      extents.forEach((extent) => {
-        if (extent.geometry) {
-          featureCollection.features.push({
-            type: 'Feature',
-            properties: {},
-            geometry: extent.geometry,
-          })
-        } else if (extent.bbox?.length >= 0) {
-          featureCollection.features.push({
-            type: 'Feature',
-            properties: {},
-            geometry: this.bboxCoordsToGeometry(extent.bbox),
-          })
-        }
-      })
-
       const layer: MapContextLayer = {
         type: 'geojson',
-        data: featureCollection,
+        data: spatialExtentsToFeatureCollection(extents),
         label: 'Spatial extents',
         style: {
           'stroke-color': 'black',
@@ -71,18 +48,4 @@ export class SpatialExtentComponent {
   )
 
   error = ''
-
-  bboxCoordsToGeometry(bbox: [number, number, number, number]): Geometry {
-    const geometry = new Polygon([
-      [
-        [bbox[0], bbox[1]],
-        [bbox[0], bbox[3]],
-        [bbox[2], bbox[3]],
-        [bbox[2], bbox[1]],
-        [bbox[0], bbox[1]],
-      ],
-    ])
-
-    return new GeoJSON().writeGeometryObject(geometry)
-  }
 }

--- a/libs/ui/map/src/lib/components/spatial-extent/spatial-extent.component.ts
+++ b/libs/ui/map/src/lib/components/spatial-extent/spatial-extent.component.ts
@@ -1,15 +1,11 @@
 import { ChangeDetectorRef, Component, inject, Input } from '@angular/core'
 import { CommonModule } from '@angular/common'
-import {
-  createViewFromLayer,
-  MapContext,
-  MapContextLayer,
-} from '@geospatial-sdk/core'
+import { createViewFromLayer, MapContext } from '@geospatial-sdk/core'
 import { MapContainerComponent } from '../map-container/map-container.component'
 import { BehaviorSubject, from, Observable, of } from 'rxjs'
 import { map, switchMap, tap } from 'rxjs/operators'
 import { DatasetSpatialExtent } from '@geonetwork-ui/common/domain/model/record'
-import { spatialExtentsToFeatureCollection } from '@geonetwork-ui/util/shared'
+import { createSpatialExtentLayer } from '../../map-utils'
 
 @Component({
   selector: 'gn-ui-spatial-extent',
@@ -27,18 +23,9 @@ export class SpatialExtentComponent {
   spatialExtents$ = new BehaviorSubject<DatasetSpatialExtent[]>([])
   mapContext$: Observable<MapContext> = this.spatialExtents$.pipe(
     switchMap((extents) => {
-      if (extents.length === 0) {
+      const layer = createSpatialExtentLayer(extents)
+      if (!layer) {
         return of(null)
-      }
-      const layer: MapContextLayer = {
-        type: 'geojson',
-        data: spatialExtentsToFeatureCollection(extents),
-        label: 'Spatial extents',
-        style: {
-          'stroke-color': 'black',
-          'stroke-width': 2,
-          'fill-color': 'rgba(153, 153, 153, 0.3)',
-        },
       }
       return from(createViewFromLayer(layer)).pipe(
         map((view) => ({ view, layers: [layer] }) as MapContext),

--- a/libs/ui/map/src/lib/map-utils.spec.ts
+++ b/libs/ui/map/src/lib/map-utils.spec.ts
@@ -8,6 +8,8 @@ import {
 import Map from 'ol/Map.js'
 import MapBrowserEvent from 'ol/MapBrowserEvent.js'
 import {
+  createSpatialExtentLayer,
+  DEFAULT_SPATIAL_EXTENT_STYLE,
   dragPanCondition,
   mouseWheelZoomCondition,
   prioritizePageScroll,
@@ -98,6 +100,59 @@ describe('map utils', () => {
       })
       it('with no PinchRotate interaction', () => {
         expect(pinchRotate).toBeFalsy()
+      })
+    })
+  })
+
+  describe('createSpatialExtentLayer', () => {
+    const extents = [{ bbox: [0, 0, 1, 1] as [number, number, number, number] }]
+
+    it('returns null when there is no extent', () => {
+      expect(createSpatialExtentLayer([])).toBeNull()
+    })
+    it('returns null when no extent can be represented', () => {
+      expect(createSpatialExtentLayer([{ description: 'no shape' }])).toBeNull()
+    })
+    it('builds a geojson layer with the default style and label', () => {
+      expect(createSpatialExtentLayer(extents)).toEqual({
+        type: 'geojson',
+        data: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              properties: {},
+              geometry: {
+                type: 'Polygon',
+                coordinates: [
+                  [
+                    [0, 0],
+                    [0, 1],
+                    [1, 1],
+                    [1, 0],
+                    [0, 0],
+                  ],
+                ],
+              },
+            },
+          ],
+        },
+        label: 'Spatial extents',
+        style: DEFAULT_SPATIAL_EXTENT_STYLE,
+      })
+    })
+    it('applies the provided overrides', () => {
+      const style = { 'stroke-color': 'red' }
+      expect(
+        createSpatialExtentLayer(extents, {
+          label: 'Custom',
+          clickable: false,
+          style,
+        })
+      ).toMatchObject({
+        label: 'Custom',
+        clickable: false,
+        style,
       })
     })
   })

--- a/libs/ui/map/src/lib/map-utils.ts
+++ b/libs/ui/map/src/lib/map-utils.ts
@@ -12,6 +12,54 @@ import {
   MouseWheelZoom,
 } from 'ol/interaction.js'
 import MapBrowserEvent from 'ol/MapBrowserEvent.js'
+import type { DatasetSpatialExtent } from '@geonetwork-ui/common/domain/model/record'
+import type {
+  MapContextLayer,
+  MapContextLayerGeojson,
+} from '@geospatial-sdk/core'
+import { spatialExtentsToFeatureCollection } from '@geonetwork-ui/util/shared'
+
+export type SpatialExtentLayerStyle = NonNullable<
+  MapContextLayerGeojson['style']
+>
+
+/**
+ * Default style for a spatial-extent layer: a solid black outline over a
+ * translucent grey fill.
+ */
+export const DEFAULT_SPATIAL_EXTENT_STYLE: SpatialExtentLayerStyle = {
+  'stroke-color': 'black',
+  'stroke-width': 2,
+  'fill-color': 'rgba(153, 153, 153, 0.3)',
+}
+
+/**
+ * Builds a GeoJSON map layer drawing the given spatial extents: each extent is
+ * rendered from its own geometry or, when only a bounding box is available,
+ * from a polygon derived from that box.
+ *
+ * @returns the layer, or `null` when none of the extents can be represented.
+ */
+export function createSpatialExtentLayer(
+  extents: DatasetSpatialExtent[],
+  overrides?: {
+    label?: string
+    clickable?: boolean
+    style?: SpatialExtentLayerStyle
+  }
+): MapContextLayer | null {
+  const data = spatialExtentsToFeatureCollection(extents)
+  if (data.features.length === 0) {
+    return null
+  }
+  return {
+    type: 'geojson',
+    data,
+    label: 'Spatial extents',
+    style: DEFAULT_SPATIAL_EXTENT_STYLE,
+    ...overrides,
+  }
+}
 
 export function prioritizePageScroll(interactions: Collection<Interaction>) {
   interactions.clear()

--- a/libs/util/shared/src/lib/utils/geojson.spec.ts
+++ b/libs/util/shared/src/lib/utils/geojson.spec.ts
@@ -1,4 +1,10 @@
-import { getGeometryBoundingBox, getGeometryFromGeoJSON } from './geojson'
+import {
+  bboxToPolygon,
+  getGeometryBoundingBox,
+  getGeometryFromGeoJSON,
+  spatialExtentsToFeatureCollection,
+  spatialExtentToGeometry,
+} from './geojson'
 import {
   GeometryCollection,
   LineString,
@@ -156,6 +162,115 @@ describe('geojson utils', () => {
       }
       const bbox = getGeometryBoundingBox(geom)
       expect(bbox).toEqual([-100, -200, 130, 20])
+    })
+  })
+
+  describe('bboxToPolygon', () => {
+    it('builds a closed polygon ring from a bounding box', () => {
+      expect(bboxToPolygon([0, 0, 1, 1])).toEqual({
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 1],
+            [1, 1],
+            [1, 0],
+            [0, 0],
+          ],
+        ],
+      })
+    })
+    it('handles negative coordinates', () => {
+      expect(bboxToPolygon([-10, -5, 10, 5])).toEqual({
+        type: 'Polygon',
+        coordinates: [
+          [
+            [-10, -5],
+            [-10, 5],
+            [10, 5],
+            [10, -5],
+            [-10, -5],
+          ],
+        ],
+      })
+    })
+  })
+
+  describe('spatialExtentToGeometry', () => {
+    const geometry: Polygon = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [0, 2],
+          [2, 2],
+          [2, 0],
+          [0, 0],
+        ],
+      ],
+    }
+    it('returns the geometry when present', () => {
+      expect(spatialExtentToGeometry({ geometry })).toBe(geometry)
+    })
+    it('prefers the geometry over the bounding box', () => {
+      expect(spatialExtentToGeometry({ geometry, bbox: [0, 0, 1, 1] })).toBe(
+        geometry
+      )
+    })
+    it('derives a polygon from the bounding box when no geometry', () => {
+      expect(spatialExtentToGeometry({ bbox: [0, 0, 1, 1] })).toEqual(
+        bboxToPolygon([0, 0, 1, 1])
+      )
+    })
+    it('returns null when neither geometry nor bbox is set', () => {
+      expect(spatialExtentToGeometry({})).toBeNull()
+    })
+  })
+
+  describe('spatialExtentsToFeatureCollection', () => {
+    const geometry: Polygon = {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [0, 2],
+          [2, 2],
+          [2, 0],
+          [0, 0],
+        ],
+      ],
+    }
+    it('returns an empty feature collection for an empty list', () => {
+      expect(spatialExtentsToFeatureCollection([])).toEqual({
+        type: 'FeatureCollection',
+        features: [],
+      })
+    })
+    it('builds one feature per usable extent (geometry or bbox)', () => {
+      expect(
+        spatialExtentsToFeatureCollection([
+          { geometry },
+          { bbox: [0, 0, 1, 1] },
+        ])
+      ).toEqual({
+        type: 'FeatureCollection',
+        features: [
+          { type: 'Feature', properties: {}, geometry },
+          {
+            type: 'Feature',
+            properties: {},
+            geometry: bboxToPolygon([0, 0, 1, 1]),
+          },
+        ],
+      })
+    })
+    it('skips extents that have neither geometry nor bbox', () => {
+      const fc = spatialExtentsToFeatureCollection([
+        { description: 'no shape' },
+        { bbox: [0, 0, 1, 1] },
+      ])
+      expect(fc.features).toHaveLength(1)
+      expect(fc.features[0].geometry).toEqual(bboxToPolygon([0, 0, 1, 1]))
     })
   })
 })

--- a/libs/util/shared/src/lib/utils/geojson.ts
+++ b/libs/util/shared/src/lib/utils/geojson.ts
@@ -5,7 +5,7 @@ import type {
   Polygon,
   Position,
 } from 'geojson'
-import { DatasetSpatialExtent } from '@geonetwork-ui/common/domain/model/record'
+import type { DatasetSpatialExtent } from '@geonetwork-ui/common/domain/model/record'
 
 /**
  * @returns The geometry if available, otherwise null.

--- a/libs/util/shared/src/lib/utils/geojson.ts
+++ b/libs/util/shared/src/lib/utils/geojson.ts
@@ -1,4 +1,11 @@
-import type { Feature, FeatureCollection, Geometry, Position } from 'geojson'
+import type {
+  Feature,
+  FeatureCollection,
+  Geometry,
+  Polygon,
+  Position,
+} from 'geojson'
+import { DatasetSpatialExtent } from '@geonetwork-ui/common/domain/model/record'
 
 /**
  * @returns The geometry if available, otherwise null.
@@ -92,5 +99,55 @@ export function getGeometryBoundingBox(geometry: Geometry): BoundingBox {
       )
     case 'Point':
       return coordinatesReducer(emptyExtent, geometry.coordinates)
+  }
+}
+
+/**
+ * Builds the closed GeoJSON Polygon matching the given bounding box.
+ */
+export function bboxToPolygon(bbox: BoundingBox): Polygon {
+  const [minX, minY, maxX, maxY] = bbox
+  return {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [minX, minY],
+        [minX, maxY],
+        [maxX, maxY],
+        [maxX, minY],
+        [minX, minY],
+      ],
+    ],
+  }
+}
+
+/**
+ * Returns the geometry carried by a spatial extent, falling back to the polygon
+ * derived from its bounding box. Returns null when the extent has neither.
+ */
+export function spatialExtentToGeometry(
+  extent: DatasetSpatialExtent
+): Geometry | null {
+  if (extent.geometry) return extent.geometry
+  if (extent.bbox) return bboxToPolygon(extent.bbox)
+  return null
+}
+
+/**
+ * Converts a list of dataset spatial extents into a GeoJSON FeatureCollection,
+ * e.g. to be used as the data source of a map layer.
+ */
+export function spatialExtentsToFeatureCollection(
+  extents: DatasetSpatialExtent[]
+): FeatureCollection {
+  return {
+    type: 'FeatureCollection',
+    features: extents.reduce<Feature[]>((features, extent) => {
+      const geometry = spatialExtentToGeometry(extent)
+      if (geometry) {
+        features.push({ type: 'Feature', properties: {}, geometry })
+      }
+      return features
+    }, []),
   }
 }


### PR DESCRIPTION
All code has been generated by Claude.

One remark concerning the addition of the GeoJSON layer for the extent: do you think it would have been better to rely on the map state, or is it OK to add it on top of the layers like this?

No dedicated overlay tests yet.
No extent drawn if there is no map.

<img width="1010" height="547" alt="Screenshot from 2026-06-24 13-29-29" src="https://github.com/user-attachments/assets/e3176782-e199-4130-aad7-8bbc0a185d85" />

## Context

In the datahub record **data preview** (map tab), the metadata often declares a spatial extent (a bbox, sometimes a polygon). Until now this extent was only used to compute the map's _initial zoom_ as a fallback — it was never **drawn** on the map.

This PR overlays the metadata's declared spatial extent on top of the previewed data, so users can see the dataset's announced footprint alongside the actual data.

## What changed

- **Shared geometry helpers** (`libs/util/shared`, `utils/geojson.ts`): the `bbox → polygon` and `spatialExtents → FeatureCollection` logic that previously lived (privately) inside `SpatialExtentComponent` is extracted into pure, reusable helpers — `bboxToPolygon()`, `spatialExtentToGeometry()` and `spatialExtentsToFeatureCollection()`. They are placed in their canonical home next to the existing `getGeometryBoundingBox()` / `BoundingBox`, following the repo guideline that cross-cutting helpers belong in `util/shared`, not tucked inside a `ui/*` lib.
- **`MapUtilsService.getRecordExtentLayer()`** (`libs/feature/map`): a new method, sitting right beside the existing `getRecordExtent()`, that builds the overlay layer from a record's `spatialExtents` (each extent uses its `geometry` when present, otherwise its `bbox` converted to a polygon). The layer is `clickable: false` so it never interferes with feature selection, and the method returns `null` when no usable extent exists.
- **`SpatialExtentComponent`** (`libs/ui/map`): now consumes `spatialExtentsToFeatureCollection()`, dropping its duplicated `bboxCoordsToGeometry` method and its direct OpenLayers dependency. Its visual rendering is unchanged.
- **`MapViewComponent.mapContext$`** (`libs/feature/record`): appends `mapUtils.getRecordExtentLayer(metadata)` **last** in the `layers` array, so the extent is drawn on top of the data.

## Why it's non-intrusive

- The extent layer is appended **after** the data layer, so `createViewFromLayer(layers[0])` still computes the initial zoom from the data — the `view` logic is untouched (it keeps falling back to the record extent only when the data provides no view of its own). The display of the extent and the computation of the initial view are kept as two distinct concerns.
- The legend (`gn-ui-map-legend`) only reads `layers[0]`, so no spurious legend entry is added.
- No cross-layer leak: pure helpers live in `util/shared`, the map↔record transform lives in `feature/map`, and the smart component in `feature/record` just orchestrates.
- The overlay is styled to stay readable without hiding the data underneath (dashed black outline over a very light fill).

## Tests

- Existing `spatial-extent` and `map-view` suites pass. The direct unit test on the removed `bboxCoordsToGeometry` method is dropped (the `bbox → polygon` path is still covered end-to-end by the existing "layer with bbox" test); the `map-view` `MapUtilsService` mock gains a `getRecordExtentLayer` stub returning `null` (the fixture metadata has no `spatialExtents`), so the existing `layers` assertions still hold.
- Dedicated unit tests for the new helpers and for the extent actually being overlaid in the preview are intentionally left as a follow-up.

## Manual check

Open a record that has a map and a declared extent, e.g. `/dataset/implantation-des-arceaux-velos-a-roubaix`, and look at the map tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
