### PR TITLE
Type association types, rename identifier field

### DIFF
--- a/libs/api/metadata-converter/src/lib/fixtures/generic.records.ts
+++ b/libs/api/metadata-converter/src/lib/fixtures/generic.records.ts
@@ -195,23 +195,23 @@ As such, **it is not very interesting at all.**`,
   sourceRecords: [],
   associatedRecords: [
     {
-      uuid: 'b1882436-3016-421e-9dfd-0326cca998f2',
+      uniqueIdentifier: 'b1882436-3016-421e-9dfd-0326cca998f2',
       associationType: 'crossReference',
     },
     {
-      uuid: 'b1741571-bbda-4732-a807-cbc36b64d54f',
+      uniqueIdentifier: 'b1741571-bbda-4732-a807-cbc36b64d54f',
       associationType: 'crossReference',
     },
     {
-      uuid: 'bdcb789c-4b02-4c0c-863a-98dac4ed0240',
+      uniqueIdentifier: 'bdcb789c-4b02-4c0c-863a-98dac4ed0240',
       associationType: 'crossReference',
     },
     {
-      uuid: 'c0112b86-a6e3-4df3-9da1-2927376076f4',
+      uniqueIdentifier: 'c0112b86-a6e3-4df3-9da1-2927376076f4',
       associationType: 'partOfSeamlessDatabase',
     },
     {
-      uuid: '7451e2bd-22e8-4a74-a999-01c58b630369',
+      uniqueIdentifier: '7451e2bd-22e8-4a74-a999-01c58b630369',
       associationType: 'largerWorkCitation',
     },
   ],

--- a/libs/api/metadata-converter/src/lib/fixtures/metawal.records.ts
+++ b/libs/api/metadata-converter/src/lib/fixtures/metawal.records.ts
@@ -422,23 +422,23 @@ Depuis, ce sont les Districts routiers qui assurent la tenue à jour de ces info
   sourceRecords: [],
   associatedRecords: [
     {
-      uuid: 'b1882436-3016-421e-9dfd-0326cca998f2',
+      uniqueIdentifier: 'b1882436-3016-421e-9dfd-0326cca998f2',
       associationType: 'crossReference',
     },
     {
-      uuid: 'b1741571-bbda-4732-a807-cbc36b64d54f',
+      uniqueIdentifier: 'b1741571-bbda-4732-a807-cbc36b64d54f',
       associationType: 'crossReference',
     },
     {
-      uuid: 'bdcb789c-4b02-4c0c-863a-98dac4ed0240',
+      uniqueIdentifier: 'bdcb789c-4b02-4c0c-863a-98dac4ed0240',
       associationType: 'crossReference',
     },
     {
-      uuid: 'c0112b86-a6e3-4df3-9da1-2927376076f4',
+      uniqueIdentifier: 'c0112b86-a6e3-4df3-9da1-2927376076f4',
       associationType: 'partOfSeamlessDatabase',
     },
     {
-      uuid: '7451e2bd-22e8-4a74-a999-01c58b630369',
+      uniqueIdentifier: '7451e2bd-22e8-4a74-a999-01c58b630369',
       associationType: 'largerWorkCitation',
     },
   ],

--- a/libs/api/metadata-converter/src/lib/iso19115-3/read-parts.spec.ts
+++ b/libs/api/metadata-converter/src/lib/iso19115-3/read-parts.spec.ts
@@ -601,7 +601,7 @@ describe('read parts', () => {
 </mdb:MD_Metadata>`)
         )
         expect(readAssociatedRecords(root)).toEqual([
-          { uuid: 'abc-123', associationType: 'crossReference' },
+          { uniqueIdentifier: 'abc-123', associationType: 'crossReference' },
         ])
       })
     })
