### PR TITLE
feat(search): add SpatialExtentGeocodingSearchComponent

### DIFF
--- a/conf/default.toml
+++ b/conf/default.toml
@@ -116,6 +116,15 @@ background_color = "#fdfbff"
 # will not be shown under the main search bar. Defaults to false.
 # do_not_use_default_search_preset = false
 
+# Optional; JSONPaths (resolved against the geocoding result) used to derive the label
+# and geometry shown when searching by spatial extent. main_label_jsonpath and
+# geometry_string_jsonpath default to '$.label' and '$.geom'.
+# [search.spatial_extent_service]
+# main_label_jsonpath = "$.label"
+# secondary_label_jsonpath = "$.properties.citycode[0]"
+# tertiary_label_jsonpath = "$.properties.category[1]"
+# geometry_string_jsonpath = "$.geom"
+
 # One or several search presets visible in form of badges can be defined here; every search preset is composed of:
 # - a name (which can be a translation key)
 # - a sort criteria (prepend the field name with - to do a descending sort):

--- a/libs/feature/search/src/index.ts
+++ b/libs/feature/search/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/feature-search.module'
 export * from './lib/geocoding/geocoding.service'
 export * from './lib/location-search/location-search.component'
+export * from './lib/spatial-extent-geocoding-search/spatial-extent-geocoding-search.component'
 export * from './lib/filter-geometry.token'
 export * from './lib/record-url.token'
 export * from './lib/state/actions'

--- a/libs/feature/search/src/lib/geocoding/spatial-extent-result.parser.spec.ts
+++ b/libs/feature/search/src/lib/geocoding/spatial-extent-result.parser.spec.ts
@@ -1,0 +1,70 @@
+import { GeocodingResult } from '@geospatial-sdk/geocoding'
+import { parseSpatialExtentResult } from './spatial-extent-result.parser'
+
+describe('parseSpatialExtentResult', () => {
+  const paths = {
+    mainLabel: '$.properties.name[0]',
+    geometry: '$.geom',
+  }
+
+  function buildResult(properties: Record<string, unknown>): GeocodingResult {
+    return {
+      label: 'Beaufort',
+      geom: { type: 'Point', coordinates: [6.0, 45.7] },
+      properties,
+    }
+  }
+
+  it('overrides the label and geom using the configured JSONPaths, resolved against properties', () => {
+    const result = buildResult({
+      name: ['Beaufort-sur-Doron'],
+    })
+
+    const parsed = parseSpatialExtentResult(result, paths)
+
+    expect(parsed.label).toBe('Beaufort-sur-Doron')
+    expect(parsed.geom).toEqual(result.geom)
+    expect(parsed.properties).toBe(result.properties)
+  })
+
+  it('falls back to the original label when the label path does not match', () => {
+    const result = buildResult({})
+
+    const parsed = parseSpatialExtentResult(result, paths)
+
+    expect(parsed.label).toBe('Beaufort')
+  })
+
+  it('leaves label and geom untouched when no paths are configured', () => {
+    const result = buildResult({ name: ['Beaufort-sur-Doron'] })
+
+    const parsed = parseSpatialExtentResult(result, {})
+
+    expect(parsed.label).toBe('Beaufort')
+    expect(parsed.geom).toEqual(result.geom)
+  })
+
+  it('resolves secondary and tertiary labels using the configured JSONPaths', () => {
+    const result = buildResult({
+      citycode: ['38150'],
+      category: ['poi', 'commune'],
+    })
+
+    const parsed = parseSpatialExtentResult(result, {
+      secondaryLabel: '$.properties.citycode[0]',
+      tertiaryLabel: '$.properties.category[1]',
+    })
+
+    expect(parsed.secondaryLabel).toBe('38150')
+    expect(parsed.tertiaryLabel).toBe('commune')
+  })
+
+  it('leaves secondary and tertiary labels undefined when not configured or not matching', () => {
+    const result = buildResult({})
+
+    const parsed = parseSpatialExtentResult(result, {})
+
+    expect(parsed.secondaryLabel).toBeUndefined()
+    expect(parsed.tertiaryLabel).toBeUndefined()
+  })
+})

