### PR TITLE
[Notify-Reuse]: remove first and last name

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset/datasetNotifyReuse.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetNotifyReuse.cy.ts
@@ -148,8 +148,6 @@ describe('Declare a reuse', () => {
       cy.wait('@saveRecord')
         .its('request.body')
         .should('contain', 'My great reuse')
-        .should('contain', 'Barbara')
-        .should('contain', 'Roberts')
         .should('contain', 'Barbie Inc.')
       cy.get('.cdk-overlay-container').should(
         'not.contain.text',

--- a/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.spec.ts
+++ b/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.spec.ts
@@ -265,8 +265,6 @@ describe('NotifyReuseFormComponent', () => {
       ])
       expect(saved.contactsForResource).toEqual([
         {
-          firstName: 'John',
-          lastName: 'Doe',
           email: 'reuser@example.com',
           role: 'point_of_contact',
           organization: { name: 'Owner Org' },

--- a/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.ts
+++ b/libs/feature/notify-reuse/src/lib/notify-reuse-form/notify-reuse-form.component.ts
@@ -166,8 +166,6 @@ export class NotifyReuseFormComponent implements OnDestroy {
       description: this.translate.instant('notify.reuse.link.description'),
     }
     const contact: Individual = {
-      firstName: this.me()?.name,
-      lastName: this.me()?.surname,
       email: this.email(),
       role: 'point_of_contact',
       organization: { name: this.me()?.organisation },


### PR DESCRIPTION
### Description

This PR is a follow up on https://github.com/geonetwork/geonetwork-ui/pull/1662 and https://github.com/geonetwork/geonetwork-ui/pull/1666.

It removes the firstname and lastname from the notified reuse, as the user can't edit those in the first declaration form, and those information are personal (the organization is kept, as it is not personal, and hard to write correctly). 

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [X] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

- Serve both the DataHub and the Metadata-Editor
- In the default.toml, set the reuse_form_url to point to the Metadata-Editor url
- login with the John Doe user: johndoe/p4ssworD_
- navigate to a dataset record, for example http://localhost:4200/dataset/ed34db28-5dd4-480f-bf29-dc08f0086131
- click on the "Declare a reuse" button, fill the form, submit
- Check that the name and surname are not set in the light edit page
- Check that the organization is correctly set in the light edit page

---

**This work is sponsored by [DataGrandEst](https://www.datagrandest.fr)**.