### PR TITLE
[Datahub] Display record associations alongside the existing links

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset/datasetLinkedRecords.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetLinkedRecords.cy.ts
@@ -76,7 +76,7 @@ describe('dataset: linked records', () => {
       .find('h3')
       .eq(6)
       .as('associatedRecordsTitle')
-      .should('contain', 'Records referencing this record')
+      .should('contain', 'Records referencing the current one')
     cy.get('@associatedRecordsTitle').next('span').should('contain', '(1)')
 
     // it should generate a total of 12 internal link cards for all linked records

--- a/apps/datahub-e2e/src/e2e/dataset/datasetLinkedRecords.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetLinkedRecords.cy.ts
@@ -3,7 +3,7 @@ beforeEach(() => {
   // Note: The links to the reuse and service also exist in the dump, but not all the links between the datasets
   cy.intercept(
     'POST',
-    '/geonetwork/srv/api/search/records/_search?bucket=bucket&relatedType=fcats&relatedType=hassources',
+    '/geonetwork/srv/api/search/records/_search?bucket=bucket&relatedType=fcats&relatedType=hassources&relatedType=siblings&relatedType=associated',
     {
       fixture: 'alea-de-debordement.json',
     }
@@ -55,10 +55,34 @@ describe('dataset: linked records', () => {
       .should('contain', 'Associated services')
     cy.get('@associatedServicesTitle').next('span').should('contain', '(1)')
 
-    // it should generate a total of 8 internal link cards for all linked records
+    // it should display one grid per sibling association type, below the source grids
+    cy.get('datahub-record-internal-links')
+      .find('h3')
+      .eq(4)
+      .as('crossReferenceTitle')
+      .should('contain', 'Cross reference')
+    cy.get('@crossReferenceTitle').next('span').should('contain', '(2)')
+
+    cy.get('datahub-record-internal-links')
+      .find('h3')
+      .eq(5)
+      .as('largerWorkTitle')
+      .should('contain', 'Larger work citation')
+    cy.get('@largerWorkTitle').next('span').should('contain', '(1)')
+
+    // it should display the reverse (untyped) associations last, leaving out the one
+    // record that is already listed as a sibling
+    cy.get('datahub-record-internal-links')
+      .find('h3')
+      .eq(6)
+      .as('associatedRecordsTitle')
+      .should('contain', 'Records referencing this record')
+    cy.get('@associatedRecordsTitle').next('span').should('contain', '(1)')
+
+    // it should generate a total of 12 internal link cards for all linked records
     cy.get('datahub-record-linked-records')
       .find('datahub-record-internal-links')
       .find('gn-ui-internal-link-card')
-      .should('have.length', 8)
+      .should('have.length', 12)
   })
 })

--- a/apps/datahub-e2e/src/e2e/dataset/datasetPreview.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset/datasetPreview.cy.ts
@@ -597,7 +597,7 @@ describe('Preview section', () => {
         beforeEach(() => {
           cy.intercept(
             'POST',
-            '/geonetwork/srv/api/search/records/_search?bucket=bucket&relatedType=fcats&relatedType=hassources',
+            '/geonetwork/srv/api/search/records/_search?bucket=bucket&relatedType=fcats&relatedType=hassources&relatedType=siblings&relatedType=associated',
             {
               fixture: 'tms-record-source-removed.json',
             }

--- a/apps/datahub-e2e/src/fixtures/alea-de-debordement.json
+++ b/apps/datahub-e2e/src/fixtures/alea-de-debordement.json
@@ -1418,6 +1418,70 @@
               },
               "_id": "7eb795c2-d612-4b5e-b15e-d985b0f4e697"
             }
+          ],
+          "siblings": [
+            {
+              "origin": "catalog",
+              "properties": {
+                "associationType": "crossReference",
+                "initiativeType": ""
+              },
+              "_source": {
+                "uuid": "e27e7006-fdf9-4004-b6c5-af2a5a5c025c"
+              },
+              "_id": "e27e7006-fdf9-4004-b6c5-af2a5a5c025c"
+            },
+            {
+              "origin": "catalog",
+              "properties": {
+                "associationType": "crossReference",
+                "initiativeType": ""
+              },
+              "_source": {
+                "uuid": "a3774ef6-809d-4dd1-984f-9254f49cbd0a"
+              },
+              "_id": "a3774ef6-809d-4dd1-984f-9254f49cbd0a"
+            },
+            {
+              "origin": "catalog",
+              "properties": {
+                "associationType": "largerWorkCitation",
+                "initiativeType": ""
+              },
+              "_source": {
+                "uuid": "ee965118-2416-4d48-b07e-bbc696f002c2"
+              },
+              "_id": "ee965118-2416-4d48-b07e-bbc696f002c2"
+            },
+            {
+              "origin": "remote",
+              "properties": {
+                "associationType": "crossReference",
+                "initiativeType": ""
+              },
+              "_source": {
+                "uuid": "04bcec79-5b25-4b16-b635-73115f7456e4"
+              },
+              "_id": "04bcec79-5b25-4b16-b635-73115f7456e4"
+            }
+          ],
+          "associated": [
+            {
+              "origin": "catalog",
+              "properties": null,
+              "_source": {
+                "uuid": "ce551730-ee1a-4de3-9b49-7e432375d08a"
+              },
+              "_id": "ce551730-ee1a-4de3-9b49-7e432375d08a"
+            },
+            {
+              "origin": "catalog",
+              "properties": null,
+              "_source": {
+                "uuid": "e27e7006-fdf9-4004-b6c5-af2a5a5c025c"
+              },
+              "_id": "e27e7006-fdf9-4004-b6c5-af2a5a5c025c"
+            }
           ]
         }
       }

--- a/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.html
+++ b/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.html
@@ -28,3 +28,15 @@
     [records]="linkedServices$ | async"
   ></datahub-record-internal-links>
 }
+@for (group of siblings$ | async | keyvalue; track group.key) {
+  <datahub-record-internal-links
+    [title]="'domain.record.associationType.' + group.key | translate"
+    [records]="group.value"
+  ></datahub-record-internal-links>
+}
+@if (hasAssociated$ | async) {
+  <datahub-record-internal-links
+    [title]="'record.metadata.linked.associatedRecords' | translate"
+    [records]="associated$ | async"
+  ></datahub-record-internal-links>
+}

--- a/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.spec.ts
+++ b/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.spec.ts
@@ -16,10 +16,7 @@ describe('RecordLinkedRecordsComponent', () => {
       imports: [RecordLinkedRecordsComponent],
       providers: [
         MockProvider(MdViewFacade, {
-          sources$: new BehaviorSubject([]),
-          sourceOf$: new BehaviorSubject([]),
-          siblings$: new BehaviorSubject({}),
-          associated$: new BehaviorSubject([]),
+          associatedRecords$: new BehaviorSubject([]),
         }),
       ],
     }).compileComponents()

--- a/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.spec.ts
+++ b/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.spec.ts
@@ -18,6 +18,8 @@ describe('RecordLinkedRecordsComponent', () => {
         MockProvider(MdViewFacade, {
           sources$: new BehaviorSubject([]),
           sourceOf$: new BehaviorSubject([]),
+          siblings$: new BehaviorSubject({}),
+          associated$: new BehaviorSubject([]),
         }),
       ],
     }).compileComponents()

--- a/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.spec.ts
+++ b/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.spec.ts
@@ -3,20 +3,71 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { RecordLinkedRecordsComponent } from './record-linked-records.component'
 import { MockBuilder, MockProvider } from 'ng-mocks'
 import { MdViewFacade } from '@geonetwork-ui/feature/record'
-import { BehaviorSubject } from 'rxjs'
+import { BehaviorSubject, firstValueFrom } from 'rxjs'
+import { By } from '@angular/platform-browser'
+import { LinkedRecord } from '@geonetwork-ui/common/domain/model/record'
+
+const linkedRecords = [
+  {
+    record: { uniqueIdentifier: 'src-1', kind: 'dataset' },
+    relation: 'source',
+  },
+  {
+    record: { uniqueIdentifier: 'ds-1', kind: 'dataset' },
+    relation: 'sourceOf',
+  },
+  {
+    record: { uniqueIdentifier: 'reuse-1', kind: 'reuse' },
+    relation: 'sourceOf',
+  },
+  {
+    record: { uniqueIdentifier: 'svc-1', kind: 'service' },
+    relation: 'sourceOf',
+  },
+  {
+    record: { uniqueIdentifier: 'sib-1', kind: 'dataset' },
+    relation: 'sibling',
+    associationType: 'crossReference',
+  },
+  {
+    record: { uniqueIdentifier: 'sib-2', kind: 'dataset' },
+    relation: 'sibling',
+    associationType: 'largerWorkCitation',
+  },
+  {
+    record: { uniqueIdentifier: 'sib-3', kind: 'dataset' },
+    relation: 'sibling',
+    associationType: 'crossReference',
+  },
+  {
+    record: { uniqueIdentifier: 'assoc-1', kind: 'dataset' },
+    relation: 'associated',
+  },
+] as LinkedRecord[]
 
 describe('RecordLinkedRecordsComponent', () => {
   let component: RecordLinkedRecordsComponent
   let fixture: ComponentFixture<RecordLinkedRecordsComponent>
+  let facadeLinkedRecords$: BehaviorSubject<LinkedRecord[]>
+
+  const renderedGrids = () =>
+    fixture.debugElement
+      .queryAll(By.css('datahub-record-internal-links'))
+      .map((grid) =>
+        grid.componentInstance.records.map(
+          ({ uniqueIdentifier }) => uniqueIdentifier
+        )
+      )
 
   beforeEach(() => MockBuilder(RecordLinkedRecordsComponent))
 
   beforeEach(async () => {
+    facadeLinkedRecords$ = new BehaviorSubject<LinkedRecord[]>([])
     await TestBed.configureTestingModule({
       imports: [RecordLinkedRecordsComponent],
       providers: [
         MockProvider(MdViewFacade, {
-          associatedRecords$: new BehaviorSubject([]),
+          linkedRecords$: facadeLinkedRecords$,
         }),
       ],
     }).compileComponents()
@@ -28,5 +79,36 @@ describe('RecordLinkedRecordsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  it('renders no grid when the record has no linked record', () => {
+    expect(renderedGrids()).toEqual([])
+  })
+
+  it('renders one grid per relation, siblings split by association type', () => {
+    facadeLinkedRecords$.next(linkedRecords)
+    fixture.detectChanges()
+
+    expect(renderedGrids()).toEqual([
+      ['src-1'], // source datasets
+      ['ds-1'], // reverse lineage, datasets
+      ['reuse-1'], // reverse lineage, reuses
+      ['svc-1'], // reverse lineage, services
+      ['sib-1', 'sib-3'], // crossReference
+      ['sib-2'], // largerWorkCitation
+      ['assoc-1'], // reverse associations, last
+    ])
+  })
+
+  it('groups the siblings by association type', async () => {
+    facadeLinkedRecords$.next(linkedRecords)
+
+    expect(await firstValueFrom(component.siblings$)).toEqual({
+      crossReference: [
+        { uniqueIdentifier: 'sib-1', kind: 'dataset' },
+        { uniqueIdentifier: 'sib-3', kind: 'dataset' },
+      ],
+      largerWorkCitation: [{ uniqueIdentifier: 'sib-2', kind: 'dataset' }],
+    })
   })
 })

--- a/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.ts
+++ b/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.ts
@@ -31,6 +31,8 @@ export class RecordLinkedRecordsComponent {
   linkedServices$ = this.metadataViewFacade.sourceOf$.pipe(
     map((records) => records?.filter((record) => record?.kind === 'service'))
   )
+  siblings$ = this.metadataViewFacade.siblings$
+  associated$ = this.metadataViewFacade.associated$
 
   get hasSourceDatasets$() {
     return this.sourceDatasets$.pipe(map((records) => records?.length > 0))
@@ -43,5 +45,8 @@ export class RecordLinkedRecordsComponent {
   }
   get hasLinkedServices$() {
     return this.linkedServices$.pipe(map((records) => records?.length > 0))
+  }
+  get hasAssociated$() {
+    return this.associated$.pipe(map((records) => records?.length > 0))
   }
 }

--- a/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.ts
+++ b/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.ts
@@ -26,8 +26,8 @@ import {
 export class RecordLinkedRecordsComponent {
   protected metadataViewFacade = inject(MdViewFacade)
 
-  private associatedRecords$ = this.metadataViewFacade.associatedRecords$.pipe(
-    map((associatedRecords) => associatedRecords ?? [])
+  private linkedRecords$ = this.metadataViewFacade.linkedRecords$.pipe(
+    map((linkedRecords) => linkedRecords ?? [])
   )
 
   sourceDatasets$ = this.recordsOf('source')
@@ -36,9 +36,9 @@ export class RecordLinkedRecordsComponent {
   linkedServices$ = this.recordsOf('sourceOf', 'service')
   associated$ = this.recordsOf('associated')
 
-  siblings$ = this.associatedRecords$.pipe(
-    map((associatedRecords) =>
-      associatedRecords
+  siblings$ = this.linkedRecords$.pipe(
+    map((linkedRecords) =>
+      linkedRecords
         .filter(({ relation }) => relation === 'sibling')
         .reduce(
           (groups, { record, associationType }) => {
@@ -66,9 +66,9 @@ export class RecordLinkedRecordsComponent {
   hasAssociated$ = this.associated$.pipe(map((records) => records.length > 0))
 
   private recordsOf(relation: RecordRelation, kind?: CatalogRecord['kind']) {
-    return this.associatedRecords$.pipe(
-      map((associatedRecords) =>
-        associatedRecords
+    return this.linkedRecords$.pipe(
+      map((linkedRecords) =>
+        linkedRecords
           .filter((associated) => associated.relation === relation)
           .map(({ record }) => record)
           .filter((record) => !kind || record.kind === kind)

--- a/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.ts
+++ b/apps/datahub/src/app/record/record-linked-records/record-linked-records.component.ts
@@ -4,6 +4,11 @@ import { map } from 'rxjs'
 import { RecordInternalLinksComponent } from '../record-internal-links/record-internal-links.component'
 import { CommonModule } from '@angular/common'
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core'
+import {
+  AssociationType,
+  CatalogRecord,
+  RecordRelation,
+} from '@geonetwork-ui/common/domain/model/record'
 
 @Component({
   selector: 'datahub-record-linked-records',
@@ -21,32 +26,53 @@ import { TranslateDirective, TranslatePipe } from '@ngx-translate/core'
 export class RecordLinkedRecordsComponent {
   protected metadataViewFacade = inject(MdViewFacade)
 
-  sourceDatasets$ = this.metadataViewFacade.sources$
-  linkedDatasets$ = this.metadataViewFacade.sourceOf$.pipe(
-    map((records) => records?.filter((record) => record?.kind === 'dataset'))
+  private associatedRecords$ = this.metadataViewFacade.associatedRecords$.pipe(
+    map((associatedRecords) => associatedRecords ?? [])
   )
-  linkedReuses$ = this.metadataViewFacade.sourceOf$.pipe(
-    map((records) => records?.filter((record) => record?.kind === 'reuse'))
-  )
-  linkedServices$ = this.metadataViewFacade.sourceOf$.pipe(
-    map((records) => records?.filter((record) => record?.kind === 'service'))
-  )
-  siblings$ = this.metadataViewFacade.siblings$
-  associated$ = this.metadataViewFacade.associated$
 
-  get hasSourceDatasets$() {
-    return this.sourceDatasets$.pipe(map((records) => records?.length > 0))
-  }
-  get hasLinkedDatasets$() {
-    return this.linkedDatasets$.pipe(map((records) => records?.length > 0))
-  }
-  get hasLinkedReuses$() {
-    return this.linkedReuses$.pipe(map((records) => records?.length > 0))
-  }
-  get hasLinkedServices$() {
-    return this.linkedServices$.pipe(map((records) => records?.length > 0))
-  }
-  get hasAssociated$() {
-    return this.associated$.pipe(map((records) => records?.length > 0))
+  sourceDatasets$ = this.recordsOf('source')
+  linkedDatasets$ = this.recordsOf('sourceOf', 'dataset')
+  linkedReuses$ = this.recordsOf('sourceOf', 'reuse')
+  linkedServices$ = this.recordsOf('sourceOf', 'service')
+  associated$ = this.recordsOf('associated')
+
+  siblings$ = this.associatedRecords$.pipe(
+    map((associatedRecords) =>
+      associatedRecords
+        .filter(({ relation }) => relation === 'sibling')
+        .reduce(
+          (groups, { record, associationType }) => {
+            groups[associationType] ??= []
+            groups[associationType].push(record)
+            return groups
+          },
+          {} as Partial<Record<AssociationType, CatalogRecord[]>>
+        )
+    )
+  )
+
+  hasSourceDatasets$ = this.sourceDatasets$.pipe(
+    map((records) => records.length > 0)
+  )
+  hasLinkedDatasets$ = this.linkedDatasets$.pipe(
+    map((records) => records.length > 0)
+  )
+  hasLinkedReuses$ = this.linkedReuses$.pipe(
+    map((records) => records.length > 0)
+  )
+  hasLinkedServices$ = this.linkedServices$.pipe(
+    map((records) => records.length > 0)
+  )
+  hasAssociated$ = this.associated$.pipe(map((records) => records.length > 0))
+
+  private recordsOf(relation: RecordRelation, kind?: CatalogRecord['kind']) {
+    return this.associatedRecords$.pipe(
+      map((associatedRecords) =>
+        associatedRecords
+          .filter((associated) => associated.relation === relation)
+          .map(({ record }) => record)
+          .filter((record) => !kind || record.kind === kind)
+      )
+    )
   }
 }

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
@@ -48,7 +48,7 @@ class MdViewFacadeMock {
   otherLinks$ = new BehaviorSubject([])
   stacLinks$ = new BehaviorSubject([])
   related$ = new BehaviorSubject(null)
-  associatedRecords$ = new BehaviorSubject([])
+  linkedRecords$ = new BehaviorSubject([])
   featureCatalog$ = new BehaviorSubject(null)
   error$ = new BehaviorSubject(null)
   isMetadataLoading$ = new BehaviorSubject(false)
@@ -415,7 +415,7 @@ describe('RecordMetadataComponent', () => {
       expect(linkedSection()).toBeFalsy()
     })
     it('renders for a record having any linked record', () => {
-      facade.associatedRecords$.next([
+      facade.linkedRecords$.next([
         { record: { title: 'a sibling' }, relation: 'sibling' },
       ])
       fixture.detectChanges()

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
@@ -50,6 +50,8 @@ class MdViewFacadeMock {
   related$ = new BehaviorSubject(null)
   sources$ = new BehaviorSubject([])
   sourceOf$ = new BehaviorSubject([])
+  siblings$ = new BehaviorSubject({})
+  associated$ = new BehaviorSubject([])
   featureCatalog$ = new BehaviorSubject(null)
   error$ = new BehaviorSubject(null)
   isMetadataLoading$ = new BehaviorSubject(false)
@@ -404,6 +406,31 @@ describe('RecordMetadataComponent', () => {
       it('Related component renders', () => {
         expect(relatedComponent).toBeTruthy()
       })
+    })
+  })
+
+  describe('linked records section', () => {
+    const linkedSection = () =>
+      fixture.debugElement.query(By.css('#linked-records'))
+
+    it('does not render without any linked record', () => {
+      fixture.detectChanges()
+      expect(linkedSection()).toBeFalsy()
+    })
+    it('renders for a record having only source datasets', () => {
+      facade.sources$.next([{ title: 'a source' }])
+      fixture.detectChanges()
+      expect(linkedSection()).toBeTruthy()
+    })
+    it('renders for a record having only siblings', () => {
+      facade.siblings$.next({ crossReference: [{ title: 'a sibling' }] })
+      fixture.detectChanges()
+      expect(linkedSection()).toBeTruthy()
+    })
+    it('renders for a record having only reverse associations', () => {
+      facade.associated$.next([{ title: 'an associated record' }])
+      fixture.detectChanges()
+      expect(linkedSection()).toBeTruthy()
     })
   })
 

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.spec.ts
@@ -48,10 +48,7 @@ class MdViewFacadeMock {
   otherLinks$ = new BehaviorSubject([])
   stacLinks$ = new BehaviorSubject([])
   related$ = new BehaviorSubject(null)
-  sources$ = new BehaviorSubject([])
-  sourceOf$ = new BehaviorSubject([])
-  siblings$ = new BehaviorSubject({})
-  associated$ = new BehaviorSubject([])
+  associatedRecords$ = new BehaviorSubject([])
   featureCatalog$ = new BehaviorSubject(null)
   error$ = new BehaviorSubject(null)
   isMetadataLoading$ = new BehaviorSubject(false)
@@ -417,18 +414,10 @@ describe('RecordMetadataComponent', () => {
       fixture.detectChanges()
       expect(linkedSection()).toBeFalsy()
     })
-    it('renders for a record having only source datasets', () => {
-      facade.sources$.next([{ title: 'a source' }])
-      fixture.detectChanges()
-      expect(linkedSection()).toBeTruthy()
-    })
-    it('renders for a record having only siblings', () => {
-      facade.siblings$.next({ crossReference: [{ title: 'a sibling' }] })
-      fixture.detectChanges()
-      expect(linkedSection()).toBeTruthy()
-    })
-    it('renders for a record having only reverse associations', () => {
-      facade.associated$.next([{ title: 'an associated record' }])
+    it('renders for a record having any linked record', () => {
+      facade.associatedRecords$.next([
+        { record: { title: 'a sibling' }, relation: 'sibling' },
+      ])
       fixture.detectChanges()
       expect(linkedSection()).toBeTruthy()
     })

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -208,19 +208,8 @@ export class RecordMetadataComponent {
     map((records) => records?.length > 0)
   )
 
-  displayLinked$ = combineLatest([
-    this.metadataViewFacade.sources$,
-    this.metadataViewFacade.sourceOf$,
-    this.metadataViewFacade.siblings$,
-    this.metadataViewFacade.associated$,
-  ]).pipe(
-    map(
-      ([sources, sourceOf, siblings, associated]) =>
-        sources?.length > 0 ||
-        sourceOf?.length > 0 ||
-        Object.keys(siblings ?? {}).length > 0 ||
-        associated?.length > 0
-    )
+  displayLinked$ = this.metadataViewFacade.associatedRecords$.pipe(
+    map((associatedRecords) => associatedRecords?.length > 0)
   )
 
   displayFeatureCatalog$ = combineLatest([

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -211,8 +211,16 @@ export class RecordMetadataComponent {
   displayLinked$ = combineLatest([
     this.metadataViewFacade.sources$,
     this.metadataViewFacade.sourceOf$,
+    this.metadataViewFacade.siblings$,
+    this.metadataViewFacade.associated$,
   ]).pipe(
-    map(([sources, sourceOf]) => sources?.length > 0 || sourceOf?.length > 0)
+    map(
+      ([sources, sourceOf, siblings, associated]) =>
+        sources?.length > 0 ||
+        sourceOf?.length > 0 ||
+        Object.keys(siblings ?? {}).length > 0 ||
+        associated?.length > 0
+    )
   )
 
   displayFeatureCatalog$ = combineLatest([

--- a/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
+++ b/apps/datahub/src/app/record/record-metadata/record-metadata.component.ts
@@ -208,8 +208,8 @@ export class RecordMetadataComponent {
     map((records) => records?.length > 0)
   )
 
-  displayLinked$ = this.metadataViewFacade.associatedRecords$.pipe(
-    map((associatedRecords) => associatedRecords?.length > 0)
+  displayLinked$ = this.metadataViewFacade.linkedRecords$.pipe(
+    map((linkedRecords) => linkedRecords?.length > 0)
   )
 
   displayFeatureCatalog$ = combineLatest([

--- a/docs/apps/datahub-sections-fields.md
+++ b/docs/apps/datahub-sections-fields.md
@@ -8,9 +8,9 @@ outline: deep
 
 ### Linked records
 
-The section about linked records is displayed only when the record's ES indexation contains links of type `source` or `hassource` to other records.
+The section about linked records is displayed only when the record's ES indexation contains links of type `source`, `hassource`, `siblings` or `associated` to other records.
 
-These links are indexed when the underlying records contains lineage information:
+The `source` and `hassource` links are indexed when the underlying records contains lineage information:
 
 - iso 19139
 
@@ -46,6 +46,56 @@ The `source` elements can be repeated as many times as necessary.
 A source containing only an `uuidref` is still valid and will be indexed.
 
 The reverse link will be created as long as the `uuidref` points to an existing record in the catalog.
+
+#### Record associations
+
+Below those grids, one grid is displayed per association type, followed by a grid of the reverse associations (the records pointing at this one).
+
+The `siblings` and `associated` links are indexed when the underlying records contains association information:
+
+- iso 19139
+
+```
+  <gmd:aggregationInfo>
+     <gmd:MD_AggregateInformation>
+        <gmd:aggregateDataSetIdentifier>
+           <gmd:MD_Identifier>
+              <gmd:code>
+                 <gco:CharacterString>789c5bab-157a-46cd-babe-12de5128eea9</gco:CharacterString>
+              </gmd:code>
+           </gmd:MD_Identifier>
+        </gmd:aggregateDataSetIdentifier>
+        <gmd:associationType>
+           <gmd:DS_AssociationTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#DS_AssociationTypeCode"
+                                       codeListValue="largerWorkCitation"/>
+        </gmd:associationType>
+     </gmd:MD_AggregateInformation>
+  </gmd:aggregationInfo>
+```
+
+- iso 19115-3
+
+```
+  <mri:associatedResource>
+     <mri:MD_AssociatedResource>
+        <mri:associationType>
+           <mri:DS_AssociationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode"
+                                       codeListValue="crossReference"/>
+        </mri:associationType>
+        <mri:metadataReference uuidref="789c5bab-157a-46cd-babe-12de5128eea9"/>
+     </mri:MD_AssociatedResource>
+  </mri:associatedResource>
+```
+
+The `aggregationInfo` / `associatedResource` elements can be repeated as many times as necessary.
+
+Each grid is titled after the association type.
+
+The reverse grid has no association type, as that information belongs to the other record.
+
+A record already listed under an association type is left out of the reverse grid, the association being the more precise relation.
+
+A card is only displayed as long as the identifier points to an existing record in the catalog.
 
 ## Dataset
 

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.spec.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.spec.ts
@@ -251,6 +251,52 @@ describe('Gn4FieldMapper', () => {
                   },
                 },
               ],
+              siblings: [
+                {
+                  origin: 'catalog',
+                  properties: { associationType: 'crossReference' },
+                  _source: {
+                    uuid: 'sibling-001',
+                  },
+                },
+                {
+                  origin: 'catalog',
+                  properties: { associationType: 'largerWorkCitation' },
+                  _source: {
+                    uuid: 'sibling-002',
+                  },
+                },
+                {
+                  origin: 'remote',
+                  properties: { associationType: 'crossReference' },
+                  _source: {
+                    uuid: 'sibling-003',
+                  },
+                },
+              ],
+              associated: [
+                {
+                  origin: 'catalog',
+                  properties: null,
+                  _source: {
+                    uuid: 'associated-001',
+                  },
+                },
+                {
+                  origin: 'remote',
+                  properties: null,
+                  _source: {
+                    uuid: 'associated-002',
+                  },
+                },
+                {
+                  origin: 'catalog',
+                  properties: null,
+                  _source: {
+                    uuid: 'sibling-001',
+                  },
+                },
+              ],
             },
           }
           const result = mappingFn(output, source)
@@ -258,6 +304,17 @@ describe('Gn4FieldMapper', () => {
             extras: {
               featureCatalogIdentifier: 'featurecatalog-001',
               sourceOfIdentifiers: ['hassource-001'],
+              siblings: [
+                {
+                  uniqueIdentifier: 'sibling-001',
+                  associationType: 'crossReference',
+                },
+                {
+                  uniqueIdentifier: 'sibling-002',
+                  associationType: 'largerWorkCitation',
+                },
+              ],
+              associatedIdentifiers: ['associated-001'],
             },
           })
         })

--- a/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
+++ b/libs/api/metadata-converter/src/lib/gn4/gn4.field.mapper.ts
@@ -15,9 +15,11 @@ import {
 } from './atomic-operations'
 import { MetadataUrlService } from './metadata-url.service'
 import { inject, Injectable } from '@angular/core'
+import { getAssociationTypeFromCode } from '../iso19139/utils/association-type.mapper'
 import { getStatusFromStatusCode } from '../iso19139/utils/status.mapper'
 import { getUpdateFrequencyFromFrequencyCode } from '../iso19139/utils/update-frequency.mapper'
 import {
+  AssociatedRecord,
   CatalogRecord,
   Constraint,
   DatasetSpatialExtent,
@@ -318,25 +320,16 @@ export class Gn4FieldMapper {
         output
       ),
     related: (output, source) => {
+      const related = <SourceWithUnknownProps>selectField(source, 'related')
       const fcatSource = selectField(
-        getFirstValue(
-          selectField(
-            <SourceWithUnknownProps>selectField(source, 'related'),
-            'fcats'
-          )
-        ) ?? {},
+        getFirstValue(selectField(related, 'fcats')) ?? {},
         '_source'
       )
       const featureCatalogIdentifier: string = selectField(
         <SourceWithUnknownProps>fcatSource,
         'uuid'
       )
-      const sourceOfLinks = getAsArray(
-        selectField(
-          <SourceWithUnknownProps>selectField(source, 'related'),
-          'hassources'
-        )
-      )
+      const sourceOfLinks = getAsArray(selectField(related, 'hassources'))
       const sourceOfIdentifiers: string[] = sourceOfLinks
         .filter((link) => link['origin'] === 'catalog')
         .map((link) => {
@@ -345,12 +338,49 @@ export class Gn4FieldMapper {
             'uuid'
           )
         })
-      const extraValues: Record<string, string | string[]> = {}
+      const siblingLinks = getAsArray(selectField(related, 'siblings'))
+      const siblings: AssociatedRecord[] = siblingLinks
+        .filter((link) => link['origin'] === 'catalog')
+        .map((link) => ({
+          uniqueIdentifier: selectField<string>(
+            selectField(<SourceWithUnknownProps>link, '_source'),
+            'uuid'
+          ),
+          associationType: getAssociationTypeFromCode(
+            selectField<string>(
+              selectField(<SourceWithUnknownProps>link, 'properties'),
+              'associationType'
+            )
+          ),
+        }))
+      const associatedLinks = getAsArray(selectField(related, 'associated'))
+      const associatedIdentifiers: string[] = associatedLinks
+        .filter((link) => link['origin'] === 'catalog')
+        .map((link) => {
+          return selectField<string>(
+            selectField(<SourceWithUnknownProps>link, '_source'),
+            'uuid'
+          )
+        })
+        .filter(
+          (uuid) =>
+            !siblings.some((sibling) => sibling.uniqueIdentifier === uuid)
+        )
+      const extraValues: Record<
+        string,
+        string | string[] | AssociatedRecord[]
+      > = {}
       if (featureCatalogIdentifier) {
         extraValues.featureCatalogIdentifier = featureCatalogIdentifier
       }
       if (sourceOfIdentifiers && sourceOfIdentifiers.length > 0) {
         extraValues.sourceOfIdentifiers = sourceOfIdentifiers
+      }
+      if (associatedIdentifiers && associatedIdentifiers.length > 0) {
+        extraValues.associatedIdentifiers = associatedIdentifiers
+      }
+      if (siblings && siblings.length > 0) {
+        extraValues.siblings = siblings
       }
       return Object.keys(extraValues).length > 0
         ? this.addExtra(extraValues, output)

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.spec.ts
@@ -810,13 +810,14 @@ describe('ElasticsearchService', () => {
       uuid = '132132132132321'
       payload = service.getMetadataByIdsPayload([uuid])
     })
-    it('returns ES payload', () => {
+    it('returns ES payload sized to the number of ids', () => {
       expect(payload).toEqual({
         query: {
           ids: {
             values: [uuid],
           },
         },
+        size: 1,
       })
     })
   })

--- a/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
+++ b/libs/api/repository/src/lib/gn4/elasticsearch/elasticsearch.service.ts
@@ -141,6 +141,7 @@ export class ElasticsearchService {
           values: uuids,
         },
       },
+      size: uuids.length,
     }
   }
 

--- a/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
@@ -37,7 +37,7 @@ import {
 import {
   CatalogRecord,
   DatasetFeatureCatalog,
-  RelatedRecord,
+  LinkedRecord,
 } from '@geonetwork-ui/common/domain/model/record'
 import { map } from 'rxjs/operators'
 import { HttpErrorResponse, provideHttpClient } from '@angular/common/http'
@@ -535,8 +535,8 @@ describe('Gn4Repository', () => {
       expect(results).toStrictEqual(datasetRecordsFixture())
     })
   })
-  describe('getAssociatedRecords', () => {
-    let associatedRecords: RelatedRecord[]
+  describe('getLinkedRecords', () => {
+    let linkedRecords: LinkedRecord[]
     const mockRecord = {
       ...SAMPLE_RECORD_WITH_EXTRAS,
       extras: {
@@ -566,8 +566,8 @@ describe('Gn4Repository', () => {
               .map((id) => ({ uniqueIdentifier: id }))
           )
         )
-      associatedRecords = await lastValueFrom(
-        repository.getAssociatedRecords(mockRecord)
+      linkedRecords = await lastValueFrom(
+        repository.getLinkedRecords(mockRecord)
       )
     })
     it('calls getMultipleRecords once per relation holding identifiers', () => {
@@ -587,7 +587,7 @@ describe('Gn4Repository', () => {
       ])
     })
     it('tags each record with its relation, keeping a record related twice under both relations', () => {
-      expect(associatedRecords).toEqual([
+      expect(linkedRecords).toEqual([
         {
           record: { uniqueIdentifier: 'source-1' },
           relation: 'source',
@@ -633,7 +633,7 @@ describe('Gn4Repository', () => {
               )
         )
       const result = await lastValueFrom(
-        repository.getAssociatedRecords(mockRecord)
+        repository.getLinkedRecords(mockRecord)
       )
       expect(result.map(({ relation }) => relation)).toEqual([
         'source',
@@ -646,7 +646,7 @@ describe('Gn4Repository', () => {
     it('returns an empty array if the record has no relation at all', async () => {
       const recordWithoutRelations = { ...mockRecord, extras: {} }
       const result = await lastValueFrom(
-        repository.getAssociatedRecords(recordWithoutRelations)
+        repository.getLinkedRecords(recordWithoutRelations)
       )
       expect(result).toEqual([])
     })

--- a/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
@@ -418,7 +418,7 @@ describe('Gn4Repository', () => {
       it('calls the API with correct parameters', () => {
         expect(spySearch).toHaveBeenCalledWith(
           'bucket',
-          ['fcats', 'hassources'],
+          ['fcats', 'hassources', 'siblings', 'associated'],
           '{"uuids":["feature-catalog-identifier"]}'
         )
       })
@@ -599,6 +599,102 @@ describe('Gn4Repository', () => {
       const recordWithoutSourceOf = { ...mockRecord, extras: {} }
       const result = await lastValueFrom(
         repository.getSourceOf(recordWithoutSourceOf)
+      )
+      expect(result).toBeNull()
+    })
+  })
+  describe('getSiblings', () => {
+    let siblings: Record<string, CatalogRecord[]>
+    const mockRecord = {
+      ...SAMPLE_RECORD_WITH_EXTRAS,
+      extras: {
+        siblings: [
+          {
+            uniqueIdentifier: 'sibling-1',
+            associationType: 'crossReference',
+          },
+          {
+            uniqueIdentifier: 'sibling-2',
+            associationType: 'largerWorkCitation',
+          },
+          {
+            uniqueIdentifier: 'sibling-3',
+            associationType: 'crossReference',
+          },
+          {
+            uniqueIdentifier: 'not-in-catalog',
+            associationType: 'crossReference',
+          },
+        ],
+      },
+    }
+    beforeEach(async () => {
+      repository.getMultipleRecords = jest
+        .fn()
+        .mockImplementation((ids) =>
+          of(
+            ids
+              .filter((id) => id !== 'not-in-catalog')
+              .map((id) => ({ uniqueIdentifier: id }))
+          )
+        )
+      siblings = await lastValueFrom(repository.getSiblings(mockRecord))
+    })
+    it('calls getMultipleRecords for sibling identifiers', () => {
+      expect(repository.getMultipleRecords).toHaveBeenCalledWith([
+        'sibling-1',
+        'sibling-2',
+        'sibling-3',
+        'not-in-catalog',
+      ])
+    })
+    it('returns the siblings bucketed by association type, without the identifiers missing from the catalog', () => {
+      expect(siblings).toEqual({
+        crossReference: [
+          { uniqueIdentifier: 'sibling-1' },
+          { uniqueIdentifier: 'sibling-3' },
+        ],
+        largerWorkCitation: [{ uniqueIdentifier: 'sibling-2' }],
+      })
+    })
+    it('returns null if no siblings are defined', async () => {
+      const recordWithoutSiblings = { ...mockRecord, extras: {} }
+      const result = await lastValueFrom(
+        repository.getSiblings(recordWithoutSiblings)
+      )
+      expect(result).toBeNull()
+    })
+  })
+  describe('getAssociated', () => {
+    let associated: CatalogRecord[]
+    const mockRecord = {
+      ...SAMPLE_RECORD_WITH_EXTRAS,
+      extras: {
+        associatedIdentifiers: ['associated-1', 'associated-2'],
+      },
+    }
+    beforeEach(async () => {
+      repository.getMultipleRecords = jest
+        .fn()
+        .mockImplementation((ids) => of(ids.map((id) => ({ uuid: id }))))
+      associated = await lastValueFrom(repository.getAssociated(mockRecord))
+    })
+    it('calls getMultipleRecords for associated identifiers', () => {
+      expect(repository.getMultipleRecords).toHaveBeenCalledWith([
+        'associated-1',
+        'associated-2',
+      ])
+    })
+    it('returns the associated records as an array of CatalogRecord', () => {
+      expect(associated).toEqual([
+        { uuid: 'associated-1' },
+        { uuid: 'associated-2' },
+      ])
+    })
+    it('returns null if no associatedIdentifiers are defined', async () => {
+      const recordWithoutAssociated = { ...mockRecord, extras: {} }
+      const result = await lastValueFrom(
+        repository.getAssociated(recordWithoutAssociated)
       )
       expect(result).toBeNull()
     })

--- a/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.spec.ts
@@ -37,6 +37,7 @@ import {
 import {
   CatalogRecord,
   DatasetFeatureCatalog,
+  RelatedRecord,
 } from '@geonetwork-ui/common/domain/model/record'
 import { map } from 'rxjs/operators'
 import { HttpErrorResponse, provideHttpClient } from '@angular/common/http'
@@ -534,98 +535,25 @@ describe('Gn4Repository', () => {
       expect(results).toStrictEqual(datasetRecordsFixture())
     })
   })
-  describe('getSources', () => {
-    let sources: CatalogRecord[]
+  describe('getAssociatedRecords', () => {
+    let associatedRecords: RelatedRecord[]
     const mockRecord = {
       ...SAMPLE_RECORD_WITH_EXTRAS,
       extras: {
-        sourcesIdentifiers: ['source-1', 'source-2'],
-      },
-    }
-
-    beforeEach(async () => {
-      repository.getMultipleRecords = jest
-        .fn()
-        .mockImplementation((ids) => of(ids.map((id) => ({ uuid: id }))))
-      sources = await lastValueFrom(repository.getSources(mockRecord))
-    })
-
-    it('calls getMultipleRecords for source identifiers', () => {
-      expect(repository.getMultipleRecords).toHaveBeenCalledWith([
-        'source-1',
-        'source-2',
-      ])
-    })
-
-    it('returns the sources as an array of CatalogRecord', () => {
-      expect(sources).toEqual([{ uuid: 'source-1' }, { uuid: 'source-2' }])
-    })
-
-    it('returns null if no sourcesIdentifiers are defined', async () => {
-      const recordWithoutSources = { ...mockRecord, extras: {} }
-      const result = await lastValueFrom(
-        repository.getSources(recordWithoutSources)
-      )
-      expect(result).toBeNull()
-    })
-  })
-  describe('getSourceOf', () => {
-    let sourceOf: CatalogRecord[]
-    const mockRecord = {
-      ...SAMPLE_RECORD_WITH_EXTRAS,
-      extras: {
-        sourceOfIdentifiers: ['hasSource-1', 'hasSource-2'],
-      },
-    }
-    beforeEach(async () => {
-      repository.getMultipleRecords = jest
-        .fn()
-        .mockImplementation((ids) => of(ids.map((id) => ({ uuid: id }))))
-      sourceOf = await lastValueFrom(repository.getSourceOf(mockRecord))
-    })
-    it('calls getMultipleRecords for hasSource identifiers', () => {
-      expect(repository.getMultipleRecords).toHaveBeenCalledWith([
-        'hasSource-1',
-        'hasSource-2',
-      ])
-    })
-    it('returns the sourceOf as an array of CatalogRecord', () => {
-      expect(sourceOf).toEqual([
-        { uuid: 'hasSource-1' },
-        { uuid: 'hasSource-2' },
-      ])
-    })
-    it('returns null if no sourceOfIdentifiers are defined', async () => {
-      const recordWithoutSourceOf = { ...mockRecord, extras: {} }
-      const result = await lastValueFrom(
-        repository.getSourceOf(recordWithoutSourceOf)
-      )
-      expect(result).toBeNull()
-    })
-  })
-  describe('getSiblings', () => {
-    let siblings: Record<string, CatalogRecord[]>
-    const mockRecord = {
-      ...SAMPLE_RECORD_WITH_EXTRAS,
-      extras: {
+        sourcesIdentifiers: ['source-1'],
+        sourceOfIdentifiers: ['source-1', 'hassource-1'],
         siblings: [
-          {
-            uniqueIdentifier: 'sibling-1',
-            associationType: 'crossReference',
-          },
+          { uniqueIdentifier: 'sibling-1', associationType: 'crossReference' },
           {
             uniqueIdentifier: 'sibling-2',
             associationType: 'largerWorkCitation',
-          },
-          {
-            uniqueIdentifier: 'sibling-3',
-            associationType: 'crossReference',
           },
           {
             uniqueIdentifier: 'not-in-catalog',
             associationType: 'crossReference',
           },
         ],
+        associatedIdentifiers: ['associated-1'],
       },
     }
     beforeEach(async () => {
@@ -638,65 +566,89 @@ describe('Gn4Repository', () => {
               .map((id) => ({ uniqueIdentifier: id }))
           )
         )
-      siblings = await lastValueFrom(repository.getSiblings(mockRecord))
+      associatedRecords = await lastValueFrom(
+        repository.getAssociatedRecords(mockRecord)
+      )
     })
-    it('calls getMultipleRecords for sibling identifiers', () => {
+    it('calls getMultipleRecords once per relation holding identifiers', () => {
+      expect(repository.getMultipleRecords).toHaveBeenCalledTimes(4)
+      expect(repository.getMultipleRecords).toHaveBeenCalledWith(['source-1'])
+      expect(repository.getMultipleRecords).toHaveBeenCalledWith([
+        'source-1',
+        'hassource-1',
+      ])
       expect(repository.getMultipleRecords).toHaveBeenCalledWith([
         'sibling-1',
         'sibling-2',
-        'sibling-3',
         'not-in-catalog',
       ])
-    })
-    it('returns the siblings bucketed by association type, without the identifiers missing from the catalog', () => {
-      expect(siblings).toEqual({
-        crossReference: [
-          { uniqueIdentifier: 'sibling-1' },
-          { uniqueIdentifier: 'sibling-3' },
-        ],
-        largerWorkCitation: [{ uniqueIdentifier: 'sibling-2' }],
-      })
-    })
-    it('returns null if no siblings are defined', async () => {
-      const recordWithoutSiblings = { ...mockRecord, extras: {} }
-      const result = await lastValueFrom(
-        repository.getSiblings(recordWithoutSiblings)
-      )
-      expect(result).toBeNull()
-    })
-  })
-  describe('getAssociated', () => {
-    let associated: CatalogRecord[]
-    const mockRecord = {
-      ...SAMPLE_RECORD_WITH_EXTRAS,
-      extras: {
-        associatedIdentifiers: ['associated-1', 'associated-2'],
-      },
-    }
-    beforeEach(async () => {
-      repository.getMultipleRecords = jest
-        .fn()
-        .mockImplementation((ids) => of(ids.map((id) => ({ uuid: id }))))
-      associated = await lastValueFrom(repository.getAssociated(mockRecord))
-    })
-    it('calls getMultipleRecords for associated identifiers', () => {
       expect(repository.getMultipleRecords).toHaveBeenCalledWith([
         'associated-1',
-        'associated-2',
       ])
     })
-    it('returns the associated records as an array of CatalogRecord', () => {
-      expect(associated).toEqual([
-        { uuid: 'associated-1' },
-        { uuid: 'associated-2' },
+    it('tags each record with its relation, keeping a record related twice under both relations', () => {
+      expect(associatedRecords).toEqual([
+        {
+          record: { uniqueIdentifier: 'source-1' },
+          relation: 'source',
+          associationType: undefined,
+        },
+        {
+          record: { uniqueIdentifier: 'source-1' },
+          relation: 'sourceOf',
+          associationType: undefined,
+        },
+        {
+          record: { uniqueIdentifier: 'hassource-1' },
+          relation: 'sourceOf',
+          associationType: undefined,
+        },
+        {
+          record: { uniqueIdentifier: 'sibling-1' },
+          relation: 'sibling',
+          associationType: 'crossReference',
+        },
+        {
+          record: { uniqueIdentifier: 'sibling-2' },
+          relation: 'sibling',
+          associationType: 'largerWorkCitation',
+        },
+        {
+          record: { uniqueIdentifier: 'associated-1' },
+          relation: 'associated',
+          associationType: undefined,
+        },
       ])
     })
-    it('returns null if no associatedIdentifiers are defined', async () => {
-      const recordWithoutAssociated = { ...mockRecord, extras: {} }
+    it('keeps the other relations when one request fails', async () => {
+      repository.getMultipleRecords = jest
+        .fn()
+        .mockImplementation((ids) =>
+          ids.includes('associated-1')
+            ? throwError(() => 'api')
+            : of(
+                ids
+                  .filter((id) => id !== 'not-in-catalog')
+                  .map((id) => ({ uniqueIdentifier: id }))
+              )
+        )
       const result = await lastValueFrom(
-        repository.getAssociated(recordWithoutAssociated)
+        repository.getAssociatedRecords(mockRecord)
       )
-      expect(result).toBeNull()
+      expect(result.map(({ relation }) => relation)).toEqual([
+        'source',
+        'sourceOf',
+        'sourceOf',
+        'sibling',
+        'sibling',
+      ])
+    })
+    it('returns an empty array if the record has no relation at all', async () => {
+      const recordWithoutRelations = { ...mockRecord, extras: {} }
+      const result = await lastValueFrom(
+        repository.getAssociatedRecords(recordWithoutRelations)
+      )
+      expect(result).toEqual([])
     })
   })
   describe('aggregate', () => {

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -15,11 +15,12 @@ import {
 import { PublicationVersionError } from '@geonetwork-ui/common/domain/model/error'
 import {
   AssociatedRecord,
-  AssociationType,
   CatalogRecord,
   DatasetFeatureCatalog,
   DatasetFeatureType,
   LanguageCode,
+  RecordRelation,
+  RelatedRecord,
 } from '@geonetwork-ui/common/domain/model/record'
 import {
   Aggregations,
@@ -251,59 +252,43 @@ export class Gn4Repository implements RecordsRepositoryInterface {
       )
   }
 
-  getSources(record: CatalogRecord): Observable<CatalogRecord[]> {
-    const sourcesIdentifiers = record.extras?.['sourcesIdentifiers'] as string[]
-    if (sourcesIdentifiers && sourcesIdentifiers.length > 0) {
-      return this.getMultipleRecords(sourcesIdentifiers)
+  getAssociatedRecords(record: CatalogRecord): Observable<RelatedRecord[]> {
+    const siblings = (record.extras?.['siblings'] ?? []) as AssociatedRecord[]
+    const relations: Array<[RecordRelation, string[]]> = [
+      ['source', (record.extras?.['sourcesIdentifiers'] ?? []) as string[]],
+      ['sourceOf', (record.extras?.['sourceOfIdentifiers'] ?? []) as string[]],
+      ['sibling', siblings.map(({ uniqueIdentifier }) => uniqueIdentifier)],
+      [
+        'associated',
+        (record.extras?.['associatedIdentifiers'] ?? []) as string[],
+      ],
+    ]
+    const requested = relations.filter(
+      ([, identifiers]) => identifiers.length > 0
+    )
+    if (requested.length === 0) {
+      return of([])
     }
-    return of(null)
-  }
-
-  getSourceOf(record: CatalogRecord): Observable<CatalogRecord[]> {
-    const sourceOfIdentifiers = record.extras?.[
-      'sourceOfIdentifiers'
-    ] as string[]
-    if (sourceOfIdentifiers && sourceOfIdentifiers.length > 0) {
-      return this.getMultipleRecords(sourceOfIdentifiers)
-    }
-    return of(null)
-  }
-
-  getSiblings(
-    record: CatalogRecord
-  ): Observable<Partial<Record<AssociationType, CatalogRecord[]>>> {
-    const siblings = record.extras?.['siblings'] as AssociatedRecord[]
-    if (siblings && siblings.length > 0) {
-      return this.getMultipleRecords(
-        siblings.map(({ uniqueIdentifier }) => uniqueIdentifier)
-      ).pipe(
-        map((records) =>
-          records?.reduce(
-            (groups, record) => {
-              const { associationType } = siblings.find(
-                ({ uniqueIdentifier }) =>
-                  uniqueIdentifier === record.uniqueIdentifier
-              )
-              groups[associationType] ??= []
-              groups[associationType].push(record)
-              return groups
-            },
-            {} as Partial<Record<AssociationType, CatalogRecord[]>>
-          )
+    return forkJoin(
+      requested.map(([relation, identifiers]) =>
+        this.getMultipleRecords(identifiers).pipe(
+          map((records) =>
+            (records ?? []).map((record) => ({
+              record,
+              relation,
+              associationType:
+                relation === 'sibling'
+                  ? siblings.find(
+                      ({ uniqueIdentifier }) =>
+                        uniqueIdentifier === record.uniqueIdentifier
+                    ).associationType
+                  : undefined,
+            }))
+          ),
+          catchError(() => of([]))
         )
       )
-    }
-    return of(null)
-  }
-
-  getAssociated(record: CatalogRecord): Observable<CatalogRecord[]> {
-    const associatedIdentifiers = record.extras?.[
-      'associatedIdentifiers'
-    ] as string[]
-    if (associatedIdentifiers && associatedIdentifiers.length > 0) {
-      return this.getMultipleRecords(associatedIdentifiers)
-    }
-    return of(null)
+    ).pipe(map((groups) => groups.flat()))
   }
 
   aggregate(params: AggregationsParams): Observable<Aggregations> {

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -19,8 +19,8 @@ import {
   DatasetFeatureCatalog,
   DatasetFeatureType,
   LanguageCode,
+  LinkedRecord,
   RecordRelation,
-  RelatedRecord,
 } from '@geonetwork-ui/common/domain/model/record'
 import {
   Aggregations,
@@ -252,7 +252,7 @@ export class Gn4Repository implements RecordsRepositoryInterface {
       )
   }
 
-  getAssociatedRecords(record: CatalogRecord): Observable<RelatedRecord[]> {
+  getLinkedRecords(record: CatalogRecord): Observable<LinkedRecord[]> {
     const siblings = (record.extras?.['siblings'] ?? []) as AssociatedRecord[]
     const relations: Array<[RecordRelation, string[]]> = [
       ['source', (record.extras?.['sourcesIdentifiers'] ?? []) as string[]],
@@ -281,7 +281,7 @@ export class Gn4Repository implements RecordsRepositoryInterface {
                   ? siblings.find(
                       ({ uniqueIdentifier }) =>
                         uniqueIdentifier === record.uniqueIdentifier
-                    ).associationType
+                    )?.associationType
                   : undefined,
             }))
           ),

--- a/libs/api/repository/src/lib/gn4/gn4-repository.ts
+++ b/libs/api/repository/src/lib/gn4/gn4-repository.ts
@@ -14,6 +14,8 @@ import {
 } from '@geonetwork-ui/api/metadata-converter'
 import { PublicationVersionError } from '@geonetwork-ui/common/domain/model/error'
 import {
+  AssociatedRecord,
+  AssociationType,
   CatalogRecord,
   DatasetFeatureCatalog,
   DatasetFeatureType,
@@ -145,7 +147,7 @@ export class Gn4Repository implements RecordsRepositoryInterface {
     return this.gn4SearchApi
       .search(
         'bucket',
-        ['fcats', 'hassources'],
+        ['fcats', 'hassources', 'siblings', 'associated'],
         JSON.stringify(
           this.gn4SearchHelper.getMetadataByIdsPayload([uniqueIdentifier])
         )
@@ -263,6 +265,43 @@ export class Gn4Repository implements RecordsRepositoryInterface {
     ] as string[]
     if (sourceOfIdentifiers && sourceOfIdentifiers.length > 0) {
       return this.getMultipleRecords(sourceOfIdentifiers)
+    }
+    return of(null)
+  }
+
+  getSiblings(
+    record: CatalogRecord
+  ): Observable<Partial<Record<AssociationType, CatalogRecord[]>>> {
+    const siblings = record.extras?.['siblings'] as AssociatedRecord[]
+    if (siblings && siblings.length > 0) {
+      return this.getMultipleRecords(
+        siblings.map(({ uniqueIdentifier }) => uniqueIdentifier)
+      ).pipe(
+        map((records) =>
+          records?.reduce(
+            (groups, record) => {
+              const { associationType } = siblings.find(
+                ({ uniqueIdentifier }) =>
+                  uniqueIdentifier === record.uniqueIdentifier
+              )
+              groups[associationType] ??= []
+              groups[associationType].push(record)
+              return groups
+            },
+            {} as Partial<Record<AssociationType, CatalogRecord[]>>
+          )
+        )
+      )
+    }
+    return of(null)
+  }
+
+  getAssociated(record: CatalogRecord): Observable<CatalogRecord[]> {
+    const associatedIdentifiers = record.extras?.[
+      'associatedIdentifiers'
+    ] as string[]
+    if (associatedIdentifiers && associatedIdentifiers.length > 0) {
+      return this.getMultipleRecords(associatedIdentifiers)
     }
     return of(null)
   }

--- a/libs/common/domain/src/lib/model/record/metadata.model.ts
+++ b/libs/common/domain/src/lib/model/record/metadata.model.ts
@@ -294,6 +294,18 @@ export interface AssociatedRecord {
   associationType: AssociationType
 }
 
+/**
+ * Nature of the link between a record and another one; the association type is
+ * only known for 'sibling' relations, as it is held by the declaring record.
+ */
+export type RecordRelation = 'source' | 'sourceOf' | 'sibling' | 'associated'
+
+export interface RelatedRecord {
+  record: CatalogRecord
+  relation: RecordRelation
+  associationType?: AssociationType
+}
+
 export interface DatasetRecord extends BaseRecord {
   kind: 'dataset'
   status: RecordStatus

--- a/libs/common/domain/src/lib/model/record/metadata.model.ts
+++ b/libs/common/domain/src/lib/model/record/metadata.model.ts
@@ -300,7 +300,7 @@ export interface AssociatedRecord {
  */
 export type RecordRelation = 'source' | 'sourceOf' | 'sibling' | 'associated'
 
-export interface RelatedRecord {
+export interface LinkedRecord {
   record: CatalogRecord
   relation: RecordRelation
   associationType?: AssociationType

--- a/libs/common/domain/src/lib/repository/records-repository.interface.ts
+++ b/libs/common/domain/src/lib/repository/records-repository.interface.ts
@@ -10,7 +10,7 @@ import {
   CatalogRecord,
   DatasetFeatureCatalog,
   LanguageCode,
-  RelatedRecord,
+  LinkedRecord,
 } from '../model/record'
 
 export abstract class RecordsRepositoryInterface {
@@ -24,9 +24,7 @@ export abstract class RecordsRepositoryInterface {
   abstract getSimilarRecords(
     similarTo: CatalogRecord
   ): Observable<CatalogRecord[]>
-  abstract getAssociatedRecords(
-    record: CatalogRecord
-  ): Observable<RelatedRecord[]>
+  abstract getLinkedRecords(record: CatalogRecord): Observable<LinkedRecord[]>
   abstract fuzzySearch(query: string): Observable<SearchResults>
   abstract canDuplicate(record: CatalogRecord): boolean
   abstract canDelete(record: CatalogRecord): Observable<boolean>

--- a/libs/common/domain/src/lib/repository/records-repository.interface.ts
+++ b/libs/common/domain/src/lib/repository/records-repository.interface.ts
@@ -7,10 +7,10 @@ import {
   SearchResults,
 } from '../model/search'
 import {
-  AssociationType,
   CatalogRecord,
   DatasetFeatureCatalog,
   LanguageCode,
+  RelatedRecord,
 } from '../model/record'
 
 export abstract class RecordsRepositoryInterface {
@@ -24,12 +24,9 @@ export abstract class RecordsRepositoryInterface {
   abstract getSimilarRecords(
     similarTo: CatalogRecord
   ): Observable<CatalogRecord[]>
-  abstract getSources(record: CatalogRecord): Observable<CatalogRecord[]>
-  abstract getSourceOf(record: CatalogRecord): Observable<CatalogRecord[]>
-  abstract getSiblings(
+  abstract getAssociatedRecords(
     record: CatalogRecord
-  ): Observable<Partial<Record<AssociationType, CatalogRecord[]>>>
-  abstract getAssociated(record: CatalogRecord): Observable<CatalogRecord[]>
+  ): Observable<RelatedRecord[]>
   abstract fuzzySearch(query: string): Observable<SearchResults>
   abstract canDuplicate(record: CatalogRecord): boolean
   abstract canDelete(record: CatalogRecord): Observable<boolean>

--- a/libs/common/domain/src/lib/repository/records-repository.interface.ts
+++ b/libs/common/domain/src/lib/repository/records-repository.interface.ts
@@ -7,6 +7,7 @@ import {
   SearchResults,
 } from '../model/search'
 import {
+  AssociationType,
   CatalogRecord,
   DatasetFeatureCatalog,
   LanguageCode,
@@ -25,6 +26,10 @@ export abstract class RecordsRepositoryInterface {
   ): Observable<CatalogRecord[]>
   abstract getSources(record: CatalogRecord): Observable<CatalogRecord[]>
   abstract getSourceOf(record: CatalogRecord): Observable<CatalogRecord[]>
+  abstract getSiblings(
+    record: CatalogRecord
+  ): Observable<Partial<Record<AssociationType, CatalogRecord[]>>>
+  abstract getAssociated(record: CatalogRecord): Observable<CatalogRecord[]>
   abstract fuzzySearch(query: string): Observable<SearchResults>
   abstract canDuplicate(record: CatalogRecord): boolean
   abstract canDelete(record: CatalogRecord): Observable<boolean>

--- a/libs/feature/record/src/lib/state/mdview.actions.ts
+++ b/libs/feature/record/src/lib/state/mdview.actions.ts
@@ -1,6 +1,7 @@
 import { DatavizChartConfigModel } from '@geonetwork-ui/common/domain/model/dataviz/dataviz-configuration.model'
 import { createAction, props } from '@ngrx/store'
 import {
+  AssociationType,
   CatalogRecord,
   DatasetFeatureCatalog,
   UserFeedback,
@@ -62,6 +63,16 @@ export const setSources = createAction(
 export const setSourceOf = createAction(
   '[Metadata view] Set has sources',
   props<{ sourceOf: CatalogRecord[] }>()
+)
+
+export const setSiblings = createAction(
+  '[Metadata view] Set siblings',
+  props<{ siblings: Partial<Record<AssociationType, CatalogRecord[]>> }>()
+)
+
+export const setAssociated = createAction(
+  '[Metadata view] Set associated',
+  props<{ associated: CatalogRecord[] }>()
 )
 
 /*

--- a/libs/feature/record/src/lib/state/mdview.actions.ts
+++ b/libs/feature/record/src/lib/state/mdview.actions.ts
@@ -1,9 +1,9 @@
 import { DatavizChartConfigModel } from '@geonetwork-ui/common/domain/model/dataviz/dataviz-configuration.model'
 import { createAction, props } from '@ngrx/store'
 import {
-  AssociationType,
   CatalogRecord,
   DatasetFeatureCatalog,
+  RelatedRecord,
   UserFeedback,
 } from '@geonetwork-ui/common/domain/model/record'
 
@@ -55,24 +55,9 @@ export const setRelated = createAction(
   props<{ related: CatalogRecord[] }>()
 )
 
-export const setSources = createAction(
-  '[Metadata view] Set sources',
-  props<{ sources: CatalogRecord[] }>()
-)
-
-export const setSourceOf = createAction(
-  '[Metadata view] Set has sources',
-  props<{ sourceOf: CatalogRecord[] }>()
-)
-
-export const setSiblings = createAction(
-  '[Metadata view] Set siblings',
-  props<{ siblings: Partial<Record<AssociationType, CatalogRecord[]>> }>()
-)
-
-export const setAssociated = createAction(
-  '[Metadata view] Set associated',
-  props<{ associated: CatalogRecord[] }>()
+export const setAssociatedRecords = createAction(
+  '[Metadata view] Set associated records',
+  props<{ associatedRecords: RelatedRecord[] }>()
 )
 
 /*

--- a/libs/feature/record/src/lib/state/mdview.actions.ts
+++ b/libs/feature/record/src/lib/state/mdview.actions.ts
@@ -3,7 +3,7 @@ import { createAction, props } from '@ngrx/store'
 import {
   CatalogRecord,
   DatasetFeatureCatalog,
-  RelatedRecord,
+  LinkedRecord,
   UserFeedback,
 } from '@geonetwork-ui/common/domain/model/record'
 
@@ -55,9 +55,9 @@ export const setRelated = createAction(
   props<{ related: CatalogRecord[] }>()
 )
 
-export const setAssociatedRecords = createAction(
+export const setLinkedRecords = createAction(
   '[Metadata view] Set associated records',
-  props<{ associatedRecords: RelatedRecord[] }>()
+  props<{ linkedRecords: LinkedRecord[] }>()
 )
 
 /*

--- a/libs/feature/record/src/lib/state/mdview.effects.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.spec.ts
@@ -18,7 +18,7 @@ import { MdViewEffects } from './mdview.effects'
 import { hot } from 'jasmine-marbles'
 import {
   CatalogRecord,
-  RelatedRecord,
+  LinkedRecord,
 } from '@geonetwork-ui/common/domain/model/record'
 import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
 import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.service.interface'
@@ -35,7 +35,7 @@ class RecordsRepositoryMock {
   search = jest.fn(() => of(searchResultsFixture()))
   getRecord = jest.fn(() => of(datasetRecordsFixture()[0]))
   getSimilarRecords = jest.fn(() => of(datasetRecordsFixture()))
-  getAssociatedRecords = jest.fn(() =>
+  getLinkedRecords = jest.fn(() =>
     of(
       datasetRecordsFixture().map((record) => ({
         record,
@@ -164,36 +164,36 @@ describe('MdViewEffects', () => {
     })
   })
 
-  describe('loadAssociatedRecords$', () => {
+  describe('loadLinkedRecords$', () => {
     describe('when load full success', () => {
-      it('dispatch setAssociatedRecords', () => {
+      it('dispatch setLinkedRecords', () => {
         actions = hot('-a-|', {
           a: MdViewActions.loadFullMetadataSuccess({ full }),
         })
         const expected = hot('-a-|', {
-          a: MdViewActions.setAssociatedRecords({
-            associatedRecords: datasetRecordsFixture().map((record) => ({
+          a: MdViewActions.setLinkedRecords({
+            linkedRecords: datasetRecordsFixture().map((record) => ({
               record,
               relation: 'sibling',
               associationType: 'crossReference',
-            })) as RelatedRecord[],
+            })) as LinkedRecord[],
           }),
         })
-        expect(effects.loadAssociatedRecords$).toBeObservable(expected)
+        expect(effects.loadLinkedRecords$).toBeObservable(expected)
       })
     })
     describe('when api fails', () => {
       beforeEach(() => {
-        repository.getAssociatedRecords = jest.fn(() => throwError(() => 'api'))
+        repository.getLinkedRecords = jest.fn(() => throwError(() => 'api'))
       })
-      it('dispatch setAssociatedRecords with null', () => {
+      it('dispatch setLinkedRecords with null', () => {
         actions = hot('-a-|', {
           a: MdViewActions.loadFullMetadataSuccess({ full }),
         })
         const expected = hot('-(a|)', {
-          a: MdViewActions.setAssociatedRecords({ associatedRecords: null }),
+          a: MdViewActions.setLinkedRecords({ linkedRecords: null }),
         })
-        expect(effects.loadAssociatedRecords$).toBeObservable(expected)
+        expect(effects.loadLinkedRecords$).toBeObservable(expected)
       })
     })
   })

--- a/libs/feature/record/src/lib/state/mdview.effects.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.spec.ts
@@ -16,7 +16,10 @@ import { Observable, of, throwError } from 'rxjs'
 import * as MdViewActions from './mdview.actions'
 import { MdViewEffects } from './mdview.effects'
 import { hot } from 'jasmine-marbles'
-import { CatalogRecord } from '@geonetwork-ui/common/domain/model/record'
+import {
+  CatalogRecord,
+  RelatedRecord,
+} from '@geonetwork-ui/common/domain/model/record'
 import { RecordsRepositoryInterface } from '@geonetwork-ui/common/domain/repository/records-repository.interface'
 import { PlatformServiceInterface } from '@geonetwork-ui/common/domain/platform.service.interface'
 import { Router } from '@angular/router'
@@ -32,10 +35,15 @@ class RecordsRepositoryMock {
   search = jest.fn(() => of(searchResultsFixture()))
   getRecord = jest.fn(() => of(datasetRecordsFixture()[0]))
   getSimilarRecords = jest.fn(() => of(datasetRecordsFixture()))
-  getSources = jest.fn(() => of(datasetRecordsFixture()))
-  getSourceOf = jest.fn(() => of(datasetRecordsFixture()))
-  getSiblings = jest.fn(() => of({ crossReference: datasetRecordsFixture() }))
-  getAssociated = jest.fn(() => of(datasetRecordsFixture()))
+  getAssociatedRecords = jest.fn(() =>
+    of(
+      datasetRecordsFixture().map((record) => ({
+        record,
+        relation: 'sibling',
+        associationType: 'crossReference',
+      }))
+    )
+  )
 }
 
 class PlatformServiceInterfaceMock {
@@ -156,128 +164,39 @@ describe('MdViewEffects', () => {
     })
   })
 
-  describe('loadSources$', () => {
+  describe('loadAssociatedRecords$', () => {
     describe('when load full success', () => {
-      it('dispatch setSources', () => {
+      it('dispatch setAssociatedRecords', () => {
         actions = hot('-a-|', {
           a: MdViewActions.loadFullMetadataSuccess({ full }),
         })
         const expected = hot('-a-|', {
-          a: MdViewActions.setSources({
-            sources: datasetRecordsFixture() as CatalogRecord[],
+          a: MdViewActions.setAssociatedRecords({
+            associatedRecords: datasetRecordsFixture().map((record) => ({
+              record,
+              relation: 'sibling',
+              associationType: 'crossReference',
+            })) as RelatedRecord[],
           }),
         })
-        expect(effects.loadSources$).toBeObservable(expected)
+        expect(effects.loadAssociatedRecords$).toBeObservable(expected)
       })
     })
     describe('when api fails', () => {
       beforeEach(() => {
-        repository.getSources = jest.fn(() => throwError(() => 'api'))
+        repository.getAssociatedRecords = jest.fn(() => throwError(() => 'api'))
       })
-      it('dispatch loadFullFailure', () => {
+      it('dispatch setAssociatedRecords with null', () => {
         actions = hot('-a-|', {
           a: MdViewActions.loadFullMetadataSuccess({ full }),
         })
         const expected = hot('-(a|)', {
-          a: MdViewActions.setSources({ sources: null }),
+          a: MdViewActions.setAssociatedRecords({ associatedRecords: null }),
         })
-        expect(effects.loadSources$).toBeObservable(expected)
+        expect(effects.loadAssociatedRecords$).toBeObservable(expected)
       })
     })
   })
-
-  describe('loadSourceOf$', () => {
-    describe('when load full success', () => {
-      it('dispatch setSourceOf', () => {
-        actions = hot('-a-|', {
-          a: MdViewActions.loadFullMetadataSuccess({ full }),
-        })
-        const expected = hot('-a-|', {
-          a: MdViewActions.setSourceOf({
-            sourceOf: datasetRecordsFixture() as CatalogRecord[],
-          }),
-        })
-        expect(effects.loadSourceOf$).toBeObservable(expected)
-      })
-      describe('when api fails', () => {
-        beforeEach(() => {
-          repository.getSourceOf = jest.fn(() => throwError(() => 'api'))
-        })
-        it('dispatch loadFullFailure', () => {
-          actions = hot('-a-|', {
-            a: MdViewActions.loadFullMetadataSuccess({ full }),
-          })
-          const expected = hot('-(a|)', {
-            a: MdViewActions.setSourceOf({ sourceOf: null }),
-          })
-          expect(effects.loadSourceOf$).toBeObservable(expected)
-        })
-      })
-    })
-  })
-
-  describe('loadSiblings$', () => {
-    describe('when load full success', () => {
-      it('dispatch setSiblings', () => {
-        actions = hot('-a-|', {
-          a: MdViewActions.loadFullMetadataSuccess({ full }),
-        })
-        const expected = hot('-a-|', {
-          a: MdViewActions.setSiblings({
-            siblings: {
-              crossReference: datasetRecordsFixture() as CatalogRecord[],
-            },
-          }),
-        })
-        expect(effects.loadSiblings$).toBeObservable(expected)
-      })
-      describe('when api fails', () => {
-        beforeEach(() => {
-          repository.getSiblings = jest.fn(() => throwError(() => 'api'))
-        })
-        it('dispatch setSiblings with null', () => {
-          actions = hot('-a-|', {
-            a: MdViewActions.loadFullMetadataSuccess({ full }),
-          })
-          const expected = hot('-(a|)', {
-            a: MdViewActions.setSiblings({ siblings: null }),
-          })
-          expect(effects.loadSiblings$).toBeObservable(expected)
-        })
-      })
-    })
-  })
-
-  describe('loadAssociated$', () => {
-    describe('when load full success', () => {
-      it('dispatch setAssociated', () => {
-        actions = hot('-a-|', {
-          a: MdViewActions.loadFullMetadataSuccess({ full }),
-        })
-        const expected = hot('-a-|', {
-          a: MdViewActions.setAssociated({
-            associated: datasetRecordsFixture() as CatalogRecord[],
-          }),
-        })
-        expect(effects.loadAssociated$).toBeObservable(expected)
-      })
-      describe('when api fails', () => {
-        beforeEach(() => {
-          repository.getAssociated = jest.fn(() => throwError(() => 'api'))
-        })
-        it('dispatch setAssociated with null', () => {
-          actions = hot('-a-|', {
-            a: MdViewActions.loadFullMetadataSuccess({ full }),
-          })
-          const expected = hot('-(a|)', {
-            a: MdViewActions.setAssociated({ associated: null }),
-          })
-          expect(effects.loadAssociated$).toBeObservable(expected)
-        })
-      })
-    })
-  })
-
   describe('loadUserFeedbacks$', () => {
     describe('when loadUserFeedbacks success', () => {
       it('should dispatch loadUserFeedbacksSuccess when API call is successful', () => {

--- a/libs/feature/record/src/lib/state/mdview.effects.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.spec.ts
@@ -34,6 +34,8 @@ class RecordsRepositoryMock {
   getSimilarRecords = jest.fn(() => of(datasetRecordsFixture()))
   getSources = jest.fn(() => of(datasetRecordsFixture()))
   getSourceOf = jest.fn(() => of(datasetRecordsFixture()))
+  getSiblings = jest.fn(() => of({ crossReference: datasetRecordsFixture() }))
+  getAssociated = jest.fn(() => of(datasetRecordsFixture()))
 }
 
 class PlatformServiceInterfaceMock {
@@ -209,6 +211,68 @@ describe('MdViewEffects', () => {
             a: MdViewActions.setSourceOf({ sourceOf: null }),
           })
           expect(effects.loadSourceOf$).toBeObservable(expected)
+        })
+      })
+    })
+  })
+
+  describe('loadSiblings$', () => {
+    describe('when load full success', () => {
+      it('dispatch setSiblings', () => {
+        actions = hot('-a-|', {
+          a: MdViewActions.loadFullMetadataSuccess({ full }),
+        })
+        const expected = hot('-a-|', {
+          a: MdViewActions.setSiblings({
+            siblings: {
+              crossReference: datasetRecordsFixture() as CatalogRecord[],
+            },
+          }),
+        })
+        expect(effects.loadSiblings$).toBeObservable(expected)
+      })
+      describe('when api fails', () => {
+        beforeEach(() => {
+          repository.getSiblings = jest.fn(() => throwError(() => 'api'))
+        })
+        it('dispatch setSiblings with null', () => {
+          actions = hot('-a-|', {
+            a: MdViewActions.loadFullMetadataSuccess({ full }),
+          })
+          const expected = hot('-(a|)', {
+            a: MdViewActions.setSiblings({ siblings: null }),
+          })
+          expect(effects.loadSiblings$).toBeObservable(expected)
+        })
+      })
+    })
+  })
+
+  describe('loadAssociated$', () => {
+    describe('when load full success', () => {
+      it('dispatch setAssociated', () => {
+        actions = hot('-a-|', {
+          a: MdViewActions.loadFullMetadataSuccess({ full }),
+        })
+        const expected = hot('-a-|', {
+          a: MdViewActions.setAssociated({
+            associated: datasetRecordsFixture() as CatalogRecord[],
+          }),
+        })
+        expect(effects.loadAssociated$).toBeObservable(expected)
+      })
+      describe('when api fails', () => {
+        beforeEach(() => {
+          repository.getAssociated = jest.fn(() => throwError(() => 'api'))
+        })
+        it('dispatch setAssociated with null', () => {
+          actions = hot('-a-|', {
+            a: MdViewActions.loadFullMetadataSuccess({ full }),
+          })
+          const expected = hot('-(a|)', {
+            a: MdViewActions.setAssociated({ associated: null }),
+          })
+          expect(effects.loadAssociated$).toBeObservable(expected)
         })
       })
     })

--- a/libs/feature/record/src/lib/state/mdview.effects.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.ts
@@ -92,6 +92,28 @@ export class MdViewEffects {
     )
   )
 
+  loadSiblings$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(MdViewActions.loadFullMetadataSuccess),
+      switchMap(({ full }) => this.recordsRepository.getSiblings(full)),
+      map((siblings) => {
+        return MdViewActions.setSiblings({ siblings })
+      }),
+      catchError(() => of(MdViewActions.setSiblings({ siblings: null })))
+    )
+  )
+
+  loadAssociated$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(MdViewActions.loadFullMetadataSuccess),
+      switchMap(({ full }) => this.recordsRepository.getAssociated(full)),
+      map((associated) => {
+        return MdViewActions.setAssociated({ associated })
+      }),
+      catchError(() => of(MdViewActions.setAssociated({ associated: null })))
+    )
+  )
+
   /*
     UserFeedback effects
   */

--- a/libs/feature/record/src/lib/state/mdview.effects.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.ts
@@ -70,17 +70,15 @@ export class MdViewEffects {
     )
   )
 
-  loadAssociatedRecords$ = createEffect(() =>
+  loadLinkedRecords$ = createEffect(() =>
     this.actions$.pipe(
       ofType(MdViewActions.loadFullMetadataSuccess),
-      switchMap(({ full }) =>
-        this.recordsRepository.getAssociatedRecords(full)
-      ),
-      map((associatedRecords) => {
-        return MdViewActions.setAssociatedRecords({ associatedRecords })
+      switchMap(({ full }) => this.recordsRepository.getLinkedRecords(full)),
+      map((linkedRecords) => {
+        return MdViewActions.setLinkedRecords({ linkedRecords })
       }),
       catchError(() =>
-        of(MdViewActions.setAssociatedRecords({ associatedRecords: null }))
+        of(MdViewActions.setLinkedRecords({ linkedRecords: null }))
       )
     )
   )

--- a/libs/feature/record/src/lib/state/mdview.effects.ts
+++ b/libs/feature/record/src/lib/state/mdview.effects.ts
@@ -70,47 +70,18 @@ export class MdViewEffects {
     )
   )
 
-  loadSources$ = createEffect(() =>
+  loadAssociatedRecords$ = createEffect(() =>
     this.actions$.pipe(
       ofType(MdViewActions.loadFullMetadataSuccess),
-      switchMap(({ full }) => this.recordsRepository.getSources(full)),
-      map((sources) => {
-        return MdViewActions.setSources({ sources })
+      switchMap(({ full }) =>
+        this.recordsRepository.getAssociatedRecords(full)
+      ),
+      map((associatedRecords) => {
+        return MdViewActions.setAssociatedRecords({ associatedRecords })
       }),
-      catchError(() => of(MdViewActions.setSources({ sources: null })))
-    )
-  )
-
-  loadSourceOf$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(MdViewActions.loadFullMetadataSuccess),
-      switchMap(({ full }) => this.recordsRepository.getSourceOf(full)),
-      map((sourceOf) => {
-        return MdViewActions.setSourceOf({ sourceOf })
-      }),
-      catchError(() => of(MdViewActions.setSourceOf({ sourceOf: null })))
-    )
-  )
-
-  loadSiblings$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(MdViewActions.loadFullMetadataSuccess),
-      switchMap(({ full }) => this.recordsRepository.getSiblings(full)),
-      map((siblings) => {
-        return MdViewActions.setSiblings({ siblings })
-      }),
-      catchError(() => of(MdViewActions.setSiblings({ siblings: null })))
-    )
-  )
-
-  loadAssociated$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(MdViewActions.loadFullMetadataSuccess),
-      switchMap(({ full }) => this.recordsRepository.getAssociated(full)),
-      map((associated) => {
-        return MdViewActions.setAssociated({ associated })
-      }),
-      catchError(() => of(MdViewActions.setAssociated({ associated: null })))
+      catchError(() =>
+        of(MdViewActions.setAssociatedRecords({ associatedRecords: null }))
+      )
     )
   )
 

--- a/libs/feature/record/src/lib/state/mdview.facade.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.spec.ts
@@ -268,22 +268,22 @@ describe('MdViewFacade', () => {
     })
   })
 
-  describe('associatedRecords$', () => {
+  describe('linkedRecords$', () => {
     it('emits associated records', () => {
-      const associatedRecords = [
+      const linkedRecords = [
         { record: datasetRecordsFixture()[1], relation: 'sourceOf' as const },
       ]
       store.setState({
         [METADATA_VIEW_FEATURE_STATE_KEY]: {
           ...initialMetadataViewState,
           metadata: datasetRecordsFixture()[0],
-          associatedRecords,
+          linkedRecords,
         },
       })
       const expected = hot('a', {
-        a: associatedRecords,
+        a: linkedRecords,
       })
-      expect(facade.associatedRecords$).toBeObservable(expected)
+      expect(facade.linkedRecords$).toBeObservable(expected)
     })
   })
 

--- a/libs/feature/record/src/lib/state/mdview.facade.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.spec.ts
@@ -268,35 +268,22 @@ describe('MdViewFacade', () => {
     })
   })
 
-  describe('sources$', () => {
-    it('emits sources', () => {
+  describe('associatedRecords$', () => {
+    it('emits associated records', () => {
+      const associatedRecords = [
+        { record: datasetRecordsFixture()[1], relation: 'sourceOf' as const },
+      ]
       store.setState({
         [METADATA_VIEW_FEATURE_STATE_KEY]: {
           ...initialMetadataViewState,
           metadata: datasetRecordsFixture()[0],
-          sources: [datasetRecordsFixture()[1]],
+          associatedRecords,
         },
       })
       const expected = hot('a', {
-        a: [datasetRecordsFixture()[1]],
+        a: associatedRecords,
       })
-      expect(facade.sources$).toBeObservable(expected)
-    })
-  })
-
-  describe('sourceOf$', () => {
-    it('emits sourceOf', () => {
-      store.setState({
-        [METADATA_VIEW_FEATURE_STATE_KEY]: {
-          ...initialMetadataViewState,
-          metadata: datasetRecordsFixture()[0],
-          sourceOf: [datasetRecordsFixture()[1]],
-        },
-      })
-      const expected = hot('a', {
-        a: [datasetRecordsFixture()[1]],
-      })
-      expect(facade.sourceOf$).toBeObservable(expected)
+      expect(facade.associatedRecords$).toBeObservable(expected)
     })
   })
 

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -74,9 +74,7 @@ export class MdViewFacade {
 
   related$ = this.store.pipe(select(MdViewSelectors.getRelated))
 
-  associatedRecords$ = this.store.pipe(
-    select(MdViewSelectors.getAssociatedRecords)
-  )
+  linkedRecords$ = this.store.pipe(select(MdViewSelectors.getLinkedRecords))
 
   chartConfig$ = this.store.pipe(select(MdViewSelectors.getChartConfig))
 

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -78,6 +78,10 @@ export class MdViewFacade {
 
   sourceOf$ = this.store.pipe(select(MdViewSelectors.getSourceOf))
 
+  siblings$ = this.store.pipe(select(MdViewSelectors.getSiblings))
+
+  associated$ = this.store.pipe(select(MdViewSelectors.getAssociated))
+
   chartConfig$ = this.store.pipe(select(MdViewSelectors.getChartConfig))
 
   allLinks$ = this.metadata$.pipe(

--- a/libs/feature/record/src/lib/state/mdview.facade.ts
+++ b/libs/feature/record/src/lib/state/mdview.facade.ts
@@ -74,13 +74,9 @@ export class MdViewFacade {
 
   related$ = this.store.pipe(select(MdViewSelectors.getRelated))
 
-  sources$ = this.store.pipe(select(MdViewSelectors.getSources))
-
-  sourceOf$ = this.store.pipe(select(MdViewSelectors.getSourceOf))
-
-  siblings$ = this.store.pipe(select(MdViewSelectors.getSiblings))
-
-  associated$ = this.store.pipe(select(MdViewSelectors.getAssociated))
+  associatedRecords$ = this.store.pipe(
+    select(MdViewSelectors.getAssociatedRecords)
+  )
 
   chartConfig$ = this.store.pipe(select(MdViewSelectors.getChartConfig))
 

--- a/libs/feature/record/src/lib/state/mdview.reducer.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.reducer.spec.ts
@@ -135,24 +135,24 @@ describe('metadataViewReducer', () => {
     })
   })
 
-  describe('setAssociatedRecords', () => {
+  describe('setLinkedRecords', () => {
     let action
-    const associatedRecords = [
+    const linkedRecords = [
       {
         record: datasetRecordsFixture()[1],
         relation: 'sourceOf' as const,
       },
     ]
     beforeEach(() => {
-      action = MdViewActions.setAssociatedRecords({
-        associatedRecords,
+      action = MdViewActions.setLinkedRecords({
+        linkedRecords,
       })
     })
     it('set associated records', () => {
       const state = reducer({ ...initialMetadataViewState }, action)
       expect(state).toEqual({
         ...initialMetadataViewState,
-        associatedRecords,
+        linkedRecords,
       })
     })
   })

--- a/libs/feature/record/src/lib/state/mdview.reducer.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.reducer.spec.ts
@@ -135,36 +135,24 @@ describe('metadataViewReducer', () => {
     })
   })
 
-  describe('setSources', () => {
+  describe('setAssociatedRecords', () => {
     let action
-    const sources = [datasetRecordsFixture()[1]]
+    const associatedRecords = [
+      {
+        record: datasetRecordsFixture()[1],
+        relation: 'sourceOf' as const,
+      },
+    ]
     beforeEach(() => {
-      action = MdViewActions.setSources({
-        sources,
+      action = MdViewActions.setAssociatedRecords({
+        associatedRecords,
       })
     })
-    it('set sources', () => {
+    it('set associated records', () => {
       const state = reducer({ ...initialMetadataViewState }, action)
       expect(state).toEqual({
         ...initialMetadataViewState,
-        sources,
-      })
-    })
-  })
-
-  describe('setSourceOf', () => {
-    let action
-    const sourceOf = [datasetRecordsFixture()[1]]
-    beforeEach(() => {
-      action = MdViewActions.setSourceOf({
-        sourceOf,
-      })
-    })
-    it('set has sources', () => {
-      const state = reducer({ ...initialMetadataViewState }, action)
-      expect(state).toEqual({
-        ...initialMetadataViewState,
-        sourceOf,
+        associatedRecords,
       })
     })
   })

--- a/libs/feature/record/src/lib/state/mdview.reducer.ts
+++ b/libs/feature/record/src/lib/state/mdview.reducer.ts
@@ -4,7 +4,7 @@ import { DatavizChartConfigModel } from '@geonetwork-ui/common/domain/model/data
 import {
   CatalogRecord,
   DatasetFeatureCatalog,
-  RelatedRecord,
+  LinkedRecord,
   UserFeedback,
 } from '@geonetwork-ui/common/domain/model/record'
 
@@ -15,7 +15,7 @@ export interface MetadataViewState {
   error: { notFound?: boolean; otherError?: string } | null
   metadata?: Partial<CatalogRecord>
   related?: CatalogRecord[]
-  associatedRecords?: RelatedRecord[]
+  linkedRecords?: LinkedRecord[]
   userFeedbacks?: UserFeedback[]
   allUserFeedbacksLoading: boolean
   addUserFeedbackLoading: boolean
@@ -77,13 +77,10 @@ const metadataViewReducer = createReducer(
     related,
   })),
 
-  on(
-    MetadataViewActions.setAssociatedRecords,
-    (state, { associatedRecords }) => ({
-      ...state,
-      associatedRecords,
-    })
-  ),
+  on(MetadataViewActions.setLinkedRecords, (state, { linkedRecords }) => ({
+    ...state,
+    linkedRecords,
+  })),
 
   /*
     ChartConfig reducers

--- a/libs/feature/record/src/lib/state/mdview.reducer.ts
+++ b/libs/feature/record/src/lib/state/mdview.reducer.ts
@@ -2,6 +2,7 @@ import { Action, createReducer, on } from '@ngrx/store'
 import * as MetadataViewActions from './mdview.actions'
 import { DatavizChartConfigModel } from '@geonetwork-ui/common/domain/model/dataviz/dataviz-configuration.model'
 import {
+  AssociationType,
   CatalogRecord,
   DatasetFeatureCatalog,
   UserFeedback,
@@ -16,6 +17,8 @@ export interface MetadataViewState {
   related?: CatalogRecord[]
   sources?: CatalogRecord[]
   sourceOf?: CatalogRecord[]
+  siblings?: Partial<Record<AssociationType, CatalogRecord[]>>
+  associated?: CatalogRecord[]
   userFeedbacks?: UserFeedback[]
   allUserFeedbacksLoading: boolean
   addUserFeedbackLoading: boolean
@@ -85,6 +88,16 @@ const metadataViewReducer = createReducer(
   on(MetadataViewActions.setSourceOf, (state, { sourceOf }) => ({
     ...state,
     sourceOf,
+  })),
+
+  on(MetadataViewActions.setSiblings, (state, { siblings }) => ({
+    ...state,
+    siblings,
+  })),
+
+  on(MetadataViewActions.setAssociated, (state, { associated }) => ({
+    ...state,
+    associated,
   })),
 
   /*

--- a/libs/feature/record/src/lib/state/mdview.reducer.ts
+++ b/libs/feature/record/src/lib/state/mdview.reducer.ts
@@ -2,9 +2,9 @@ import { Action, createReducer, on } from '@ngrx/store'
 import * as MetadataViewActions from './mdview.actions'
 import { DatavizChartConfigModel } from '@geonetwork-ui/common/domain/model/dataviz/dataviz-configuration.model'
 import {
-  AssociationType,
   CatalogRecord,
   DatasetFeatureCatalog,
+  RelatedRecord,
   UserFeedback,
 } from '@geonetwork-ui/common/domain/model/record'
 
@@ -15,10 +15,7 @@ export interface MetadataViewState {
   error: { notFound?: boolean; otherError?: string } | null
   metadata?: Partial<CatalogRecord>
   related?: CatalogRecord[]
-  sources?: CatalogRecord[]
-  sourceOf?: CatalogRecord[]
-  siblings?: Partial<Record<AssociationType, CatalogRecord[]>>
-  associated?: CatalogRecord[]
+  associatedRecords?: RelatedRecord[]
   userFeedbacks?: UserFeedback[]
   allUserFeedbacksLoading: boolean
   addUserFeedbackLoading: boolean
@@ -80,25 +77,13 @@ const metadataViewReducer = createReducer(
     related,
   })),
 
-  on(MetadataViewActions.setSources, (state, { sources }) => ({
-    ...state,
-    sources,
-  })),
-
-  on(MetadataViewActions.setSourceOf, (state, { sourceOf }) => ({
-    ...state,
-    sourceOf,
-  })),
-
-  on(MetadataViewActions.setSiblings, (state, { siblings }) => ({
-    ...state,
-    siblings,
-  })),
-
-  on(MetadataViewActions.setAssociated, (state, { associated }) => ({
-    ...state,
-    associated,
-  })),
+  on(
+    MetadataViewActions.setAssociatedRecords,
+    (state, { associatedRecords }) => ({
+      ...state,
+      associatedRecords,
+    })
+  ),
 
   /*
     ChartConfig reducers

--- a/libs/feature/record/src/lib/state/mdview.selectors.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.selectors.spec.ts
@@ -143,11 +143,11 @@ describe('MdView Selectors', () => {
       })
     })
 
-    describe('getAssociatedRecords', () => {
+    describe('getLinkedRecords', () => {
       it('returns associated records', () => {
-        const results = MdViewSelectors.getAssociatedRecords.projector({
+        const results = MdViewSelectors.getLinkedRecords.projector({
           ...state,
-          associatedRecords: [{ record: relatedRecord, relation: 'sibling' }],
+          linkedRecords: [{ record: relatedRecord, relation: 'sibling' }],
         })
         expect(results).toEqual([
           { record: relatedRecord, relation: 'sibling' },

--- a/libs/feature/record/src/lib/state/mdview.selectors.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.selectors.spec.ts
@@ -163,6 +163,26 @@ describe('MdView Selectors', () => {
       })
     })
 
+    describe('getSiblings', () => {
+      it('returns sibling records bucketed by association type', () => {
+        const results = MdViewSelectors.getSiblings.projector({
+          ...state,
+          siblings: { crossReference: [relatedRecord] },
+        })
+        expect(results).toEqual({ crossReference: [relatedRecord] })
+      })
+    })
+
+    describe('getAssociated', () => {
+      it('returns associated records', () => {
+        const results = MdViewSelectors.getAssociated.projector({
+          ...state,
+          associated: [relatedRecord],
+        })
+        expect(results).toEqual([relatedRecord])
+      })
+    })
+
     describe('getChartConfig', () => {
       it('returns chart config', () => {
         const results = MdViewSelectors.getChartConfig.projector({

--- a/libs/feature/record/src/lib/state/mdview.selectors.spec.ts
+++ b/libs/feature/record/src/lib/state/mdview.selectors.spec.ts
@@ -143,43 +143,15 @@ describe('MdView Selectors', () => {
       })
     })
 
-    describe('getSources', () => {
-      it('returns sources records', () => {
-        const results = MdViewSelectors.getSources.projector({
-          ...state,
-          sources: [relatedRecord],
-        })
-        expect(results).toEqual([relatedRecord])
-      })
-    })
-
-    describe('getSourceOf', () => {
-      it('returns has sources records', () => {
-        const results = MdViewSelectors.getSourceOf.projector({
-          ...state,
-          sourceOf: [relatedRecord],
-        })
-        expect(results).toEqual([relatedRecord])
-      })
-    })
-
-    describe('getSiblings', () => {
-      it('returns sibling records bucketed by association type', () => {
-        const results = MdViewSelectors.getSiblings.projector({
-          ...state,
-          siblings: { crossReference: [relatedRecord] },
-        })
-        expect(results).toEqual({ crossReference: [relatedRecord] })
-      })
-    })
-
-    describe('getAssociated', () => {
+    describe('getAssociatedRecords', () => {
       it('returns associated records', () => {
-        const results = MdViewSelectors.getAssociated.projector({
+        const results = MdViewSelectors.getAssociatedRecords.projector({
           ...state,
-          associated: [relatedRecord],
+          associatedRecords: [{ record: relatedRecord, relation: 'sibling' }],
         })
-        expect(results).toEqual([relatedRecord])
+        expect(results).toEqual([
+          { record: relatedRecord, relation: 'sibling' },
+        ])
       })
     })
 

--- a/libs/feature/record/src/lib/state/mdview.selectors.ts
+++ b/libs/feature/record/src/lib/state/mdview.selectors.ts
@@ -41,24 +41,9 @@ export const getRelated = createSelector(
   (state: MetadataViewState) => state.related
 )
 
-export const getSources = createSelector(
+export const getAssociatedRecords = createSelector(
   getMdViewState,
-  (state: MetadataViewState) => state.sources
-)
-
-export const getSourceOf = createSelector(
-  getMdViewState,
-  (state: MetadataViewState) => state.sourceOf
-)
-
-export const getSiblings = createSelector(
-  getMdViewState,
-  (state: MetadataViewState) => state.siblings
-)
-
-export const getAssociated = createSelector(
-  getMdViewState,
-  (state: MetadataViewState) => state.associated
+  (state: MetadataViewState) => state.associatedRecords
 )
 /*
   Metadata selectors

--- a/libs/feature/record/src/lib/state/mdview.selectors.ts
+++ b/libs/feature/record/src/lib/state/mdview.selectors.ts
@@ -50,6 +50,16 @@ export const getSourceOf = createSelector(
   getMdViewState,
   (state: MetadataViewState) => state.sourceOf
 )
+
+export const getSiblings = createSelector(
+  getMdViewState,
+  (state: MetadataViewState) => state.siblings
+)
+
+export const getAssociated = createSelector(
+  getMdViewState,
+  (state: MetadataViewState) => state.associated
+)
 /*
   Metadata selectors
 */

--- a/libs/feature/record/src/lib/state/mdview.selectors.ts
+++ b/libs/feature/record/src/lib/state/mdview.selectors.ts
@@ -41,9 +41,9 @@ export const getRelated = createSelector(
   (state: MetadataViewState) => state.related
 )
 
-export const getAssociatedRecords = createSelector(
+export const getLinkedRecords = createSelector(
   getMdViewState,
-  (state: MetadataViewState) => state.associatedRecords
+  (state: MetadataViewState) => state.linkedRecords
 )
 /*
   Metadata selectors

--- a/translations/de.json
+++ b/translations/de.json
@@ -550,6 +550,7 @@
   "record.metadata.languages": "Sprachen",
   "record.metadata.link.postgis.table": "Tabelle:",
   "record.metadata.link.postgis.tooltip": "PostGIS-Ressourcen haben keinen Zugriffslink.",
+  "record.metadata.linked.associatedRecords": "",
   "record.metadata.linked.datasets": "Verknüpfte Datensätze",
   "record.metadata.linked.records": "Verknüpfte Inhalte",
   "record.metadata.linked.reuses": "Verknüpfte Wiederverwendungen",

--- a/translations/en.json
+++ b/translations/en.json
@@ -550,6 +550,7 @@
   "record.metadata.languages": "Languages",
   "record.metadata.link.postgis.table": "table :",
   "record.metadata.link.postgis.tooltip": "PostGIS resources do not have access links",
+  "record.metadata.linked.associatedRecords": "Records referencing this record",
   "record.metadata.linked.datasets": "Associated datasets",
   "record.metadata.linked.records": "Associated content",
   "record.metadata.linked.reuses": "Associated reuses",

--- a/translations/en.json
+++ b/translations/en.json
@@ -550,7 +550,7 @@
   "record.metadata.languages": "Languages",
   "record.metadata.link.postgis.table": "table :",
   "record.metadata.link.postgis.tooltip": "PostGIS resources do not have access links",
-  "record.metadata.linked.associatedRecords": "Records referencing this record",
+  "record.metadata.linked.associatedRecords": "Records referencing the current one",
   "record.metadata.linked.datasets": "Associated datasets",
   "record.metadata.linked.records": "Associated content",
   "record.metadata.linked.reuses": "Associated reuses",

--- a/translations/es.json
+++ b/translations/es.json
@@ -550,6 +550,7 @@
   "record.metadata.languages": "",
   "record.metadata.link.postgis.table": "",
   "record.metadata.link.postgis.tooltip": "",
+  "record.metadata.linked.associatedRecords": "",
   "record.metadata.linked.datasets": "",
   "record.metadata.linked.records": "",
   "record.metadata.linked.reuses": "",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -550,7 +550,7 @@
   "record.metadata.languages": "Langues",
   "record.metadata.link.postgis.table": "table :",
   "record.metadata.link.postgis.tooltip": "Les ressources de type PostGIS n'ont pas de lien d'accès",
-  "record.metadata.linked.associatedRecords": "Fiches faisant référence à cette fiche",
+  "record.metadata.linked.associatedRecords": "Jeux de données faisant référence à celui-ci",
   "record.metadata.linked.datasets": "Jeux de données associés",
   "record.metadata.linked.records": "Contenus associés",
   "record.metadata.linked.reuses": "Réutilisations associées",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -550,6 +550,7 @@
   "record.metadata.languages": "Langues",
   "record.metadata.link.postgis.table": "table :",
   "record.metadata.link.postgis.tooltip": "Les ressources de type PostGIS n'ont pas de lien d'accès",
+  "record.metadata.linked.associatedRecords": "Fiches faisant référence à cette fiche",
   "record.metadata.linked.datasets": "Jeux de données associés",
   "record.metadata.linked.records": "Contenus associés",
   "record.metadata.linked.reuses": "Réutilisations associées",

--- a/translations/it.json
+++ b/translations/it.json
@@ -550,6 +550,7 @@
   "record.metadata.languages": "Lingue",
   "record.metadata.link.postgis.table": "",
   "record.metadata.link.postgis.tooltip": "",
+  "record.metadata.linked.associatedRecords": "",
   "record.metadata.linked.datasets": "",
   "record.metadata.linked.records": "",
   "record.metadata.linked.reuses": "",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -550,6 +550,7 @@
   "record.metadata.languages": "",
   "record.metadata.link.postgis.table": "",
   "record.metadata.link.postgis.tooltip": "",
+  "record.metadata.linked.associatedRecords": "",
   "record.metadata.linked.datasets": "",
   "record.metadata.linked.records": "",
   "record.metadata.linked.reuses": "",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -550,6 +550,7 @@
   "record.metadata.languages": "",
   "record.metadata.link.postgis.table": "",
   "record.metadata.link.postgis.tooltip": "",
+  "record.metadata.linked.associatedRecords": "",
   "record.metadata.linked.datasets": "",
   "record.metadata.linked.records": "",
   "record.metadata.linked.reuses": "",

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -550,6 +550,7 @@
   "record.metadata.languages": "",
   "record.metadata.link.postgis.table": "",
   "record.metadata.link.postgis.tooltip": "",
+  "record.metadata.linked.associatedRecords": "",
   "record.metadata.linked.datasets": "",
   "record.metadata.linked.records": "",
   "record.metadata.linked.reuses": "",


### PR DESCRIPTION
### Description

This PR displays record associations in the Datahub, next to the lineage links already shown in the **Associated content** section.

Two relations are added, both requested through the `relatedType` search param:

- `siblings`: the associations the record declares itself. They carry an association type, so one grid is rendered per type, titled with the existing `domain.record.associationType.*` label.
- `associated`: the reverse direction. No type, so a single grid is rendered.

The new grids are appended below the existing source/hasSource grids, unlike the mockup.

Only links resolving in the catalog are kept (`origin === 'catalog'`), so an invalid UUID gets no card. When a record is both a sibling and a reverse association, only the sibling relation is kept.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Architectural changes

Two methods are added to `RecordsRepositoryInterface` (`getSiblings()`, `getAssociated()`) and two fields to `MetadataViewState`.

<!--
Describe here any changes to the project architecture: adding/removing modules or libraries, changing dependencies between libraries and apps, changes to external NPM dependencies...
-->

### Screenshots
<img width="2038" height="1790" alt="image" src="https://github.com/user-attachments/assets/b3f67e54-075a-4aaf-9cb1-0c797a526f57" />

<img width="1895" height="1757" alt="image" src="https://github.com/user-attachments/assets/9ca4fb2a-b6a0-4933-8272-5d7013083676" />

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [x] If **new logic** ⚙️ is introduced: unit tests were added
- [x] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [x] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Point `proxy-config.js` at `https://dev.geo2france.fr`
2. Open the Associated content section of the following records:
    - 2d866ed2-fc45-433f-8161-e1c83fa7a64a
    - 9a1e05cc-b3d3-40ab-aea3-80a995936712
    - 3feffd63-ab0b-4f03-84e8-b2c324c93bbe
    - 789c5bab-157a-46cd-babe-12de5128eea9
    - 945d5653-3359-44cf-8080-86f84eafaa3b


<!-- **This work is sponsored by [Organization ABC](xx)**. -->