--- a/libs/feature/search/src/lib/geocoding/spatial-extent-result.parser.ts
+++ b/libs/feature/search/src/lib/geocoding/spatial-extent-result.parser.ts
@@ -1,0 +1,49 @@
+import { JSONPath } from 'jsonpath-plus'
+import { GeocodingResult } from '@geospatial-sdk/geocoding'
+import { Geometry } from 'geojson'
+
+export interface SpatialExtentJsonPaths {
+  mainLabel?: string
+  secondaryLabel?: string
+  tertiaryLabel?: string
+  geometry?: string
+}
+
+export interface SpatialExtentResult extends GeocodingResult {
+  secondaryLabel?: string
+  tertiaryLabel?: string
+}
+
+const DEFAULT_MAIN_LABEL_PATH = '$.label'
+const DEFAULT_GEOMETRY_PATH = '$.geom'
+
+function resolveJsonPath(json: object, path: string): unknown {
+  return JSONPath({ path, json, wrap: false, eval: false })
+}
+
+function resolveJsonPathAsString(
+  json: object,
+  path?: string
+): string | undefined {
+  if (!path) return undefined
+  const value = resolveJsonPath(json, path)
+  return typeof value === 'string' && value ? value : undefined
+}
+
+export function parseSpatialExtentResult(
+  result: GeocodingResult,
+  paths: SpatialExtentJsonPaths
+): SpatialExtentResult {
+  const label = resolveJsonPath(
+    result,
+    paths.mainLabel ?? DEFAULT_MAIN_LABEL_PATH
+  )
+  const geom = resolveJsonPath(result, paths.geometry ?? DEFAULT_GEOMETRY_PATH)
+  return {
+    ...result,
+    label: typeof label === 'string' && label ? label : result.label,
+    geom: (geom as Geometry) ?? result.geom,
+    secondaryLabel: resolveJsonPathAsString(result, paths.secondaryLabel),
+    tertiaryLabel: resolveJsonPathAsString(result, paths.tertiaryLabel),
+  }
+}

--- a/libs/feature/search/src/lib/spatial-extent-geocoding-search/spatial-extent-geocoding-search.component.html
+++ b/libs/feature/search/src/lib/spatial-extent-geocoding-search/spatial-extent-geocoding-search.component.html
@@ -1,0 +1,13 @@
+<gn-ui-location-search
+  [displayWithTemplate]="itemTpl"
+  (resultSelected)="handleResultSelected($event)"
+></gn-ui-location-search>
+
+<ng-template #itemTpl let-result>
+  <div class="py-2">
+    @if (getSecondaryLabel(result)) {
+      <div class="gn-ui-card-detail">{{ getSecondaryLabel(result) }}</div>
+    }
+    <div class="gn-ui-card-title">{{ getMainLabel(result) }}</div>
+  </div>
+</ng-template>

