### PR TITLE
Switch to OSM svwd03 maplibre-style as default basemap

### DIFF
--- a/libs/ui/map/src/lib/components/map-container/map-container.component.spec.ts
+++ b/libs/ui/map/src/lib/components/map-container/map-container.component.spec.ts
@@ -12,7 +12,10 @@ import {
   mapCtxLayerXyzFixture,
 } from '@geonetwork-ui/common/fixtures'
 import { applyContextDiffToMap } from '@geospatial-sdk/openlayers'
-import { MapContainerComponent } from './map-container.component'
+import {
+  DEFAULT_BASEMAP_LAYER,
+  MapContainerComponent,
+} from './map-container.component'
 import { computeMapContextDiff } from '@geospatial-sdk/core'
 
 jest.mock('@geospatial-sdk/core', () => ({
@@ -65,13 +68,6 @@ class OpenLayersMapMock {
   }
 }
 
-const defaultBaseMap = {
-  attributions:
-    '<span>© <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, © <a href="https://carto.com/">Carto</a></span>',
-  type: 'xyz',
-  url: 'https://{a-c}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png',
-}
-
 describe('MapContainerComponent', () => {
   let component: MapContainerComponent
   let fixture: ComponentFixture<MapContainerComponent>
@@ -101,7 +97,7 @@ describe('MapContainerComponent', () => {
   describe('#processContext', () => {
     it('returns a default context if null provided', () => {
       expect(component.processContext(null)).toEqual({
-        layers: [defaultBaseMap],
+        layers: [DEFAULT_BASEMAP_LAYER],
         view: {
           center: [0, 15],
           zoom: 2,
@@ -114,7 +110,7 @@ describe('MapContainerComponent', () => {
         view: null,
       }
       expect(component.processContext(context)).toEqual({
-        layers: [defaultBaseMap, mapCtxLayerWmsFixture()],
+        layers: [DEFAULT_BASEMAP_LAYER, mapCtxLayerWmsFixture()],
         view: {
           center: [0, 15],
           zoom: 2,
@@ -125,7 +121,7 @@ describe('MapContainerComponent', () => {
       component['basemapLayers'] = [mapCtxLayerXyzFixture()]
       const context = { layers: [], view: null }
       expect(component.processContext(context)).toEqual({
-        layers: [defaultBaseMap, mapCtxLayerXyzFixture()],
+        layers: [DEFAULT_BASEMAP_LAYER, mapCtxLayerXyzFixture()],
         view: {
           center: [0, 15],
           zoom: 2,
@@ -150,7 +146,7 @@ describe('MapContainerComponent', () => {
       }
       const context = { layers: [mapCtxLayerXyzFixture()], view: null }
       expect(component.processContext(context)).toEqual({
-        layers: [defaultBaseMap, mapCtxLayerXyzFixture()],
+        layers: [DEFAULT_BASEMAP_LAYER, mapCtxLayerXyzFixture()],
         view: {
           center: [0, 15],
           zoom: 2,
@@ -249,11 +245,11 @@ describe('MapContainerComponent', () => {
       })
       expect(computeMapContextDiff).toHaveBeenCalledWith(
         {
-          layers: [defaultBaseMap, ...mapCtxFixture().layers],
+          layers: [DEFAULT_BASEMAP_LAYER, ...mapCtxFixture().layers],
           view: mapCtxFixture().view,
         },
         {
-          layers: [defaultBaseMap, mapCtxLayerWmsFixture()],
+          layers: [DEFAULT_BASEMAP_LAYER, mapCtxLayerWmsFixture()],
           view: mapCtxFixture().view,
         }
       )

--- a/libs/ui/map/src/lib/components/map-container/map-container.component.ts
+++ b/libs/ui/map/src/lib/components/map-container/map-container.component.ts
@@ -34,6 +34,7 @@ import {
   MapEventsByType,
   SourceLoadErrorEvent,
   SourceLoadErrorType,
+  MapContextLayerMapLibreStyle,
 } from '@geospatial-sdk/core'
 import {
   applyContextDiffToMap,
@@ -55,10 +56,9 @@ import {
 import { matSwipeOutline } from '@ng-icons/material-icons/outline'
 import { transformExtent } from 'ol/proj.js'
 
-const DEFAULT_BASEMAP_LAYER: MapContextLayerXyz = {
-  type: 'xyz',
-  url: `https://{a-c}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png`,
-  attributions: `<span>© <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, © <a href="https://carto.com/">Carto</a></span>`,
+export const DEFAULT_BASEMAP_LAYER: MapContextLayerMapLibreStyle = {
+  type: 'maplibre-style',
+  styleUrl: `https://vector.openstreetmap.org/styles/svwd/svwd03style.json`,
 }
 
 const DEFAULT_VIEW: MapContextView = {


### PR DESCRIPTION
### Description

This PR removes the cartocdn basemap, as now an api key is required to get a clean display.

The new basemap uses OSM vector tiles, with a maplibre-style on top.
The map is slower. This could be improved, but requires a `geospatial-sdk` development (not part of this PR).
As a basemap, the new style is also a bit more dominant, but this is the only OSM style working out of the box.

### Screenshots

Before:

<img width="1021" height="710" alt="Screenshot from 2026-08-28 12-04-03" src="https://github.com/user-attachments/assets/07596551-a109-449c-a92f-60f1667c6494" />

After:

<img width="1021" height="710" alt="Screenshot from 2026-08-28 14-42-54" src="https://github.com/user-attachments/assets/ed89e514-79c8-48bf-abc8-ab23e44761a3" />
<img width="1021" height="710" alt="Screenshot from 2026-08-28 15-00-14" src="https://github.com/user-attachments/assets/60390625-6b5d-4944-b085-28add4eb2e22" />
<img width="1021" height="710" alt="Screenshot from 2026-08-28 15-01-00" src="https://github.com/user-attachments/assets/78920f49-5a66-4885-b6c4-d022ba391961" />

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

Run the docker composition locally
Navigate to http://localhost:4200/dataset/ed34db28-5dd4-480f-bf29-dc08f0086131 or any record with a map preview
Check the map preview

---

<!--
Please give credit to the sponsor of this work if possible.
-->

<!-- **This work is sponsored by [Rennes Métropoles](https://metropole.rennes.fr/)**. -->
