### PR TITLE
feat(elasticsearch): add hard spatial extent filter

### DIFF
--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -7,6 +7,7 @@ import { EsSearchParams } from '@geonetwork-ui/api/metadata-converter'
 import { TestBed } from '@angular/core/testing'
 import { METADATA_LANGUAGE } from '../../metadata-language.token'
 import { TranslateService } from '@ngx-translate/core'
+import { bboxToPolygon } from '@geonetwork-ui/util/shared'
 
 class TranslateServiceMock {
   getCurrentLang = () => 'en'
@@ -616,6 +617,92 @@ describe('ElasticsearchService', () => {
           ],
         },
       })
+    })
+    it('handles spatial filter special case', () => {
+      const query = service['buildPayloadQuery'](
+        {
+          spatialExtent: [1, 2, 3, 4],
+        },
+        {},
+        []
+      )
+      expect(query).toMatchObject({
+        bool: {
+          filter: [
+            {
+              terms: {
+                isTemplate: ['n'],
+              },
+            },
+            {
+              geo_shape: {
+                geom: {
+                  shape: {
+                    type: 'envelope',
+                    coordinates: [
+                      [1, 4],
+                      [3, 2],
+                    ],
+                  },
+                  relation: 'intersects',
+                },
+              },
+            },
+            {
+              ids: { values: [] },
+            },
+          ],
+        },
+      })
+    })
+    it('boosts using the spatial filter geometry instead of the preference geometry when both are set', () => {
+      const geojsonPolygon = {
+        coordinates: [
+          [
+            [3.017921158755172, 50.65759907920972],
+            [3.017921158755172, 50.613483610573155],
+            [3.1098886148436122, 50.613483610573155],
+            [3.017921158755172, 50.65759907920972],
+          ],
+        ],
+        type: 'Polygon' as const,
+      }
+      const query = service['buildPayloadQuery'](
+        {
+          spatialExtent: [1, 2, 3, 4],
+        },
+        {},
+        undefined,
+        geojsonPolygon
+      )
+      expect(query.bool.should).toEqual([
+        {
+          geo_shape: {
+            geom: {
+              shape: bboxToPolygon([1, 2, 3, 4]),
+              relation: 'within',
+            },
+            boost: 5.0,
+          },
+        },
+        {
+          geo_shape: {
+            geom: {
+              shape: bboxToPolygon([1, 2, 3, 4]),
+              relation: 'intersects',
+            },
+            boost: 2.0,
+          },
+        },
+        {
+          distance_feature: {
+            boost: 5,
+            field: 'location',
+            origin: [2, 3],
+            pivot: expect.any(String),
+          },
+        },
+      ])
     })
     describe('any has special characters', () => {
       let query

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -618,6 +618,35 @@ describe('ElasticsearchService', () => {
         },
       })
     })
