### PR TITLE
fix(ui): fix pagination dots not centered in firefox

### DIFF
--- a/libs/ui/layout/src/lib/block-list/block-list.component.css
+++ b/libs/ui/layout/src/lib/block-list/block-list.component.css
@@ -3,6 +3,7 @@
 }
 
 :host {
+  display: block;
   position: relative;
 }
 


### PR DESCRIPTION
### Description

Fixes #1387: pagination dots (used by `gn-ui-block-list`, e.g. the "Links" / "Downloads" / "API" sections of a record page) were not displayed properly in Firefox — only the first dot was visible, cut off at the left edge, instead of all dots centered.

Root cause: `gn-ui-block-list`'s host element only set `position: relative`, leaving `display` at its default (`inline`, since it's a custom element). Combining `position: relative` with `display: inline` on a containing block is a known cross-browser inconsistency for how the containing block is resolved for absolutely-positioned, percentage-width descendants. The pagination dots container (`position: absolute; width: 100%`) resolved against that ambiguous containing block — Chrome sized it correctly (full width), Firefox collapsed it to a few pixels, and `overflow-hidden` clipped everything but the first dot.

Fix: explicitly set `display: block` on `gn-ui-block-list`'s `:host`, making the containing block unambiguous in both engines.

### Architectural changes

None.

### Screenshots

N/A (CSS-only fix; verified visually in both Chrome and Firefox — see "How to test").

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [x] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

1. Open a record page with more than one page of links (e.g. "Links", "Downloads", or "API" section with enough items to paginate) in Firefox.
2. Before this fix: only the first pagination dot is visible (cut off at the left), the rest are clipped.
3. After this fix: all pagination dots render, centered, and paging through them works the same as in Chrome.
4. Alternatively, use the Storybook story `Layout/BlockListComponent` (17 items, `pageSize: 5`) for a deterministic repro independent of catalog data.