### PR TITLE
Add clickable and hoverable false to new vector tiles default basemap

### DIFF
--- a/libs/ui/map/src/lib/components/map-container/map-container.component.ts
+++ b/libs/ui/map/src/lib/components/map-container/map-container.component.ts
@@ -58,6 +58,8 @@ import { transformExtent } from 'ol/proj.js'
 export const DEFAULT_BASEMAP_LAYER: MapContextLayerMapLibreStyle = {
   type: 'maplibre-style',
   styleUrl: `https://basemaps.cartocdn.com/gl/positron-gl-style/style.json`,
+  clickable: false,
+  hoverable: false,
 }
 
 const DEFAULT_VIEW: MapContextView = {


### PR DESCRIPTION
### Description

This PR is a follow up of https://github.com/geonetwork/geonetwork-ui/pull/1704.

Switching to a vector tiles basemap, the layer should be configured as `clickable` and `hoverable` false, to prevent issue with non-GeoJSON objects.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new logic** ⚙️ is introduced: unit tests were added
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **new UI components** 🕹️ are introduced: corresponding stories in Storybook were created
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label
- [ ] The [documentation website](https://geonetwork.github.io/geonetwork-ui/main/docs/) 📚 has received the love it deserves

### How to test

Copy or point your local Datahub to:
https://mel.integration.apps.gs-fr-prod.camptocamp.com/catalogue/dataset/ilevia-parkingrelais
Most of the points can't be clicked before the fix.

---

<!--
Please give credit to the sponsor of this work if possible.
-->

**This work is sponsored by [Métropole Européenne de Lille](https://data.lillemetropole.fr/)**.
