### PR TITLE
[Datahub] Align resource contact panel styling with mockup

### DIFF
--- a/libs/ui/elements/src/lib/contact-details/contact-details.component.html
+++ b/libs/ui/elements/src/lib/contact-details/contact-details.component.html
@@ -1,5 +1,5 @@
 <div
-  class="bg-gray-50 text-primary-black rounded border border-gray-200 shadow-md p-4 flex flex-col gap-3 w-full"
+  class="bg-gray-50 text-black rounded border border-gray-200 shadow-md p-4 flex flex-col gap-3 w-full"
   data-test="contact-details"
 >
   @if (displayName) {

--- a/libs/ui/elements/src/lib/contact-details/contact-details.component.html
+++ b/libs/ui/elements/src/lib/contact-details/contact-details.component.html
@@ -1,5 +1,5 @@
 <div
-  class="bg-gray-50 rounded border border-gray-200 shadow-md p-4 flex flex-col gap-3 w-full"
+  class="bg-gray-50 text-primary-black rounded border border-gray-200 shadow-md p-4 flex flex-col gap-3 w-full"
   data-test="contact-details"
 >
   @if (displayName) {

--- a/libs/ui/elements/src/lib/contact-pill/contact-pill.component.html
+++ b/libs/ui/elements/src/lib/contact-pill/contact-pill.component.html
@@ -1,5 +1,5 @@
 <gn-ui-button
-  [type]="overlayOpen ? 'primary' : 'primary-light'"
+  [type]="overlayOpen ? 'gray-light' : 'primary-light'"
   extraClass="group w-full min-h-12 gap-3 justify-between py-2 pl-5 pr-4 rounded"
   data-test="contact-pill"
   (buttonClick)="toggleOverlay()"
@@ -7,12 +7,16 @@
   #overlayOrigin="cdkOverlayOrigin"
 >
   <span
-    class="font-title font-medium text-base leading-tight text-primary-black truncate group-hover:text-white"
+    class="font-title font-medium text-base leading-tight truncate"
+    [class]="!overlayOpen ? 'text-primary-black group-hover:text-white' : ''"
     [title]="displayName"
     >{{ displayName }}</span
   >
   <div
-    class="gn-ui-card-icon items-center justify-center w-10 h-8 group-hover:border-white group-hover:text-white"
+    class="gn-ui-card-icon items-center justify-center w-10 h-8"
+    [class]="
+      !overlayOpen ? 'group-hover:border-white group-hover:text-white' : ''
+    "
   >
     @if (overlayOpen) {
       <ng-icon class="!w-6 !h-6 !text-[24px]" name="matClose"></ng-icon>

--- a/libs/ui/elements/src/lib/contact-pill/contact-pill.component.html
+++ b/libs/ui/elements/src/lib/contact-pill/contact-pill.component.html
@@ -7,7 +7,7 @@
   #overlayOrigin="cdkOverlayOrigin"
 >
   <span
-    class="font-title font-medium text-base leading-tight truncate group-hover:text-white"
+    class="font-title font-medium text-base leading-tight text-primary-black truncate group-hover:text-white"
     [title]="displayName"
     >{{ displayName }}</span
   >

--- a/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
+++ b/libs/ui/elements/src/lib/metadata-info/metadata-info.component.html
@@ -113,7 +113,7 @@
   >
     <div class="flex flex-col gap-1 pt-3 pb-4">
       @for (group of contactGroups; track group.role) {
-        <div class="flex flex-col gap-1 rounded bg-gray-50 py-4 px-2">
+        <div class="flex flex-col gap-1 rounded py-4 px-2">
           <p class="text-xs font-normal text-black">
             {{ group.roleLabel | translate }}
           </p>

--- a/libs/ui/inputs/src/lib/button/button.component.stories.ts
+++ b/libs/ui/inputs/src/lib/button/button.component.stories.ts
@@ -57,6 +57,7 @@ export const Primary: StoryObj<ButtonComponentWithContent> = {
         'outline',
         'light',
         'gray',
+        'gray-light',
         'black',
         'primary-light',
       ],

--- a/libs/ui/inputs/src/lib/button/button.component.ts
+++ b/libs/ui/inputs/src/lib/button/button.component.ts
@@ -25,6 +25,7 @@ export class ButtonComponent {
       | 'outline'
       | 'light'
       | 'gray'
+      | 'gray-light'
       | 'black'
       | 'primary-light'
   ) {
@@ -44,6 +45,9 @@ export class ButtonComponent {
         break
       case 'gray':
         this.btnClass = 'gn-ui-btn-gray'
+        break
+      case 'gray-light':
+        this.btnClass = 'gn-ui-btn-gray-light'
         break
       case 'black':
         this.btnClass = 'gn-ui-btn-black'

--- a/tailwind.base.css
+++ b/tailwind.base.css
@@ -119,6 +119,12 @@
     border-gray-100 focus:ring-4 focus:ring-gray-50;
   }
 
+  .gn-ui-btn-gray-light {
+    @apply gn-ui-btn text-black
+    bg-gray-50 hover:bg-gray-100 focus:bg-gray-100 active:bg-gray-200
+    border-gray-50 focus:ring-4 focus:ring-gray-100;
+  }
+
   .gn-ui-btn-black {
     @apply gn-ui-btn text-white
     bg-black hover:bg-gray-950 focus:bg-gray-950 active:bg-gray-900


### PR DESCRIPTION
### Description

This PR aligns the resource Contacts panel with the provided mockup.

- Removes the grey background from contact-group containers.
- Contact-pill labels use `primary-black` (closed state), turning white on hover.
- Adds a reusable `gray-light` button type and applies it to the **open/active**
  contact pill, so the expanded pill reads as selected; its label and icon are black.
- Expanded contact details use black text and icons.

### Screenshots

<img width="4032" height="3024" alt="BeforeAfterLandscape copy (1) (1)" src="https://github.com/user-attachments/assets/806a7e4a-d66b-4156-bc86-48adc53fa126" />


<img width="4032" height="3024" alt="BeforeAfterLandscape copy (1)" src="https://github.com/user-attachments/assets/fb72afe3-c048-4937-990a-eb65a5469181" />


### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Open a record containing resource contacts.
2. Expand the Contacts panel.
3. Confirm contact groups have no grey background.
4. Confirm contact-pill labels use the `primary-black` theme color.
5. Open a contact pill.
6. Confirm all contact-detail text and icons use `text-black`.
7. Confirm the open pill uses the light-grey (`gray-light`) style, and its label/icons
   and the contact-detail text are black.