### PR TITLE
[Datahub]: hide contact details when missing

### DIFF
--- a/libs/ui/elements/src/lib/contact-details/contact-details.component.html
+++ b/libs/ui/elements/src/lib/contact-details/contact-details.component.html
@@ -1,12 +1,12 @@
 <div
-  class="bg-gray-50 text-black rounded border border-gray-200 shadow-md p-4 flex flex-col gap-3 w-full"
+  class="bg-gray-50 text-black rounded border border-gray-200 shadow-md p-4 flex flex-col gap-2 w-full"
   data-test="contact-details"
 >
   @if (displayName) {
-    <div class="flex items-center gap-3">
+    <div class="flex items-center gap-2.5">
       @if (organization?.logoUrl?.href) {
         <div
-          class="flex items-center justify-center rounded-md bg-white w-14 h-14 shrink-0 overflow-hidden"
+          class="flex items-center justify-center rounded-lg bg-white w-14 h-14 shrink-0 overflow-hidden"
         >
           <gn-ui-thumbnail
             class="relative h-full w-full"
@@ -23,74 +23,66 @@
     </div>
   }
 
-  <!-- Email + phone: always shown; icon dimmed when field is absent -->
-  <div class="grid grid-cols-2 gap-1 rounded-md overflow-hidden">
-    <div class="bg-gray-100 flex items-center gap-2 px-3 py-2">
-      <ng-icon
-        class="!w-5 !h-5 !text-[20px] shrink-0"
-        [class.opacity-30]="!contact.email"
-        [class.opacity-75]="!!contact.email"
-        name="matMailOutline"
-      ></ng-icon>
+  @if (contact.email || contact.phone) {
+    <div
+      class="grid gap-1 items-start"
+      [class.grid-cols-2]="contact.email && contact.phone"
+    >
       @if (contact.email) {
-        <a
-          [href]="'mailto:' + contact.email"
-          class="text-sm break-all hover:underline"
-          data-test="contact-details-email"
-          >{{ contact.email }}</a
-        >
+        <div class="bg-gray-100 rounded-lg flex items-center gap-2 px-3 py-2">
+          <ng-icon
+            class="!w-5 !h-5 !text-[20px] shrink-0 opacity-30"
+            name="matMailOutline"
+          ></ng-icon>
+          <a
+            [href]="'mailto:' + contact.email"
+            class="text-sm break-all hover:underline"
+            data-test="contact-details-email"
+            >{{ contact.email }}</a
+          >
+        </div>
       }
-    </div>
-    <div class="bg-gray-100 flex items-center gap-2 px-3 py-2">
-      <ng-icon
-        class="!w-5 !h-5 !text-[20px] shrink-0"
-        [class.opacity-30]="!contact.phone"
-        [class.opacity-75]="!!contact.phone"
-        name="matCallOutline"
-      ></ng-icon>
       @if (contact.phone) {
-        <span class="text-sm" data-test="contact-details-phone">{{
-          contact.phone
-        }}</span>
+        <div class="bg-gray-100 rounded-lg flex items-center gap-2 px-3 py-2">
+          <ng-icon
+            class="!w-5 !h-5 !text-[20px] shrink-0 opacity-30"
+            name="matCallOutline"
+          ></ng-icon>
+          <span class="text-sm" data-test="contact-details-phone">{{
+            contact.phone
+          }}</span>
+        </div>
       }
     </div>
-  </div>
+  }
 
-  <!-- Address: always shown; icon dimmed when absent -->
-  <div class="bg-gray-100 rounded-md flex items-start gap-2 px-3 py-2">
-    <ng-icon
-      class="!w-5 !h-5 !text-[20px] shrink-0 mt-0.5"
-      [class.opacity-30]="!addressLines.length"
-      [class.opacity-75]="!!addressLines.length"
-      name="matLocationOnOutline"
-    ></ng-icon>
-    @if (addressLines.length) {
+  @if (addressLines.length) {
+    <div class="bg-gray-100 rounded-lg flex items-start gap-2 px-3 py-2">
+      <ng-icon
+        class="!w-5 !h-5 !text-[20px] shrink-0 mt-0.5 opacity-30"
+        name="matLocationOnOutline"
+      ></ng-icon>
       <div class="flex flex-col" data-test="contact-details-address">
         @for (line of addressLines; track line) {
           <p class="text-sm m-0">{{ line }}</p>
         }
       </div>
-    }
-  </div>
+    </div>
+  }
 
-  <!-- Website: only shown when org exists; icon dimmed when absent -->
-  @if (organization) {
-    <div class="bg-gray-100 rounded-md flex items-center gap-2 px-3 py-2">
+  @if (organization?.website) {
+    <div class="bg-gray-100 rounded-lg flex items-center gap-2 px-3 py-2">
       <ng-icon
-        class="!w-5 !h-5 !text-[20px] shrink-0"
-        [class.opacity-30]="!organization.website"
-        [class.opacity-75]="!!organization.website"
+        class="!w-5 !h-5 !text-[20px] shrink-0 opacity-30"
         name="matOpenInNew"
       ></ng-icon>
-      @if (organization.website) {
-        <a
-          [href]="organization.website.href"
-          target="_blank"
-          class="text-sm break-all hover:underline"
-          data-test="contact-details-website"
-          >{{ organization.website.href }}</a
-        >
-      }
+      <a
+        [href]="organization.website.href"
+        target="_blank"
+        class="text-sm break-all hover:underline"
+        data-test="contact-details-website"
+        >{{ organization.website.href }}</a
+      >
     </div>
   }
 </div>

--- a/libs/ui/elements/src/lib/contact-details/contact-details.component.spec.ts
+++ b/libs/ui/elements/src/lib/contact-details/contact-details.component.spec.ts
@@ -124,15 +124,12 @@ describe('ContactDetailsComponent', () => {
       })
     })
 
