### PR TITLE
Sync peer dep and main dep

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -30,9 +30,9 @@
     "@ngrx/store": "19.x || 20.x || 21.x",
     "@ngrx/store-devtools": "19.x || 20.x || 21.x",
     "@ngrx/operators": "19.x || 20.x || 21.x",
-    "@ngx-translate/core": "16.x",
-    "@ngx-translate/http-loader": "16.x",
-    "flag-icons": "^7.3.2",
+    "@ngx-translate/core": "17.x",
+    "@ngx-translate/http-loader": "17.x",
+    "flag-icons": "~7.5.0",
     "rxjs": "7.x",
     "zone.js": "*",
     "tailwindcss": "3.x"


### PR DESCRIPTION
This PR fixes the divergence between the main dependencies and the required peer dependencies for custom apps.

This is needed to let any custom app upgrade to this version of geonetwork-ui.

Tested with mel-dataplatform.