@@ -673,8 +673,8 @@ describe('read parts', () => {
 </mdb:MD_Metadata>`)
         )
         expect(readAssociatedRecords(root)).toEqual([
-          { uuid: 'uuid-1', associationType: 'crossReference' },
-          { uuid: 'uuid-2', associationType: 'largerWorkCitation' },
+          { uniqueIdentifier: 'uuid-1', associationType: 'crossReference' },
+          { uniqueIdentifier: 'uuid-2', associationType: 'largerWorkCitation' },
         ])
       })
     })

--- a/libs/api/metadata-converter/src/lib/iso19115-3/write-parts.spec.ts
+++ b/libs/api/metadata-converter/src/lib/iso19115-3/write-parts.spec.ts
@@ -861,13 +861,13 @@ describe('write parts', () => {
       })
     })
 
-    describe('associatedRecords has an entry with an empty uuid', () => {
+    describe('associatedRecords has an entry with an empty identifier', () => {
       it('does not serialize it', () => {
         writeAssociatedRecords(
           {
             ...datasetRecord,
             associatedRecords: [
-              { uuid: '', associationType: 'crossReference' },
+              { uniqueIdentifier: '', associationType: 'crossReference' },
             ],
           },
           rootEl
@@ -886,7 +886,10 @@ describe('write parts', () => {
           {
             ...datasetRecord,
             associatedRecords: [
-              { uuid: 'abc-123', associationType: 'crossReference' },
+              {
+                uniqueIdentifier: 'abc-123',
+                associationType: 'crossReference',
+              },
             ],
           },
           rootEl
@@ -914,8 +917,11 @@ describe('write parts', () => {
           {
             ...datasetRecord,
             associatedRecords: [
-              { uuid: 'uuid-1', associationType: 'crossReference' },
-              { uuid: 'uuid-2', associationType: 'largerWorkCitation' },
+              { uniqueIdentifier: 'uuid-1', associationType: 'crossReference' },
+              {
+                uniqueIdentifier: 'uuid-2',
+                associationType: 'largerWorkCitation',
+              },
             ],
           },
           rootEl
@@ -967,7 +973,7 @@ describe('write parts', () => {
           {
             ...datasetRecord,
             associatedRecords: [
-              { uuid: 'new-uuid', associationType: 'stereoMate' },
+              { uniqueIdentifier: 'new-uuid', associationType: 'stereoMate' },
             ],
           },
           rootEl

--- a/libs/api/metadata-converter/src/lib/iso19115-3/write-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19115-3/write-parts.ts
@@ -587,7 +587,7 @@ export function writeAssociatedRecords(
     removeChildrenByName('mri:associatedResource'),
     appendChildren(
       ...record.associatedRecords
-        .filter((assoc) => assoc.uuid && assoc.associationType)
+        .filter((assoc) => assoc.uniqueIdentifier && assoc.associationType)
         .map((assoc) =>
           pipe(
             createNestedElement(
@@ -608,7 +608,7 @@ export function writeAssociatedRecords(
               ),
               pipe(
                 createElement('mri:metadataReference'),
-                writeAttribute('uuidref', assoc.uuid)
+                writeAttribute('uuidref', assoc.uniqueIdentifier)
               )
             )
           )

--- a/libs/api/metadata-converter/src/lib/iso19139/read-parts.spec.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/read-parts.spec.ts
@@ -917,7 +917,7 @@ describe('read parts', () => {
           expect(readAssociatedRecords(recordRootEl)).toEqual([])
         })
       })
-      describe('association type outside the shared values', () => {
+      describe('association type outside the codelist', () => {
         beforeEach(() => {
           const aggregationInfoEl = getRootElement(
             parseXmlString(`
@@ -931,7 +931,7 @@ describe('read parts', () => {
       </gmd:MD_Identifier>
     </gmd:aggregateDataSetIdentifier>
     <gmd:associationType>
-      <gmd:DS_AssociationTypeCode codeListValue="isComposedOf"/>
+      <gmd:DS_AssociationTypeCode codeListValue="source"/>
     </gmd:associationType>
   </gmd:MD_AggregateInformation>
 </gmd:aggregationInfo>`)
@@ -941,9 +941,9 @@ describe('read parts', () => {
             appendChildren(() => aggregationInfoEl)
           )(recordRootEl)
         })
-        it('maps the association type to other', () => {
+        it('maps the association type to crossReference', () => {
           expect(readAssociatedRecords(recordRootEl)).toEqual([
-            { uniqueIdentifier: 'abc-123', associationType: 'other' },
+            { uniqueIdentifier: 'abc-123', associationType: 'crossReference' },
           ])
         })
       })

--- a/libs/api/metadata-converter/src/lib/iso19139/read-parts.spec.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/read-parts.spec.ts
@@ -833,7 +833,7 @@ describe('read parts', () => {
           expect(readAssociatedRecords(recordRootEl)).toEqual([])
         })
       })
-      describe('one aggregationInfo with uuid and type', () => {
+      describe('one aggregationInfo with an identifier and a type', () => {
         beforeEach(() => {
           const aggregationInfoEl = getRootElement(
             parseXmlString(`
@@ -859,11 +859,11 @@ describe('read parts', () => {
         })
         it('returns the association', () => {
           expect(readAssociatedRecords(recordRootEl)).toEqual([
-            { uuid: 'abc-123', associationType: 'crossReference' },
+            { uniqueIdentifier: 'abc-123', associationType: 'crossReference' },
           ])
         })
       })
-      describe('uuid stored as gmx:Anchor', () => {
+      describe('identifier stored as gmx:Anchor', () => {
         beforeEach(() => {
           const aggregationInfoEl = getRootElement(
             parseXmlString(`
@@ -887,13 +887,13 @@ describe('read parts', () => {
             appendChildren(() => aggregationInfoEl)
           )(recordRootEl)
         })
-        it('returns the association with the anchor text as uuid', () => {
+        it('returns the association with the anchor text as the identifier', () => {
           expect(readAssociatedRecords(recordRootEl)).toEqual([
-            { uuid: 'anchor-uuid', associationType: 'source' },
+            { uniqueIdentifier: 'anchor-uuid', associationType: 'source' },
           ])
         })
       })
-      describe('missing uuid', () => {
+      describe('missing identifier', () => {
         beforeEach(() => {
           const aggregationInfoEl = getRootElement(
             parseXmlString(`
@@ -983,8 +983,11 @@ describe('read parts', () => {
         })
         it('returns all associations, in order', () => {
           expect(readAssociatedRecords(recordRootEl)).toEqual([
-            { uuid: 'uuid-1', associationType: 'crossReference' },
-            { uuid: 'uuid-2', associationType: 'largerWorkCitation' },
+            { uniqueIdentifier: 'uuid-1', associationType: 'crossReference' },
+            {
+              uniqueIdentifier: 'uuid-2',
+              associationType: 'largerWorkCitation',
+            },
           ])
         })
       })

--- a/libs/api/metadata-converter/src/lib/iso19139/read-parts.spec.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/read-parts.spec.ts
@@ -877,7 +877,7 @@ describe('read parts', () => {
       </gmd:MD_Identifier>
     </gmd:aggregateDataSetIdentifier>
     <gmd:associationType>
-      <gmd:DS_AssociationTypeCode codeListValue="source"/>
+      <gmd:DS_AssociationTypeCode codeListValue="crossReference"/>
     </gmd:associationType>
   </gmd:MD_AggregateInformation>
 </gmd:aggregationInfo>`)
@@ -889,7 +889,10 @@ describe('read parts', () => {
         })
         it('returns the association with the anchor text as the identifier', () => {
           expect(readAssociatedRecords(recordRootEl)).toEqual([
-            { uniqueIdentifier: 'anchor-uuid', associationType: 'source' },
+            {
+              uniqueIdentifier: 'anchor-uuid',
+              associationType: 'crossReference',
+            },
           ])
         })
       })
@@ -912,6 +915,36 @@ describe('read parts', () => {
         })
         it('ignores the association', () => {
           expect(readAssociatedRecords(recordRootEl)).toEqual([])
+        })
+      })
+      describe('association type outside the shared values', () => {
+        beforeEach(() => {
+          const aggregationInfoEl = getRootElement(
+            parseXmlString(`
+<gmd:aggregationInfo>
+  <gmd:MD_AggregateInformation>
+    <gmd:aggregateDataSetIdentifier>
+      <gmd:MD_Identifier>
+        <gmd:code>
+          <gco:CharacterString>abc-123</gco:CharacterString>
+        </gmd:code>
+      </gmd:MD_Identifier>
+    </gmd:aggregateDataSetIdentifier>
+    <gmd:associationType>
+      <gmd:DS_AssociationTypeCode codeListValue="isComposedOf"/>
+    </gmd:associationType>
+  </gmd:MD_AggregateInformation>
+</gmd:aggregationInfo>`)
+          )
+          pipe(
+            findIdentification(),
+            appendChildren(() => aggregationInfoEl)
+          )(recordRootEl)
+        })
+        it('maps the association type to other', () => {
+          expect(readAssociatedRecords(recordRootEl)).toEqual([
+            { uniqueIdentifier: 'abc-123', associationType: 'other' },
+          ])
         })
       })
       describe('missing association type', () => {

--- a/libs/api/metadata-converter/src/lib/iso19139/read-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/read-parts.ts
@@ -939,7 +939,7 @@ export function extractAssociatedRecords(
     mapArray((el) => {
       const aggregateEl = findChildElement(aggregateName, false)(el)
       const uniqueIdentifier = readIdentifier(aggregateEl)
-      // kept as read, so that a value outside the codelist survives a round trip
+      // kept as read, so that a value outside the shared set survives a round trip
       const associationType = pipe(
         findNestedElement('gmd:associationType', 'gmd:DS_AssociationTypeCode'),
         readAttribute('codeListValue')

--- a/libs/api/metadata-converter/src/lib/iso19139/read-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/read-parts.ts
@@ -1,6 +1,5 @@
 import {
   AssociatedRecord,
-  AssociationType,
   Constraint,
   ConstraintTranslations,
   DatasetOnlineResource,
@@ -52,6 +51,7 @@ import {
   readText,
   XmlElement,
 } from '../xml-utils'
+import { getAssociationTypeFromCode } from './utils/association-type.mapper'
 import { readGeometry } from './utils/geometry'
 import { fullNameToParts } from './utils/individual-name'
 import { getKeywordTypeFromKeywordTypeCode } from './utils/keyword.mapper'
@@ -939,13 +939,15 @@ export function extractAssociatedRecords(
     mapArray((el) => {
       const aggregateEl = findChildElement(aggregateName, false)(el)
       const uniqueIdentifier = readIdentifier(aggregateEl)
-      // kept as read, so that a value outside the shared set survives a round trip
-      const associationType = pipe(
+      const associationTypeCode = pipe(
         findNestedElement('gmd:associationType', 'gmd:DS_AssociationTypeCode'),
         readAttribute('codeListValue')
-      )(aggregateEl) as AssociationType
-      if (!uniqueIdentifier || !associationType) return null
-      return { uniqueIdentifier, associationType }
+      )(aggregateEl)
+      if (!uniqueIdentifier || !associationTypeCode) return null
+      return {
+        uniqueIdentifier,
+        associationType: getAssociationTypeFromCode(associationTypeCode),
+      }
     }),
     filterArray((r): r is AssociatedRecord => r !== null)
   )

--- a/libs/api/metadata-converter/src/lib/iso19139/read-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/read-parts.ts
@@ -1,5 +1,6 @@
 import {
   AssociatedRecord,
+  AssociationType,
   Constraint,
   ConstraintTranslations,
   DatasetOnlineResource,
@@ -931,19 +932,20 @@ export function readSourceRecords(rootEl: XmlElement): SourceRecord[] {
 export function extractAssociatedRecords(
   containerName: string,
   aggregateName: string,
-  readUuid: ChainableFunction<XmlElement, string>
+  readIdentifier: ChainableFunction<XmlElement, string>
 ): ChainableFunction<XmlElement, AssociatedRecord[]> {
   return pipe(
     findChildrenElement(containerName, false),
     mapArray((el) => {
       const aggregateEl = findChildElement(aggregateName, false)(el)
-      const uuid = readUuid(aggregateEl)
+      const uniqueIdentifier = readIdentifier(aggregateEl)
+      // kept as read, so that a value outside the codelist survives a round trip
       const associationType = pipe(
         findNestedElement('gmd:associationType', 'gmd:DS_AssociationTypeCode'),
         readAttribute('codeListValue')
-      )(aggregateEl)
-      if (!uuid || !associationType) return null
-      return { uuid, associationType }
+      )(aggregateEl) as AssociationType
+      if (!uniqueIdentifier || !associationType) return null
+      return { uniqueIdentifier, associationType }
     }),
     filterArray((r): r is AssociatedRecord => r !== null)
   )

--- a/libs/api/metadata-converter/src/lib/iso19139/utils/association-type.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/utils/association-type.mapper.ts
@@ -1,0 +1,12 @@
+import {
+  AssociationType,
+  associationTypeValues,
+} from '@geonetwork-ui/common/domain/model/record'
+
+export function getAssociationTypeFromCode(
+  associationTypeCode: string
+): AssociationType {
+  return associationTypeValues.includes(associationTypeCode as AssociationType)
+    ? (associationTypeCode as AssociationType)
+    : 'other'
+}

--- a/libs/api/metadata-converter/src/lib/iso19139/utils/association-type.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/utils/association-type.mapper.ts
@@ -8,5 +8,5 @@ export function getAssociationTypeFromCode(
 ): AssociationType {
   return associationTypeValues.includes(associationTypeCode as AssociationType)
     ? (associationTypeCode as AssociationType)
-    : 'other'
+    : 'crossReference'
 }

--- a/libs/api/metadata-converter/src/lib/iso19139/write-parts.spec.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/write-parts.spec.ts
@@ -1287,13 +1287,13 @@ describe('write parts', () => {
       })
     })
 
-    describe('associatedRecords has an entry with an empty uuid', () => {
+    describe('associatedRecords has an entry with an empty identifier', () => {
       it('does not serialize it', () => {
         writeAssociatedRecords(
           {
             ...datasetRecord,
             associatedRecords: [
-              { uuid: '', associationType: 'crossReference' },
+              { uniqueIdentifier: '', associationType: 'crossReference' },
             ],
           },
           rootEl
@@ -1312,7 +1312,10 @@ describe('write parts', () => {
           {
             ...datasetRecord,
             associatedRecords: [
-              { uuid: 'abc-123', associationType: 'crossReference' },
+              {
+                uniqueIdentifier: 'abc-123',
+                associationType: 'crossReference',
+              },
             ],
           },
           rootEl
@@ -1346,8 +1349,11 @@ describe('write parts', () => {
           {
             ...datasetRecord,
             associatedRecords: [
-              { uuid: 'uuid-1', associationType: 'crossReference' },
-              { uuid: 'uuid-2', associationType: 'largerWorkCitation' },
+              { uniqueIdentifier: 'uuid-1', associationType: 'crossReference' },
+              {
+                uniqueIdentifier: 'uuid-2',
+                associationType: 'largerWorkCitation',
+              },
             ],
           },
           rootEl
@@ -1417,7 +1423,7 @@ describe('write parts', () => {
           {
             ...datasetRecord,
             associatedRecords: [
-              { uuid: 'new-uuid', associationType: 'stereoMate' },
+              { uniqueIdentifier: 'new-uuid', associationType: 'stereoMate' },
             ],
           },
           rootEl

--- a/libs/api/metadata-converter/src/lib/iso19139/write-parts.ts
+++ b/libs/api/metadata-converter/src/lib/iso19139/write-parts.ts
@@ -1276,7 +1276,7 @@ export function writeAssociatedRecords(
     removeChildrenByName('gmd:aggregationInfo'),
     appendChildren(
       ...record.associatedRecords
-        .filter((assoc) => assoc.uuid && assoc.associationType)
+        .filter((assoc) => assoc.uniqueIdentifier && assoc.associationType)
         .map((assoc) =>
           pipe(
             createNestedElement(
@@ -1290,7 +1290,7 @@ export function writeAssociatedRecords(
                   'gmd:MD_Identifier',
                   'gmd:code'
                 ),
-                writeCharacterString(assoc.uuid)
+                writeCharacterString(assoc.uniqueIdentifier)
               ),
               pipe(
                 createNestedElement(

--- a/libs/common/domain/src/lib/model/record/metadata.model.ts
+++ b/libs/common/domain/src/lib/model/record/metadata.model.ts
@@ -260,12 +260,29 @@ export interface SourceRecord {
   href?: string
 }
 
+// hardcoded from the DS_AssociationTypeCode codelists of both standards; the first
+// four are defined by both, 'source' only by ISO19139 and the rest only by ISO19115-3
+export const associationTypeValues = [
+  'crossReference',
+  'largerWorkCitation',
+  'partOfSeamlessDatabase',
+  'stereoMate',
+  'source',
+  'isComposedOf',
+  'collectiveTitle',
+  'series',
+  'dependency',
+  'revisionOf',
+] as const
+
+export type AssociationType = (typeof associationTypeValues)[number]
+
 /**
  * Represents another record associated with this one (e.g. a parent/sibling dataset).
  */
 export interface AssociatedRecord {
-  uuid: string
-  associationType: string
+  uniqueIdentifier: string
+  associationType: AssociationType
 }
 
 export interface DatasetRecord extends BaseRecord {

--- a/libs/common/domain/src/lib/model/record/metadata.model.ts
+++ b/libs/common/domain/src/lib/model/record/metadata.model.ts
@@ -260,14 +260,18 @@ export interface SourceRecord {
   href?: string
 }
 
-// DS_AssociationTypeCode values shared by ISO19139 and ISO19115-3, any other value
-// being mapped to 'other'
+// DS_AssociationTypeCode values of the ISO19115-3 codelist, any unrecognized value
+// being mapped to 'crossReference'
 export const associationTypeValues = [
   'crossReference',
   'largerWorkCitation',
   'partOfSeamlessDatabase',
   'stereoMate',
-  'other',
+  'isComposedOf',
+  'collectiveTitle',
+  'series',
+  'dependency',
+  'revisionOf',
 ] as const
 
 export type AssociationType = (typeof associationTypeValues)[number]

--- a/libs/common/domain/src/lib/model/record/metadata.model.ts
+++ b/libs/common/domain/src/lib/model/record/metadata.model.ts
@@ -260,12 +260,14 @@ export interface SourceRecord {
   href?: string
 }
 
-// DS_AssociationTypeCode values shared by ISO19139 and ISO19115-3
+// DS_AssociationTypeCode values shared by ISO19139 and ISO19115-3, any other value
+// being mapped to 'other'
 export const associationTypeValues = [
   'crossReference',
   'largerWorkCitation',
   'partOfSeamlessDatabase',
   'stereoMate',
+  'other',
 ] as const
 
 export type AssociationType = (typeof associationTypeValues)[number]

--- a/libs/common/domain/src/lib/model/record/metadata.model.ts
+++ b/libs/common/domain/src/lib/model/record/metadata.model.ts
@@ -260,19 +260,12 @@ export interface SourceRecord {
   href?: string
 }
 
-// hardcoded from the DS_AssociationTypeCode codelists of both standards; the first
-// four are defined by both, 'source' only by ISO19139 and the rest only by ISO19115-3
+// DS_AssociationTypeCode values shared by ISO19139 and ISO19115-3
 export const associationTypeValues = [
   'crossReference',
   'largerWorkCitation',
   'partOfSeamlessDatabase',
   'stereoMate',
-  'source',
-  'isComposedOf',
-  'collectiveTitle',
-  'series',
-  'dependency',
-  'revisionOf',
 ] as const
 
 export type AssociationType = (typeof associationTypeValues)[number]


### PR DESCRIPTION
### Description

Follow-up to #1661, addressing review feedback:

- `AssociatedRecord.associationType` was a bare `string`; it's now an `AssociationType` union derived from `associationTypeValues`
- `AssociatedRecord.uuid` is renamed to `uniqueIdentifier`


### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

No behavior change to verify manually.