-    it('shows the website row but no link', () => {
+    it('hides the website when absent', () => {
       expect(
         fixture.nativeElement.querySelector(
           '[data-test="contact-details-website"]'
         )
       ).toBeNull()
-      expect(
-        fixture.nativeElement.querySelector('ng-icon[name="matOpenInNew"]')
-      ).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
### Description

This PR removes contact details when missing, to get a cleaner UI.

It also fixes gaps, border radiuses and grid stretch.

### Screenshots

No details:
<img width="972" height="278" alt="Screenshot from 2026-07-16 16-19-16" src="https://github.com/user-attachments/assets/a00576a7-8857-4249-a228-814ca0f00ff0" />

Mail only:
<img width="972" height="324" alt="Screenshot from 2026-07-16 16-19-48" src="https://github.com/user-attachments/assets/90517e04-1b4b-40e9-afa2-b53bb62d83f2" />

With thumbnail:
<img width="972" height="420" alt="Screenshot from 2026-07-16 16-20-13" src="https://github.com/user-attachments/assets/dee4b865-8ec7-4ba0-9ea0-f26b38289590" />

With multi-line mail, keep phone on one line:
<img width="972" height="452" alt="Screenshot from 2026-07-16 16-20-32" src="https://github.com/user-attachments/assets/ee9a6d7e-fbe4-4d51-94f4-cd4cf96f4a99" />

Single line mail and phone:
<img width="972" height="465" alt="Screenshot from 2026-07-16 16-20-45" src="https://github.com/user-attachments/assets/c55e1429-19e6-414a-a944-e9d6176e53a7" />


### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

Open the record based on the URL in the screenshots.
The last one can be imported from there: 
https://geoportal.georhena.eu/geonetwork/srv/api/records/b083f353-9c12-4001-a409-3d78e854a604/formatters/xml

---

**This work is sponsored by [DataGrandEst](https://www.datagrandest.fr)**.
