### PR TITLE
chore: remove Coveralls

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,11 +60,6 @@ jobs:
       - run: npx nx affected -t lint --parallel=3
       - run: npx nx affected -t test --parallel=3 --configuration=ci --ci --codeCoverage --coverageReporters=lcov
 
-      - name: Coveralls
-        uses: coverallsapp/github-action@v2
-        with:
-          allow-empty: true
-
   #      - name: Archive Code Coverage Results (on main)
   #        if: github.event_name != 'pull_request'
   #        uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Workflow status](https://github.com/geonetwork/geonetwork-ui/actions/workflows/checks.yml/badge.svg) &nbsp;&nbsp; ![Workflow status](https://github.com/geonetwork/geonetwork-ui/actions/workflows/snyk-security.yml/badge.svg) &nbsp;&nbsp; ![Workflow status](https://github.com/geonetwork/geonetwork-ui/actions/workflows/artifacts.yml/badge.svg) &nbsp;&nbsp; [![Coverage Status](https://coveralls.io/repos/github/geonetwork/geonetwork-ui/badge.svg?branch=main)](https://coveralls.io/github/geonetwork/geonetwork-ui?branch=main)
+![Workflow status](https://github.com/geonetwork/geonetwork-ui/actions/workflows/checks.yml/badge.svg) &nbsp;&nbsp; ![Workflow status](https://github.com/geonetwork/geonetwork-ui/actions/workflows/snyk-security.yml/badge.svg) &nbsp;&nbsp; ![Workflow status](https://github.com/geonetwork/geonetwork-ui/actions/workflows/artifacts.yml/badge.svg)
 
 # GeoNetwork UI
 


### PR DESCRIPTION
Test coverage is still collected but not surfaced any more. I could not find any easy enough tool to use, and I don't think it's worth it to invest more time in a metrics that is not that essential anyway.

Also worth noting that coveralls 1. is currently down and 2. used to give false metrics because of the way tests were run in the mono repo.

Note that the code coverage of the project can still be inspected locally when running tests for instance.

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Organization ABC](xx)**. -->
