### PR TITLE
[Notify-Reuse]: contact for resource, double edit button

### DIFF
--- a/apps/datahub/src/app/record/record-header/record-header.service.spec.ts
+++ b/apps/datahub/src/app/record/record-header/record-header.service.spec.ts
@@ -7,11 +7,13 @@ import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/reposit
 import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
 
 let _edit_url_template = 'http://edit/${record_id}'
+let _reuse_form_url = ''
 jest.mock('@geonetwork-ui/util/app-config', () => {
   return {
     getGlobalConfig() {
       return {
         EDIT_URL_TEMPLATE: _edit_url_template,
+        REUSE_FORM_URL: _reuse_form_url,
       }
     },
   }
@@ -80,8 +82,22 @@ describe('RecordHeaderService', () => {
       })
     })
 
-    it('should call repository if EDIT_URL_TEMPLATE is present', (done) => {
+    it('should return of(false) if EDIT_URL_TEMPLATE is present but REUSE_FORM_URL is also present', (done) => {
       service.metadata$.next({ uniqueIdentifier: 'test' } as any)
+      _edit_url_template = 'http://edit/${record_id}'
+      _reuse_form_url = 'http://reuse-form'
+
+      service.canEditFromUrl$.subscribe((result) => {
+        expect(result).toBe(false)
+        expect(recordsRepoMock.canEditIndexedRecord).not.toHaveBeenCalled()
+        done()
+      })
+    })
+
+    it('should call repository if EDIT_URL_TEMPLATE is present and REUSE_FORM_URL is absent', (done) => {
+      service.metadata$.next({ uniqueIdentifier: 'test' } as any)
+      _edit_url_template = 'http://edit/${record_id}'
+      _reuse_form_url = ''
       recordsRepoMock.canEditIndexedRecord.mockReturnValue(of(true))
 
       service.canEditFromUrl$.subscribe((result) => {

--- a/apps/datahub/src/app/record/record-header/record-header.service.ts
+++ b/apps/datahub/src/app/record/record-header/record-header.service.ts
@@ -23,7 +23,9 @@ export class RecordHeaderService {
   canEditFromUrl$ = this.metadata$.pipe(
     switchMap((metadata) =>
       getGlobalConfig().EDIT_URL_TEMPLATE
-        ? this.recordsRepository.canEditIndexedRecord(metadata)
+        ? getGlobalConfig().REUSE_FORM_URL
+          ? of(false)
+          : this.recordsRepository.canEditIndexedRecord(metadata)
         : of(false)
     )
   )

--- a/apps/metadata-editor/src/app/light-edit/light-edit-page.component.html
+++ b/apps/metadata-editor/src/app/light-edit/light-edit-page.component.html
@@ -30,9 +30,9 @@
                   editor.record.form.section.lightPointOfContact.label
                 </div>
               </div>
-              @if (pointOfContact$ | async; as pointOfContact) {
+              @if (firstContactForResource$ | async; as contact) {
                 <gn-ui-contact-details-form
-                  [contact]="pointOfContact"
+                  [contact]="contact"
                   (contactChange)="handleContactChange($event)"
                 ></gn-ui-contact-details-form>
               }

--- a/apps/metadata-editor/src/app/light-edit/light-edit-page.component.spec.ts
+++ b/apps/metadata-editor/src/app/light-edit/light-edit-page.component.spec.ts
@@ -150,6 +150,63 @@ describe('LightEditPageComponent', () => {
     })
   })
 
+  describe('contactForResource handling', () => {
+    it('emits the existing contact merged with defaults when contactsForResource has data', (done) => {
+      const existingContact = {
+        firstName: 'Jean',
+        lastName: 'Dupont',
+        email: 'jean.dupont@example.com',
+        role: 'author' as const,
+        organization: { name: 'GéoOrganisation' },
+      }
+
+      ;(facade.record$ as BehaviorSubject<any>).next({
+        ...simpleReuseRecordFixture(),
+        contactsForResource: [existingContact],
+      })
+
+      component.firstContactForResource$.subscribe((contact) => {
+        expect(contact).toEqual(existingContact)
+        done()
+      })
+    })
+
+    it('updates contactsForResource on facade when handleContactChange is called', () => {
+      facade.updateRecordField = jest.fn()
+
+      const initialContacts = [
+        { firstName: 'Old', lastName: 'Contact', email: 'old@example.com' },
+        {
+          firstName: 'Second',
+          lastName: 'Contact',
+          email: 'second@example.com',
+        },
+      ]
+
+      ;(facade.record$ as BehaviorSubject<any>).next({
+        ...simpleReuseRecordFixture(),
+        contactsForResource: initialContacts,
+      })
+
+      fixture.detectChanges()
+
+      const updatedContact = {
+        firstName: 'New',
+        lastName: 'Contact',
+        email: 'new@example.com',
+        role: 'point_of_contact' as const,
+        organization: { name: 'New Org' },
+      }
+
+      component.handleContactChange(updatedContact as any)
+
+      expect(facade.updateRecordField).toHaveBeenCalledWith(
+        'contactsForResource',
+        [updatedContact, initialContacts[1]]
+      )
+    })
+  })
+
   describe('notifications', () => {
     beforeEach(() => {
       fixture.detectChanges()

--- a/apps/metadata-editor/src/app/light-edit/light-edit-page.component.ts
+++ b/apps/metadata-editor/src/app/light-edit/light-edit-page.component.ts
@@ -57,16 +57,8 @@ export class LightEditPageComponent implements OnInit, OnDestroy {
     `center /cover url('assets/img/header_bg.webp')`
 
   private contacts: Individual[] = []
-  // the record's first contact, with empty defaults for any missing field
-  pointOfContact$ = this.facade.record$.pipe(
-    map((record) => ({
-      firstName: '',
-      lastName: '',
-      email: '',
-      role: 'point_of_contact' as const,
-      organization: { name: '' },
-      ...record.contacts?.[0],
-    }))
+  firstContactForResource$ = this.facade.record$.pipe(
+    map((record) => record.contactsForResource?.[0])
   )
 
   ngOnInit(): void {
@@ -84,7 +76,7 @@ export class LightEditPageComponent implements OnInit, OnDestroy {
 
     this.subscription.add(
       this.facade.record$.subscribe((record) => {
-        this.contacts = record.contacts ?? []
+        this.contacts = record.contactsForResource ?? []
       })
     )
 
@@ -134,7 +126,7 @@ export class LightEditPageComponent implements OnInit, OnDestroy {
   }
 
   handleContactChange(contact: Individual) {
-    this.facade.updateRecordField('contacts', [
+    this.facade.updateRecordField('contactsForResource', [
       contact,
       ...this.contacts.slice(1),
     ])

--- a/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.spec.ts
+++ b/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.spec.ts
@@ -263,7 +263,7 @@ describe('NotifyReuseFormComponent', () => {
           description: 'notify.reuse.link.description',
         },
       ])
-      expect(saved.contacts).toEqual([
+      expect(saved.contactsForResource).toEqual([
         {
           firstName: 'John',
           lastName: 'Doe',

--- a/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.ts
+++ b/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.ts
@@ -192,8 +192,8 @@ export class NotifyReuseFormComponent implements OnDestroy {
       legalConstraints: [NOT_KNOWN_CONSTRAINT],
       securityConstraints: [],
       otherConstraints: [],
-      contacts: [contact],
-      contactsForResource: [],
+      contacts: [],
+      contactsForResource: [contact],
       lineage: '',
       sourceRecords: [
         {


### PR DESCRIPTION
### Description

This PR is a follow-up on https://github.com/geonetwork/geonetwork-ui/pull/1662.

It switches from contacts to contactsForResource when declaring and light editing a reuse. This is the proper way to manage contacts for a reuse declared from the Datahub, and it allows the user to see the edits right away in the Datahub.

It also removes the top bar edit button in the Datahub reuse page, when the `notify-reuse` feature is activated, to prevent users from missclicking. The top bar button was initially meant as a shortcut for editor users on a platform to quickly access the full edit page, but when a platform activates the `notify-reuse` feature, priority is given to the light edit page for reuses.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

- serve both the DataHub and the Metadata-Editor
- in the default.toml, set the `reuse_form_url` to point to the Metadata-Editor url
- login with the John Doe user: johndoe/p4ssworD_
- navigate to a dataset record, for example http://localhost:4200/dataset/ed34db28-5dd4-480f-bf29-dc08f0086131
- click on the "Declare a reuse" button, fill the form, submit
- check that the name, surname and organization are correctly set in the light edit page
- go back to the reuse page in the DataHub
- check that the contact is correctly displayed in the DataHub, both as main contact and in the list of contacts
<img width="1019" height="364" alt="image" src="https://github.com/user-attachments/assets/916dc0b8-7208-4bf3-90b5-8283dbc9c268" />

---

**This work is sponsored by [DataGrandEst](https://www.datagrandest.fr)**.