--- a/libs/feature/search/src/lib/spatial-extent-geocoding-search/spatial-extent-geocoding-search.component.spec.ts
+++ b/libs/feature/search/src/lib/spatial-extent-geocoding-search/spatial-extent-geocoding-search.component.spec.ts
@@ -1,0 +1,149 @@
+import { Component } from '@angular/core'
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { By } from '@angular/platform-browser'
+import { OverlayContainer } from '@angular/cdk/overlay'
+import { of } from 'rxjs'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
+import { provideI18n } from '@geonetwork-ui/util/i18n'
+import { AutocompleteComponent } from '@geonetwork-ui/ui/inputs'
+import { GeocodingResult } from '@geospatial-sdk/geocoding'
+import { getOptionalSearchConfig } from '@geonetwork-ui/util/app-config'
+import { SpatialExtentGeocodingSearchComponent } from './spatial-extent-geocoding-search.component'
+import { GeocodingService } from '../geocoding/geocoding.service'
+
+jest.mock('@geonetwork-ui/util/app-config', () => ({
+  getOptionalSearchConfig: jest.fn(),
+}))
+
+const RESULT_WITH_ALL: GeocodingResult = {
+  label: 'Beaufort',
+  geom: { type: 'Point', coordinates: [6.771, 45.72] },
+  properties: { category: ['poi', 'commune'], citycode: ['73270'] },
+}
+
+const RESULT_WITHOUT_GEOM: GeocodingResult = {
+  label: 'Eurométropole de Strasbourg',
+  geom: null,
+  properties: { category: ['poi', 'epci'] },
+}
+
+@Component({
+  imports: [SpatialExtentGeocodingSearchComponent],
+  standalone: true,
+  template: `
+    <gn-ui-spatial-extent-geocoding-search
+      (bboxSelected)="bboxSelected($event)"
+    ></gn-ui-spatial-extent-geocoding-search>
+  `,
+})
+class HostComponent {
+  bboxSelected = jest.fn()
+}
+
+describe('SpatialExtentGeocodingSearchComponent', () => {
+  let component: SpatialExtentGeocodingSearchComponent
+  let fixture: ComponentFixture<SpatialExtentGeocodingSearchComponent>
+
+  beforeEach(async () => {
+    ;(getOptionalSearchConfig as jest.Mock).mockReturnValue({
+      SPATIAL_EXTENT_SERVICE: {
+        SECONDARY_LABEL_JSONPATH: '$.properties.category[1]',
+        TERTIARY_LABEL_JSONPATH: '$.properties.citycode[0]',
+      },
+    })
+
+    await TestBed.configureTestingModule({
+      imports: [SpatialExtentGeocodingSearchComponent, NoopAnimationsModule],
+      providers: [
+        provideI18n(),
+        {
+          provide: GeocodingService,
+          useValue: { query: jest.fn(() => of([RESULT_WITH_ALL])) },
+        },
+      ],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(SpatialExtentGeocodingSearchComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+
+  it('does not emit when the selected result has no geometry', () => {
+    const emitted = jest.fn()
+    component.bboxSelected.subscribe(emitted)
+
+    component.handleResultSelected(RESULT_WITHOUT_GEOM)
+
+    expect(emitted).not.toHaveBeenCalled()
+  })
+
+  it('emits the bounding box computed from the selected geometry', () => {
+    const emitted = jest.fn()
+    component.bboxSelected.subscribe(emitted)
+
+    component.handleResultSelected(RESULT_WITH_ALL)
+
+    expect(emitted).toHaveBeenCalledWith([6.771, 45.72, 6.771, 45.72])
+  })
+
+  it('resolves the secondary and main labels using the configured JSONPaths', () => {
+    expect(component.getSecondaryLabel(RESULT_WITH_ALL)).toEqual('commune')
+    expect(component.getMainLabel(RESULT_WITH_ALL)).toEqual('Beaufort, 73270')
+  })
+
+  it('resolves an undefined secondary label and the plain main label when no paths are configured', () => {
+    ;(getOptionalSearchConfig as jest.Mock).mockReturnValue(null)
+    fixture = TestBed.createComponent(SpatialExtentGeocodingSearchComponent)
+    component = fixture.componentInstance
+
+    expect(component.getSecondaryLabel(RESULT_WITH_ALL)).toBeUndefined()
+    expect(component.getMainLabel(RESULT_WITH_ALL)).toEqual('Beaufort')
+  })
+
+  it('renders the item template with secondary, main and tertiary labels', () => {
+    jest.useFakeTimers()
+    const hostFixture = TestBed.createComponent(HostComponent)
+    hostFixture.detectChanges()
+    const autocomplete = hostFixture.debugElement.query(
+      By.directive(AutocompleteComponent)
+    ).componentInstance as AutocompleteComponent
+    autocomplete.inputRef.nativeElement.value = 'bea'
+    autocomplete.inputRef.nativeElement.dispatchEvent(new InputEvent('input'))
+    jest.runOnlyPendingTimers()
+    hostFixture.detectChanges()
+
+    const overlayContainer =
+      TestBed.inject(OverlayContainer).getContainerElement()
+    expect(overlayContainer.textContent).toContain('commune')
+    expect(overlayContainer.textContent).toContain('Beaufort, 73270')
+  })
+
+  it('selecting a result emits the bbox on the host', () => {
+    jest.useFakeTimers()
+    const hostFixture = TestBed.createComponent(HostComponent)
+    hostFixture.detectChanges()
+    const autocomplete = hostFixture.debugElement.query(
+      By.directive(AutocompleteComponent)
+    ).componentInstance as AutocompleteComponent
+    autocomplete.inputRef.nativeElement.value = 'bea'
+    autocomplete.inputRef.nativeElement.dispatchEvent(new InputEvent('input'))
+    jest.runOnlyPendingTimers()
+    hostFixture.detectChanges()
+
+    autocomplete.handleSelection({
+      option: { value: RESULT_WITH_ALL },
+    } as never)
+
+    expect(hostFixture.componentInstance.bboxSelected).toHaveBeenCalledWith([
+      6.771, 45.72, 6.771, 45.72,
+    ])
+  })
+})

--- a/libs/feature/search/src/lib/spatial-extent-geocoding-search/spatial-extent-geocoding-search.component.stories.ts
+++ b/libs/feature/search/src/lib/spatial-extent-geocoding-search/spatial-extent-geocoding-search.component.stories.ts
@@ -1,0 +1,94 @@
+import { applicationConfig, Meta, StoryObj } from '@storybook/angular'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+import { importProvidersFrom } from '@angular/core'
+import { of } from 'rxjs'
+import { GeocodingResult } from '@geospatial-sdk/geocoding'
+import { provideI18n } from '@geonetwork-ui/util/i18n'
+import { loadAppConfig } from '@geonetwork-ui/util/app-config'
+import { SpatialExtentGeocodingSearchComponent } from './spatial-extent-geocoding-search.component'
+import { GeocodingService } from '../geocoding/geocoding.service'
+
+// SpatialExtentGeocodingSearchComponent reads its JSONPath config from
+// getOptionalSearchConfig(), which is only populated by loadAppConfig(); mock
+// fetch just for that call so the story actually exercises the secondary/
+// tertiary label rendering, instead of always falling back to the plain label.
+async function loadStorySearchConfig() {
+  const originalFetch = window.fetch
+  window.fetch = (() =>
+    Promise.resolve({
+      ok: true,
+      text: () =>
+        Promise.resolve(`
+[global]
+geonetwork4_api_url = "/geonetwork/srv/api"
+proxy_path = "/proxy/?url="
+
+[theme]
+primary_color = "#093564"
+secondary_color = "#c2e9dc"
+main_color = "#212029"
+background_color = "#fdfbff"
+
+[search.spatial_extent_service]
+secondary_label_jsonpath = '$.properties.category[1]'
+tertiary_label_jsonpath = '$.properties.citycode[0]'
+`),
+    })) as unknown as typeof fetch
+  await loadAppConfig().finally(() => {
+    window.fetch = originalFetch
+  })
+}
+
+const results: GeocodingResult[] = [
+  {
+    label: 'Beaufort',
+    geom: { type: 'Point', coordinates: [6.771, 45.72] },
+    properties: { category: ['poi', 'commune'], citycode: ['38150'] },
+  },
+  {
+    label: 'Beaufort',
+    geom: { type: 'Point', coordinates: [6.099, 45.72] },
+    properties: { category: ['poi', 'commune'], citycode: ['73180'] },
+  },
+  {
+    label: 'Beaufort',
+    geom: { type: 'Point', coordinates: [4.099, 44.13] },
+    properties: { category: ['poi', 'commune'], citycode: ['05202'] },
+  },
+]
+
+export default {
+  title: 'Search/SpatialExtentGeocodingSearchComponent',
+  component: SpatialExtentGeocodingSearchComponent,
+  decorators: [
+    applicationConfig({
+      providers: [
+        importProvidersFrom(BrowserAnimationsModule),
+        provideI18n(),
+        {
+          provide: GeocodingService,
+          useValue: {
+            query: (text: string) =>
+              of(
+                results.filter((r) =>
+                  r.label.toLowerCase().includes(text.toLowerCase())
+                )
+              ),
+          },
+        },
+      ],
+    }),
+  ],
+  argTypes: {
+    bboxSelected: { action: 'bboxSelected' },
+  },
+} as Meta<SpatialExtentGeocodingSearchComponent>
+
+export const Default: StoryObj<SpatialExtentGeocodingSearchComponent> = {
+  loaders: [
+    async () => {
+      await loadStorySearchConfig()
+      return {}
+    },
+  ],
+}

--- a/libs/feature/search/src/lib/spatial-extent-geocoding-search/spatial-extent-geocoding-search.component.ts
+++ b/libs/feature/search/src/lib/spatial-extent-geocoding-search/spatial-extent-geocoding-search.component.ts
@@ -1,0 +1,53 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Output,
+} from '@angular/core'
+import { GeocodingResult } from '@geospatial-sdk/geocoding'
+import { BoundingBox, getGeometryBoundingBox } from '@geonetwork-ui/util/shared'
+import { getOptionalSearchConfig } from '@geonetwork-ui/util/app-config'
+import { LocationSearchComponent } from '../location-search/location-search.component'
+import {
+  parseSpatialExtentResult,
+  SpatialExtentJsonPaths,
+} from '../geocoding/spatial-extent-result.parser'
+
+@Component({
+  selector: 'gn-ui-spatial-extent-geocoding-search',
+  templateUrl: './spatial-extent-geocoding-search.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [LocationSearchComponent],
+})
+export class SpatialExtentGeocodingSearchComponent {
+  @Output() bboxSelected = new EventEmitter<BoundingBox>()
+
+  private get jsonPaths(): SpatialExtentJsonPaths {
+    const config = getOptionalSearchConfig()?.SPATIAL_EXTENT_SERVICE
+    return {
+      mainLabel: config?.MAIN_LABEL_JSONPATH,
+      secondaryLabel: config?.SECONDARY_LABEL_JSONPATH,
+      tertiaryLabel: config?.TERTIARY_LABEL_JSONPATH,
+      geometry: config?.GEOMETRY_STRING_JSONPATH,
+    }
+  }
+
+  getSecondaryLabel(result: GeocodingResult): string | undefined {
+    return parseSpatialExtentResult(result, this.jsonPaths).secondaryLabel
+  }
+
+  getMainLabel(result: GeocodingResult): string {
+    const { label, tertiaryLabel } = parseSpatialExtentResult(
+      result,
+      this.jsonPaths
+    )
+    return tertiaryLabel ? `${label}, ${tertiaryLabel}` : label
+  }
+
+  handleResultSelected(result: GeocodingResult) {
+    const { geom } = parseSpatialExtentResult(result, this.jsonPaths)
+    if (!geom) return
+    this.bboxSelected.emit(getGeometryBoundingBox(geom))
+  }
+}

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.css
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.css
@@ -16,10 +16,6 @@ gn-ui-button {
   --gn-ui-button-padding: 0;
   font-size: 1em;
 }
-ng-icon.search {
-  margin-top: 0.6rem;
-  margin-left: 0.6rem;
-}
 gn-ui-button:last-of-type {
   --gn-ui-button-rounded: 0 var(--gn-ui-text-input-rounded, 0.25em)
     var(--gn-ui-text-input-rounded, 0.25em) 0;

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.html
@@ -1,9 +1,9 @@
 <span class="w-full inline-block relative">
   @if (!allowSubmit) {
     <div
-      class="absolute inset-y-[--icon-padding] left-[--icon-padding] w-[--icon-width] pointer-events-none"
+      class="absolute inset-y-[--icon-padding] left-[--icon-padding] w-[--icon-width] pointer-events-none flex items-center justify-center"
     >
-      <ng-icon name="iconoirSearch" class="text-primary search"></ng-icon>
+      <ng-icon name="iconoirSearch" class="text-primary"></ng-icon>
     </div>
   }
   <div class="flex flex-row">

--- a/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
+++ b/libs/ui/inputs/src/lib/autocomplete/autocomplete.component.ts
@@ -134,13 +134,13 @@ export class AutocompleteComponent
   getExtraClass(): string {
     if (this.allowSubmit) {
       if (this.enterButton) {
-        return 'border rounded-lg absolute w-8 h-8 right-[calc(var(--icon-width)+var(--icon-padding))] inset-y-[--icon-padding]'
+        return 'border rounded-lg absolute w-8 h-8 right-[calc(var(--icon-width)+var(--icon-padding))] top-1/2 -translate-y-1/2'
       } else {
-        return 'border rounded-lg absolute w-8 h-8 right-[calc(var(--icon-width)+0.25*var(--icon-width))] inset-y-[calc(0.25*var(--icon-width))]'
+        return 'border rounded-lg absolute w-8 h-8 right-[calc(var(--icon-width)+0.25*var(--icon-width))] top-1/2 -translate-y-1/2'
       }
     } else {
       if (!this.enterButton) {
-        return 'border rounded-lg absolute w-8 h-8 right-2 inset-y-2'
+        return 'border rounded-lg absolute w-8 h-8 right-2 top-1/2 -translate-y-1/2'
       }
     }
     return 'border rounded-lg absolute w-8 h-8'

--- a/libs/util/app-config/src/lib/app-config.spec.ts
+++ b/libs/util/app-config/src/lib/app-config.spec.ts
@@ -184,6 +184,12 @@ describe('app config utils', () => {
             'topic',
             'license',
           ],
+          SPATIAL_EXTENT_SERVICE: {
+            MAIN_LABEL_JSONPATH: '$.properties.name[0]',
+            SECONDARY_LABEL_JSONPATH: '$.properties.citycode[0]',
+            TERTIARY_LABEL_JSONPATH: '$.properties.category[1]',
+            GEOMETRY_STRING_JSONPATH: '$.properties.truegeometry',
+          },
         })
       })
     })

--- a/libs/util/app-config/src/lib/app-config.ts
+++ b/libs/util/app-config/src/lib/app-config.ts
@@ -253,6 +253,7 @@ export function loadAppConfig(configUrl = 'assets/configuration/default.toml') {
           'advanced_filters',
           'limit',
           'spatial_extent_max_file_size',
+          'spatial_extent_service',
         ],
         warnings,
         errors
@@ -265,6 +266,10 @@ export function loadAppConfig(configUrl = 'assets/configuration/default.toml') {
         warnings,
         errors
       )
+      const parsedSpatialExtentService =
+        parsedSearchSection?.spatial_extent_service as
+          | Record<string, string>
+          | undefined
       searchConfig =
         parsedSearchSection === null
           ? null
@@ -284,6 +289,18 @@ export function loadAppConfig(configUrl = 'assets/configuration/default.toml') {
               LIMIT: parsedSearchSection.limit,
               SPATIAL_EXTENT_MAX_FILE_SIZE:
                 parsedSearchSection.spatial_extent_max_file_size,
+              SPATIAL_EXTENT_SERVICE: parsedSpatialExtentService
+                ? {
+                    MAIN_LABEL_JSONPATH:
+                      parsedSpatialExtentService.main_label_jsonpath,
+                    SECONDARY_LABEL_JSONPATH:
+                      parsedSpatialExtentService.secondary_label_jsonpath,
+                    TERTIARY_LABEL_JSONPATH:
+                      parsedSpatialExtentService.tertiary_label_jsonpath,
+                    GEOMETRY_STRING_JSONPATH:
+                      parsedSpatialExtentService.geometry_string_jsonpath,
+                  }
+                : undefined,
             } as SearchConfig)
 
       const parsedMetadataQualitySection = parseConfigSection(

--- a/libs/util/app-config/src/lib/fixtures.ts
+++ b/libs/util/app-config/src/lib/fixtures.ts
@@ -43,6 +43,12 @@ filter_geometry_url = 'https://my.domain.org/geom.json'
 do_not_use_default_search_preset = false
 advanced_filters = ['publicationYear', 'documentStandard', 'inspireKeyword', 'topic', 'license']
 
+[search.spatial_extent_service]
+main_label_jsonpath = '$.properties.name[0]'
+secondary_label_jsonpath = '$.properties.citycode[0]'
+tertiary_label_jsonpath = '$.properties.category[1]'
+geometry_string_jsonpath = '$.properties.truegeometry'
+
 [[search_preset]]
 sort = "-createDate"
 name = 'filterByOrgs'

--- a/libs/util/app-config/src/lib/model.ts
+++ b/libs/util/app-config/src/lib/model.ts
@@ -55,6 +55,13 @@ export interface SearchPreset {
   filters: Record<string, string[] | string>
 }
 
+export interface SpatialExtentServiceConfig {
+  MAIN_LABEL_JSONPATH?: string
+  SECONDARY_LABEL_JSONPATH?: string
+  TERTIARY_LABEL_JSONPATH?: string
+  GEOMETRY_STRING_JSONPATH?: string
+}
+
 export interface SearchConfig {
   RECORD_KIND_QUICK_FILTER?: boolean
   FILTER_GEOMETRY_URL?: string
@@ -64,6 +71,7 @@ export interface SearchConfig {
   ADVANCED_FILTERS?: []
   LIMIT?: number
   SPATIAL_EXTENT_MAX_FILE_SIZE?: number
+  SPATIAL_EXTENT_SERVICE?: SpatialExtentServiceConfig
 }
 
 export interface MetadataQualityConfig {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "embla-carousel": "~8.6.0",
         "flag-icons": "~7.5.0",
         "geojson-validation": "~1.0.2",
+        "jsonpath-plus": "^10.4.0",
         "marked": "~17.0.4",
         "ngx-dropzone": "~3.1.0",
         "ngx-translate-messageformat-compiler": "~7.2.0",
@@ -7232,6 +7233,30 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
       }
     },
     "node_modules/@jsonjoy.com/base64": {
@@ -29310,6 +29335,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "dev": true,
@@ -29461,6 +29495,24 @@
         "node >= 0.2.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/jsprim": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "embla-carousel": "~8.6.0",
     "flag-icons": "~7.5.0",
     "geojson-validation": "~1.0.2",
+    "jsonpath-plus": "^10.4.0",
     "marked": "~17.0.4",
     "ngx-dropzone": "~3.1.0",
     "ngx-translate-messageformat-compiler": "~7.2.0",


### PR DESCRIPTION
Stacked on top of #1711 (geocoding_provider config), which is itself a
continuation of #1709 (location-search-component).

Adds a `[search.spatial_extent_service]` config section
(`main/secondary/tertiary_label_json_pointer`) and
`parseSpatialExtentResult()`, which derives a result's secondary/tertiary
label from these JSON Pointers (RFC 6901), resolved against the whole
`GeocodingResult`. `main_label_json_pointer` defaults to `/label`; the
other two have no default.

The label formatting and bounding-box emission (from the selected
result's `geom`, which every provider already normalizes) live directly
on `LocationSearchComponent` as its default item template/`bboxSelected`
output -- no separate wrapper component.

fixes #1710