### PR TITLE
[Metadata-Editor]: restore hiding legal constraints when empty

### DIFF
--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.spec.ts
@@ -180,45 +180,46 @@ describe('FormFieldConstraintsShortcutsComponent', () => {
       return calls[calls.length - 1]
     }
 
-    describe.each(['securityConstraints', 'otherConstraints'])(
-      'for field %s',
-      (fieldName) => {
-        it('is visible if not empty at first and no toggles activated', () => {
-          sampleRecord$.next({
-            ...sampleRecord,
-            [fieldName]: [{ text: 'some constraint' }],
-          })
-          fixture.detectChanges()
-          expect(getLastCallForField(fieldName)).toEqual([
-            { model: fieldName },
-            true,
-          ])
+    describe.each([
+      'legalConstraints',
+      'securityConstraints',
+      'otherConstraints',
+    ])('for field %s', (fieldName) => {
+      it('is visible if not empty at first and no toggles activated', () => {
+        sampleRecord$.next({
+          ...sampleRecord,
+          [fieldName]: [{ text: 'some constraint' }],
         })
-        it('is hidden if not empty at first and NOT_APPLICABLE_CONSTRAINT present', () => {
-          sampleRecord$.next({
-            ...sampleRecord,
-            [fieldName]: [{ text: 'some constraint' }],
-            legalConstraints: [NOT_APPLICABLE_CONSTRAINT],
-          })
-          fixture.detectChanges()
-          expect(getLastCallForField(fieldName)).toEqual([
-            { model: fieldName },
-            false,
-          ])
+        fixture.detectChanges()
+        expect(getLastCallForField(fieldName)).toEqual([
+          { model: fieldName },
+          true,
+        ])
+      })
+      it('is hidden if not empty at first and NOT_APPLICABLE_CONSTRAINT present', () => {
+        sampleRecord$.next({
+          ...sampleRecord,
+          [fieldName]: [{ text: 'some constraint' }],
+          legalConstraints: [NOT_APPLICABLE_CONSTRAINT],
         })
-        it('is hidden if field is empty', () => {
-          sampleRecord$.next({
-            ...sampleRecord,
-            [fieldName]: [],
-          })
-          fixture.detectChanges()
-          expect(getLastCallForField(fieldName)).toEqual([
-            { model: fieldName },
-            false,
-          ])
+        fixture.detectChanges()
+        expect(getLastCallForField(fieldName)).toEqual([
+          { model: fieldName },
+          false,
+        ])
+      })
+      it('is hidden if field is empty', () => {
+        sampleRecord$.next({
+          ...sampleRecord,
+          [fieldName]: [],
         })
-      }
-    )
+        fixture.detectChanges()
+        expect(getLastCallForField(fieldName)).toEqual([
+          { model: fieldName },
+          false,
+        ])
+      })
+    })
   })
 
   describe('unsubscribe on destroy', () => {

--- a/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.ts
+++ b/libs/feature/editor/src/lib/components/record-form/form-field/form-field-constraints-shortcuts/form-field-constraints-shortcuts.component.ts
@@ -138,6 +138,7 @@ export class FormFieldConstraintsShortcutsComponent implements OnDestroy {
             this.editorFacade.setFieldVisibility({ model }, visible)
           })
       }
+      hideEmptyConstraints(this.legalConstraints$, 'legalConstraints')
       hideEmptyConstraints(this.securityConstraints$, 'securityConstraints')
       hideEmptyConstraints(this.otherConstraints$, 'otherConstraints')
     })


### PR DESCRIPTION
### Description

Revert "fix(form-field-constraints): do not hide legalConstraints field when empty"

This reverts commit a8fe4960c17b5addea923c2825fca234338c7ed7.

Before:
<img width="1029" height="509" alt="image" src="https://github.com/user-attachments/assets/5314e874-73e0-4cf5-9f86-d767511df402" />

After:
<img width="1030" height="337" alt="image" src="https://github.com/user-attachments/assets/2bcb993e-2c9f-4af2-84d9-60657e320237" />

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

Open a record in the Metadata-Editor, add and remove legal constraints, check that the block is correctly hidden when removing all the elements from the list.

---

**This work is sponsored by [DataGrandEst](https://www.datagrandest.fr)**.
