### PR TITLE
[Webcomponents]: restore extracted material styles

### DIFF
--- a/apps/webcomponents/src/material-styles.css
+++ b/apps/webcomponents/src/material-styles.css
@@ -1,0 +1,483 @@
+/* These classes were extracted from the full Material theme to save size */
+.cdk-overlay-pane {
+  position: absolute;
+  pointer-events: auto;
+  box-sizing: border-box;
+  z-index: 1000;
+  display: flex;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.cdk-overlay-connected-position-bounding-box {
+  position: absolute;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  min-width: 1px;
+  min-height: 1px;
+}
+
+.cdk-overlay-backdrop {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  pointer-events: auto;
+  transition: opacity 400ms cubic-bezier(0.25, 0.8, 0.25, 1);
+  opacity: 0;
+}
+
+.cdk-overlay-backdrop.cdk-overlay-backdrop-showing {
+  opacity: 1;
+}
+
+.cdk-overlay-transparent-backdrop {
+  transition:
+    visibility 1ms linear,
+    opacity 1ms linear;
+  visibility: hidden;
+  opacity: 1;
+}
+
+.cdk-overlay-transparent-backdrop.cdk-overlay-backdrop-showing {
+  opacity: 0;
+  visibility: visible;
+}
+
+.mat-mdc-option.suggestion.mat-mdc-option-active {
+  background-color: var(--color-primary-lightest);
+}
+
+/* TODO(mdc-migration): The following rule targets internal classes of autocomplete that may no longer apply for the MDC version. */
+.mat-mdc-autocomplete-panel
+  .mat-mdc-option.mat-selected:not(.mat-active):not(:hover):not(
+    .mat-option-disabled
+  ) {
+  color: rgba(0, 0, 0, 0.87);
+}
+
+.mat-mdc-option:hover:not(.mat-option-disabled),
+.mat-mdc-option:focus:not(.mat-option-disabled) {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+/* TODO(mdc-migration): The following rule targets internal classes of option that may no longer apply for the MDC version. */
+.mat-mdc-option.mat-selected:not(.mat-mdc-option-multiple):not(
+    .mat-option-disabled
+  ) {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.mat-mdc-select-panel
+  .mat-mdc-option.mat-selected:not(.mat-mdc-option-multiple) {
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.mdc-menu-surface.mat-mdc-autocomplete-panel {
+  margin-top: 10px !important;
+  border-radius: 8px;
+  background: white;
+  box-shadow:
+    0 2px 4px -1px #0003,
+    0 4px 5px #00000024,
+    0 1px 10px #0000001f;
+}
+
+/* set up CSS variables for material (extracted from the prebuilt theme) */
+:host {
+  --mat-tab-container-height: 48px;
+  --mat-tab-divider-color: transparent;
+  --mat-tab-divider-height: 0;
+  --mat-tab-active-indicator-height: 2px;
+  --mat-tab-active-indicator-shape: 0;
+  --mat-checkbox-disabled-selected-checkmark-color: white;
+  --mat-checkbox-selected-focus-state-layer-opacity: 0.12;
+  --mat-checkbox-selected-hover-state-layer-opacity: 0.04;
+  --mat-checkbox-selected-pressed-state-layer-opacity: 0.12;
+  --mat-checkbox-unselected-focus-state-layer-opacity: 0.12;
+  --mat-checkbox-unselected-hover-state-layer-opacity: 0.04;
+  --mat-checkbox-unselected-pressed-state-layer-opacity: 0.12;
+  --mat-checkbox-touch-target-size: 48px;
+  --mat-checkbox-disabled-label-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-checkbox-label-text-color: rgba(0, 0, 0, 0.87);
+  --mat-checkbox-disabled-selected-icon-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-checkbox-disabled-unselected-icon-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-checkbox-selected-checkmark-color: white;
+  --mat-checkbox-selected-focus-icon-color: #ff4081;
+  --mat-checkbox-selected-hover-icon-color: #ff4081;
+  --mat-checkbox-selected-icon-color: #ff4081;
+  --mat-checkbox-selected-pressed-icon-color: #ff4081;
+  --mat-checkbox-unselected-focus-icon-color: rgba(0, 0, 0, 0.87);
+  --mat-checkbox-unselected-hover-icon-color: rgba(0, 0, 0, 0.87);
+  --mat-checkbox-unselected-icon-color: rgba(0, 0, 0, 0.54);
+  --mat-checkbox-selected-focus-state-layer-color: #ff4081;
+  --mat-checkbox-selected-hover-state-layer-color: #ff4081;
+  --mat-checkbox-selected-pressed-state-layer-color: #ff4081;
+  --mat-checkbox-unselected-focus-state-layer-color: rgba(0, 0, 0, 0.87);
+  --mat-checkbox-unselected-hover-state-layer-color: rgba(0, 0, 0, 0.87);
+  --mat-checkbox-unselected-pressed-state-layer-color: rgba(0, 0, 0, 0.87);
+  --mat-checkbox-touch-target-display: block;
+  --mat-checkbox-state-layer-size: 40px;
+  --mat-checkbox-label-text-font: Roboto, sans-serif;
+  --mat-checkbox-label-text-line-height: 20px;
+  --mat-checkbox-label-text-size: 14px;
+  --mat-checkbox-label-text-tracking: 0.0178571429em;
+  --mat-checkbox-label-text-weight: 400;
+  --mat-button-filled-container-shape: 4px;
+  --mat-button-filled-horizontal-padding: 16px;
+  --mat-button-filled-icon-offset: -4px;
+  --mat-button-filled-icon-spacing: 8px;
+  --mat-button-filled-touch-target-size: 48px;
+  --mat-button-outlined-container-shape: 4px;
+  --mat-button-outlined-horizontal-padding: 15px;
+  --mat-button-outlined-icon-offset: -4px;
+  --mat-button-outlined-icon-spacing: 8px;
+  --mat-button-outlined-keep-touch-target: false;
+  --mat-button-outlined-outline-width: 1px;
+  --mat-button-outlined-touch-target-size: 48px;
+  --mat-button-protected-container-elevation-shadow: 0px 3px 1px -2px
+      rgba(0, 0, 0, 0.2),
+    0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
+  --mat-button-protected-container-shape: 4px;
+  --mat-button-protected-disabled-container-elevation-shadow: 0px 0px 0px 0px
+      rgba(0, 0, 0, 0.2),
+    0px 0px 0px 0px rgba(0, 0, 0, 0.14), 0px 0px 0px 0px rgba(0, 0, 0, 0.12);
+  --mat-button-protected-focus-container-elevation-shadow: 0px 2px 4px -1px
+      rgba(0, 0, 0, 0.2),
+    0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12);
+  --mat-button-protected-horizontal-padding: 16px;
+  --mat-button-protected-hover-container-elevation-shadow: 0px 2px 4px -1px
+      rgba(0, 0, 0, 0.2),
+    0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12);
+  --mat-button-protected-icon-offset: -4px;
+  --mat-button-protected-icon-spacing: 8px;
+  --mat-button-protected-pressed-container-elevation-shadow: 0px 5px 5px -3px
+      rgba(0, 0, 0, 0.2),
+    0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12);
+  --mat-button-protected-touch-target-size: 48px;
+  --mat-button-text-container-shape: 4px;
+  --mat-button-text-horizontal-padding: 8px;
+  --mat-button-text-icon-offset: 0;
+  --mat-button-text-icon-spacing: 8px;
+  --mat-button-text-with-icon-horizontal-padding: 8px;
+  --mat-button-text-touch-target-size: 48px;
+  --mat-button-tonal-container-shape: 4px;
+  --mat-button-tonal-horizontal-padding: 16px;
+  --mat-button-tonal-icon-offset: -4px;
+  --mat-button-tonal-icon-spacing: 8px;
+  --mat-button-tonal-touch-target-size: 48px;
+  --mat-button-filled-container-color: white;
+  --mat-button-filled-disabled-container-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 12%,
+    transparent
+  );
+  --mat-button-filled-disabled-label-text-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-button-filled-disabled-state-layer-color: rgba(0, 0, 0, 0.54);
+  --mat-button-filled-focus-state-layer-opacity: 0.12;
+  --mat-button-filled-hover-state-layer-opacity: 0.04;
+  --mat-button-filled-label-text-color: rgba(0, 0, 0, 0.87);
+  --mat-button-filled-pressed-state-layer-opacity: 0.12;
+  --mat-button-filled-ripple-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 12%,
+    transparent
+  );
+  --mat-button-filled-state-layer-color: rgba(0, 0, 0, 0.87);
+  --mat-button-outlined-disabled-label-text-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-button-outlined-disabled-outline-color: rgba(0, 0, 0, 0.12);
+  --mat-button-outlined-disabled-state-layer-color: rgba(0, 0, 0, 0.54);
+  --mat-button-outlined-focus-state-layer-opacity: 0.12;
+  --mat-button-outlined-hover-state-layer-opacity: 0.04;
+  --mat-button-outlined-label-text-color: rgba(0, 0, 0, 0.87);
+  --mat-button-outlined-outline-color: rgba(0, 0, 0, 0.12);
+  --mat-button-outlined-pressed-state-layer-opacity: 0.12;
+  --mat-button-outlined-ripple-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 12%,
+    transparent
+  );
+  --mat-button-outlined-state-layer-color: rgba(0, 0, 0, 0.87);
+  --mat-button-protected-container-color: white;
+  --mat-button-protected-disabled-container-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 12%,
+    transparent
+  );
+  --mat-button-protected-disabled-label-text-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-button-protected-disabled-state-layer-color: rgba(0, 0, 0, 0.54);
+  --mat-button-protected-focus-state-layer-opacity: 0.12;
+  --mat-button-protected-hover-state-layer-opacity: 0.04;
+  --mat-button-protected-label-text-color: rgba(0, 0, 0, 0.87);
+  --mat-button-protected-pressed-state-layer-opacity: 0.12;
+  --mat-button-protected-ripple-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 12%,
+    transparent
+  );
+  --mat-button-protected-state-layer-color: rgba(0, 0, 0, 0.87);
+  --mat-button-text-disabled-label-text-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-button-text-disabled-state-layer-color: rgba(0, 0, 0, 0.54);
+  --mat-button-text-focus-state-layer-opacity: 0.12;
+  --mat-button-text-hover-state-layer-opacity: 0.04;
+  --mat-button-text-label-text-color: rgba(0, 0, 0, 0.87);
+  --mat-button-text-pressed-state-layer-opacity: 0.12;
+  --mat-button-text-ripple-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 12%,
+    transparent
+  );
+  --mat-button-text-state-layer-color: rgba(0, 0, 0, 0.87);
+  --mat-button-tonal-container-color: white;
+  --mat-button-tonal-disabled-container-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 12%,
+    transparent
+  );
+  --mat-button-tonal-disabled-label-text-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-button-tonal-disabled-state-layer-color: rgba(0, 0, 0, 0.54);
+  --mat-button-tonal-focus-state-layer-opacity: 0.12;
+  --mat-button-tonal-hover-state-layer-opacity: 0.04;
+  --mat-button-tonal-label-text-color: rgba(0, 0, 0, 0.87);
+  --mat-button-tonal-pressed-state-layer-opacity: 0.12;
+  --mat-button-tonal-ripple-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 12%,
+    transparent
+  );
+  --mat-button-tonal-state-layer-color: rgba(0, 0, 0, 0.87);
+  --mat-button-filled-container-height: 36px;
+  --mat-button-filled-touch-target-display: block;
+  --mat-button-outlined-container-height: 36px;
+  --mat-button-outlined-touch-target-display: block;
+  --mat-button-protected-container-height: 36px;
+  --mat-button-protected-touch-target-display: block;
+  --mat-button-text-container-height: 36px;
+  --mat-button-text-touch-target-display: block;
+  --mat-button-tonal-container-height: 36px;
+  --mat-button-tonal-touch-target-display: block;
+  --mat-button-filled-label-text-font: Roboto, sans-serif;
+  --mat-button-filled-label-text-size: 14px;
+  --mat-button-filled-label-text-tracking: 0.0892857143em;
+  --mat-button-filled-label-text-transform: none;
+  --mat-button-filled-label-text-weight: 500;
+  --mat-button-outlined-label-text-font: Roboto, sans-serif;
+  --mat-button-outlined-label-text-size: 14px;
+  --mat-button-outlined-label-text-tracking: 0.0892857143em;
+  --mat-button-outlined-label-text-transform: none;
+  --mat-button-outlined-label-text-weight: 500;
+  --mat-button-protected-label-text-font: Roboto, sans-serif;
+  --mat-button-protected-label-text-size: 14px;
+  --mat-button-protected-label-text-tracking: 0.0892857143em;
+  --mat-button-protected-label-text-transform: none;
+  --mat-button-protected-label-text-weight: 500;
+  --mat-button-text-label-text-font: Roboto, sans-serif;
+  --mat-button-text-label-text-size: 14px;
+  --mat-button-text-label-text-tracking: 0.0892857143em;
+  --mat-button-text-label-text-transform: none;
+  --mat-button-text-label-text-weight: 500;
+  --mat-button-tonal-label-text-font: Roboto, sans-serif;
+  --mat-button-tonal-label-text-size: 14px;
+  --mat-button-tonal-label-text-tracking: 0.0892857143em;
+  --mat-button-tonal-label-text-transform: none;
+  --mat-button-tonal-label-text-weight: 500;
+  --mat-progress-spinner-active-indicator-width: 4px;
+  --mat-progress-spinner-size: 48px;
+  --mat-progress-spinner-active-indicator-color: #3f51b5;
+  --mat-option-selected-state-label-text-color: #3f51b5;
+  --mat-option-label-text-color: rgba(0, 0, 0, 0.87);
+  --mat-option-hover-state-layer-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 4%,
+    transparent
+  );
+  --mat-option-focus-state-layer-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 12%,
+    transparent
+  );
+  --mat-option-selected-state-layer-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 12%,
+    transparent
+  );
+  --mat-dialog-container-shape: 4px;
+  --mat-dialog-container-elevation-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2),
+    0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
+  --mat-dialog-container-max-width: 80vw;
+  --mat-dialog-container-small-max-width: 80vw;
+  --mat-dialog-container-min-width: 0;
+  --mat-dialog-actions-alignment: start;
+  --mat-dialog-actions-padding: 8px;
+  --mat-dialog-content-padding: 20px 24px;
+  --mat-dialog-with-actions-content-padding: 20px 24px;
+  --mat-dialog-headline-padding: 0 24px 9px;
+  --mat-dialog-container-color: white;
+  --mat-dialog-subhead-color: rgba(0, 0, 0, 0.87);
+  --mat-dialog-supporting-text-color: rgba(0, 0, 0, 0.54);
+  --mat-dialog-subhead-font: Roboto, sans-serif;
+  --mat-dialog-subhead-line-height: 32px;
+  --mat-dialog-subhead-size: 20px;
+  --mat-dialog-subhead-weight: 500;
+  --mat-dialog-subhead-tracking: 0.0125em;
+  --mat-dialog-supporting-text-font: Roboto, sans-serif;
+  --mat-dialog-supporting-text-line-height: 24px;
+  --mat-dialog-supporting-text-size: 16px;
+  --mat-dialog-supporting-text-weight: 400;
+  --mat-dialog-supporting-text-tracking: 0.03125em;
+  --mat-tooltip-container-shape: 4px;
+  --mat-tooltip-supporting-text-line-height: 16px;
+  --mat-tooltip-container-color: #424242;
+  --mat-tooltip-supporting-text-color: white;
+  --mat-tooltip-supporting-text-font: Roboto, sans-serif;
+  --mat-tooltip-supporting-text-size: 12px;
+  --mat-tooltip-supporting-text-weight: 400;
+  --mat-tooltip-supporting-text-tracking: 0.0333333333em;
+  --mat-radio-disabled-selected-icon-opacity: 0.38;
+  --mat-radio-disabled-unselected-icon-opacity: 0.38;
+  --mat-radio-state-layer-size: 40px;
+  --mat-radio-touch-target-size: 48px;
+  --mat-sort-arrow-color: rgba(0, 0, 0, 0.87);
+  --mat-paginator-page-size-select-width: 84px;
+  --mat-paginator-page-size-select-touch-target-height: 48px;
+  --mat-paginator-container-text-color: rgba(0, 0, 0, 0.87);
+  --mat-paginator-container-background-color: white;
+  --mat-paginator-enabled-icon-color: rgba(0, 0, 0, 0.54);
+  --mat-paginator-disabled-icon-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-paginator-container-size: 56px;
+  --mat-paginator-form-field-container-height: 40px;
+  --mat-paginator-form-field-container-vertical-padding: 8px;
+  --mat-paginator-touch-target-display: block;
+  --mat-paginator-container-text-font: Roboto, sans-serif;
+  --mat-paginator-container-text-line-height: 20px;
+  --mat-paginator-container-text-size: 12px;
+  --mat-paginator-container-text-tracking: 0.0333333333em;
+  --mat-paginator-container-text-weight: 400;
+  --mat-paginator-select-trigger-text-size: 12px;
+  --mat-autocomplete-container-shape: 4px;
+  --mat-autocomplete-container-elevation-shadow: 0px 5px 5px -3px
+      rgba(0, 0, 0, 0.2),
+    0px 8px 10px 1px rgba(0, 0, 0, 0.14), 0px 3px 14px 2px rgba(0, 0, 0, 0.12);
+  --mat-autocomplete-background-color: white;
+  --mat-datepicker-calendar-container-shape: 4px;
+  --mat-datepicker-calendar-container-touch-shape: 4px;
+  --mat-datepicker-calendar-container-elevation-shadow: 0px 2px 4px -1px
+      rgba(0, 0, 0, 0.2),
+    0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 1px 10px 0px rgba(0, 0, 0, 0.12);
+  --mat-datepicker-calendar-container-touch-elevation-shadow: 0px 11px 15px -7px
+      rgba(0, 0, 0, 0.2),
+    0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
+  --mat-datepicker-calendar-date-in-range-state-background-color: color-mix(
+    in srgb,
+    #3f51b5 20%,
+    transparent
+  );
+  --mat-datepicker-calendar-date-in-comparison-range-state-background-color: color-mix(
+    in srgb,
+    #ff4081 20%,
+    transparent
+  );
+  --mat-datepicker-calendar-date-in-overlap-range-state-background-color: #a8dab5;
+  --mat-datepicker-calendar-date-in-overlap-range-selected-state-background-color: rgb(
+    69.5241935484,
+    163.4758064516,
+    93.9516129032
+  );
+  --mat-datepicker-calendar-date-selected-state-text-color: white;
+  --mat-datepicker-calendar-date-selected-state-background-color: #3f51b5;
+  --mat-datepicker-calendar-date-selected-disabled-state-background-color: color-mix(
+    in srgb,
+    #3f51b5 38%,
+    transparent
+  );
+  --mat-datepicker-calendar-date-today-selected-state-outline-color: white;
+  --mat-datepicker-calendar-date-focus-state-background-color: color-mix(
+    in srgb,
+    #3f51b5 12%,
+    transparent
+  );
+  --mat-datepicker-calendar-date-hover-state-background-color: color-mix(
+    in srgb,
+    #3f51b5 4%,
+    transparent
+  );
+  --mat-datepicker-toggle-active-state-icon-color: #3f51b5;
+  --mat-datepicker-toggle-icon-color: rgba(0, 0, 0, 0.54);
+  --mat-datepicker-calendar-body-label-text-color: rgba(0, 0, 0, 0.54);
+  --mat-datepicker-calendar-period-button-text-color: rgba(0, 0, 0, 0.87);
+  --mat-datepicker-calendar-period-button-icon-color: rgba(0, 0, 0, 0.54);
+  --mat-datepicker-calendar-navigation-button-icon-color: rgba(0, 0, 0, 0.54);
+  --mat-datepicker-calendar-header-divider-color: rgba(0, 0, 0, 0.12);
+  --mat-datepicker-calendar-header-text-color: rgba(0, 0, 0, 0.54);
+  --mat-datepicker-calendar-date-today-outline-color: rgba(0, 0, 0, 0.54);
+  --mat-datepicker-calendar-date-today-disabled-state-outline-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-datepicker-calendar-date-text-color: rgba(0, 0, 0, 0.87);
+  --mat-datepicker-calendar-date-outline-color: transparent;
+  --mat-datepicker-calendar-date-disabled-state-text-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-datepicker-calendar-date-preview-state-outline-color: rgba(
+    0,
+    0,
+    0,
+    0.54
+  );
+  --mat-datepicker-range-input-separator-color: rgba(0, 0, 0, 0.87);
+  --mat-datepicker-range-input-disabled-state-separator-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-datepicker-range-input-disabled-state-text-color: color-mix(
+    in srgb,
+    rgba(0, 0, 0, 0.87) 38%,
+    transparent
+  );
+  --mat-datepicker-calendar-container-background-color: white;
+  --mat-datepicker-calendar-container-text-color: rgba(0, 0, 0, 0.87);
+}

