### PR TITLE
fix(editor): preserve unrepresented service protocols

### DIFF
--- a/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.html
+++ b/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.html
@@ -20,7 +20,10 @@
     [disabled]="disabled"
     (change)="resetAllFormFields()"
   >
-    @for (protocolOption of availableProtocolOptions; track protocolOption) {
+    @for (
+      protocolOption of availableProtocolOptions;
+      track protocolOption.value
+    ) {
       <mat-radio-button [value]="protocolOption.value">
         {{ protocolOption.label | translate }}
       </mat-radio-button>

--- a/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.spec.ts
+++ b/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.spec.ts
@@ -55,6 +55,76 @@ describe('OnlineServiceResourceInputComponent', () => {
         'wmts',
       ])
     })
+
+    it('represents a stored unlisted protocol with the Other label', () => {
+      component.service = {
+        type: 'service',
+        url: new URL('https://example.com/stac'),
+        accessServiceProtocol: 'stac',
+      }
+
+      const options = component.availableProtocolOptions
+      expect(options.find((option) => option.value === 'stac')).toEqual({
+        label: 'editor.record.onlineResource.protocol.other',
+        value: 'stac',
+      })
+      expect(options.some((option) => option.value === 'other')).toBe(false)
+    })
+
+    it('appends a stored unlisted protocol when Other is not configured', () => {
+      component.protocolOptions = ['wms', 'wfs']
+      component.service = {
+        type: 'service',
+        url: new URL('https://example.com/stac'),
+        accessServiceProtocol: 'stac',
+      }
+
+      expect(component.availableProtocolOptions.map((o) => o.value)).toEqual([
+        'wms',
+        'wfs',
+        'stac',
+      ])
+    })
+
+    it('does not mutate configured options while representing a stored protocol', () => {
+      const allOptions = component.allProtocolOptions.map((option) => ({
+        ...option,
+      }))
+      const configuredOptions = ['wms', 'other'] as const
+      component.protocolOptions = [...configuredOptions]
+      component.service = {
+        type: 'service',
+        url: new URL('https://example.com/stac'),
+        accessServiceProtocol: 'stac',
+      }
+
+      void component.availableProtocolOptions
+
+      expect(component.allProtocolOptions).toEqual(allOptions)
+      expect(component.protocolOptions).toEqual(configuredOptions)
+    })
+
+    it('restores standard options after selecting a represented protocol', () => {
+      component.service = {
+        type: 'service',
+        url: new URL('https://example.com/stac'),
+        accessServiceProtocol: 'stac',
+      }
+      expect(
+        component.availableProtocolOptions.some(
+          (option) => option.value === 'stac'
+        )
+      ).toBe(true)
+
+      component.service = {
+        type: 'service',
+        url: new URL('https://example.com/wms'),
+        accessServiceProtocol: 'wms',
+      }
+      expect(component.availableProtocolOptions).toEqual(
+        component.allProtocolOptions
+      )
+    })
   })
 
   describe('url display', () => {

--- a/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.ts
+++ b/libs/feature/editor/src/lib/components/online-service-resource-input/online-service-resource-input.component.ts
@@ -44,6 +44,9 @@ marker('editor.record.form.field.onlineResource.edit.identifier.placeholder')
 marker(
   'editor.record.form.field.onlineResource.edit.identifier.placeholder.wps'
 )
+const OTHER_PROTOCOL_LABEL = marker(
+  'editor.record.onlineResource.protocol.other'
+)
 
 @Component({
   selector: 'gn-ui-online-service-resource-input',
@@ -123,16 +126,40 @@ export class OnlineServiceResourceInputComponent {
       value: 'esriRest',
     },
     {
-      label: marker('editor.record.onlineResource.protocol.other'),
+      label: OTHER_PROTOCOL_LABEL,
       value: 'other',
     },
   ]
 
   get availableProtocolOptions() {
-    if (!this.protocolOptions) return this.allProtocolOptions
-    return this.protocolOptions.flatMap(
-      (v) => this.allProtocolOptions.find((o) => o.value === v) ?? []
-    )
+    const baseOptions = !this.protocolOptions
+      ? this.allProtocolOptions
+      : this.protocolOptions.flatMap(
+          (value) =>
+            this.allProtocolOptions.find((option) => option.value === value) ??
+            []
+        )
+    const currentProtocol = this._service?.accessServiceProtocol
+
+    if (
+      !currentProtocol ||
+      baseOptions.some((option) => option.value === currentProtocol)
+    ) {
+      return baseOptions
+    }
+
+    const currentProtocolOption = {
+      label: OTHER_PROTOCOL_LABEL,
+      value: currentProtocol,
+    }
+
+    if (baseOptions.some((option) => option.value === 'other')) {
+      return baseOptions.map((option) =>
+        option.value === 'other' ? currentProtocolOption : option
+      )
+    }
+
+    return [...baseOptions, currentProtocolOption]
   }
 
   get activeLayerSuggestion() {


### PR DESCRIPTION
### Description

Preserve an existing online-service protocol when it is valid in the data model but absent from the editor's curated protocol list.

- Replace the generic `Other` option with an option carrying the stored protocol value when needed.
- Restore the normal curated options automatically after the protocol changes to a represented value.
- Keep the source protocol arrays immutable and track rendered options by value.
- Add regression coverage for replacement, append, immutability, and restoration behavior.

Closes #1390. Supersedes #1688 with the reviewed replacement branch.

### Architectural changes

None. This change is local to the existing editor component and adds no dependencies.

### Screenshots

Not applicable; the change preserves the existing radio-option presentation.

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

- `npx nx test feature-editor` (41 suites, 297 tests)
- `npx nx lint feature-editor`
- `npx prettier --check` for the three changed component files
- `npx nx build metadata-editor --configuration=production`

### AI assistance

This PR was developed and reviewed with AI assistance from OpenAI Codex, Grok, and Google Antigravity (Gemini). Codex led the final implementation and validation, Grok independently reviewed the final diff, and Antigravity also contributed during development. The submitted patch passed the focused unit tests, lint, formatting, and production build listed above. I reviewed the submitted changes as the human owner and take responsibility for them; no independent maintainer review has been posted yet.
