### PR TITLE
[Metadata-Editor] Highlight the section when a quality-panel field is hidden

### DIFF
--- a/apps/metadata-editor-e2e/src/e2e/edit/editor-form.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/edit/editor-form.cy.ts
@@ -200,6 +200,26 @@ describe('editor form', () => {
       cy.get('gn-ui-record-form')
         .find('gn-ui-form-field.gn-ui-field-focus-glow')
         .should('not.exist')
+
+      // it should highlight the whole section when the target field is hidden
+      // (toggling a shortcut on then off leaves the emptied field hidden)
+      cy.get('[data-cy=constraints-shortcut-toggles]')
+        .find('gn-ui-check-toggle label')
+        .eq(0)
+        .click()
+      cy.get('[data-cy=constraints-shortcut-toggles]')
+        .find('gn-ui-check-toggle label')
+        .eq(0)
+        .click()
+      cy.get('[data-cy=legalConstraints]').should('not.exist')
+      cy.get('gn-ui-metadata-quality-panel')
+        .find(
+          '[data-cy="md-quality-btn-editor.record.form.field.legalConstraints"]'
+        )
+        .click()
+      cy.get('gn-ui-record-form .gn-ui-field-focus-glow')
+        .find('[data-cy=constraints-shortcut-toggles]')
+        .should('exist')
     })
   })
 

--- a/libs/feature/editor/src/lib/components/record-form/form-field/field-focus.directive.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/field-focus.directive.spec.ts
@@ -104,6 +104,14 @@ describe('FieldFocusDirective', () => {
       expect(el.classList.contains('gn-ui-field-focus-glow')).toBe(true)
     })
 