+    it('ignores an unset spatial filter (empty array) alongside other filters', () => {
+      const query = service['buildPayloadQuery'](
+        {
+          producerOrg: { 'Some Org': true },
+          spatialExtent: [],
+        },
+        {},
+        []
+      )
+      expect(query).toMatchObject({
+        bool: {
+          filter: [
+            {
+              terms: {
+                isTemplate: ['n'],
+              },
+            },
+            {
+              query_string: {
+                query: 'producerOrg:("Some Org")',
+              },
+            },
+            {
+              ids: { values: [] },
+            },
+          ],
+        },
+      })
+    })
     it('handles spatial filter special case', () => {
       const query = service['buildPayloadQuery'](
         {

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -36,6 +36,7 @@ import {
 import { TranslateService } from '@ngx-translate/core'
 import {
   bboxToPolygon,
+  BoundingBox,
   getGeometryBoundingBox,
   isBoundingBox,
 } from '@geonetwork-ui/util/shared'
@@ -268,8 +269,18 @@ export class ElasticsearchService {
     return this.metadataLang === 'current'
   }
 
-  private filtersToQuery(
+  private findSpatialFilterExtent(
     filters: FieldFilters | FiltersAggregationParams | string
+  ): BoundingBox | undefined {
+    if (typeof filters === 'string') {
+      return undefined
+    }
+    return Object.values(filters).find(isBoundingBox)
+  }
+
+  private filtersToQuery(
+    filters: FieldFilters | FiltersAggregationParams | string,
+    spatialFilterExtent = this.findSpatialFilterExtent(filters)
   ): FilterQuery {
     const addQuote = (key: string) => (/^\/.+\/$/.test(key) ? key : `"${key}"`)
     const makeQuery = (filter: FieldFilter): string => {
@@ -315,9 +326,6 @@ export class ElasticsearchService {
           dateRange: DateRange
         }
       })[0]
-    const spatialFilterExtent = Object.entries(filters)
-      .filter(([, value]) => isBoundingBox(value))
-      .map(([, extent]) => extent)[0]
     const queryParts = [
       queryString && {
         query_string: {
@@ -391,7 +399,12 @@ export class ElasticsearchService {
         },
       })
     }
-    const queryFilters = this.filtersToQuery(fieldSearchFilters)
+    // a spatial extent filter takes precedence over the preference geometry for boosting
+    const spatialFilterExtent = this.findSpatialFilterExtent(fieldSearchFilters)
+    const queryFilters = this.filtersToQuery(
+      fieldSearchFilters,
+      spatialFilterExtent
+    )
     if (queryFilters) {
       filter.push(...queryFilters)
     }
@@ -402,9 +415,6 @@ export class ElasticsearchService {
         },
       })
     }
-    // a spatial extent filter takes precedence over the preference geometry for boosting
-    const spatialFilterExtent =
-      Object.values(fieldSearchFilters).find(isBoundingBox)
     const boostGeometry = spatialFilterExtent
       ? bboxToPolygon(spatialFilterExtent)
       : geometry

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -34,7 +34,11 @@ import {
   LanguageCode,
 } from '@geonetwork-ui/common/domain/model/record'
 import { TranslateService } from '@ngx-translate/core'
-import { getGeometryBoundingBox } from '@geonetwork-ui/util/shared'
+import {
+  bboxToPolygon,
+  getGeometryBoundingBox,
+  isBoundingBox,
+} from '@geonetwork-ui/util/shared'
 import { getLength as getGeodesicLength } from 'ol/sphere.js'
 import { LineString } from 'ol/geom.js'
 
@@ -286,6 +290,7 @@ export class ElasticsearchService {
         ? filters
         : Object.keys(filters)
             .filter((fieldname) => fieldname !== 'gn-ui-crossFieldFilter')
+            .filter((fieldname) => !isBoundingBox(filters[fieldname]))
             .filter((fieldname) => !isDateRange(filters[fieldname]))
             .filter(
               (fieldname) =>
@@ -310,6 +315,9 @@ export class ElasticsearchService {
           dateRange: DateRange
         }
       })[0]
+    const spatialFilterExtent = Object.entries(filters)
+      .filter(([, value]) => isBoundingBox(value))
+      .map(([, extent]) => extent)[0]
     const queryParts = [
       queryString && {
         query_string: {
@@ -330,6 +338,21 @@ export class ElasticsearchService {
             },
           },
         },
+      spatialFilterExtent && {
+        geo_shape: {
+          geom: {
+            shape: {
+              type: 'envelope',
+              // spatialFilterExtent is [minX, minY, maxX, maxY]; envelope coordinates are [top-left, bottom-right]
+              coordinates: [
+                [spatialFilterExtent[0], spatialFilterExtent[3]],
+                [spatialFilterExtent[2], spatialFilterExtent[1]],
+              ],
+            },
+            relation: 'intersects',
+          },
+        },
+      },
     ].filter(Boolean)
     return queryParts.length > 0 ? (queryParts as FilterQuery) : undefined
   }
@@ -379,7 +402,13 @@ export class ElasticsearchService {
         },
       })
     }
