### PR TITLE
[Notify-Reuse]: better contact prefill, support overviews

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset/datasetNotifyReuse.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetNotifyReuse.cy.ts
@@ -145,11 +145,12 @@ describe('Declare a reuse', () => {
         .eq(1)
         .type('https://example.com/my-reuse')
       cy.get('@overlay').find('gn-ui-button').last().find('button').click()
-      // the serialized record carries the entered title (linking the reuse
-      // back to the source dataset)
       cy.wait('@saveRecord')
         .its('request.body')
         .should('contain', 'My great reuse')
+        .should('contain', 'Barbara')
+        .should('contain', 'Roberts')
+        .should('contain', 'Barbie Inc.')
       cy.get('.cdk-overlay-container').should(
         'not.contain.text',
         'Declare a reuse'

--- a/apps/metadata-editor-e2e/src/e2e/edit/light-edit.cy.ts
+++ b/apps/metadata-editor-e2e/src/e2e/edit/light-edit.cy.ts
@@ -1,16 +1,26 @@
 describe('light edit page', () => {
-  // seeded reuse record (also used by datahub-e2e reuse specs) - read only here
-  const reuseUuid = '7eb795c2-d612-4b5e-b15e-d985b0f4e697'
-  const reuseTitle =
-    'Carte dynamique sur la répartition des ongulés sauvages en France'
+  let reuseUuid: any
+
+  beforeEach(() => {
+    cy.editor_createRecordCopy(
+      '7eb795c2-d612-4b5e-b15e-d985b0f4e697', // reuse record
+      'ongulés', // one result search term
+      'johndoe',
+      'p4ssworD_'
+    ).then((uuid) => {
+      reuseUuid = uuid
+    })
+  })
 
   it('light edit page tests', () => {
-    cy.login('admin', 'admin', false)
-    cy.clearRecordDrafts()
+    cy.login('johndoe', 'p4ssworD_', false)
 
     // Display
-    // should show the record form without the full editor tools
+    // should not show the leave button without a redirect_on_leave param
     cy.visit(`/light-edit/${reuseUuid}`)
+    cy.get('[data-cy="leave-button"]').should('not.exist')
+
+    // should show the record form without the full editor tools
     cy.get('gn-ui-record-form').should('be.visible')
     cy.get('md-editor-sidebar').should('not.exist')
     cy.get('md-editor-page-selector').should('not.exist')
@@ -19,8 +29,6 @@ describe('light edit page', () => {
     cy.get('[data-cy="save-status"]').should('not.exist')
     cy.get('[data-test="light-edit-background"]').should('exist')
     cy.get('[data-cy="save-button"]').should('be.visible')
-    // should not show the leave button without a redirect_on_leave param
-    cy.get('[data-cy="leave-button"]').should('not.exist')
 
     // Leave
     // should navigate to the redirect_on_leave url
@@ -30,26 +38,45 @@ describe('light edit page', () => {
         redirectUrl
       )}`
     )
-    cy.get('gn-ui-record-form').should('be.visible')
     cy.get('[data-cy="leave-button"]').should('be.visible').click()
     cy.url().should('include', 'from=light-edit')
 
     // Save
     // should save the record and show a success notification
-    // edit a disposable copy so the seeded record is left untouched
-    cy.editor_createRecordCopy(reuseUuid, reuseTitle).then((copyUuid) => {
-      cy.visit(`/light-edit/${copyUuid}`)
-      cy.get('gn-ui-form-field[ng-reflect-model=abstract] textarea').as(
-        'abstractField'
-      )
-      cy.get('@abstractField').clear()
-      cy.get('@abstractField').type('modified by the light edit e2e test')
-      cy.get('[data-cy="save-button"]').click()
-      cy.get('gn-ui-notification', { timeout: 15000 }).should(
-        'contain',
-        'Reuse saved'
-      )
-      cy.url().should('include', `/light-edit/${copyUuid}`)
-    })
+    cy.visit(`/light-edit/${reuseUuid}`)
+    cy.get('gn-ui-form-field[ng-reflect-model=abstract] textarea').as(
+      'abstractField'
+    )
+    cy.get('@abstractField').type(
+      '{selectall}{del}modified by the light edit e2e test'
+    )
+    cy.get('gn-ui-image-input').find('img').should('have.length', 1)
+    cy.get('gn-ui-image-input').find('gn-ui-button').eq(1).click()
+    cy.get('gn-ui-image-input').find('img').should('have.length', 0)
+    cy.get('gn-ui-form-field-overviews label').selectFile(
+      'src/fixtures/sample.png'
+    )
+    cy.get('gn-ui-image-input').find('img').should('have.length', 1)
+    cy.intercept({
+      method: 'PUT',
+      pathname: '**/records',
+    }).as('insertRecord')
+    cy.get('[data-cy="save-button"]').click()
+    cy.wait('@insertRecord')
+    cy.get('gn-ui-notification').should('contain', 'Reuse saved')
+    // reload the page to check that the changes were persisted
+    cy.intercept({
+      method: 'GET',
+      url: '**/attachments/sample.png',
+    }).as('importUrlRequest')
+    cy.visit(`/light-edit/${reuseUuid}`)
+    cy.get('@abstractField').should(
+      'contain.value',
+      'modified by the light edit e2e test'
+    )
+    cy.get('@importUrlRequest')
+      .its('response.statusCode')
+      .should('be.oneOf', [200, 304]) // the backend may respond with a "not changed" code
+    cy.get('gn-ui-image-input').find('img').should('have.length', 1)
   })
 })

--- a/apps/metadata-editor/src/app/new-record.resolver.ts
+++ b/apps/metadata-editor/src/app/new-record.resolver.ts
@@ -28,15 +28,17 @@ export class NewRecordResolver {
       map((userContact) => {
         const recordKind = 'dataset'
         const catalogRecord: CatalogRecord = {
+          kind: recordKind,
+          status: 'ongoing',
           uniqueIdentifier: null,
           title: this.translateService.instant('editor.new.record.title', {
             recordKind,
           }),
           abstract: '',
+          overviews: [],
           ownerOrganization: {
             name: 'Owner organization',
           },
-          contacts: userContact ? [userContact] : [],
           recordUpdated: new Date(),
           updateFrequency: 'unknown',
           otherLanguages: [],
@@ -47,10 +49,8 @@ export class NewRecordResolver {
           legalConstraints: [NOT_KNOWN_CONSTRAINT],
           securityConstraints: [],
           otherConstraints: [],
-          overviews: [],
+          contacts: userContact ? [userContact] : [],
           contactsForResource: userContact ? [userContact] : [],
-          kind: recordKind,
-          status: 'ongoing',
           lineage: '',
           sourceRecords: [],
           onlineResources: [],

--- a/libs/api/metadata-converter/src/lib/dcat-ap/dcat-ap.converter.ts
+++ b/libs/api/metadata-converter/src/lib/dcat-ap/dcat-ap.converter.ts
@@ -499,6 +499,8 @@ export class DcatApConverter extends BaseConverter<string> {
     if (record.kind === 'dataset') {
       fieldChanged('status') &&
         this.writers['status'](record, dataStore, recordNode)
+    }
+    if (record.kind === 'dataset' || record.kind === 'reuse') {
       fieldChanged('updateFrequency') &&
         this.writers['updateFrequency'](record, dataStore, recordNode)
       fieldChanged('spatialRepresentation') &&

--- a/libs/api/metadata-converter/src/lib/iso19139/iso19139.converter.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/iso19139.converter.ts
@@ -205,7 +205,7 @@ export class Iso19139Converter extends BaseConverter<string> {
     record.contacts.map((c) => fixLanguages(c.organization))
     record.contactsForResource.map((c) => fixLanguages(c.organization))
     fixLanguages(record.ownerOrganization)
-    if (record.kind === 'dataset') {
+    if (record.kind === 'dataset' || record.kind === 'reuse') {
       record.spatialExtents.map(fixLanguages)
     }
 
@@ -408,6 +408,8 @@ export class Iso19139Converter extends BaseConverter<string> {
 
     if (record.kind === 'dataset') {
       fieldChanged('status') && this.writers['status'](record, rootEl)
+    }
+    if (record.kind === 'dataset' || record.kind === 'reuse') {
       fieldChanged('updateFrequency') &&
         this.writers['updateFrequency'](record, rootEl)
       fieldChanged('spatialRepresentation') &&
@@ -417,9 +419,6 @@ export class Iso19139Converter extends BaseConverter<string> {
         this.writers['temporalExtents'](record, rootEl)
       fieldChanged('spatialExtents') &&
         this.writers['spatialExtents'](record, rootEl)
-    }
-
-    if (record.kind === 'dataset' || record.kind === 'reuse') {
       ;(fieldChanged('lineage') || fieldChanged('translations')) &&
         this.writers['lineage'](record, rootEl)
       fieldChanged('sourceRecords') &&

--- a/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.spec.ts
+++ b/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.spec.ts
@@ -65,6 +65,7 @@ class PlatformServiceMock {
       name: 'John',
       surname: 'Doe',
       email: 'logged-user@example.com',
+      organisation: 'Owner Org',
     })
   )
 }
@@ -258,12 +259,17 @@ describe('NotifyReuseFormComponent', () => {
         {
           type: 'link',
           url: new URL('https://example.com/my-reuse'),
-          name: 'https://example.com/my-reuse',
           description: 'notify.reuse.link.description',
         },
       ])
       expect(saved.contacts).toEqual([
-        { email: 'reuser@example.com', role: 'point_of_contact' },
+        {
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'reuser@example.com',
+          role: 'point_of_contact',
+          organization: { name: 'Owner Org' },
+        },
       ])
     })
 

--- a/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.ts
+++ b/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.ts
@@ -30,8 +30,10 @@ import {
 } from '@geonetwork-ui/common/domain/model/record'
 import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.service.interface'
 import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
+import { NOT_KNOWN_CONSTRAINT } from '@geonetwork-ui/feature/editor'
 import { NotificationsService } from '@geonetwork-ui/feature/notifications'
 import { ButtonComponent, TextInputComponent } from '@geonetwork-ui/ui/inputs'
+import { getOptionalEditorConfig } from '@geonetwork-ui/util/app-config'
 import { NgIcon, provideIcons, provideNgIconsConfig } from '@ng-icons/core'
 import { iconoirAppWindow, iconoirPlusCircle } from '@ng-icons/iconoir'
 import { matCloseOutline } from '@ng-icons/material-icons/outline'
@@ -155,36 +157,44 @@ export class NotifyReuseFormComponent implements OnDestroy {
 
   submit() {
     if (!this.isFormValid()) return
+    const defaultLang =
+      getOptionalEditorConfig()?.NEW_RECORD_DEFAULT_LANGUAGE ??
+      this.translate.currentLang
     const onlineResource: OnlineLinkResource = {
       type: 'link',
       url: new URL(this.url()),
-      name: this.url(),
       description: this.translate.instant('notify.reuse.link.description'),
     }
     const contact: Individual = {
+      firstName: this.me()?.name,
+      lastName: this.me()?.surname,
       email: this.email(),
       role: 'point_of_contact',
+      organization: { name: this.me()?.organisation },
     }
     const reuseRecord: ReuseRecord = {
-      uniqueIdentifier: '',
       kind: 'reuse',
+      reuseType: 'application',
+      uniqueIdentifier: null,
       title: this.title(),
       abstract: '',
-      ownerOrganization: { name: '' },
-      contacts: [contact],
-      contactsForResource: [],
+      overviews: [],
+      ownerOrganization: {
+        name: 'Owner organization',
+      },
       recordUpdated: new Date(),
+      updateFrequency: 'unknown',
+      otherLanguages: [],
+      defaultLanguage: defaultLang,
       topics: [],
       keywords: [],
       licenses: [],
-      legalConstraints: [],
+      legalConstraints: [NOT_KNOWN_CONSTRAINT],
       securityConstraints: [],
       otherConstraints: [],
-      overviews: [],
-      defaultLanguage: 'en',
-      otherLanguages: [],
+      contacts: [contact],
+      contactsForResource: [],
       lineage: '',
-      reuseType: 'application',
       sourceRecords: [
         {
           uuid: this.record()?.uniqueIdentifier ?? '',

--- a/tools/e2e/commands.ts
+++ b/tools/e2e/commands.ts
@@ -26,7 +26,9 @@ declare namespace Cypress {
     deleteRecord(uuid: string): void
     editor_createRecordCopy(
       uuidToCopy?: string,
-      titleToCopy?: string
+      titleToCopy?: string,
+      username?: string,
+      password?: string
     ): Chainable<string | number | string[]>
     editor_readFormUniqueIdentifier(): Chainable<string | number | string[]>
     editor_wrapPreviousDraft(uuid: string): void
@@ -245,39 +247,42 @@ Cypress.Commands.add('deleteRecord', (uuid: string) => {
     })
 })
 
-Cypress.Commands.add('editor_createRecordCopy', (uuidToCopy, titleToCopy) => {
-  cy.login('admin', 'admin', false)
-  cy.viewport(1920, 2400)
+Cypress.Commands.add(
+  'editor_createRecordCopy',
+  (uuidToCopy, titleToCopy, username, password) => {
+    cy.login(username ?? 'admin', password ?? 'admin', false)
+    cy.viewport(1920, 2400)
 
-  cy.clearRecordDrafts()
+    cy.clearRecordDrafts()
 
-  const recordTitle = titleToCopy ?? 'station épuration'
-  const recordUuid = uuidToCopy ?? '011963da-afc0-494c-a2cc-5cbd59e122e4'
+    const recordTitle = titleToCopy ?? 'station épuration'
+    const recordUuid = uuidToCopy ?? '011963da-afc0-494c-a2cc-5cbd59e122e4'
 
-  // Clear any existing copy of the test record
-  cy.visit('/catalog/search')
-  cy.get('gn-ui-fuzzy-search input').type(
-    //`{selectall}{del}${recordTitle}{enter}`
-    `{selectall}{del}{enter}${recordTitle}{enter}` // FIXME: we should not need to press "enter" before typing something to search! there is a debounce problem here
-  )
-  cy.get('[data-cy="table-row"]')
-    .should('have.length.lt', 10) // making sure the records were updated
-    .then((rows$) => {
-      if (rows$.length === 1) {
-        return
-      }
-      // there is a copy: delete it
-      cy.get('[data-test="record-menu-button"]').eq(1).click()
-      cy.get('[data-test="record-menu-delete-button"]').click()
-      cy.get('[data-cy="confirm-button"]').click()
-      cy.log('An existing copy of the test record was found and deleted.')
-    })
+    // Clear any existing copy of the test record
+    cy.visit('/catalog/search')
+    cy.get('gn-ui-fuzzy-search input').type(
+      //`{selectall}{del}${recordTitle}{enter}`
+      `{selectall}{del}{enter}${recordTitle}{enter}` // FIXME: we should not need to press "enter" before typing something to search! there is a debounce problem here
+    )
+    cy.get('[data-cy="table-row"]')
+      .should('have.length.lt', 10) // making sure the records were updated
+      .then((rows$) => {
+        if (rows$.length === 1) {
+          return
+        }
+        // there is a copy: delete it
+        cy.get('[data-test="record-menu-button"]').eq(1).click()
+        cy.get('[data-test="record-menu-delete-button"]').click()
+        cy.get('[data-cy="confirm-button"]').click()
+        cy.log('An existing copy of the test record was found and deleted.')
+      })
 
-  // Duplicate the Stations d'épuration record
-  cy.visit(`/duplicate/${recordUuid}`)
-  cy.url().should('include', '/edit/')
-  return cy.editor_readFormUniqueIdentifier()
-})
+    // Duplicate the Stations d'épuration record
+    cy.visit(`/duplicate/${recordUuid}`)
+    cy.url().should('include', '/edit/')
+    return cy.editor_readFormUniqueIdentifier()
+  }
+)
 
 Cypress.Commands.add('editor_readFormUniqueIdentifier', () => {
   // wait for the url to contain edit


### PR DESCRIPTION
### Description

This PR is a follow up on #1607 and #1619.

The contact was prefilled only with the email, but the name, surname and organization name should be prefilled too.
The online resource link name was set to the URL, but this can lead to inconsistency if the URL is changed afterwards but not the name, so removing the name altogether here.

The reuse and service kinds were unlocked, but not entirely available in the converters.
Adding a test on the overview of the reuse, as this was one of the locked fields in the converter.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

- Serve both the DataHub and the Metadata-Editor
- In the default.toml, set the reuse_form_url to point to the Metadata-Editor url
- login with the John Doe user: johndoe/p4ssworD_
- navigate to a dataset record, for example http://localhost:4200/dataset/ed34db28-5dd4-480f-bf29-dc08f0086131
- click on the "Declare a reuse" button, fill the form, submit
- Check that the name, surname and organization are correctly set in the light edit page
- Add a graphic overview, save, reload and/or go back to the reuse page in the DataHub
- Check that the graphic overview is still present

---

**This work is sponsored by [DataGrandEst](https://www.datagrandest.fr)**.
