### PR TITLE
[Editor]: new facade method to save without publish

### DIFF
--- a/apps/metadata-editor/src/app/edit/components/publish-button/publish-button.component.spec.ts
+++ b/apps/metadata-editor/src/app/edit/components/publish-button/publish-button.component.spec.ts
@@ -20,7 +20,7 @@ class EditorFacadeMock {
     recordUpdated: new Date('2023-01-01'),
     extras: { ownerInfo: '1|John|Doe' },
   })
-  saveRecord = jest.fn()
+  saveAndPublishRecord = jest.fn()
   saveSuccess$ = new BehaviorSubject(true)
   checkHasRecordChanged = jest.fn()
   hasRecordChanged$ = new Subject()
@@ -144,12 +144,12 @@ describe('PublishButtonComponent', () => {
     })
   })
 
-  describe('#saveRecord', () => {
+  describe('#saveAndPublishRecord', () => {
     beforeEach(async () => {
-      await component.saveRecord()
+      await component.saveAndPublishRecord()
     })
-    it('should call facade.saveRecord', () => {
-      expect(facade.saveRecord).toHaveBeenCalled()
+    it('should call facade.saveAndPublishRecord', () => {
+      expect(facade.saveAndPublishRecord).toHaveBeenCalled()
       expect(recordsApiService.setRecordOwnership).toHaveBeenCalledWith(
         304,
         0,
@@ -158,10 +158,13 @@ describe('PublishButtonComponent', () => {
     })
   })
   describe('#confirmPublish', () => {
-    it('should call saveRecord', () => {
-      const saveRecordSpy = jest.spyOn(component, 'saveRecord')
+    it('should call saveAndPublishRecord', () => {
+      const saveAndPublishRecordSpy = jest.spyOn(
+        component,
+        'saveAndPublishRecord'
+      )
       component.confirmPublish()
-      expect(saveRecordSpy).toHaveBeenCalled()
+      expect(saveAndPublishRecordSpy).toHaveBeenCalled()
     })
   })
 
@@ -179,28 +182,34 @@ describe('PublishButtonComponent', () => {
         component,
         'openConfirmationMenu'
       )
-      const saveRecordSpy = jest.spyOn(component, 'saveRecord')
+      const saveAndPublishRecordSpy = jest.spyOn(
+        component,
+        'saveAndPublishRecord'
+      )
 
       component.verifyPublishConditions()
       facade.hasRecordChanged$.next(null)
       facade.hasRecordChanged$.next({ date: new Date(), user: 'John Doe' })
 
       expect(openConfirmationMenuSpy).toHaveBeenCalled()
-      expect(saveRecordSpy).not.toHaveBeenCalled()
+      expect(saveAndPublishRecordSpy).not.toHaveBeenCalled()
     })
 
-    it('should call saveRecord if hasRecordChanged emits without a date', () => {
+    it('should call saveAndPublishRecord if hasRecordChanged emits without a date', () => {
       const openConfirmationMenuSpy = jest.spyOn(
         component,
         'openConfirmationMenu'
       )
-      const saveRecordSpy = jest.spyOn(component, 'saveRecord')
+      const saveAndPublishRecordSpy = jest.spyOn(
+        component,
+        'saveAndPublishRecord'
+      )
 
       component.verifyPublishConditions()
       facade.hasRecordChanged$.next(null)
       facade.hasRecordChanged$.next({ date: undefined, user: undefined })
 
-      expect(saveRecordSpy).toHaveBeenCalled()
+      expect(saveAndPublishRecordSpy).toHaveBeenCalled()
       expect(openConfirmationMenuSpy).not.toHaveBeenCalled()
     })
   })

--- a/apps/metadata-editor/src/app/edit/components/publish-button/publish-button.component.ts
+++ b/apps/metadata-editor/src/app/edit/components/publish-button/publish-button.component.ts
@@ -98,7 +98,7 @@ export class PublishButtonComponent implements OnDestroy {
   }
 
   confirmPublish() {
-    this.saveRecord()
+    this.saveAndPublishRecord()
     this.closeMenu()
   }
 
@@ -156,7 +156,7 @@ export class PublishButtonComponent implements OnDestroy {
           this.publishWarning = hasChanged
           this.openConfirmationMenu()
         } else {
-          this.saveRecord()
+          this.saveAndPublishRecord()
         }
       })
 
@@ -170,8 +170,8 @@ export class PublishButtonComponent implements OnDestroy {
       .subscribe()
   }
 
-  saveRecord() {
-    this.facade.saveRecord()
+  saveAndPublishRecord() {
+    this.facade.saveAndPublishRecord()
     this.facade.saveSuccess$
       .pipe(
         take(1),

--- a/libs/feature/editor/src/lib/+state/editor.actions.ts
+++ b/libs/feature/editor/src/lib/+state/editor.actions.ts
@@ -29,7 +29,10 @@ export const markRecordAsChanged = createAction(
   '[Editor] Mark record as changed'
 )
 
-export const saveRecord = createAction('[Editor] Save record')
+export const saveRecord = createAction(
+  '[Editor] Save record',
+  props<{ publish: boolean }>()
+)
 export const saveRecordSuccess = createAction('[Editor] Save record success')
 export const saveRecordFailure = createAction(
   '[Editor] Save record failure',

--- a/libs/feature/editor/src/lib/+state/editor.effects.spec.ts
+++ b/libs/feature/editor/src/lib/+state/editor.effects.spec.ts
@@ -78,18 +78,20 @@ describe('EditorEffects', () => {
 
   describe('saveRecord$', () => {
     describe('when api success', () => {
-      it('dispatch saveRecordSuccess', () => {
+      it('dispatch saveRecordSuccess and isPublished', () => {
         actions = hot('-a---|', {
-          a: EditorActions.saveRecord(),
+          a: EditorActions.saveRecord({ publish: true }),
         })
-        const expected = hot('-a---|', {
+        const expected = hot('-(ab)|', {
           a: EditorActions.saveRecordSuccess(),
+          b: EditorActions.isPublished({ isPublished: true }),
         })
         expect(effects.saveRecord$).toBeObservable(expected)
         expect(service.saveRecord).toHaveBeenCalledWith(
           datasetRecordsFixture()[0],
           '<xml>blabla</xml>',
-          []
+          [],
+          true
         )
       })
     })
@@ -102,7 +104,7 @@ describe('EditorEffects', () => {
       })
       it('dispatch saveRecordFailure', () => {
         actions = hot('-a-|', {
-          a: EditorActions.saveRecord(),
+          a: EditorActions.saveRecord({ publish: true }),
         })
         const expected = hot('-a-|', {
           a: EditorActions.saveRecordFailure({ error: new Error('oopsie') }),

--- a/libs/feature/editor/src/lib/+state/editor.effects.ts
+++ b/libs/feature/editor/src/lib/+state/editor.effects.ts
@@ -28,30 +28,37 @@ export class EditorEffects {
         this.store.select(selectRecordSource),
         this.store.select(selectEditorConfig)
       ),
-      switchMap(([, record, recordSource, fieldsConfig]) =>
-        this.editorService.saveRecord(record, recordSource, fieldsConfig).pipe(
-          switchMap(([savedRecord, savedRecordSource]) => {
-            const actions: Action[] = [EditorActions.saveRecordSuccess()]
+      switchMap(([{ publish }, record, recordSource, fieldsConfig]) =>
+        this.editorService
+          .saveRecord(record, recordSource, fieldsConfig, publish)
+          .pipe(
+            switchMap(([savedRecord, savedRecordSource]) => {
+              const actions: Action[] = [EditorActions.saveRecordSuccess()]
 
-            if (!record?.uniqueIdentifier) {
-              actions.push(
-                EditorActions.openRecord({
-                  record: savedRecord,
-                  recordSource: savedRecordSource,
+              if (publish) {
+                // saving without publishing doesn't unpublish
+                actions.push(EditorActions.isPublished({ isPublished: true }))
+              }
+
+              if (!record?.uniqueIdentifier) {
+                actions.push(
+                  EditorActions.openRecord({
+                    record: savedRecord,
+                    recordSource: savedRecordSource,
+                  })
+                )
+              }
+
+              return of(...actions)
+            }),
+            catchError((error) =>
+              of(
+                EditorActions.saveRecordFailure({
+                  error,
                 })
               )
-            }
-
-            return of(...actions)
-          }),
-          catchError((error) =>
-            of(
-              EditorActions.saveRecordFailure({
-                error,
-              })
             )
           )
-        )
       )
     )
   )

--- a/libs/feature/editor/src/lib/+state/editor.facade.spec.ts
+++ b/libs/feature/editor/src/lib/+state/editor.facade.spec.ts
@@ -62,10 +62,17 @@ describe('EditorFacade', () => {
       expect(spy).toHaveBeenCalledWith(setPage)
     })
 
-    it('saveRecord() should dispatch saveRecord action', () => {
+    it('saveRecord() should dispatch saveRecord action with publish flag set to false', () => {
       const spy = jest.spyOn(store, 'dispatch')
       facade.saveRecord()
-      const action = EditorActions.saveRecord()
+      const action = EditorActions.saveRecord({ publish: false })
+      expect(spy).toHaveBeenCalledWith(action)
+    })
+
+    it('saveAndPublishRecord() should dispatch saveRecord action with publish flag set to true', () => {
+      const spy = jest.spyOn(store, 'dispatch')
+      facade.saveAndPublishRecord()
+      const action = EditorActions.saveRecord({ publish: true })
       expect(spy).toHaveBeenCalledWith(action)
     })
 

--- a/libs/feature/editor/src/lib/+state/editor.facade.ts
+++ b/libs/feature/editor/src/lib/+state/editor.facade.ts
@@ -54,7 +54,11 @@ export class EditorFacade {
   }
 
   saveRecord() {
-    this.store.dispatch(EditorActions.saveRecord())
+    this.store.dispatch(EditorActions.saveRecord({ publish: false }))
+  }
+
+  saveAndPublishRecord() {
+    this.store.dispatch(EditorActions.saveRecord({ publish: true }))
   }
 
   undoRecordDraft() {

--- a/libs/feature/editor/src/lib/services/editor.service.spec.ts
+++ b/libs/feature/editor/src/lib/services/editor.service.spec.ts
@@ -54,18 +54,19 @@ describe('EditorService', () => {
   })
 
   describe('saveRecord', () => {
-    describe('Existing records', () => {
-      let savedRecord: [CatalogRecord, string, boolean]
+    describe('Existing records, publish true', () => {
+      let savedRecord: [CatalogRecord, string]
       beforeEach(async () => {
         savedRecord = await firstValueFrom(
           service.saveRecord(
             SAMPLE_RECORD,
             '<xml>blabla</xml>',
-            DEFAULT_CONFIGURATION
+            DEFAULT_CONFIGURATION,
+            true
           )
         )
       })
-      it('calls with publishToAll true for existing records', () => {
+      it('calls with publishToAll', () => {
         const expected = {
           ...SAMPLE_RECORD,
           recordUpdated: expect.any(Date),
@@ -85,8 +86,8 @@ describe('EditorService', () => {
         expect(arg.recordUpdated).not.toEqual(SAMPLE_RECORD.recordUpdated)
       })
     })
-    describe('New records', () => {
-      let savedRecord: [CatalogRecord, string, boolean]
+    describe('New records, publish false', () => {
+      let savedRecord: [CatalogRecord, string]
       const NEW_RECORD = {
         ...SAMPLE_RECORD,
         uniqueIdentifier: null,
@@ -97,7 +98,8 @@ describe('EditorService', () => {
           service.saveRecord(
             NEW_RECORD,
             '<xml>blabla</xml>',
-            DEFAULT_CONFIGURATION
+            DEFAULT_CONFIGURATION,
+            false
           )
         )
       })

--- a/libs/feature/editor/src/lib/services/editor.service.ts
+++ b/libs/feature/editor/src/lib/services/editor.service.ts
@@ -16,7 +16,8 @@ export class EditorService {
   saveRecord(
     record: CatalogRecord,
     recordSource: string,
-    fieldsConfig: EditorConfig
+    fieldsConfig: EditorConfig,
+    publish: boolean
   ): Observable<[CatalogRecord, string]> {
     const savedRecord = { ...record }
 
@@ -34,15 +35,9 @@ export class EditorService {
         })
       }
     }
-    let publishToAll = true
-    // if the record is new, generate a new unique identifier and pass publishToAll as false
-    if (!record.uniqueIdentifier) {
-      savedRecord.uniqueIdentifier = null
-      publishToAll = false
-    }
 
     return this.recordsRepository
-      .saveRecord(savedRecord, recordSource, publishToAll)
+      .saveRecord(savedRecord, recordSource, publish)
       .pipe(
         switchMap((uniqueIdentifier) =>
           this.recordsRepository.openRecordForEdition(uniqueIdentifier)


### PR DESCRIPTION
### Description

This PR introduces a new method in the editor facade, to allow saving with or without publishing distinctly. 

It also fixes the publish state when publishing for the first time on a record. The publication status was only checked on open. Now it's always set to true when saving with publishing in success.

Note: no changes in e2e tests as of now, this will need to be tested when used in the reuse light edit page.

Breaking Change: the `saveRecord` of the editor facade will only save as of now, use the `saveAndPublishRecord` to get the same behavior as previous `saveRecord`

### Architectural changes

The editor service is only responsible for saving with or without publishing as it's told.
The publish boolean set to false for new records comes from higher up in the application (editor-page).

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

No regression:
Open the Metadata-Editor and create a new record. 
Make sure that the record is correctly saved but not published in GeoNetwork.
Edit the record and publish.
Check that the top tooltap displays the translation for `editor.record.saveStatus.recordUpToDate`.
Make sure the changes are correctly saved and the record is published in GeoNetwork.

New feature:
In the publish button in the Metadata-Editor, replace `this.facade.saveAndPublishRecord()` with `this.facade.saveRecord()`.
Open the Metadata-Editor and create a new record. 
Make sure that the record is correctly saved but not published in GeoNetwork.
Edit the record and save.
Check that the top tooltap displays the translation for `editor.record.saveStatus.recordNotPublished`.
Make sure the changes are correctly saved and the record is not published in GeoNetwork.

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [DataGrandEst](https://www.datagrandest.fr)**.
