### PR TITLE
ci: skip e2e screenshots PR comment for dependabot/fork runs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -292,7 +292,7 @@ jobs:
             apps/metadata-editor-e2e/cypress/screenshots/**/*
 
       - uses: thollander/actions-comment-pull-request@v2
-        if: always() && github.event_name == 'pull_request' && steps.upload-screenshots.outputs.artifact-url
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && steps.upload-screenshots.outputs.artifact-url
         with:
           message: '📷 Screenshots are [here](${{ steps.upload-screenshots.outputs.artifact-url }})!'
           comment_tag: screenshots-url


### PR DESCRIPTION
## Problem

Dependabot PRs (e.g. #1625) fail CI at the `e2e-run` job's screenshots-comment step with:

> Error: Resource not accessible by integration

The e2e tests themselves pass; only the trailing `thollander/actions-comment-pull-request` step fails. Dependabot- and fork-triggered `pull_request` runs receive a **read-only** `GITHUB_TOKEN`, so posting a PR comment returns 403.

This step is the only one of the four comment steps in `checks.yml` missing the actor/fork guard that the siblings (`affected-recap`, `wc-e2e-run`, `build-npm-package`) already carry. It only started surfacing once the Node 24 lockfile update let dependabot runs get past `npm ci` and reach this step.

## Fix

Add the same guard so the (impossible) comment is skipped on dependabot/fork runs while the e2e tests still run:

```yaml
&& github.event.pull_request.head.repo.full_name == github.repository
&& github.actor != 'dependabot[bot]'
```

## Verification

After merge, trigger a rebase on a failing dependabot PR **via `@dependabot rebase`** (so the run's actor stays `dependabot[bot]` and actually exercises the read-only path) and confirm the `e2e-run` job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)