--- a/apps/webcomponents/src/styles.css
+++ b/apps/webcomponents/src/styles.css
@@ -1,6 +1,7 @@
 @import '../../../tailwind.base.css';
 @import 'node_modules/tippy.js/dist/tippy.css';
 @import 'node_modules/ol/ol.css';
+@import './material-styles.css';
 
 @tailwind base;
 @tailwind components;


### PR DESCRIPTION
### Description

This PR restores the material styles for webcomponents as they were set in https://github.com/geonetwork/geonetwork-ui/pull/1511/changes/b5134426eb00bb651ce768386499d9be58806392, and before they were removed in  https://github.com/geonetwork/geonetwork-ui/pull/1525.

### Screenshots

Before the fix:
<img width="759" height="539" alt="Screenshot from 2026-08-05 14-12-34" src="https://github.com/user-attachments/assets/c1fe34bb-cea8-42cb-adca-97ebc5dbdb4c" />
<img width="1020" height="539" alt="Screenshot from 2026-08-05 14-13-02" src="https://github.com/user-attachments/assets/ab33fbf8-e37c-4ecc-8946-01c8c3201af9" />
<img width="227" height="127" alt="Screenshot from 2026-08-05 14-14-16" src="https://github.com/user-attachments/assets/a1e00734-2037-432c-aa3c-6de949ed056d" />

After the fix:
<img width="764" height="526" alt="Screenshot from 2026-08-05 14-29-18" src="https://github.com/user-attachments/assets/8bac2bae-dd70-4872-a313-20530d5df9c1" />
<img width="1017" height="526" alt="Screenshot from 2026-08-05 14-28-57" src="https://github.com/user-attachments/assets/7f4a2bf3-b43d-488d-8e2d-86bbdcdbf5a9" />
<img width="227" height="127" alt="Screenshot from 2026-08-05 14-25-57" src="https://github.com/user-attachments/assets/0ee40ae8-97d2-4e19-ae7d-f74b54f17116" />


### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Follow these instructions in "docs/guide/webcomponents.md" to run the webcomponents in the local doc/demo.
Make sure all styles are correctly applied.
