### PR TITLE
docs: fix typos and stale Node version reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to AI coding agents (Claude Code, and any tool that 
 
 GeoNetwork-UI is an Nx monorepo of Angular applications and Web Components that provide a modern UI on top of a GeoNetwork 4 catalog backend. It is built on Angular 20, NgRx, RxJS, Tailwind, and OpenLayers.
 
-Node version is pinned in `.nvmrc` (currently 20.19.0); `engines` requires Node >= 20.
+Node version is pinned in `.nvmrc` (currently 24); `engines` requires Node >= 24.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Then select the file(s) you want to test in the interface.
 
 Start docker from 'support-services', and then in the project root folder :
 
---> ALl tests :
+--> All tests :
 
 ```shell script
-npx nx e2e  (app_name)
+npx nx e2e (app_name)
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -136,12 +136,12 @@ git push upstream 2.7.x # replace "upstream" with your remote repo name
 
 #### With the backport bot
 
-On a PR that needs to be backported, (create and) add the ``backport-to-2.7.x` label (replace `2.7.x` with the wanted patch branch name).
+On a PR that needs to be backported, (create and) add the `backport-to-2.7.x` label (replace `2.7.x` with the wanted patch branch name).
 
 A new PR should automatically be created on the `2.7.x` branch, with the commits cherry-picked, or an indication of commits that couldn't be cherry-picked.
 
 #### Manually
 
-If the automatic backport is not successfull, you can either resolve the conflicts, or try to cherry-pick the needed correctly.
+If the automatic backport is not successful, you can either resolve the conflicts, or try to cherry-pick the needed commits manually.
 
-Be careful that comitting outside a PR will prevent the release notes on this next version to be generated automatically.
+Be careful that committing outside a PR will prevent the release notes on this next version to be generated automatically.


### PR DESCRIPTION
Fix typos in README and RELEASE, and update AGENTS.md's Node version note from 20.19.0 to 24 to match .nvmrc and package.json engines.
