### PR TITLE
Fix(package): Add material-date-fns-adapter peerDependency

### DIFF
--- a/docs/guide/custom-app.md
+++ b/docs/guide/custom-app.md
@@ -136,6 +136,7 @@ Here we are inheriting from the GeoNetwork-UI base Tailwind config, which provid
 ```shell
 npm install --save \
   @angular/material \
+  @angular/material-date-fns-adapter \
   @angular/cdk \
   @ngrx/component \
   @ngrx/effects \

--- a/package/package.json
+++ b/package/package.json
@@ -21,6 +21,7 @@
     "@angular/core": "19.x || 20.x || 21.x",
     "@angular/forms": "19.x || 20.x || 21.x",
     "@angular/material": "19.x || 20.x || 21.x",
+    "@angular/material-date-fns-adapter": "19.x || 20.x",
     "@angular/platform-browser": "19.x || 20.x || 21.x",
     "@angular/platform-browser-dynamic": "19.x || 20.x || 21.x",
     "@angular/router": "19.x || 20.x || 21.x",


### PR DESCRIPTION
### Description

Follow-up to #1693 to fix npm package dependency for `@angular/material-date-fns-adapter`

Note: Does not add 21.x due to dep conflict with @angular/core@20

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

