### PR TITLE
Change `assert` to `with` for Node 24

### DIFF
--- a/tools/update-all-package-json.js
+++ b/tools/update-all-package-json.js
@@ -1,4 +1,4 @@
-import packageJson from '../package.json' assert { type: 'json' }
+import packageJson from '../package.json' with { type: 'json' }
 import { rewriteFiles } from './file-utils.js'
 import path from 'path'
 import { fileURLToPath } from 'url'


### PR DESCRIPTION
The `assert` keyword has been deprecated and replaced by `with` in Node 24.