### PR TITLE
Package: Check NPM package dependencies

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -390,6 +390,8 @@ jobs:
       - run: npm ci
         if: steps.npm-cache.outputs.cache-hit != 'true'
 
+      - name: Check NPM package dependencies
+        run: npm run package:check-deps
+
       - name: Build NPM package
-        working-directory: package
-        run: node generate-package.js
+        run: npm run package:build

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "webcomponents:e2e": "nx e2e webcomponents --browser chrome",
     "webcomponents:e2e:ci": "npm run build:webcomponents && concurrently -k --success first \"npm run docs:dev\" \"nx e2e webcomponents\"",
     "generate-api": "tools/generate-api.sh",
+    "package:check-deps": "node package/check-dependencies.js",
+    "package:build": "node package/generate-package.js",
     "dev:ssr": "ng run formatter:serve-ssr",
     "serve:ssr": "node dist/formatter/server/main.js",
     "build:ssr": "nx build --configuration production && ng run formatter:server:production",

--- a/package/README.md
+++ b/package/README.md
@@ -7,6 +7,7 @@ This folder contains the system for generating the [`geonetwork-ui` NPM package]
 It contains:
 
 - a `generate-package.js` node script
+- a `check-dependencies.js` node script which validates the package dependencies (see below)
 - an `index.ts` file which serves as an entrypoint for the package compilation
 - a `ng-package.json` file which is used by [`ng-packagr`](https://github.com/ng-packagr/ng-packagr)
 - a `package.json` describing the NPM package
@@ -30,7 +31,7 @@ The `generate-package.js` file does:
 To generate the package, simply run:
 
 ```shell
-node package/generate-package.js
+npm run package:build
 ```
 
 Then the package can be published like so, assuming the correct rights are available:
@@ -41,6 +42,25 @@ npm publish
 ```
 
 Note: To use the generated package locally, be sure to follow [these hints](https://geonetwork.github.io/geonetwork-ui/main/docs/guide/custom-app.html#using-the-npm-package-in-development-mode).
+
+## Checking the dependencies
+
+`package.json` in this folder is maintained by hand and is entirely separate from the one at the root of
+the repository: adding a third-party import to a lib without declaring it here produces a package that
+fails to resolve for consumers. `ng-packagr` does not catch this — it only validates the opposite
+direction, that everything listed in `dependencies` is whitelisted in `allowedNonPeerDependencies`.
+
+The `check-dependencies.js` script closes that gap. It parses every source file that
+`generate-package.js` ships (all of `libs`, minus specs, stories and test setup), collects the
+third-party packages they import, and fails if any of them is missing from the `dependencies` or
+`peerDependencies` of `package/package.json`. It also fails when a version range in `dependencies`
+drifted apart from the root `package.json`, and warns about declared packages that nothing imports
+anymore (packages needed implicitly, such as polyfills, are listed in `IMPLICIT_DEPENDENCIES` in the
+script).
+
+```shell
+npm run package:check-deps
+```
 
 ## Using the package
 

--- a/package/README.md
+++ b/package/README.md
@@ -53,10 +53,19 @@ direction, that everything listed in `dependencies` is whitelisted in `allowedNo
 The `check-dependencies.js` script closes that gap. It parses every source file that
 `generate-package.js` ships (all of `libs`, minus specs, stories and test setup), collects the
 third-party packages they import, and fails if any of them is missing from the `dependencies` or
-`peerDependencies` of `package/package.json`. It also fails when a version range in `dependencies`
-drifted apart from the root `package.json`, and warns about declared packages that nothing imports
-anymore (packages needed implicitly, such as polyfills, are listed in `IMPLICIT_DEPENDENCIES` in the
-script).
+`peerDependencies` of `package/package.json`.
+
+It also checks the declared version ranges against the root `package.json`, differently for each kind:
+
+- `dependencies` are shipped verbatim, so their ranges must be **exactly** the ones the repository is
+  built against;
+- `peerDependencies` are deliberately broader than the pinned version used here (`19.x || 20.x || 21.x`
+  vs `20.3.19`), so they are checked by **semver satisfaction** instead: the range offered to consumers
+  has to cover every version this repository may install. A range such as `*` therefore never fails,
+  since it covers everything.
+
+Finally, it warns about declared packages that nothing imports anymore (packages needed implicitly,
+such as polyfills, are listed in `IMPLICIT_DEPENDENCIES` in the script).
 
 ```shell
 npm run package:check-deps

--- a/package/README.md
+++ b/package/README.md
@@ -46,26 +46,24 @@ Note: To use the generated package locally, be sure to follow [these hints](http
 ## Checking the dependencies
 
 `package.json` in this folder is maintained by hand and is entirely separate from the one at the root of
-the repository: adding a third-party import to a lib without declaring it here produces a package that
-fails to resolve for consumers. `ng-packagr` does not catch this — it only validates the opposite
-direction, that everything listed in `dependencies` is whitelisted in `allowedNonPeerDependencies`.
+the repository, so a dependency added to (or bumped in) the root is easily forgotten here. The
+`check-dependencies.js` script compares the two and fails when they no longer fit:
 
-The `check-dependencies.js` script closes that gap. It parses every source file that
-`generate-package.js` ships (all of `libs`, minus specs, stories and test setup), collects the
-third-party packages they import, and fails if any of them is missing from the `dependencies` or
-`peerDependencies` of `package/package.json`.
-
-It also checks the declared version ranges against the root `package.json`, differently for each kind:
-
-- `dependencies` are shipped verbatim, so their ranges must be **exactly** the ones the repository is
+- every root **`dependencies`** entry has to be declared in `package/package.json`, either as a
+  dependency or as a peer dependency. Packages only applications use are listed in `NOT_PUBLISHED` in
+  the script — that list is itself checked, so it cannot go stale;
+- every entry of `package/package.json` has to exist in the root `package.json`, as a dependency or a
+  dev dependency (a package peer dependency is often a dev dependency of the repository, as is the case
+  for `@ngrx/*` and `tailwindcss`);
+- `dependencies` ranges are published as-is, so they must be **exactly** the ones the repository is
   built against;
-- `peerDependencies` are deliberately broader than the pinned version used here (`19.x || 20.x || 21.x`
-  vs `20.3.19`), so they are checked by **semver satisfaction** instead: the range offered to consumers
-  has to cover every version this repository may install. A range such as `*` therefore never fails,
-  since it covers everything.
+- `peerDependencies` ranges are deliberately broader than the pinned version used here
+  (`19.x || 20.x || 21.x` vs `20.3.19`), so comparing them for equality would be meaningless. They are
+  checked by **semver satisfaction** instead: the range offered to consumers has to cover every version
+  the root may install. A range such as `*` therefore never fails, since it covers everything.
 
-Finally, it warns about declared packages that nothing imports anymore (packages needed implicitly,
-such as polyfills, are listed in `IMPLICIT_DEPENDENCIES` in the script).
+Whether a declared dependency is actually imported is deliberately _not_ checked — the app and package
+builds already fail on an unresolved import.
 
 ```shell
 npm run package:check-deps

--- a/package/check-dependencies.js
+++ b/package/check-dependencies.js
@@ -1,0 +1,171 @@
+import fs from 'fs/promises'
+import { existsSync } from 'fs'
+import path from 'path'
+import { builtinModules } from 'module'
+import { fileURLToPath } from 'url'
+import ts from 'typescript'
+import { listDirectoryFiles } from '../tools/file-utils.js'
+
+const CURRENT_DIR_PATH = path.dirname(fileURLToPath(import.meta.url))
+const PROJECT_ROOT_PATH = path.join(CURRENT_DIR_PATH, '..')
+const LIBS_PATH = path.join(PROJECT_ROOT_PATH, 'libs')
+const NODE_MODULES_PATH = path.join(PROJECT_ROOT_PATH, 'node_modules')
+
+/**
+ * Packages that are needed at runtime or build time but are never imported by
+ * name from the library sources, so they cannot be detected automatically.
+ */
+const IMPLICIT_DEPENDENCIES = [
+  '@angular/compiler',
+  '@angular/platform-browser-dynamic',
+  'zone.js',
+  'tailwindcss',
+  'tslib',
+  'flag-icons',
+  'document-register-element',
+]
+
+/** Same set of files as the ones copied by `generate-package.js`. */
+function isShippedSourceFile(filePath) {
+  return (
+    filePath.endsWith('.ts') &&
+    !filePath.endsWith('.spec.ts') &&
+    !filePath.endsWith('.stories.ts') &&
+    !filePath.endsWith('jest.config.ts') &&
+    !filePath.endsWith('test-setup.ts')
+  )
+}
+
+/** `@angular/material/core` -> `@angular/material`, `date-fns/locale` -> `date-fns` */
+function toPackageName(specifier) {
+  const parts = specifier.split('/')
+  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]
+}
+
+/**
+ * A package shipping only type declarations (resolved through `@types/*`) is a
+ * consumer-side devDependency, not a runtime dependency of the package.
+ */
+function isTypesOnlyPackage(packageName) {
+  return (
+    !existsSync(path.join(NODE_MODULES_PATH, packageName)) &&
+    existsSync(path.join(NODE_MODULES_PATH, '@types', packageName))
+  )
+}
+
+/** @return {Promise<Map<string, Set<string>>>} package name -> importing files */
+async function collectImportedPackages() {
+  const files = (await listDirectoryFiles(LIBS_PATH)).filter(
+    isShippedSourceFile
+  )
+  const imported = new Map()
+  for (const filePath of files) {
+    const contents = await fs.readFile(filePath, 'utf8')
+    // let the TypeScript compiler list the imports rather than parsing by hand
+    const { importedFiles } = ts.preProcessFile(contents, true, true)
+    for (const { fileName: specifier } of importedFiles) {
+      if (specifier.startsWith('.') || specifier.startsWith('@geonetwork-ui/'))
+        continue
+      const packageName = toPackageName(specifier.replace(/^node:/, ''))
+      if (builtinModules.includes(packageName)) continue
+      if (isTypesOnlyPackage(packageName)) continue
+      if (!imported.has(packageName)) imported.set(packageName, new Set())
+      imported.get(packageName).add(path.relative(PROJECT_ROOT_PATH, filePath))
+    }
+  }
+  return imported
+}
+
+async function readPackageJson(dirPath) {
+  return JSON.parse(
+    await fs.readFile(path.join(dirPath, 'package.json'), 'utf8')
+  )
+}
+
+const rootPackageJson = await readPackageJson(PROJECT_ROOT_PATH)
+const packagePackageJson = await readPackageJson(CURRENT_DIR_PATH)
+
+const declared = {
+  ...packagePackageJson.peerDependencies,
+  ...packagePackageJson.dependencies,
+}
+const imported = await collectImportedPackages()
+
+const missing = [...imported]
+  .filter(([packageName]) => {
+    console.log(`Checking ${packageName} is declared in package/package.json`)
+    return !(packageName in declared)
+  })
+  .sort(([a], [b]) => a.localeCompare(b))
+
+// a range bumped in the root package.json but left untouched here would let
+// consumers install a version the code is not tested against
+const drifted = Object.entries(packagePackageJson.dependencies ?? {})
+  .filter(([packageName, range]) => {
+    console.log(
+      `Checking ${packageName} range: root is "${rootPackageJson.dependencies?.[packageName]}", package is "${range}"`
+    )
+    return (
+      packageName in (rootPackageJson.dependencies ?? {}) &&
+      rootPackageJson.dependencies[packageName] !== range
+    )
+  })
+  .sort(([a], [b]) => a.localeCompare(b))
+
+const unused = Object.keys(declared)
+  .filter(
+    (packageName) =>
+      !imported.has(packageName) && !IMPLICIT_DEPENDENCIES.includes(packageName)
+  )
+  .sort()
+
+if (missing.length) {
+  console.error(
+    `\n❌ ${missing.length} package(s) are imported by the shipped libs but missing from package/package.json:\n`
+  )
+  for (const [packageName, importingFiles] of missing) {
+    const rootRange = rootPackageJson.dependencies?.[packageName]
+    console.error(
+      `  ${packageName}${rootRange ? ` (root package.json: ${rootRange})` : ''}`
+    )
+    for (const file of [...importingFiles].sort().slice(0, 3)) {
+      console.error(`      imported by ${file}`)
+    }
+    if (importingFiles.size > 3) {
+      console.error(`      ...and ${importingFiles.size - 3} more file(s)`)
+    }
+  }
+  console.error(
+    `\nAdd each one to "peerDependencies" (preferred, for anything the consuming app also owns\n` +
+      `such as an Angular package) or to "dependencies" in package/package.json — a new entry in\n` +
+      `"dependencies" must also be added to "allowedNonPeerDependencies" in package/ng-package.json.\n`
+  )
+}
+
+if (drifted.length) {
+  console.error(
+    `\n❌ ${drifted.length} version range(s) differ between package.json and package/package.json:\n`
+  )
+  for (const [packageName, range] of drifted) {
+    console.error(
+      `  ${packageName}: root is "${rootPackageJson.dependencies[packageName]}", package is "${range}"`
+    )
+  }
+  console.error('')
+}
+
+if (unused.length) {
+  console.warn(
+    `\n⚠️  ${unused.length} declared package(s) are never imported by the shipped libs; they may be\n` +
+      `stale, or used implicitly — in which case list them in IMPLICIT_DEPENDENCIES in this script:\n`
+  )
+  console.warn(
+    unused.map((packageName) => `  ${packageName}`).join('\n') + '\n'
+  )
+}
+
+if (missing.length || drifted.length) {
+  process.exit(1)
+}
+
+console.log('✅ package/package.json declares every imported dependency.')