+    it('does not focus any descendant when focusInnerTarget is false', () => {
+      directive.focusField(false)
+      jest.runOnlyPendingTimers()
+      expect(document.activeElement).not.toBe(el.querySelector('input'))
+      expect(document.activeElement).not.toBe(el.querySelector('button'))
+      expect(el.classList.contains('gn-ui-field-focus-glow')).toBe(true)
+    })
+
     it('falls back to focusing a button when there is no text input', () => {
       const buttonFixture = TestBed.createComponent(ButtonOnlyHostComponent)
       const buttonEl = buttonFixture.nativeElement.querySelector('div')

--- a/libs/feature/editor/src/lib/components/record-form/form-field/field-focus.directive.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/field-focus.directive.ts
@@ -10,7 +10,7 @@ export class FieldFocusDirective {
 
   private el = inject(ElementRef)
 
-  public focusField() {
+  public focusField(focusInnerTarget = true) {
     setTimeout(() => {
       const host = this.el.nativeElement as HTMLElement
       const glowClass = this.gnUiFieldFocusGlowClass
@@ -25,6 +25,9 @@ export class FieldFocusDirective {
       )
 
       host.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      if (!focusInnerTarget) {
+        return
+      }
       const target =
         host.querySelector<HTMLElement>(
           'input, textarea, select, [contenteditable="true"]'

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.spec.ts
@@ -219,42 +219,6 @@ describe('FormFieldConstraintsShortcutsComponent', () => {
         })
       }
     )
-
-    describe('for field legalConstraints', () => {
-      it('is visible when no toggle is activated', () => {
-        sampleRecord$.next({
-          ...sampleRecord,
-          legalConstraints: [{ text: 'some regular constraint' }],
-        })
-        fixture.detectChanges()
-        expect(getLastCallForField('legalConstraints')).toEqual([
-          { model: 'legalConstraints' },
-          true,
-        ])
-      })
-      it('is visible when legal constraints are empty and no toggle is activated', () => {
-        sampleRecord$.next({
-          ...sampleRecord,
-          legalConstraints: [],
-        })
-        fixture.detectChanges()
-        expect(getLastCallForField('legalConstraints')).toEqual([
-          { model: 'legalConstraints' },
-          true,
-        ])
-      })
-      it('is hidden when a toggle is activated', () => {
-        sampleRecord$.next({
-          ...sampleRecord,
-          legalConstraints: [NOT_APPLICABLE_CONSTRAINT],
-        })
-        fixture.detectChanges()
-        expect(getLastCallForField('legalConstraints')).toEqual([
-          { model: 'legalConstraints' },
-          false,
-        ])
-      })
-    })
   })
 
   describe('unsubscribe on destroy', () => {

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.spec.ts
@@ -219,5 +219,57 @@ describe('FormFieldConstraintsShortcutsComponent', () => {
         })
       }
     )
+
+    describe('for field legalConstraints', () => {
+      it('is visible when no toggle is activated', () => {
+        sampleRecord$.next({
+          ...sampleRecord,
+          legalConstraints: [{ text: 'some regular constraint' }],
+        })
+        fixture.detectChanges()
+        expect(getLastCallForField('legalConstraints')).toEqual([
+          { model: 'legalConstraints' },
+          true,
+        ])
+      })
+      it('is visible when legal constraints are empty and no toggle is activated', () => {
+        sampleRecord$.next({
+          ...sampleRecord,
+          legalConstraints: [],
+        })
+        fixture.detectChanges()
+        expect(getLastCallForField('legalConstraints')).toEqual([
+          { model: 'legalConstraints' },
+          true,
+        ])
+      })
+      it('is hidden when a toggle is activated', () => {
+        sampleRecord$.next({
+          ...sampleRecord,
+          legalConstraints: [NOT_APPLICABLE_CONSTRAINT],
+        })
+        fixture.detectChanges()
+        expect(getLastCallForField('legalConstraints')).toEqual([
+          { model: 'legalConstraints' },
+          false,
+        ])
+      })
+    })
+  })
+
+  describe('unsubscribe on destroy', () => {
+    it('stops updating field visibility once the component is destroyed', () => {
+      fixture.detectChanges()
+      component.ngOnDestroy()
+      ;(editorFacade.setFieldVisibility as jest.Mock).mockClear()
+
+      sampleRecord$.next({
+        ...sampleRecord,
+        securityConstraints: [{ text: 'a new constraint' }],
+      })
+      fixture.detectChanges()
+
+      expect(editorFacade.setFieldVisibility).not.toHaveBeenCalled()
+    })
   })
 })

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.ts
@@ -119,6 +119,12 @@ export class FormFieldConstraintsShortcutsComponent implements OnDestroy {
         .subscribe((anyToggleActivated) => {
           if (anyToggleActivated) {
             this.hideAllConstraintSections()
+          } else {
+            // always keep legal constraints open to allow highlighting
+            this.editorFacade.setFieldVisibility(
+              { model: 'legalConstraints' },
+              true
+            )
           }
         })
 

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.ts
@@ -119,12 +119,6 @@ export class FormFieldConstraintsShortcutsComponent implements OnDestroy {
         .subscribe((anyToggleActivated) => {
           if (anyToggleActivated) {
             this.hideAllConstraintSections()
-          } else {
-            // always keep legal constraints open to allow highlighting
-            this.editorFacade.setFieldVisibility(
-              { model: 'legalConstraints' },
-              true
-            )
           }
         })
 

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.ts
@@ -137,13 +137,12 @@ export class FormFieldConstraintsShortcutsComponent implements OnDestroy {
           map((c) => c.length > 0),
           distinctUntilChanged()
         )
-        combineLatest([
-          isConstraintNotEmpty$,
-          this.anyToggleActivated$,
-        ]).subscribe(([isNotEmpty, anyToggleActivated]) => {
-          const visible = isNotEmpty && !anyToggleActivated
-          this.editorFacade.setFieldVisibility({ model }, visible)
-        })
+        combineLatest([isConstraintNotEmpty$, this.anyToggleActivated$])
+          .pipe(takeUntil(this.onDestroy$))
+          .subscribe(([isNotEmpty, anyToggleActivated]) => {
+            const visible = isNotEmpty && !anyToggleActivated
+            this.editorFacade.setFieldVisibility({ model }, visible)
+          })
       }
       hideEmptyConstraints(this.securityConstraints$, 'securityConstraints')
       hideEmptyConstraints(this.otherConstraints$, 'otherConstraints')

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.css
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field.component.css
@@ -1,37 +1,3 @@
 :host {
   scroll-margin-top: 90px;
 }
-
-:host.gn-ui-field-focus-glow {
-  position: relative;
-}
-
-:host.gn-ui-field-focus-glow::after {
-  content: '';
-  position: absolute;
-  inset: -8px;
-  border-radius: 8px;
-  background-color: color-mix(in srgb, var(--color-primary) 12%, transparent);
-  pointer-events: none;
-  animation: gn-ui-field-focus-glow 3s ease-out forwards;
-}
-
-:host.gn-ui-field-focus-glow::before {
-  content: '';
-  position: absolute;
-  inset: -16px;
-  border: 2px dashed var(--color-primary);
-  border-radius: 10px;
-  pointer-events: none;
-  animation: gn-ui-field-focus-glow 3s ease-out forwards;
-}
-
-@keyframes gn-ui-field-focus-glow {
-  0%,
-  55% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}

--- a/libs/feature/editor/src/lib/components/record-form/record-form.component.css
+++ b/libs/feature/editor/src/lib/components/record-form/record-form.component.css
@@ -1,0 +1,35 @@
+/* Glow applied by FieldFocusDirective (gnUiFieldFocus) to a focused field or,
+   when the field is hidden, to its whole section. */
+.gn-ui-field-focus-glow {
+  position: relative;
+}
+
+.gn-ui-field-focus-glow::after {
+  content: '';
+  position: absolute;
+  inset: -8px;
+  border-radius: 8px;
+  background-color: color-mix(in srgb, var(--color-primary) 12%, transparent);
+  pointer-events: none;
+  animation: gn-ui-field-focus-glow 3s ease-out forwards;
+}
+
+.gn-ui-field-focus-glow::before {
+  content: '';
+  position: absolute;
+  inset: -16px;
+  border: 2px dashed var(--color-primary);
+  border-radius: 10px;
+  pointer-events: none;
+  animation: gn-ui-field-focus-glow 3s ease-out forwards;
+}
+
+@keyframes gn-ui-field-focus-glow {
+  0%,
+  55% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}

--- a/libs/feature/editor/src/lib/components/record-form/record-form.component.html
+++ b/libs/feature/editor/src/lib/components/record-form/record-form.component.html
@@ -4,7 +4,11 @@
     track sectionTracker($index, section)
   ) {
     @if (!section.hidden) {
-      <div class="flex flex-col gap-6 border p-8 rounded-[8px] shadow">
+      <div
+        class="flex flex-col gap-6 border p-8 rounded-[8px] shadow scroll-mt-[90px]"
+        gnUiFieldFocus
+        #sectionFocus="fieldFocus"
+      >
         <div class="flex flex-col gap-2">
           @if (section.labelKey) {
             <div class="text-2xl font-title text-black" translate>

--- a/libs/feature/editor/src/lib/components/record-form/record-form.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/record-form.component.spec.ts
@@ -68,11 +68,8 @@ describe('RecordFormComponent', () => {
       })
     })
 
-    it('returns nulls for a field not present in the config', async () => {
-      expect(await component.getFieldLocation('organisation' as any)).toEqual({
-        page: null,
-        section: null,
-      })
+    it('returns null for a field not present in the config', async () => {
+      expect(await component.getFieldLocation('organisation' as any)).toBeNull()
     })
 
     it('counts only non-hidden sections, matching the rendered order', async () => {
@@ -171,7 +168,7 @@ describe('RecordFormComponent', () => {
       const fieldSpy = jest
         .spyOn(field.fieldFocus, 'focusField')
         .mockImplementation()
-      component.focusField('licenses', null)
+      component.focusField('licenses', -1)
       expect(fieldSpy).toHaveBeenCalled()
     })
 

--- a/libs/feature/editor/src/lib/components/record-form/record-form.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/record-form.component.spec.ts
@@ -60,15 +60,36 @@ describe('RecordFormComponent', () => {
     })
   })
 
-  describe('getPageIndexForField', () => {
-    it('should return the page index for a field present in the config', async () => {
-      expect(await component.getPageIndexForField('title')).toBe(0)
+  describe('getFieldLocation', () => {
+    it('returns the page and section index of a field in the config', async () => {
+      expect(await component.getFieldLocation('title')).toEqual({
+        page: 0,
+        section: 0,
+      })
     })
 
-    it('should return null for a field not present in the config', async () => {
-      expect(
-        await component.getPageIndexForField('organisation' as any)
-      ).toBeNull()
+    it('returns nulls for a field not present in the config', async () => {
+      expect(await component.getFieldLocation('organisation' as any)).toEqual({
+        page: null,
+        section: null,
+      })
+    })
+
+    it('counts only non-hidden sections, matching the rendered order', async () => {
+      facade.editorConfig$.next({
+        pages: [
+          {
+            sections: [
+              { hidden: true, fields: [{ model: 'abstract' }] },
+              { hidden: false, fields: [{ model: 'title' }] },
+            ],
+          },
+        ],
+      } as any)
+      expect(await component.getFieldLocation('title')).toEqual({
+        page: 0,
+        section: 0,
+      })
     })
   })
 
@@ -145,20 +166,20 @@ describe('RecordFormComponent', () => {
       fixture.detectChanges()
     })
 
-    it('focuses the form field when it is rendered', async () => {
+    it('focuses the form field when it is rendered', () => {
       const field = component.formFields().find((f) => f.model === 'licenses')
       const fieldSpy = jest
         .spyOn(field.fieldFocus, 'focusField')
         .mockImplementation()
-      await component.focusField('licenses')
+      component.focusField('licenses', null)
       expect(fieldSpy).toHaveBeenCalled()
     })
 
-    it('highlights the whole section when the field is not rendered', async () => {
+    it('highlights the whole section when the field is not rendered', () => {
       const sectionSpy = jest
         .spyOn(component.sectionFocusDirectives()[0], 'focusField')
         .mockImplementation()
-      await component.focusField('legalConstraints')
+      component.focusField('legalConstraints', 0)
       expect(sectionSpy).toHaveBeenCalled()
     })
   })

--- a/libs/feature/editor/src/lib/components/record-form/record-form.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/record-form.component.spec.ts
@@ -1,18 +1,21 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { EditorFacade } from '../../+state/editor.facade'
 import { RecordFormComponent } from './record-form.component'
-import { FormFieldComponent } from './form-field'
+import { FieldFocusDirective, FormFieldComponent } from './form-field'
 import { MockBuilder } from 'ng-mocks'
 import {
   datasetRecordsFixture,
   editorConfigFixture,
 } from '@geonetwork-ui/common/fixtures'
 import { BehaviorSubject, Subject } from 'rxjs'
+import { provideI18n } from '@geonetwork-ui/util/i18n'
+import { EditorSectionWithValues } from '../../+state/editor.models'
 
 class EditorFacadeMock {
   record$ = new BehaviorSubject(datasetRecordsFixture()[0])
   focusedField$ = new Subject<string | null>()
   editorConfig$ = new BehaviorSubject(editorConfigFixture())
+  currentSections$ = new BehaviorSubject<EditorSectionWithValues[]>([])
   currentPage$ = new BehaviorSubject(0)
   setCurrentPage = jest.fn()
   updateRecordField = jest.fn()
@@ -24,13 +27,17 @@ describe('RecordFormComponent', () => {
   let facade: EditorFacadeMock
 
   beforeEach(() => {
-    return MockBuilder(RecordFormComponent).keep(FormFieldComponent)
+    return MockBuilder(RecordFormComponent)
+      .keep(FormFieldComponent)
+      .keep(FieldFocusDirective)
   })
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RecordFormComponent],
-      providers: [{ provide: EditorFacade, useClass: EditorFacadeMock }],
+      providers: [
+        provideI18n({}, false),
+        { provide: EditorFacade, useClass: EditorFacadeMock },
+      ],
     }).compileComponents()
 
     facade = TestBed.inject(EditorFacade) as unknown as EditorFacadeMock
@@ -103,6 +110,56 @@ describe('RecordFormComponent', () => {
       it('should not navigate to a page', () => {
         expect(facade.setCurrentPage).not.toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('focusField', () => {
+    const sections: EditorSectionWithValues[] = [
+      {
+        hidden: false,
+        fields: [],
+        fieldsWithValues: [
+          {
+            config: {
+              model: 'licenses',
+              formFieldConfig: { labelKey: 'editor.record.form.field.license' },
+            },
+            value: [],
+          },
+          {
+            config: {
+              model: 'legalConstraints',
+              hidden: true,
+              formFieldConfig: {
+                labelKey: 'editor.record.form.field.legalConstraints',
+              },
+            },
+            value: [],
+          },
+        ],
+      },
+    ]
+
+    beforeEach(() => {
+      facade.currentSections$.next(sections)
+      fixture.detectChanges()
+    })
+
+    it('focuses the form field when it is rendered', async () => {
+      const field = component.formFields().find((f) => f.model === 'licenses')
+      const fieldSpy = jest
+        .spyOn(field.fieldFocus, 'focusField')
+        .mockImplementation()
+      await component.focusField('licenses')
+      expect(fieldSpy).toHaveBeenCalled()
+    })
+
+    it('highlights the whole section when the field is not rendered', async () => {
+      const sectionSpy = jest
+        .spyOn(component.sectionFocusDirectives()[0], 'focusField')
+        .mockImplementation()
+      await component.focusField('legalConstraints')
+      expect(sectionSpy).toHaveBeenCalled()
     })
   })
 

--- a/libs/feature/editor/src/lib/components/record-form/record-form.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/record-form.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core'
 import { EditorFacade } from '../../+state/editor.facade'
 import { EditorFieldValue } from '../../models'
-import { FormFieldComponent } from './form-field'
+import { FieldFocusDirective, FormFieldComponent } from './form-field'
 import { TranslateDirective } from '@ngx-translate/core'
 import {
   EditorFieldWithValue,
@@ -25,7 +25,12 @@ import { switchMap } from 'rxjs/operators'
   styleUrls: ['./record-form.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [CommonModule, FormFieldComponent, TranslateDirective],
+  imports: [
+    CommonModule,
+    FormFieldComponent,
+    FieldFocusDirective,
+    TranslateDirective,
+  ],
 })
 export class RecordFormComponent implements OnInit, OnDestroy {
   facade = inject(EditorFacade)
@@ -42,11 +47,22 @@ export class RecordFormComponent implements OnInit, OnDestroy {
   )
 
   formFields = viewChildren(FormFieldComponent)
+  sectionFocusDirectives = viewChildren<FieldFocusDirective>('sectionFocus')
 
-  focusField(model: CatalogRecordKeys) {
-    const fields = this.formFields()
-    const field = fields.find((f) => f.model === model)
-    field?.fieldFocus.focusField()
+  async focusField(model: CatalogRecordKeys) {
+    const field = this.formFields().find((f) => f.model === model)
+    if (field) {
+      field.fieldFocus.focusField()
+      return
+    }
+    // field not rendered (e.g. hidden by constraints toggles): glow its section
+    const sections = await firstValueFrom(this.facade.currentSections$)
+    const sectionIndex = sections
+      .filter((section) => !section.hidden)
+      .findIndex((section) =>
+        section.fieldsWithValues.some((f) => f.config.model === model)
+      )
+    this.sectionFocusDirectives()[sectionIndex]?.focusField()
   }
 
   ngOnInit() {

--- a/libs/feature/editor/src/lib/components/record-form/record-form.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/record-form.component.ts
@@ -42,21 +42,21 @@ export class RecordFormComponent implements OnInit, OnDestroy {
 
   focusFieldWithPage$ = this.facade.focusedField$.pipe(
     switchMap(async (field) => {
-      const { page, section } = await this.getFieldLocation(field)
-      return [field, page, section] as const
+      const location = await this.getFieldLocation(field)
+      return [field, location?.page ?? null, location?.section ?? -1] as const
     })
   )
 
   formFields = viewChildren(FormFieldComponent)
   sectionFocusDirectives = viewChildren<FieldFocusDirective>('sectionFocus')
 
-  focusField(model: CatalogRecordKeys, section: number | null) {
+  focusField(model: CatalogRecordKeys, sectionIndex: number) {
     const field = this.formFields().find((f) => f.model === model)
     if (field) {
       field.fieldFocus.focusField()
       return
     }
-    this.sectionFocusDirectives()[section]?.focusField(false)
+    this.sectionFocusDirectives()[sectionIndex]?.focusField(false)
   }
 
   ngOnInit() {
@@ -99,17 +99,17 @@ export class RecordFormComponent implements OnInit, OnDestroy {
 
   async getFieldLocation(
     model: CatalogRecordKeys
-  ): Promise<{ page: number | null; section: number | null }> {
+  ): Promise<{ page: number; section: number } | null> {
     const config = await firstValueFrom(this.facade.editorConfig$)
     const page = config.pages.findIndex((p) =>
       p.sections.some((s) => s.fields.some((f) => f.model === model))
     )
     if (page < 0) {
-      return { page: null, section: null }
+      return null
     }
     const section = config.pages[page].sections
       .filter((s) => !s.hidden)
       .findIndex((s) => s.fields.some((f) => f.model === model))
-    return { page, section: section >= 0 ? section : null }
+    return { page, section }
   }
 }

--- a/libs/feature/editor/src/lib/components/record-form/record-form.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/record-form.component.ts
@@ -41,28 +41,22 @@ export class RecordFormComponent implements OnInit, OnDestroy {
   )
 
   focusFieldWithPage$ = this.facade.focusedField$.pipe(
-    switchMap(
-      async (field) => [field, await this.getPageIndexForField(field)] as const
-    )
+    switchMap(async (field) => {
+      const { page, section } = await this.getFieldLocation(field)
+      return [field, page, section] as const
+    })
   )
 
   formFields = viewChildren(FormFieldComponent)
   sectionFocusDirectives = viewChildren<FieldFocusDirective>('sectionFocus')
 
-  async focusField(model: CatalogRecordKeys) {
+  focusField(model: CatalogRecordKeys, section: number | null) {
     const field = this.formFields().find((f) => f.model === model)
     if (field) {
       field.fieldFocus.focusField()
       return
     }
-    // field not rendered (e.g. hidden by constraints toggles): glow its section
-    const sections = await firstValueFrom(this.facade.currentSections$)
-    const sectionIndex = sections
-      .filter((section) => !section.hidden)
-      .findIndex((section) =>
-        section.fieldsWithValues.some((f) => f.config.model === model)
-      )
-    this.sectionFocusDirectives()[sectionIndex]?.focusField()
+    this.sectionFocusDirectives()[section]?.focusField(false)
   }
 
   ngOnInit() {
@@ -71,15 +65,15 @@ export class RecordFormComponent implements OnInit, OnDestroy {
         .pipe(
           withLatestFrom(
             this.facade.currentPage$,
-            ([field, fieldPage], currentPage) =>
-              [field, fieldPage, currentPage] as const
+            ([field, fieldPage, fieldSection], currentPage) =>
+              [field, fieldPage, fieldSection, currentPage] as const
           )
         )
-        .subscribe(([field, fieldPage, currentPage]) => {
+        .subscribe(([field, fieldPage, fieldSection, currentPage]) => {
           if (fieldPage !== null && fieldPage !== currentPage) {
             this.facade.setCurrentPage(fieldPage)
           }
-          setTimeout(() => this.focusField(field))
+          setTimeout(() => this.focusField(field, fieldSection))
         })
     )
   }
@@ -103,13 +97,19 @@ export class RecordFormComponent implements OnInit, OnDestroy {
     return section.labelKey
   }
 
-  async getPageIndexForField(model: CatalogRecordKeys): Promise<number | null> {
+  async getFieldLocation(
+    model: CatalogRecordKeys
+  ): Promise<{ page: number | null; section: number | null }> {
     const config = await firstValueFrom(this.facade.editorConfig$)
-    const pageIndex = config.pages.findIndex((page) =>
-      page.sections.some((section) =>
-        section.fields.some((field) => field.model === model)
-      )
+    const page = config.pages.findIndex((p) =>
+      p.sections.some((s) => s.fields.some((f) => f.model === model))
     )
-    return pageIndex >= 0 ? pageIndex : null
+    if (page < 0) {
+      return { page: null, section: null }
+    }
+    const section = config.pages[page].sections
+      .filter((s) => !s.hidden)
+      .findIndex((s) => s.fields.some((f) => f.model === model))
+    return { page, section: section >= 0 ? section : null }
   }
 }

--- a/tailwind.base.css
+++ b/tailwind.base.css
@@ -229,6 +229,39 @@
   .gn-ui-section-title {
     @apply text-title font-medium pt-9 text-[28px];
   }
+
+  /* FOCUS GLOW (added by FieldFocusDirective to a field, or its section) */
+  .gn-ui-field-focus-glow {
+    position: relative;
+  }
+  .gn-ui-field-focus-glow::after {
+    content: '';
+    position: absolute;
+    inset: -8px;
+    border-radius: 8px;
+    background-color: color-mix(in srgb, var(--color-primary) 12%, transparent);
+    pointer-events: none;
+    animation: gn-ui-field-focus-glow 3s ease-out forwards;
+  }
+  .gn-ui-field-focus-glow::before {
+    content: '';
+    position: absolute;
+    inset: -16px;
+    border: 2px dashed var(--color-primary);
+    border-radius: 10px;
+    pointer-events: none;
+    animation: gn-ui-field-focus-glow 3s ease-out forwards;
+  }
+}
+
+@keyframes gn-ui-field-focus-glow {
+  0%,
+  55% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 }
 
 html {

--- a/tailwind.base.css
+++ b/tailwind.base.css
@@ -229,39 +229,6 @@
   .gn-ui-section-title {
     @apply text-title font-medium pt-9 text-[28px];
   }
-
-  /* FOCUS GLOW (added by FieldFocusDirective to a field, or its section) */
-  .gn-ui-field-focus-glow {
-    position: relative;
-  }
-  .gn-ui-field-focus-glow::after {
-    content: '';
-    position: absolute;
-    inset: -8px;
-    border-radius: 8px;
-    background-color: color-mix(in srgb, var(--color-primary) 12%, transparent);
-    pointer-events: none;
-    animation: gn-ui-field-focus-glow 3s ease-out forwards;
-  }
-  .gn-ui-field-focus-glow::before {
-    content: '';
-    position: absolute;
-    inset: -16px;
-    border: 2px dashed var(--color-primary);
-    border-radius: 10px;
-    pointer-events: none;
-    animation: gn-ui-field-focus-glow 3s ease-out forwards;
-  }
-}
-
-@keyframes gn-ui-field-focus-glow {
-  0%,
-  55% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
 }
 
 html {


### PR DESCRIPTION
### Description

Clicking an unsatisfied criterion in the metadata quality panel navigates to that field and highlights it, but did nothing when the field was **hidden** (e.g. Legal constraints, after toggling "The conditions are unknown" on/off).

**Fix:** when the target field isn't rendered, highlight the **whole section**
containing it instead (reusing the existing `FieldFocusDirective`). The field
stays hidden. Also moved the focus-glow style to `tailwind.base.css` so fields
and sections share one definition.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Screenshots

<img width="1469" height="435" alt="image" src="https://github.com/user-attachments/assets/e4255d2b-4876-4b22-821a-f12edea18f96" />


<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

- Open record in metadata-editor or create a new one.
- Uncheck both toggles in the conditions section.
- Open the quality panel and click the unsatisfied **Legal constraints** criterion.
- The whole section should scroll into view and glow.

<!--
Describe here the steps to confirm that the changes work as they should.
-->

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
