### PR TITLE
Upgrade ogc-client for faster OGC API discovery

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset/datasetDetailPage.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetDetailPage.cy.ts
@@ -80,14 +80,18 @@ beforeEach(() => {
   // OGC API stubs
   cy.intercept(
     'GET',
-    '/data/ogcapi/collections/liste-des-jardins-familiaux-et-partages-de-roubaix/items?f=json',
+    '/data/ogcapi/collections/liste-des-jardins-familiaux-et-partages-de-roubaix/items?limit=1&f=json',
     {
       fixture: 'liste-des-jardins-familiaux-et-partages-de-roubaix_items.json',
     }
   )
-  cy.intercept('GET', '/data/ogcapi/collections/covoit-mel/items?f=json', {
-    fixture: 'covoit-mel_items.json',
-  })
+  cy.intercept(
+    'GET',
+    '/data/ogcapi/collections/covoit-mel/items?limit=1&f=json',
+    {
+      fixture: 'covoit-mel_items.json',
+    }
+  )
   cy.intercept(
     'GET',
     '/data/ogcapi/collections/liste-des-jardins-familiaux-et-partages-de-roubaix?f=json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/platform-server": "20.3.19",
         "@angular/router": "20.3.19",
         "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-        "@camptocamp/ogc-client": "1.3.1-dev.afd9c26",
+        "@camptocamp/ogc-client": "1.3.1-dev.bb345f0",
         "@geospatial-sdk/core": "0.0.5-dev.61",
         "@geospatial-sdk/geocoding": "0.0.5-dev.61",
         "@geospatial-sdk/legend": "0.0.5-dev.61",
@@ -4320,9 +4320,9 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.3.1-dev.afd9c26",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.1-dev.afd9c26.tgz",
-      "integrity": "sha512-G2YKPSIZIlO5tN+n5e/3h9OOUL3TgueTux9DlL6YFxR2FeA/qult7y7I+BS1ycUbO03HmYwf6ke7PWocy45ogQ==",
+      "version": "1.3.1-dev.bb345f0",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.1-dev.bb345f0.tgz",
+      "integrity": "sha512-zeFzc4aFucoxC/SmBoSfyRaeCAQU6UOsnV5CkjEFNcHG+V75TA5oPRZTiFZxun4ekMc21EDUvH0bvXHVcUljZQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@angular/platform-server": "20.3.19",
     "@angular/router": "20.3.19",
     "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-    "@camptocamp/ogc-client": "1.3.1-dev.afd9c26",
+    "@camptocamp/ogc-client": "1.3.1-dev.bb345f0",
     "@geospatial-sdk/core": "0.0.5-dev.61",
     "@geospatial-sdk/geocoding": "0.0.5-dev.61",
     "@geospatial-sdk/legend": "0.0.5-dev.61",

--- a/package/package.json
+++ b/package/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-    "@camptocamp/ogc-client": "1.3.1-dev.afd9c26",
+    "@camptocamp/ogc-client": "1.3.1-dev.bb345f0",
     "@geospatial-sdk/core": "0.0.5-dev.61",
     "@geospatial-sdk/geocoding": "0.0.5-dev.61",
     "@geospatial-sdk/legend": "0.0.5-dev.61",


### PR DESCRIPTION
### Description

This PR upgrades ogc-client to `1.3.1-dev.bb345f0` to fix slow initial loading of OGC API endpoints created from an `/items` URL.

Previously, discovery fetched `/items` just to read its links, pulling the server's full default page (potentially the entire collection). This version introduces `capItemsForDiscovery()` which forces `limit=1` on `/items` URLs during discovery only, actual item retrieval is unaffected.