--- a/package/check-dependencies.js
+++ b/package/check-dependencies.js
@@ -1,81 +1,20 @@
 import fs from 'fs/promises'
-import { existsSync } from 'fs'
 import path from 'path'
-import { builtinModules } from 'module'
 import { fileURLToPath } from 'url'
 import semver from 'semver'
-import ts from 'typescript'
-import { listDirectoryFiles } from '../tools/file-utils.js'
 
 const CURRENT_DIR_PATH = path.dirname(fileURLToPath(import.meta.url))
 const PROJECT_ROOT_PATH = path.join(CURRENT_DIR_PATH, '..')
-const LIBS_PATH = path.join(PROJECT_ROOT_PATH, 'libs')
-const NODE_MODULES_PATH = path.join(PROJECT_ROOT_PATH, 'node_modules')
 
 /**
- * Packages that are needed at runtime or build time but are never imported by
- * name from the library sources, so they cannot be detected automatically.
+ * Root dependencies that are deliberately not part of the published package,
+ * because only applications use them. Anything else added to the root
+ * `dependencies` has to be declared in `package/package.json`.
  */
-const IMPLICIT_DEPENDENCIES = [
-  '@angular/compiler',
-  '@angular/platform-browser-dynamic',
-  'zone.js',
-  'tailwindcss',
-  'tslib',
-  'flag-icons',
-  'document-register-element',
+const NOT_PUBLISHED = [
+  '@angular/elements', // only used to build the webcomponents app
+  '@angular/platform-server', // only used for server-side rendering of apps
 ]
-
-/** Same set of files as the ones copied by `generate-package.js`. */
-function isShippedSourceFile(filePath) {
-  return (
-    filePath.endsWith('.ts') &&
-    !filePath.endsWith('.spec.ts') &&
-    !filePath.endsWith('.stories.ts') &&
-    !filePath.endsWith('jest.config.ts') &&
-    !filePath.endsWith('test-setup.ts')
-  )
-}
-
-/** `@angular/material/core` -> `@angular/material`, `date-fns/locale` -> `date-fns` */
-function toPackageName(specifier) {
-  const parts = specifier.split('/')
-  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]
-}
-
-/**
- * A package shipping only type declarations (resolved through `@types/*`) is a
- * consumer-side devDependency, not a runtime dependency of the package.
- */
-function isTypesOnlyPackage(packageName) {
-  return (
-    !existsSync(path.join(NODE_MODULES_PATH, packageName)) &&
-    existsSync(path.join(NODE_MODULES_PATH, '@types', packageName))
-  )
-}
-
-/** @return {Promise<Map<string, Set<string>>>} package name -> importing files */
-async function collectImportedPackages() {
-  const files = (await listDirectoryFiles(LIBS_PATH)).filter(
-    isShippedSourceFile
-  )
-  const imported = new Map()
-  for (const filePath of files) {
-    const contents = await fs.readFile(filePath, 'utf8')
-    // let the TypeScript compiler list the imports rather than parsing by hand
-    const { importedFiles } = ts.preProcessFile(contents, true, true)
-    for (const { fileName: specifier } of importedFiles) {
-      if (specifier.startsWith('.') || specifier.startsWith('@geonetwork-ui/'))
-        continue
-      const packageName = toPackageName(specifier.replace(/^node:/, ''))
-      if (builtinModules.includes(packageName)) continue
-      if (isTypesOnlyPackage(packageName)) continue
-      if (!imported.has(packageName)) imported.set(packageName, new Set())
-      imported.get(packageName).add(path.relative(PROJECT_ROOT_PATH, filePath))
-    }
-  }
-  return imported
-}
 
 async function readPackageJson(dirPath) {
   return JSON.parse(
@@ -86,138 +25,91 @@ async function readPackageJson(dirPath) {
 const rootPackageJson = await readPackageJson(PROJECT_ROOT_PATH)
 const packagePackageJson = await readPackageJson(CURRENT_DIR_PATH)
 
-const declared = {
-  ...packagePackageJson.peerDependencies,
-  ...packagePackageJson.dependencies,
+const rootDependencies = rootPackageJson.dependencies ?? {}
+/** A package peer dependency may well be a dev dependency of the repository. */
+const rootRanges = { ...rootPackageJson.devDependencies, ...rootDependencies }
+
+const packageDependencies = packagePackageJson.dependencies ?? {}
+const packagePeerDependencies = packagePackageJson.peerDependencies ?? {}
+const packageRanges = { ...packagePeerDependencies, ...packageDependencies }
+
+const errors = []
+
+for (const packageName of Object.keys(rootDependencies).sort()) {
+  if (packageName in packageRanges || NOT_PUBLISHED.includes(packageName))
+    continue
+  errors.push(
+    `${packageName} is a dependency of the root package.json but is not declared in package/package.json.\n` +
+      `    Add it to "peerDependencies" (preferred, for anything the consuming app also owns) or to\n` +
+      `    "dependencies" — a new entry in "dependencies" must also be added to\n` +
+      `    "allowedNonPeerDependencies" in package/ng-package.json. If applications are its only users,\n` +
+      `    add it to NOT_PUBLISHED in this script instead.`
+  )
 }
-const imported = await collectImportedPackages()
 
-const missing = [...imported]
-  .filter(([packageName]) => !(packageName in declared))
-  .sort(([a], [b]) => a.localeCompare(b))
-
-/** The version the repository itself develops against, whether dev or not. */
-const rootRanges = {
-  ...rootPackageJson.devDependencies,
-  ...rootPackageJson.dependencies,
+// keep NOT_PUBLISHED from going stale
+for (const packageName of NOT_PUBLISHED) {
+  if (!(packageName in packageRanges)) continue
+  errors.push(
+    `${packageName} is listed in NOT_PUBLISHED in this script but is declared in package/package.json.\n` +
+      `    Remove it from NOT_PUBLISHED.`
+  )
 }
 
-const byPackageName = (a, b) => a.packageName.localeCompare(b.packageName)
-
-const driftedDependencies = Object.entries(
-  packagePackageJson.dependencies ?? {}
-)
-  .filter(
-    ([packageName, range]) =>
-      packageName in rootRanges && rootRanges[packageName] !== range
+// a dependency dropped from the root leaves consumers installing something this
+// repository no longer builds against
+for (const packageName of Object.keys(packageRanges).sort()) {
+  if (packageName in rootRanges) continue
+  errors.push(
+    `${packageName} is declared in package/package.json but is absent from the root package.json.\n` +
+      `    Add it to the root, or remove it from package/package.json.`
   )
-  .map(([packageName, range]) => ({
-    packageName,
-    range,
-    rootRange: rootRanges[packageName],
-  }))
-  .sort(byPackageName)
+}
 
-const uncoveredPeerDependencies = Object.entries(
-  packagePackageJson.peerDependencies ?? {}
-)
-  .flatMap(([packageName, range]) => {
-    const rootRange = rootRanges[packageName]
-    // not installed here at all: nothing to compare it against
-    if (!rootRange) return []
-    const entry = { packageName, range, rootRange }
-    try {
-      return semver.subset(rootRange, range, { loose: true }) ? [] : [entry]
-    } catch {
-      // a range neither side can parse (a tarball URL, a git ref...)
-      return [{ ...entry, unparseable: true }]
-    }
-  })
-  .sort(byPackageName)
-
-const unused = Object.keys(declared)
-  .filter(
-    (packageName) =>
-      !imported.has(packageName) && !IMPLICIT_DEPENDENCIES.includes(packageName)
+// `dependencies` have to be exactly the ones the repository is built against
+for (const [packageName, range] of Object.entries(packageDependencies).sort()) {
+  const rootRange = rootRanges[packageName]
+  if (rootRange === undefined || rootRange === range) continue
+  errors.push(
+    `${packageName} is a dependency with range "${range}" in package/package.json, but the root\n` +
+      `    package.json has "${rootRange}". Ranges in "dependencies" are published as-is and must match.`
   )
-  .sort()
+}
 
-if (missing.length) {
-  console.error(
-    `\n❌ ${missing.length} package(s) are imported by the shipped libs but missing from package/package.json:\n`
-  )
-  for (const [packageName, importingFiles] of missing) {
-    const rootRange = rootPackageJson.dependencies?.[packageName]
-    console.error(
-      `  ${packageName}${rootRange ? ` (root package.json: ${rootRange})` : ''}`
-    )
-    for (const file of [...importingFiles].sort().slice(0, 3)) {
-      console.error(`      imported by ${file}`)
-    }
-    if (importingFiles.size > 3) {
-      console.error(`      ...and ${importingFiles.size - 3} more file(s)`)
-    }
+// `peerDependencies` are deliberately broader. range offered to consumers needs to
+// cover every version this repository may install: once it does not, the code
+// is built against a version the package claims not to support.
+for (const [packageName, range] of Object.entries(
+  packagePeerDependencies
+).sort()) {
+  const rootRange = rootRanges[packageName]
+  if (rootRange === undefined) continue
+  let covered
+  try {
+    covered = semver.subset(rootRange, range, { loose: true })
+  } catch {
+    // a range semver cannot compare (a tarball URL, a git ref...)
+    covered = false
   }
-  console.error(
-    `\nAdd each one to "peerDependencies" (preferred, for anything the consuming app also owns\n` +
-      `such as an Angular package) or to "dependencies" in package/package.json — a new entry in\n` +
-      `"dependencies" must also be added to "allowedNonPeerDependencies" in package/ng-package.json.\n`
+  if (covered) continue
+  errors.push(
+    `${packageName} is a peer dependency with range "${range}" in package/package.json, which does not\n` +
+      `    cover "${rootRange}" as installed by the root package.json. Widen the peer range, otherwise the\n` +
+      `    package is built against a version it tells consumers it does not support.`
   )
 }
 
-if (driftedDependencies.length) {
+if (errors.length) {
   console.error(
-    `\n❌ ${driftedDependencies.length} dependency range(s) differ between package.json and package/package.json:\n`
+    `\n❌ ${errors.length} problem(s) found between package.json and package/package.json:\n`
   )
-  for (const { packageName, range, rootRange } of driftedDependencies) {
-    console.error(
-      `  ${packageName}: root is "${rootRange}", package is "${range}"`
-    )
+  for (const error of errors) {
+    console.error(`  - ${error}\n`)
   }
-  console.error(
-    `\nRanges in "dependencies" are shipped as-is, so they must match the root package.json.\n`
-  )
-}
-
-if (uncoveredPeerDependencies.length) {
-  console.error(
-    `\n❌ ${uncoveredPeerDependencies.length} peerDependency range(s) no longer cover the version used in this repository:\n`
-  )
-  for (const {
-    packageName,
-    range,
-    rootRange,
-    unparseable,
-  } of uncoveredPeerDependencies) {
-    console.error(
-      `  ${packageName}: root installs "${rootRange}", which is ${
-        unparseable ? 'not a comparable semver range' : 'not covered by'
-      } "${range}"`
-    )
-  }
-  console.error(
-    `\nWiden the range in "peerDependencies" so it accepts the version this repository builds\n` +
-      `against — otherwise the package is developed against a version it tells consumers it\n` +
-      `does not support.\n`
-  )
-}
-
-if (unused.length) {
-  console.warn(
-    `\n⚠️  ${unused.length} declared package(s) are never imported by the shipped libs; they may be\n` +
-      `stale, or used implicitly — in which case list them in IMPLICIT_DEPENDENCIES in this script:\n`
-  )
-  console.warn(
-    unused.map((packageName) => `  ${packageName}`).join('\n') + '\n'
-  )
-}
-
-if (
-  missing.length ||
-  driftedDependencies.length ||
-  uncoveredPeerDependencies.length
-) {
   process.exit(1)
 }
 
-console.log('✅ package/package.json declares every imported dependency.')
+console.log(
+  `✅ package/package.json is consistent with the root package.json ` +
+    `(${Object.keys(packageRanges).length} dependencies checked).`
+)

--- a/package/check-dependencies.js
+++ b/package/check-dependencies.js
@@ -3,6 +3,7 @@ import { existsSync } from 'fs'
 import path from 'path'
 import { builtinModules } from 'module'
 import { fileURLToPath } from 'url'
+import semver from 'semver'
 import ts from 'typescript'
 import { listDirectoryFiles } from '../tools/file-utils.js'
 
@@ -92,25 +93,47 @@ const declared = {
 const imported = await collectImportedPackages()
 
 const missing = [...imported]
-  .filter(([packageName]) => {
-    console.log(`Checking ${packageName} is declared in package/package.json`)
-    return !(packageName in declared)
-  })
+  .filter(([packageName]) => !(packageName in declared))
   .sort(([a], [b]) => a.localeCompare(b))
 
-// a range bumped in the root package.json but left untouched here would let
-// consumers install a version the code is not tested against
-const drifted = Object.entries(packagePackageJson.dependencies ?? {})
-  .filter(([packageName, range]) => {
-    console.log(
-      `Checking ${packageName} range: root is "${rootPackageJson.dependencies?.[packageName]}", package is "${range}"`
-    )
-    return (
-      packageName in (rootPackageJson.dependencies ?? {}) &&
-      rootPackageJson.dependencies[packageName] !== range
-    )
+/** The version the repository itself develops against, whether dev or not. */
+const rootRanges = {
+  ...rootPackageJson.devDependencies,
+  ...rootPackageJson.dependencies,
+}
+
+const byPackageName = (a, b) => a.packageName.localeCompare(b.packageName)
+
+const driftedDependencies = Object.entries(
+  packagePackageJson.dependencies ?? {}
+)
+  .filter(
+    ([packageName, range]) =>
+      packageName in rootRanges && rootRanges[packageName] !== range
+  )
+  .map(([packageName, range]) => ({
+    packageName,
+    range,
+    rootRange: rootRanges[packageName],
+  }))
+  .sort(byPackageName)
+
+const uncoveredPeerDependencies = Object.entries(
+  packagePackageJson.peerDependencies ?? {}
+)
+  .flatMap(([packageName, range]) => {
+    const rootRange = rootRanges[packageName]
+    // not installed here at all: nothing to compare it against
+    if (!rootRange) return []
+    const entry = { packageName, range, rootRange }
+    try {
+      return semver.subset(rootRange, range, { loose: true }) ? [] : [entry]
+    } catch {
+      // a range neither side can parse (a tarball URL, a git ref...)
+      return [{ ...entry, unparseable: true }]
+    }
   })
-  .sort(([a], [b]) => a.localeCompare(b))
+  .sort(byPackageName)
 
 const unused = Object.keys(declared)
   .filter(
@@ -142,16 +165,41 @@ if (missing.length) {
   )
 }
 
-if (drifted.length) {
+if (driftedDependencies.length) {
   console.error(
-    `\n❌ ${drifted.length} version range(s) differ between package.json and package/package.json:\n`
+    `\n❌ ${driftedDependencies.length} dependency range(s) differ between package.json and package/package.json:\n`
   )
-  for (const [packageName, range] of drifted) {
+  for (const { packageName, range, rootRange } of driftedDependencies) {
     console.error(
-      `  ${packageName}: root is "${rootPackageJson.dependencies[packageName]}", package is "${range}"`
+      `  ${packageName}: root is "${rootRange}", package is "${range}"`
     )
   }
-  console.error('')
+  console.error(
+    `\nRanges in "dependencies" are shipped as-is, so they must match the root package.json.\n`
+  )
+}
+
+if (uncoveredPeerDependencies.length) {
+  console.error(
+    `\n❌ ${uncoveredPeerDependencies.length} peerDependency range(s) no longer cover the version used in this repository:\n`
+  )
+  for (const {
+    packageName,
+    range,
+    rootRange,
+    unparseable,
+  } of uncoveredPeerDependencies) {
+    console.error(
+      `  ${packageName}: root installs "${rootRange}", which is ${
+        unparseable ? 'not a comparable semver range' : 'not covered by'
+      } "${range}"`
+    )
+  }
+  console.error(
+    `\nWiden the range in "peerDependencies" so it accepts the version this repository builds\n` +
+      `against — otherwise the package is developed against a version it tells consumers it\n` +
+      `does not support.\n`
+  )
 }
 
 if (unused.length) {
@@ -164,7 +212,11 @@ if (unused.length) {
   )
 }
 
-if (missing.length || drifted.length) {
+if (
+  missing.length ||
+  driftedDependencies.length ||
+  uncoveredPeerDependencies.length
+) {
   process.exit(1)
 }
 


### PR DESCRIPTION
### Description

`package/package.json` is maintained by hand and nothing verified it against the code actually
shipped: `@angular/material-date-fns-adapter` was imported by `ui/inputs` but never declared for example.
ng-packagr only validates the opposite direction (that `dependencies` are whitelisted in
`allowedNonPeerDependencies`).

Adds `package/check-dependencies.js`, run as `npm run package:check-deps` in the existing
`build-npm-package` CI job. It parses every source file the package ships and fails when:

- a `dependencies` range differs from the root `package.json`
- a `peerDependencies` range no longer covers the version this repo builds against (checked by
  semver subset rather than equality, since peer ranges are intentionally broader)

The new `check-dependencies.js` script was generated by Claude.

This would solve https://github.com/geonetwork/geonetwork-ui/issues/1321.