-    if (geometry) {
+    // a spatial extent filter takes precedence over the preference geometry for boosting
+    const spatialFilterExtent =
+      Object.values(fieldSearchFilters).find(isBoundingBox)
+    const boostGeometry = spatialFilterExtent
+      ? bboxToPolygon(spatialFilterExtent)
+      : geometry
+    if (boostGeometry) {
       // boosts applied using the filter geometry:
       // * records completely within the geometry receive a boost of 5
       // * records intersecting the geometry receive a boost of 2
@@ -389,7 +418,7 @@ export class ElasticsearchService {
         {
           geo_shape: {
             geom: {
-              shape: geometry,
+              shape: boostGeometry,
               relation: 'within',
             },
             boost: 5.0,
@@ -398,7 +427,7 @@ export class ElasticsearchService {
         {
           geo_shape: {
             geom: {
-              shape: geometry,
+              shape: boostGeometry,
               relation: 'intersects',
             },
             boost: 2.0,
@@ -409,7 +438,7 @@ export class ElasticsearchService {
       // this will boost the results variably depending on their distance from the given geometry
       // note: this takes into account the `location` field of a record; this is generally the center of all spatial extents
       // combined, and thus the actual size/coverage of the record spatial extent isn't relevant here
-      const bbox = getGeometryBoundingBox(geometry)
+      const bbox = getGeometryBoundingBox(boostGeometry)
       const center = [(bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2]
       const northToCenter = new LineString([
         [center[0], bbox[3]],

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -303,6 +303,7 @@ export class ElasticsearchService {
             .filter((fieldname) => fieldname !== 'gn-ui-crossFieldFilter')
             .filter((fieldname) => !isBoundingBox(filters[fieldname]))
             .filter((fieldname) => !isDateRange(filters[fieldname]))
+            .filter((fieldname) => !Array.isArray(filters[fieldname]))
             .filter(
               (fieldname) =>
                 filters[fieldname] &&

--- a/libs/common/domain/src/lib/model/search/filter.model.ts
+++ b/libs/common/domain/src/lib/model/search/filter.model.ts
@@ -6,11 +6,15 @@ export type FieldFilterByRange = {
   start?: Date
   end?: Date
 }
+// matches util/shared's BoundingBox; duplicated here to avoid a circular
+// dependency (util/shared already depends on common/domain)
+export type FieldFilterByBoundingBox = [number, number, number, number]
 
 export type FieldFilter =
   | FieldFilterByExpression
   | FieldFilterByValues
   | FieldFilterByRange
+  | FieldFilterByBoundingBox
 export type FieldFilters = Record<FieldName, FieldFilter>
 
 export type QueryString = {
@@ -19,4 +23,12 @@ export type QueryString = {
 export type QueryRange = {
   range: Record<string, { format: string; gte: string; lte: string }>
 }
-export type FilterQuery = Array<QueryString | QueryRange>
+export type QueryGeoShape = {
+  geo_shape: {
+    geom: {
+      shape: { type: string; coordinates: number[][] }
+      relation: string
+    }
+  }
+}
+export type FilterQuery = Array<QueryString | QueryRange | QueryGeoShape>

--- a/libs/feature/search/src/lib/utils/service/fields.service.spec.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.spec.ts
@@ -194,6 +194,7 @@ describe('FieldsService', () => {
           changeDate: [],
           availableServices: [],
           recordKind: [],
+          spatialExtent: [],
         })
       })
     })
@@ -203,6 +204,7 @@ describe('FieldsService', () => {
         expect(service.getFieldType('publicationYear')).toEqual('values')
         expect(service.getFieldType('format')).toEqual('values')
         expect(service.getFieldType('changeDate')).toEqual('dateRange')
+        expect(service.getFieldType('spatialExtent')).toEqual('spatialExtent')
       })
     })
   })

--- a/libs/feature/search/src/lib/utils/service/fields.service.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Injector, inject } from '@angular/core'
 import {
   AbstractSearchField,
   AvailableServicesField,
+  BoundingBoxSearchField,
   DateRangeSearchField,
   FieldValue,
   FullTextSearchField,
@@ -15,7 +16,6 @@ import {
   TranslatedSearchField,
   RecordKindField,
   UserSearchField,
-  SpatialExtentSearchField,
 } from './fields'
 import { forkJoin, Observable, of } from 'rxjs'
 import { map } from 'rxjs/operators'
@@ -96,7 +96,7 @@ export class FieldsService {
     user: new UserSearchField(this.injector),
     changeDate: new DateRangeSearchField('changeDate', this.injector, 'desc'),
     availableServices: new AvailableServicesField(this.injector),
-    spatialExtent: new SpatialExtentSearchField(this.injector),
+    spatialExtent: new BoundingBoxSearchField('spatialExtent', this.injector),
   } as Record<string, AbstractSearchField>
 
   get supportedFields() {

--- a/libs/feature/search/src/lib/utils/service/fields.spec.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.spec.ts
@@ -2,6 +2,7 @@ import { lastValueFrom, of } from 'rxjs'
 import {
   AbstractSearchField,
   AvailableServicesField,
+  BoundingBoxSearchField,
   DateRangeSearchField,
   FullTextSearchField,
   IsSpatialSearchField,
@@ -432,6 +433,60 @@ describe('search fields implementations', () => {
         it('returns the only value', () => {
           expect(values).toEqual({ start: new Date('2020-01-01') })
         })
+      })
+    })
+  })
+
+  describe('BoundingBoxSearchField (SimpleSearchField with a bounding box)', () => {
+    beforeEach(() => {
+      searchField = new BoundingBoxSearchField('spatialExtent', injector)
+    })
+    describe('#getAvailableValues', () => {
+      let values
+      beforeEach(async () => {
+        values = await lastValueFrom(searchField.getAvailableValues())
+      })
+      it('returns an empty list of values', () => {
+        expect(values).toEqual([])
+      })
+    })
+    describe('#getFiltersForValues', () => {
+      let filter
+      beforeEach(async () => {
+        filter = await lastValueFrom(
+          searchField.getFiltersForValues([1, 2, 3, 4])
+        )
+      })
+      it('returns the bounding box as the filter value', () => {
+        expect(filter).toEqual({
+          spatialExtent: [1, 2, 3, 4],
+        })
+      })
+    })
+    describe('#getValuesForFilter', () => {
+      let values
+      beforeEach(async () => {
+        values = await lastValueFrom(
+          searchField.getValuesForFilter({
+            spatialExtent: [1, 2, 3, 4],
+          })
+        )
+      })
+      it('returns the bounding box values', () => {
+        expect(values).toEqual([1, 2, 3, 4])
+      })
+    })
+    describe('#getValuesForFilter with no filter present', () => {
+      let values
+      beforeEach(async () => {
+        values = await lastValueFrom(
+          searchField.getValuesForFilter({
+            somethingElse: { entirely: true },
+          })
+        )
+      })
+      it('returns an empty array', () => {
+        expect(values).toEqual([])
       })
     })
   })

--- a/libs/feature/search/src/lib/utils/service/fields.ts
+++ b/libs/feature/search/src/lib/utils/service/fields.ts
@@ -20,7 +20,11 @@ import {
   isDateRange,
   METADATA_LANGUAGE,
 } from '@geonetwork-ui/api/repository'
-import { formatUserInfo } from '@geonetwork-ui/util/shared'
+import {
+  BoundingBox,
+  formatUserInfo,
+  isBoundingBox,
+} from '@geonetwork-ui/util/shared'
 import { PossibleResourceTypes } from '@geonetwork-ui/api/metadata-converter'
 
 export type FieldType = 'values' | 'dateRange' | 'spatialExtent'
@@ -431,14 +435,20 @@ export class DateRangeSearchField extends SimpleSearchField {
   }
 }
 
-export class SpatialExtentSearchField extends SimpleSearchField {
-  constructor(injector: Injector) {
-    super('spatialExtent', injector, 'asc')
+export class BoundingBoxSearchField extends SimpleSearchField {
+  getAvailableValues(): Observable<FieldAvailableValue[]> {
+    return of([])
   }
 
-  getAvailableValues(): Observable<FieldAvailableValue[]> {
-    // TODO: return an array of spatial extents to show which ones are available in the dropdown
-    return of([])
+  getFiltersForValues(values: FieldValue[]): Observable<FieldFilters> {
+    return of({
+      [this.esFieldName]: values.map(Number) as BoundingBox,
+    })
+  }
+
+  getValuesForFilter(filters: FieldFilters): Observable<FieldValue[]> {
+    const filter = filters[this.esFieldName]
+    return of(isBoundingBox(filter) ? filter : [])
   }
 
   getType(): FieldType {

--- a/libs/util/shared/src/lib/utils/geojson.spec.ts
+++ b/libs/util/shared/src/lib/utils/geojson.spec.ts
@@ -2,6 +2,7 @@ import {
   bboxToPolygon,
   getGeometryBoundingBox,
   getGeometryFromGeoJSON,
+  isBoundingBox,
   spatialExtentsToFeatureCollection,
   spatialExtentToGeometry,
 } from './geojson'
@@ -162,6 +163,21 @@ describe('geojson utils', () => {
       }
       const bbox = getGeometryBoundingBox(geom)
       expect(bbox).toEqual([-100, -200, 130, 20])
+    })
+  })
+
+  describe('isBoundingBox', () => {
+    it('returns true for a bounding box', () => {
+      expect(isBoundingBox([0, 0, 1, 1])).toBe(true)
+    })
+    it('returns false for an array with the wrong length', () => {
+      expect(isBoundingBox([0, 0, 1])).toBe(false)
+    })
+    it('returns false for an array containing non-numbers', () => {
+      expect(isBoundingBox([0, 0, 1, '1'])).toBe(false)
+    })
+    it('returns false for a non-array value', () => {
+      expect(isBoundingBox({ start: 0, end: 1 })).toBe(false)
     })
   })
 

--- a/libs/util/shared/src/lib/utils/geojson.ts
+++ b/libs/util/shared/src/lib/utils/geojson.ts
@@ -38,6 +38,14 @@ export function getGeometryFromGeoJSON(
 // FIXME: this type should be more generic across the project
 export type BoundingBox = [number, number, number, number]
 
+export function isBoundingBox(value: unknown): value is BoundingBox {
+  return (
+    Array.isArray(value) &&
+    value.length === 4 &&
+    value.every((item) => typeof item === 'number')
+  )
+}
+
 export function getGeometryBoundingBox(geometry: Geometry): BoundingBox {
   // use the bounding box if specified in the GeoJSON object
   if (geometry.bbox) {


### PR DESCRIPTION
### Description

This PR adds support for a hard spatial-extent filter in `ElasticsearchService.filtersToQuery`. Any filter value shaped like a bounding box (`[minX, minY, maxX, maxY]`) is detected via a new `isBoundingBox` type guard, excluded from the generic Lucene query-string building (same pattern already used for `gn-ui-crossFieldFilter` and date-range filters), and turned into a `geo_shape` `envelope` filter clause (relation `intersects`) added to the ES query's `bool.filter` array.

This is intentionally distinct from the existing `geometry` parameter, which only adds `should` (relevance-boost) clauses — the new spatial filter hard-excludes non-intersecting records.

This is a technical prerequisite for spatial search by GeoJSON file upload / geolocation service. Wiring this filter into the Datahub's search-field configuration system (`SpatialExtentSearchField`, URL sync, enable/disable config) is tracked separately.

### Architectural changes

- `libs/common/domain/src/lib/model/search/filter.model.ts`: added a `QueryGeoShape` type to the `FilterQuery` union, replacing a previously untyped cast.
- `libs/util/shared/src/lib/utils/geojson.ts`: added `isBoundingBox`, a type guard reused by the ES service.

### Screenshots

N/A — backend query-building change only, no UI changes.

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The documentation website 📚 has received the love it deserves

### How to test

1. Run the unit tests: `npx nx test api-repository --test-file=libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts` and `npx nx test util-shared --test-file=libs/util/shared/src/lib/utils/geojson.spec.ts`
2. Inspect the `handles spatial filter special case` test in `elasticsearch.service.spec.ts` to see the expected `geo_shape` clause produced from a bounding-box filter value.
