### PR TITLE
fix(editor): preserve unrepresented service protocols under Other option

### DIFF
--- a/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.spec.ts
@@ -55,6 +55,71 @@ describe('OnlineServiceResourceInputComponent', () => {
         'wmts',
       ])
     })
+
+    it('replaces the other option with the stored unrepresented protocol and Other label', () => {
+      component.service = {
+        type: 'service',
+        url: new URL('https://example.com/stac'),
+        accessServiceProtocol: 'stac' as any,
+      }
+      const options = component.availableProtocolOptions
+      const otherOption = options.find((o) => o.value === ('stac' as any))
+      expect(otherOption).toBeDefined()
+      expect(otherOption?.label).toBe(
+        'editor.record.onlineResource.protocol.other'
+      )
+      expect(options.some((o) => o.value === 'other')).toBe(false)
+    })
+
+    it('appends unrepresented protocol when other is not in protocolOptions', () => {
+      component.protocolOptions = ['wms', 'wfs']
+      component.service = {
+        type: 'service',
+        url: new URL('https://example.com/stac'),
+        accessServiceProtocol: 'stac' as any,
+      }
+      const options = component.availableProtocolOptions
+      expect(options.map((o) => o.value)).toEqual(['wms', 'wfs', 'stac'])
+    })
+
+    it('does not mutate allProtocolOptions or protocolOptions when computing availableProtocolOptions', () => {
+      const initialAll = JSON.parse(
+        JSON.stringify(component.allProtocolOptions)
+      )
+      const initialConfigured = ['wms', 'other'] as any[]
+      component.protocolOptions = [...initialConfigured]
+      component.service = {
+        type: 'service',
+        url: new URL('https://example.com/stac'),
+        accessServiceProtocol: 'stac' as any,
+      }
+      const _ = component.availableProtocolOptions
+      expect(component.allProtocolOptions).toEqual(initialAll)
+      expect(component.protocolOptions).toEqual(initialConfigured)
+    })
+
+    it('restores normal options when switched from unrepresented to known protocol', () => {
+      const initialExpected = component.allProtocolOptions.map((o) => o.value)
+      component.service = {
+        type: 'service',
+        url: new URL('https://example.com/stac'),
+        accessServiceProtocol: 'stac' as any,
+      }
+      expect(
+        component.availableProtocolOptions.some(
+          (o) => o.value === ('stac' as any)
+        )
+      ).toBe(true)
+
+      component.service = {
+        type: 'service',
+        url: new URL('https://example.com/wms'),
+        accessServiceProtocol: 'wms',
+      }
+      expect(component.availableProtocolOptions.map((o) => o.value)).toEqual(
+        initialExpected
+      )
+    })
   })
 
   describe('url display', () => {

--- a/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.ts
+++ b/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.ts
@@ -129,10 +129,41 @@ export class OnlineServiceResourceInputComponent {
   ]
 
   get availableProtocolOptions() {
-    if (!this.protocolOptions) return this.allProtocolOptions
-    return this.protocolOptions.flatMap(
-      (v) => this.allProtocolOptions.find((o) => o.value === v) ?? []
-    )
+    const baseOptions = !this.protocolOptions
+      ? this.allProtocolOptions
+      : this.protocolOptions.flatMap(
+          (v) => this.allProtocolOptions.find((o) => o.value === v) ?? []
+        )
+
+    const currentProtocol = this._service?.accessServiceProtocol
+    if (
+      !currentProtocol ||
+      baseOptions.some((o) => o.value === currentProtocol)
+    ) {
+      return baseOptions
+    }
+
+    const otherLabel = marker('editor.record.onlineResource.protocol.other')
+    const hasOtherOption = baseOptions.some((o) => o.value === 'other')
+
+    if (hasOtherOption) {
+      return baseOptions.map((o) =>
+        o.value === 'other'
+          ? {
+              label: otherLabel,
+              value: currentProtocol,
+            }
+          : o
+      )
+    }
+
+    return [
+      ...baseOptions,
+      {
+        label: otherLabel,
+        value: currentProtocol,
+      },
+    ]
   }
 
   get activeLayerSuggestion() {


### PR DESCRIPTION
## Summary
When editing a service distribution with an unrepresented stored protocol (such as `stac`, `GPFDL`, or custom protocols), `availableProtocolOptions` previously lacked any matching radio option, causing the protocol selection to be dropped or corrupted on edit.

This PR:
1. Updates `availableProtocolOptions` in `OnlineServiceResourceInputComponent` to represent an unrepresented protocol using the translated `Other` label while retaining its exact stored value.
2. Replaces the generic `other` option when present, or appends it if absent.
3. Automatically restores standard protocol options when the user switches to a known protocol.
4. Adds comprehensive unit tests in `online-service-resource-input.component.spec.ts`.

Fixes #1390
