### PR TITLE
Sort by `resourceDate` with explicit syntax

### DIFF
--- a/apps/datahub-e2e/src/e2e/datasets.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasets.cy.ts
@@ -9,6 +9,7 @@ describe('datasets', () => {
     cy.get('[data-cy="ed34db28-5dd4-480f-bf29-dc08f0086131"]').as(
       'sampleResult'
     )
+    cy.get('[data-cy="04bcec79-5b25-4b16-b635-73115f7456e4"]').as('inseeResult')
     cy.get('@results')
       .then(($results) => $results.length)
       .as('resultsCount')
@@ -49,18 +50,12 @@ describe('datasets', () => {
       cy.get('@sortBy')
         .getActiveDropdownOption()
         .invoke('attr', 'data-cy-value')
-        .should(
-          'equal',
-          'desc,revisionDateForResource,desc,publicationDateForResource,desc,creationDateForResource'
-        )
+        .should('equal', 'desc,resourceDate')
     })
   })
 
   describe('display of dataset previews', () => {
-    it('should display a placeholder for sampleResult and a logo for second results item', () => {
-      cy.get('@sortBy').selectDropdownOption(
-        'desc,revisionDateForResource,desc,publicationDateForResource,desc,creationDateForResource'
-      ) // this makes the order reliable
+    it('should display a placeholder for sampleResult and a logo for inseeResult', () => {
       cy.get('@sampleResult')
         .find('gn-ui-thumbnail')
         .find('img')
@@ -74,8 +69,7 @@ describe('datasets', () => {
         .children('div')
         .invoke('attr', 'data-cy-is-placeholder')
         .should('equal', 'true')
-      cy.get('@results')
-        .eq(1)
+      cy.get('@inseeResult')
         .find('gn-ui-thumbnail')
         .children('div')
         .invoke('attr', 'data-cy-is-placeholder')
@@ -529,9 +523,7 @@ describe('datasets', () => {
       })
 
       it('should display quality widget', () => {
-        cy.get('@sortBy').selectDropdownOption(
-          'desc,revisionDateForResource,desc,publicationDateForResource,desc,creationDateForResource'
-        )
+        cy.get('@sortBy').selectDropdownOption('desc,resourceDate')
         cy.get(
           '[data-cy="ed34db28-5dd4-480f-bf29-dc08f0086131"] gn-ui-progress-bar'
         ).should('have.attr', 'ng-reflect-value', 100)

--- a/apps/datahub-e2e/src/e2e/datasets.cy.ts
+++ b/apps/datahub-e2e/src/e2e/datasets.cy.ts
@@ -50,7 +50,7 @@ describe('datasets', () => {
       cy.get('@sortBy')
         .getActiveDropdownOption()
         .invoke('attr', 'data-cy-value')
-        .should('equal', 'desc,resourceDate')
+        .should('equal', 'desc,resourceDate.date')
     })
   })
 
@@ -523,7 +523,7 @@ describe('datasets', () => {
       })
 
       it('should display quality widget', () => {
-        cy.get('@sortBy').selectDropdownOption('desc,resourceDate')
+        cy.get('@sortBy').selectDropdownOption('desc,resourceDate.date')
         cy.get(
           '[data-cy="ed34db28-5dd4-480f-bf29-dc08f0086131"] gn-ui-progress-bar'
         ).should('have.attr', 'ng-reflect-value', 100)

--- a/apps/datahub-e2e/src/e2e/search-header/filters.cy.ts
+++ b/apps/datahub-e2e/src/e2e/search-header/filters.cy.ts
@@ -23,10 +23,14 @@ describe('filters and sorts', () => {
       .getActiveDropdownOption()
       .invoke('attr', 'data-cy-value')
       .should('equal', 'desc,resourceDate.date')
+    cy.get('@inlineFilter-dataset').check({ force: true }) // To get same result local and CI
+    cy.get('gn-ui-results-list-item')
+      .first()
+      .should('have.attr', 'data-cy', '85fb799c-aa0e-4d3a-8d6c-a574fde607e0')
     cy.screenshot({ capture: 'viewport' })
   })
 
-  it('should filter results by popularity', () => {
+  it('should sort results by popularity', () => {
     cy.get('gn-ui-fuzzy-search')
       .next()
       .find('button')

--- a/apps/datahub-e2e/src/e2e/search-header/filters.cy.ts
+++ b/apps/datahub-e2e/src/e2e/search-header/filters.cy.ts
@@ -22,10 +22,7 @@ describe('filters and sorts', () => {
     cy.get('gn-ui-sort-by gn-ui-dropdown-selector')
       .getActiveDropdownOption()
       .invoke('attr', 'data-cy-value')
-      .should(
-        'equal',
-        'desc,revisionDateForResource,desc,publicationDateForResource,desc,creationDateForResource'
-      )
+      .should('equal', 'desc,resourceDate')
     cy.screenshot({ capture: 'viewport' })
   })
 

--- a/apps/datahub-e2e/src/e2e/search-header/filters.cy.ts
+++ b/apps/datahub-e2e/src/e2e/search-header/filters.cy.ts
@@ -22,7 +22,7 @@ describe('filters and sorts', () => {
     cy.get('gn-ui-sort-by gn-ui-dropdown-selector')
       .getActiveDropdownOption()
       .invoke('attr', 'data-cy-value')
-      .should('equal', 'desc,resourceDate')
+      .should('equal', 'desc,resourceDate.date')
     cy.screenshot({ capture: 'viewport' })
   })
 

--- a/apps/datahub/src/app/home/home-header/home-header.component.html
+++ b/apps/datahub/src/app/home/home-header/home-header.component.html
@@ -50,7 +50,7 @@
             <button
               type="button"
               class="badge-btn text-primary-white bg-primary/50 hover:bg-primary/100"
-              (click)="clearSearchAndSort(SORT_BY_PARAMS.RESOURCE_DATES)"
+              (click)="clearSearchAndSort(SORT_BY_PARAMS.RESOURCE_DATE)"
             >
               <span translate>datahub.header.lastRecords</span>
             </button>

--- a/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
+++ b/apps/datahub/src/app/home/home-header/home-header.component.spec.ts
@@ -201,7 +201,7 @@ describe('HomeHeaderComponent', () => {
         expect(displaySortBadges).toEqual(true)
       })
 
-      describe('enable sort on RESOURCE_DATES', () => {
+      describe('enable sort on RESOURCE_DATE', () => {
         beforeEach(() => {
           const latestBadge = fixture.debugElement.queryAll(
             By.css('.badge-btn')
@@ -211,7 +211,7 @@ describe('HomeHeaderComponent', () => {
         it('resets filters and sort', () => {
           expect(searchService.setSortAndFilters).toHaveBeenCalledWith(
             {},
-            SortByEnum.RESOURCE_DATES
+            SortByEnum.RESOURCE_DATE
           )
         })
       })

--- a/apps/datahub/src/app/router/datahub-router.service.ts
+++ b/apps/datahub/src/app/router/datahub-router.service.ts
@@ -121,6 +121,6 @@ export class DatahubRouterService {
   }
 
   getDefaultSort(): SortByField {
-    return SortByEnum.RESOURCE_DATES
+    return SortByEnum.RESOURCE_DATE
   }
 }

--- a/apps/webcomponents/cypress/e2e/gn-datahub.cy.ts
+++ b/apps/webcomponents/cypress/e2e/gn-datahub.cy.ts
@@ -42,6 +42,7 @@ it('gn-datahub', () => {
     'have.length.above',
     0
   )
+  cy.get('gn-ui-kind-badge').eq(1).click()
   cy.get('gn-ui-results-list gn-ui-results-list-item')
     .first()
     .find('a[href]')
@@ -54,7 +55,8 @@ it('gn-datahub', () => {
   cy.url().should('contain', '#/search')
 
   // navigate to a record
-  cy.get('gn-ui-results-list gn-ui-results-list-item').eq(7).click()
+  cy.get('gn-ui-kind-badge').eq(1).click()
+  cy.get('[data-cy="7eb795c2-d612-4b5e-b15e-d985b0f4e697"]').click()
   cy.get('datahub-record-page').should('be.visible')
   cy.get('datahub-record-header').should('be.visible')
   cy.get('datahub-record-header header .font-title')

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -116,7 +116,7 @@ background_color = "#fdfbff"
 # One or several search presets visible in form of badges can be defined here; every search preset is composed of:
 # - a name (which can be a translation key)
 # - a sort criteria (prepend the field name with - to do a descending sort):
-#   - `-revisionDateForResource,-publicationDateForResource,-creationDateForResource` (resource dates)
+#   - `-resourceDate`
 #   - `-userSavedcount`
 #   - `-qualityScore`
 #   - `-_score`
@@ -134,7 +134,7 @@ background_color = "#fdfbff"
 #     filters.publicationYear = ['2023', '2022']
 #     filters.isSpatial = ['yes']
 #     filters.license = ['unknown']
-#     sort = '-revisionDateForResource,-publicationDateForResource,-creationDateForResource'
+#     sort = '-resourceDate'
 # [[search_preset]]
 #     name = 'otherFilterName'
 #     filters.q = 'Other Full text search'

--- a/conf/default.toml
+++ b/conf/default.toml
@@ -116,7 +116,7 @@ background_color = "#fdfbff"
 # One or several search presets visible in form of badges can be defined here; every search preset is composed of:
 # - a name (which can be a translation key)
 # - a sort criteria (prepend the field name with - to do a descending sort):
-#   - `-resourceDate`
+#   - `-resourceDate.date`
 #   - `-userSavedcount`
 #   - `-qualityScore`
 #   - `-_score`
@@ -134,7 +134,7 @@ background_color = "#fdfbff"
 #     filters.publicationYear = ['2023', '2022']
 #     filters.isSpatial = ['yes']
 #     filters.license = ['unknown']
-#     sort = '-resourceDate'
+#     sort = '-resourceDate.date'
 # [[search_preset]]
 #     name = 'otherFilterName'
 #     filters.q = 'Other Full text search'

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -222,7 +222,7 @@ For a detailed explanation on the classification system, see [this documentation
   - a name for the preset, which can be a translation key (mandatory)
   - a sort criteria (prepend the field name with - to do a descending sort):
 
-    - `-resourceDate`
+    - `-resourceDate.date`
     - `-userSavedcount`
     - `-qualityScore`
     - `-_score`
@@ -247,7 +247,7 @@ For a detailed explanation on the classification system, see [this documentation
   filters.publicationYear = ['2023', '2022']
   filters.isSpatial = ['yes']
   filters.license = ['unknown']
-  sort = '-resourceDate'
+  sort = '-resourceDate.date'
 
   [[search_preset]]
   name = 'otherFilter'

--- a/docs/guide/configure.md
+++ b/docs/guide/configure.md
@@ -222,7 +222,7 @@ For a detailed explanation on the classification system, see [this documentation
   - a name for the preset, which can be a translation key (mandatory)
   - a sort criteria (prepend the field name with - to do a descending sort):
 
-    - `-revisionDateForResource,-publicationDateForResource,-creationDateForResource` (resource dates)
+    - `-resourceDate`
     - `-userSavedcount`
     - `-qualityScore`
     - `-_score`
@@ -247,7 +247,7 @@ For a detailed explanation on the classification system, see [this documentation
   filters.publicationYear = ['2023', '2022']
   filters.isSpatial = ['yes']
   filters.license = ['unknown']
-  sort = '-revisionDateForResource,-publicationDateForResource,-creationDateForResource'
+  sort = '-resourceDate'
 
   [[search_preset]]
   name = 'otherFilter'

--- a/libs/api/metadata-converter/src/lib/gn4/types/elasticsearch.model.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/types/elasticsearch.model.ts
@@ -2,7 +2,19 @@ export type SortOrder = 'asc' | 'desc'
 interface SortParam {
   [key: string]: SortOrder
 }
-export type SortParams = string | SortParam | (string | SortParam)[]
+type EsFieldSort = {
+  order: SortOrder
+  mode?: 'max' | 'min'
+  missing?: '_last'
+  nested?: {
+    path: string
+  }
+}
+export type SortParams =
+  | string
+  | SortParam
+  | (string | SortParam)[]
+  | { [property: string]: EsFieldSort }
 
 export interface EsRequestAggTerm {
   field?: string

--- a/libs/api/metadata-converter/src/lib/gn4/types/elasticsearch.model.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/types/elasticsearch.model.ts
@@ -13,8 +13,8 @@ type EsFieldSort = {
 export type SortParams =
   | string
   | SortParam
-  | (string | SortParam)[]
   | { [property: string]: EsFieldSort }
+  | (string | SortParam | { [property: string]: EsFieldSort })[]
 
 export interface EsRequestAggTerm {
   field?: string

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -50,12 +50,42 @@ describe('ElasticsearchService', () => {
       expect(sort).toEqual([{ changeDate: 'desc' }])
     })
 
+    it('One nested ".date" sort and DESC direction', () => {
+      const sort = service['buildPayloadSort'](['desc', 'resourceDate.date'])
+      expect(sort).toEqual([
+        {
+          'resourceDate.date': {
+            order: 'desc',
+            mode: 'max',
+            missing: '_last',
+            nested: {
+              path: 'resourceDate',
+            },
+          },
+        },
+      ])
+    })
+
     it('Multiple sorts', () => {
       const sort = service['buildPayloadSort']([
         ['asc', '_score'],
         ['desc', 'changeDate'],
+        ['desc', 'resourceDate.date'],
       ])
-      expect(sort).toEqual([{ _score: 'asc' }, { changeDate: 'desc' }])
+      expect(sort).toEqual([
+        { _score: 'asc' },
+        { changeDate: 'desc' },
+        {
+          'resourceDate.date': {
+            order: 'desc',
+            mode: 'max',
+            missing: '_last',
+            nested: {
+              path: 'resourceDate',
+            },
+          },
+        },
+      ])
     })
   })
   describe('#stateFiltersToQueryString', () => {

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -40,6 +40,21 @@ describe('ElasticsearchService', () => {
   })
 
   describe('#Sort', () => {
+    it('Null sort', () => {
+      const sort = service['buildPayloadSort'](null)
+      expect(sort).toBeUndefined()
+    })
+
+    it('Undefined sort', () => {
+      const sort = service['buildPayloadSort'](undefined)
+      expect(sort).toBeUndefined()
+    })
+
+    it('Empty sort array', () => {
+      const sort = service['buildPayloadSort']([])
+      expect(sort).toBeUndefined()
+    })
+
     it('One sort and default direction', () => {
       const sort = service['buildPayloadSort'](['asc', '_score'])
       expect(sort).toEqual([{ _score: 'asc' }])

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -11,6 +11,7 @@ import {
   AggregationsParams,
   FieldFilter,
   FieldFilters,
+  FieldSort,
   FilterQuery,
   FiltersAggregationParams,
   SortByField,
@@ -200,25 +201,26 @@ export class ElasticsearchService {
 
   private buildPayloadSort(sortBy: SortByField): SortParams {
     if (sortBy === null) return undefined
-    // Sort by nested array of dates only works with the explicit syntax
-    if (
-      typeof sortBy[1] === 'string' &&
-      (sortBy[1] as string).endsWith('.date')
-    ) {
-      const nestedPath = sortBy[1].slice(0, sortBy[1].lastIndexOf('.date'))
-      return {
-        [sortBy[1]]: {
-          order: sortBy[0] as 'desc' | 'asc',
-          mode: sortBy[0] === 'desc' ? 'max' : 'min',
-          missing: '_last',
-          nested: {
-            path: nestedPath,
+    const fields = Array.isArray(sortBy[0])
+      ? (sortBy as FieldSort[])
+      : [sortBy as FieldSort]
+    return fields.map((field) => {
+      // Sort by nested array of dates only works with the explicit syntax
+      if (field[1].endsWith('.date')) {
+        const nestedPath = field[1].slice(0, field[1].lastIndexOf('.date'))
+        return {
+          [field[1]]: {
+            order: field[0] as 'desc' | 'asc',
+            mode: field[0] === 'desc' ? 'max' : 'min',
+            missing: '_last',
+            nested: {
+              path: nestedPath,
+            },
           },
-        },
+        }
       }
-    }
-    const fields = Array.isArray(sortBy[0]) ? sortBy : [sortBy]
-    return fields.map((field) => ({ [field[1]]: field[0] }))
+      return { [field[1]]: field[0] }
+    })
   }
 
   private injectLangInQueryStringFields(

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -200,6 +200,19 @@ export class ElasticsearchService {
 
   private buildPayloadSort(sortBy: SortByField): SortParams {
     if (sortBy === null) return undefined
+    // Sort by resourceDate only works with the explicit syntax
+    if (sortBy[1] === 'resourceDate') {
+      return {
+        'resourceDate.date': {
+          order: sortBy[0] as 'desc' | 'asc',
+          mode: sortBy[0] === 'desc' ? 'max' : 'min',
+          missing: '_last',
+          nested: {
+            path: 'resourceDate',
+          },
+        },
+      }
+    }
     const fields = Array.isArray(sortBy[0]) ? sortBy : [sortBy]
     return fields.map((field) => ({ [field[1]]: field[0] }))
   }

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -200,7 +200,7 @@ export class ElasticsearchService {
   }
 
   private buildPayloadSort(sortBy: SortByField): SortParams {
-    if (sortBy === null) return undefined
+    if (!sortBy || sortBy.length === 0) return undefined
     const fields = Array.isArray(sortBy[0])
       ? (sortBy as FieldSort[])
       : [sortBy as FieldSort]

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -200,15 +200,19 @@ export class ElasticsearchService {
 
   private buildPayloadSort(sortBy: SortByField): SortParams {
     if (sortBy === null) return undefined
-    // Sort by resourceDate only works with the explicit syntax
-    if (sortBy[1] === 'resourceDate') {
+    // Sort by nested array of dates only works with the explicit syntax
+    if (
+      typeof sortBy[1] === 'string' &&
+      (sortBy[1] as string).endsWith('.date')
+    ) {
+      const nestedPath = sortBy[1].slice(0, sortBy[1].lastIndexOf('.date'))
       return {
-        'resourceDate.date': {
+        [sortBy[1]]: {
           order: sortBy[0] as 'desc' | 'asc',
           mode: sortBy[0] === 'desc' ? 'max' : 'min',
           missing: '_last',
           nested: {
-            path: 'resourceDate',
+            path: nestedPath,
           },
         },
       }

--- a/libs/common/domain/src/lib/model/search/sort-by.model.ts
+++ b/libs/common/domain/src/lib/model/search/sort-by.model.ts
@@ -6,9 +6,5 @@ export const SortByEnum: Record<string, SortByField> = {
   RELEVANCY: ['desc', '_score'],
   QUALITY_SCORE: ['desc', 'qualityScore'],
   CHANGE_DATE: ['desc', 'changeDate'],
-  RESOURCE_DATES: [
-    ['desc', 'revisionDateForResource'],
-    ['desc', 'publicationDateForResource'],
-    ['desc', 'creationDateForResource'],
-  ],
+  RESOURCE_DATE: ['desc', 'resourceDate'],
 }

--- a/libs/common/domain/src/lib/model/search/sort-by.model.ts
+++ b/libs/common/domain/src/lib/model/search/sort-by.model.ts
@@ -6,5 +6,5 @@ export const SortByEnum: Record<string, SortByField> = {
   RELEVANCY: ['desc', '_score'],
   QUALITY_SCORE: ['desc', 'qualityScore'],
   CHANGE_DATE: ['desc', 'changeDate'],
-  RESOURCE_DATE: ['desc', 'resourceDate'],
+  RESOURCE_DATE: ['desc', 'resourceDate.date'],
 }

--- a/libs/feature/router/src/lib/default/router.service.ts
+++ b/libs/feature/router/src/lib/default/router.service.ts
@@ -62,6 +62,6 @@ export class RouterService {
   }
 
   getDefaultSort(): SortByField {
-    return SortByEnum.RESOURCE_DATES
+    return SortByEnum.RESOURCE_DATE
   }
 }

--- a/libs/feature/router/src/lib/default/services/router-search.service.spec.ts
+++ b/libs/feature/router/src/lib/default/services/router-search.service.spec.ts
@@ -118,13 +118,12 @@ describe('RouterSearchService', () => {
           Org: true,
         },
       }
-      const sort = SortByEnum.RESOURCE_DATES
+      const sort = SortByEnum.RESOURCE_DATE
       service.setSortAndFilters(filters, sort)
       expect(routerFacade.setSearch).toHaveBeenCalledWith({
         q: ['any'],
         publisher: ['Org'],
-        _sort:
-          '-revisionDateForResource,-publicationDateForResource,-creationDateForResource',
+        _sort: '-resourceDate',
       })
     })
   })

--- a/libs/feature/router/src/lib/default/services/router-search.service.spec.ts
+++ b/libs/feature/router/src/lib/default/services/router-search.service.spec.ts
@@ -123,7 +123,7 @@ describe('RouterSearchService', () => {
       expect(routerFacade.setSearch).toHaveBeenCalledWith({
         q: ['any'],
         publisher: ['Org'],
-        _sort: '-resourceDate',
+        _sort: '-resourceDate.date',
       })
     })
   })

--- a/libs/feature/router/src/lib/default/state/router.effects.spec.ts
+++ b/libs/feature/router/src/lib/default/state/router.effects.spec.ts
@@ -112,11 +112,7 @@ describe('RouterEffects', () => {
           useClass: FieldsServiceMock,
         },
         MockProvider(RouterService, {
-          getDefaultSort: () => [
-            ['desc', 'revisionDateForResource'],
-            ['desc', 'publicationDateForResource'],
-            ['desc', 'creationDateForResource'],
-          ],
+          getDefaultSort: () => ['desc', 'resourceDate'],
         }),
       ],
     })
@@ -266,14 +262,7 @@ describe('RouterEffects', () => {
           a: new SetFilters({ any: 'any' }, 'main'),
           b: new SetSortBy(['desc', 'createDate'], 'main'),
           c: new Paginate(2, 'main'),
-          d: new SetSortBy(
-            [
-              ['desc', 'revisionDateForResource'],
-              ['desc', 'publicationDateForResource'],
-              ['desc', 'creationDateForResource'],
-            ],
-            'main'
-          ),
+          d: new SetSortBy(['desc', 'resourceDate'], 'main'),
           e: new Paginate(1, 'main'),
         })
         expect(effects.syncSearchState$).toBeObservable(expected)
@@ -295,14 +284,7 @@ describe('RouterEffects', () => {
           a: new SetFilters({ any: 'any' }, 'main'),
           b: new SetSortBy(['desc', 'createDate'], 'main'),
           c: new Paginate(2, 'main'),
-          d: new SetSortBy(
-            [
-              ['desc', 'revisionDateForResource'],
-              ['desc', 'publicationDateForResource'],
-              ['desc', 'creationDateForResource'],
-            ],
-            'main'
-          ),
+          d: new SetSortBy(['desc', 'resourceDate'], 'main'),
           e: new Paginate(12, 'main'),
         })
         expect(effects.syncSearchState$).toBeObservable(expected)

--- a/libs/feature/router/src/lib/default/state/router.effects.spec.ts
+++ b/libs/feature/router/src/lib/default/state/router.effects.spec.ts
@@ -112,7 +112,7 @@ describe('RouterEffects', () => {
           useClass: FieldsServiceMock,
         },
         MockProvider(RouterService, {
-          getDefaultSort: () => ['desc', 'resourceDate'],
+          getDefaultSort: () => ['desc', 'resourceDate.date'],
         }),
       ],
     })
@@ -262,7 +262,7 @@ describe('RouterEffects', () => {
           a: new SetFilters({ any: 'any' }, 'main'),
           b: new SetSortBy(['desc', 'createDate'], 'main'),
           c: new Paginate(2, 'main'),
-          d: new SetSortBy(['desc', 'resourceDate'], 'main'),
+          d: new SetSortBy(['desc', 'resourceDate.date'], 'main'),
           e: new Paginate(1, 'main'),
         })
         expect(effects.syncSearchState$).toBeObservable(expected)
@@ -284,7 +284,7 @@ describe('RouterEffects', () => {
           a: new SetFilters({ any: 'any' }, 'main'),
           b: new SetSortBy(['desc', 'createDate'], 'main'),
           c: new Paginate(2, 'main'),
-          d: new SetSortBy(['desc', 'resourceDate'], 'main'),
+          d: new SetSortBy(['desc', 'resourceDate.date'], 'main'),
           e: new Paginate(12, 'main'),
         })
         expect(effects.syncSearchState$).toBeObservable(expected)

--- a/libs/feature/search/src/lib/sort-by/sort-by.component.ts
+++ b/libs/feature/search/src/lib/sort-by/sort-by.component.ts
@@ -34,7 +34,7 @@ export class SortByComponent implements OnInit {
     },
     {
       label: marker('results.sortBy.dateStamp'),
-      value: SortByEnum.RESOURCE_DATES,
+      value: SortByEnum.RESOURCE_DATE,
     },
     {
       label: marker('results.sortBy.popularity'),

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.spec.ts
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.spec.ts
@@ -26,7 +26,7 @@ describe('DropdownSelectorComponent', () => {
       },
       {
         label: 'results.sortBy.dateStamp',
-        value: ['desc', 'resourceDate'],
+        value: ['desc', 'resourceDate.date'],
       },
     ]
     fixture.detectChanges()
@@ -73,12 +73,12 @@ describe('DropdownSelectorComponent', () => {
 
     describe('when the provided value is a nested array', () => {
       beforeEach(() => {
-        component.selected = ['desc', 'resourceDate']
+        component.selected = ['desc', 'resourceDate.date']
       })
       it('selects the corresponding choice', () => {
         expect(component.selectedChoice).toEqual({
           label: 'results.sortBy.dateStamp',
-          value: ['desc', 'resourceDate'],
+          value: ['desc', 'resourceDate.date'],
         })
       })
     })

--- a/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.spec.ts
+++ b/libs/ui/inputs/src/lib/dropdown-selector/dropdown-selector.component.spec.ts
@@ -26,11 +26,7 @@ describe('DropdownSelectorComponent', () => {
       },
       {
         label: 'results.sortBy.dateStamp',
-        value: [
-          ['desc', 'revisionDateForResource'],
-          ['desc', 'publicationDateForResource'],
-          ['desc', 'creationDateForResource'],
-        ],
+        value: ['desc', 'resourceDate'],
       },
     ]
     fixture.detectChanges()
@@ -77,20 +73,12 @@ describe('DropdownSelectorComponent', () => {
 
     describe('when the provided value is a nested array', () => {
       beforeEach(() => {
-        component.selected = [
-          ['desc', 'revisionDateForResource'],
-          ['desc', 'publicationDateForResource'],
-          ['desc', 'creationDateForResource'],
-        ]
+        component.selected = ['desc', 'resourceDate']
       })
       it('selects the corresponding choice', () => {
         expect(component.selectedChoice).toEqual({
           label: 'results.sortBy.dateStamp',
-          value: [
-            ['desc', 'revisionDateForResource'],
-            ['desc', 'publicationDateForResource'],
-            ['desc', 'creationDateForResource'],
-          ],
+          value: ['desc', 'resourceDate'],
         })
       })
     })


### PR DESCRIPTION
### Description

This PR fixes https://github.com/geonetwork/geonetwork-ui/issues/1669.

It replaces the sort on revision date, publication date then creation date by a sort on all resource dates.

The sort on `resourceDate` is only working with the explicit syntax
```
"sort": [
  {
    "resourceDate.date": {
      "order": "desc",
      "mode": "max",
      "missing": "_last",
      "nested": {
        "path": "resourceDate"
      }
    }
  }
]
```
even though the short form 
```
"sort": [
  { "resourceDate.date": "desc" }
]
```
should be working. It's mostly the `nested` part that's needed.

TODO: 
- [X] e2e test specific to the sort by resource date
- [ ] check if this fixes https://github.com/geonetwork/geonetwork-ui/issues/1457
       => couldn't reproduce the issue

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [X] If **new logic** ⚙️ is introduced: unit tests were added
- [X] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

- Run the local docker composition
- Open GeoNetwork
- Create a record, set “azerty - revision” as title, set 08/02/2026 as revision date
- Create a record, set “azerty - publication” as title, set 08/03/2026 as revision date
- Open the Datahub
- Search for “azerty”, order by date
- See that the record “azerty - revision” now appears after the record “azerty - publication”